### PR TITLE
fix #23 Make NettyContext.addDecoder non-default

### DIFF
--- a/src/main/java/reactor/ipc/netty/NettyContext.java
+++ b/src/main/java/reactor/ipc/netty/NettyContext.java
@@ -16,12 +16,13 @@
 package reactor.ipc.netty;
 
 import java.net.InetSocketAddress;
-import java.util.Objects;
+import java.util.function.Consumer;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
+import reactor.ipc.netty.channel.ChannelOperations;
 
 /**
  * Hold contextual information for the underlying {@link Channel}
@@ -82,10 +83,9 @@ public interface NettyContext extends Disposable {
 	 * @param handler handler instance
 	 *
 	 * @return this inbound
+	 * @see ChannelOperations#addDecoder(NettyContext, Channel, String, ChannelHandler, Consumer)
 	 */
-	default NettyContext addDecoder(String name, ChannelHandler handler){
-		return addDecoder(name, handler);
-	}
+	NettyContext addDecoder(String name, ChannelHandler handler);
 
 	/**
 	 * Return remote address if remote channel {@link NettyContext} otherwise local

--- a/src/main/java/reactor/ipc/netty/channel/ServerContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ServerContextHandler.java
@@ -90,6 +90,37 @@ final class ServerContextHandler extends CloseableContextHandler<Channel>
 	}
 
 	@Override
+	public ServerContextHandler addDecoder(String name, ChannelHandler handler) {
+		return ChannelOperations.addDecoder(this, channel(), name, handler, this::removeHandler);
+	}
+
+	/**
+	 * Safely remove handler from pipeline
+	 *
+	 * @param name handler name
+	 */
+	protected final void removeHandler(String name) {
+		Channel channel = channel();
+		if (channel.isOpen() && channel.pipeline()
+		                               .context(name) != null) {
+			channel.pipeline()
+			       .remove(name);
+			if (log.isDebugEnabled()) {
+				log.debug("[ServerContextHandler] Removed handler: {}, pipeline: {}",
+						name,
+						channel.pipeline());
+			}
+		}
+		else if (log.isDebugEnabled()) {
+			log.debug("[ServerContextHandler] Non Removed handler: {}, context: {}, pipeline: {}",
+					name,
+					channel.pipeline()
+					       .context(name),
+					channel.pipeline());
+		}
+	}
+
+	@Override
 	public NettyContext onClose(Runnable onClose) {
 		onClose().subscribe(null, e -> onClose.run(), onClose);
 		return this;

--- a/src/test/java/reactor/ipc/netty/channel/ChannelOperationsTests.java
+++ b/src/test/java/reactor/ipc/netty/channel/ChannelOperationsTests.java
@@ -1,0 +1,104 @@
+package reactor.ipc.netty.channel;
+
+import java.util.Arrays;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.LineBasedFrameDecoder;
+import io.netty.handler.codec.base64.Base64Decoder;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.ipc.netty.NettyContext;
+import reactor.ipc.netty.NettyPipeline;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Simon Baslé
+ */
+public class ChannelOperationsTests {
+
+	private NettyContext createMockNettyContext(Channel channel) {
+		ServerContextHandler handler =
+				(ServerContextHandler) Mono.<NettyContext>create(sink -> {
+					NettyContext result =
+							new ServerContextHandler((ch, contextHandler, objectMessage) -> null,
+									null,
+									sink,
+									null,
+									null);
+					sink.success(result);
+				}).block();
+		handler.setFuture(new DefaultChannelPromise(channel));
+		return handler;
+	}
+
+	@Test
+	public void addByteDecoderWhenNoCodec() throws Exception {
+		ChannelHandler decoder = new LineBasedFrameDecoder(12);
+		Channel channel = new EmbeddedChannel();
+		channel.pipeline()
+		       .addLast("toto", new ChannelHandlerAdapter() { })
+		       .addLast(NettyPipeline.ReactiveBridge, new ChannelHandlerAdapter() {});
+
+		NettyContext nettyContext = createMockNettyContext(channel);
+		ChannelOperations.addDecoder(nettyContext, channel, "decoder", decoder, name -> {});
+
+		assertEquals(channel.pipeline().names(),
+				Arrays.asList("toto", "decoder", NettyPipeline.ReactiveBridge, "DefaultChannelPipeline$TailContext#0"));
+	}
+
+	@Test
+	public void addByteDecoderWhenCodec() throws Exception {
+		ChannelHandler decoder = new LineBasedFrameDecoder(12);
+		Channel channel = new EmbeddedChannel();
+		channel.pipeline()
+		       .addLast("toto", new ChannelHandlerAdapter() { })
+		       .addLast("codec", new Base64Decoder())
+		       .addLast(NettyPipeline.ReactiveBridge, new ChannelHandlerAdapter() {});
+
+		NettyContext nettyContext = createMockNettyContext(channel);
+		ChannelOperations.addDecoder(nettyContext, channel, "decoder", decoder, name -> {});
+
+		assertEquals(channel.pipeline().names(), Arrays.asList(
+				"toto", "codec",
+				"decoder$extract", "decoder",
+				NettyPipeline.ReactiveBridge, "DefaultChannelPipeline$TailContext#0"));
+	}
+
+	@Test
+	public void nonByteDecoderIgnoredWhenCodec() throws Exception {
+		ChannelHandler decoder = new ChannelHandlerAdapter() { };
+		Channel channel = new EmbeddedChannel();
+		channel.pipeline()
+		       .addLast("toto", new ChannelHandlerAdapter() { })
+		       .addLast("codec", new Base64Decoder())
+		       .addLast(NettyPipeline.ReactiveBridge, new ChannelHandlerAdapter() {});
+
+		NettyContext nettyContext = createMockNettyContext(channel);
+		ChannelOperations.addDecoder(nettyContext, channel, "decoder", decoder, name -> {});
+
+		assertEquals(channel.pipeline().names(), Arrays.asList("toto", "codec",
+				NettyPipeline.ReactiveBridge, "DefaultChannelPipeline$TailContext#0"));
+	}
+
+	@Test
+	public void nonByteDecoderAddedWhenNoCodec() throws Exception {
+		ChannelHandler decoder = new ChannelHandlerAdapter() { };
+		Channel channel = new EmbeddedChannel();
+		channel.pipeline()
+		       .addLast("toto", new ChannelHandlerAdapter() { })
+		       .addLast(NettyPipeline.ReactiveBridge, new ChannelHandlerAdapter() {});
+
+		NettyContext nettyContext = createMockNettyContext(channel);
+		ChannelOperations.addDecoder(nettyContext, channel, "decoder", decoder, name -> {});
+
+		assertEquals(channel.pipeline().names(), Arrays.asList("toto",
+				"decoder",
+				NettyPipeline.ReactiveBridge, "DefaultChannelPipeline$TailContext#0"));
+	}
+
+}


### PR DESCRIPTION
The default method was just recursively calling itself.

Added an template implementation that can be used by most implementors
in `ChannelOperations`.