### PR TITLE
Allow configuring a custom resolver for proxies in ClientOptions

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
@@ -37,6 +37,7 @@ import io.netty.channel.pool.ChannelPool;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.AttributeKey;
 import reactor.ipc.netty.resources.LoopResources;
 import reactor.ipc.netty.options.ClientOptions;
@@ -287,6 +288,14 @@ public final class HttpClientOptions extends ClientOptions {
 			@Nullable String username,
 			@Nullable Function<? super String, ? extends String> password) {
 		super.proxy(Proxy.HTTP, connectAddress, username, password);
+		return this;
+	}
+
+	public HttpClientOptions proxy(@Nonnull Supplier<? extends InetSocketAddress> connectAddress,
+			@Nullable String username,
+			@Nullable Function<? super String, ? extends String> password,
+			@Nullable AddressResolverGroup<?> resolver) {
+		super.proxy(Proxy.HTTP, connectAddress, username, password, resolver);
 		return this;
 	}
 

--- a/src/main/java/reactor/ipc/netty/options/ClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/ClientOptions.java
@@ -37,6 +37,7 @@ import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.handler.ssl.JdkSslContext;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.resolver.AddressResolverGroup;
 import io.netty.resolver.NoopAddressResolverGroup;
 import io.netty.util.NetUtil;
 import reactor.core.Exceptions;
@@ -395,13 +396,24 @@ public class ClientOptions extends NettyOptions<Bootstrap, ClientOptions> {
 			@Nonnull Supplier<? extends InetSocketAddress> connectAddress,
 			@Nullable String username,
 			@Nullable Function<? super String, ? extends String> password) {
+		return proxy(type, connectAddress, username, password, NoopAddressResolverGroup.INSTANCE);
+	}
+
+	public ClientOptions proxy(@Nonnull Proxy type,
+			@Nonnull Supplier<? extends InetSocketAddress> connectAddress,
+			@Nullable String username,
+			@Nullable Function<? super String, ? extends String> password,
+			@Nullable AddressResolverGroup<?> resolver) {
 		this.proxyUsername = username;
 		this.proxyPassword = password;
 		this.proxyAddress = Objects.requireNonNull(connectAddress, "addressSupplier");
 		this.proxyType = Objects.requireNonNull(type, "proxyType");
-		bootstrapTemplate.resolver(NoopAddressResolverGroup.INSTANCE);
+		if (resolver != null) {
+			bootstrapTemplate.resolver(resolver);
+		}
 		return this;
 	}
+
 
 	/**
 	 * Enable default sslContext support


### PR DESCRIPTION
NoopAddressResolverGroup causes UnknownHostException in some scenarios where the client is configured to use http proxy

The fix is needed for CloudFoundry Java Client library to function behind proxies:
https://github.com/cloudfoundry/cf-java-client/issues/479

Signed-off-by: Tareq Sharafy <tareq.sha@gmail.com>