### PR TITLE
fix #20 Support websocket subprotocols in HttpClientRequest

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
@@ -19,6 +19,7 @@ package reactor.ipc.netty.http.client;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -338,8 +339,12 @@ class HttpClientOperations extends HttpOperations<HttpClientResponse, HttpClient
 
 	@Override
 	public WebsocketOutbound sendWebsocket() {
+		return sendWebsocket(null);
+	}
 
-		Mono<Void> m = withWebsocketSupport(websocketUri(), null, noopHandler());
+	@Override
+	public WebsocketOutbound sendWebsocket(String subprotocol) {
+		Mono<Void> m = withWebsocketSupport(websocketUri(), subprotocol, noopHandler());
 
 		return new WebsocketOutbound() {
 			@Override

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
@@ -19,7 +19,6 @@ package reactor.ipc.netty.http.client;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -76,6 +75,7 @@ import reactor.util.Loggers;
 
 /**
  * @author Stephane Maldini
+ * @author Simon Baslé
  */
 class HttpClientOperations extends HttpOperations<HttpClientResponse, HttpClientRequest>
 		implements HttpClientResponse, HttpClientRequest {
@@ -343,10 +343,16 @@ class HttpClientOperations extends HttpOperations<HttpClientResponse, HttpClient
 	}
 
 	@Override
-	public WebsocketOutbound sendWebsocket(String subprotocol) {
-		Mono<Void> m = withWebsocketSupport(websocketUri(), subprotocol, noopHandler());
+	public WebsocketOutbound sendWebsocket(String subprotocols) {
+		Mono<Void> m = withWebsocketSupport(websocketUri(), subprotocols, noopHandler());
 
 		return new WebsocketOutbound() {
+
+			@Override
+			public String selectedSubprotocol() {
+				return null;
+			}
+
 			@Override
 			public NettyContext context() {
 				return HttpClientOperations.this;

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientRequest.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientRequest.java
@@ -186,11 +186,21 @@ public interface HttpClientRequest extends NettyOutbound, HttpInfos {
 
 	/**
 	 * Upgrade connection to Websocket and immediately send closed websocket frame
-	 * otherwise the returned {@link Mono} fail.
+	 * otherwise the returned {@link Mono} fails.
 	 *
 	 * @return a {@link Mono} completing when upgrade is confirmed
 	 */
 	WebsocketOutbound sendWebsocket();
+
+	/**
+	 * Upgrade connection to Websocket with the given {@code subprotocol} (or subprotocols,
+	 * as a comma-separated list) and immediately send closed websocket frame, otherwise
+	 * the returned {@link Mono} fails.
+	 *
+	 * @param subprotocol the websocket subprotocol to use.
+	 * @return a {@link Mono} completing when upgrade is confirmed
+	 */
+	WebsocketOutbound sendWebsocket(String subprotocol);
 
 	/**
 	 * An HTTP Form builder

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientRequest.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientRequest.java
@@ -38,6 +38,7 @@ import reactor.ipc.netty.http.websocket.WebsocketOutbound;
  * accessor related to HTTP flow : headers, params, URI, method, websocket...
  *
  * @author Stephane Maldini
+ * @author Simon Baslé
  */
 public interface HttpClientRequest extends NettyOutbound, HttpInfos {
 
@@ -185,22 +186,26 @@ public interface HttpClientRequest extends NettyOutbound, HttpInfos {
 	NettyOutbound sendHeaders();
 
 	/**
-	 * Upgrade connection to Websocket and immediately send closed websocket frame
-	 * otherwise the returned {@link Mono} fails.
+	 * Upgrade connection to Websocket.
 	 *
 	 * @return a {@link Mono} completing when upgrade is confirmed
 	 */
 	WebsocketOutbound sendWebsocket();
 
 	/**
-	 * Upgrade connection to Websocket with the given {@code subprotocol} (or subprotocols,
-	 * as a comma-separated list) and immediately send closed websocket frame, otherwise
-	 * the returned {@link Mono} fails.
+	 * Upgrade connection to Websocket, negotiating one of the given subprotocol(s).
+	 * <p>
+	 * The negotiated subprotocol cannot be directly accessed on the returned outbound,
+	 * as the negotiation hasn't yet occurred. However, the response to this request will
+	 * usually allow access to that information (by upgrading it to a websocket outbound
+	 * via {@link HttpClientResponse#receiveWebsocket()} then calling
+	 * {@link WebsocketOutbound#selectedSubprotocol()}).
 	 *
-	 * @param subprotocol the websocket subprotocol to use.
+	 * @param subprotocols the subprotocol(s) to negotiate, comma-separated, or null if not relevant.
+	 * Can be several protocols, separated by a comma, or null if no subprotocol is required.
 	 * @return a {@link Mono} completing when upgrade is confirmed
 	 */
-	WebsocketOutbound sendWebsocket(String subprotocol);
+	WebsocketOutbound sendWebsocket(String subprotocols);
 
 	/**
 	 * An HTTP Form builder

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientWSOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientWSOperations.java
@@ -42,6 +42,7 @@ import reactor.ipc.netty.http.websocket.WebsocketOutbound;
 
 /**
  * @author Stephane Maldini
+ * @author Simon Baslé
  */
 final class HttpClientWSOperations extends HttpClientOperations
 		implements WebsocketInbound, WebsocketOutbound, BiConsumer<Void, Throwable> {
@@ -84,6 +85,11 @@ final class HttpClientWSOperations extends HttpClientOperations
 	@Override
 	public boolean isWebsocket() {
 		return true;
+	}
+
+	@Override
+	public String selectedSubprotocol() {
+		return handshaker.actualSubprotocol();
 	}
 
 	@Override

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientWSOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientWSOperations.java
@@ -19,7 +19,6 @@ package reactor.ipc.netty.http.client;
 import java.net.URI;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -30,15 +29,13 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequestEncoder;
-import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
+import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Mono;
 import reactor.ipc.netty.NettyPipeline;
 import reactor.ipc.netty.http.websocket.WebsocketInbound;
 import reactor.ipc.netty.http.websocket.WebsocketOutbound;
@@ -102,8 +99,13 @@ final class HttpClientWSOperations extends HttpClientOperations
 
 			if (checkResponseCode(response)) {
 
-				if (!handshaker.isHandshakeComplete()) {
-					handshaker.finishHandshake(channel(), response);
+				try {
+					if (!handshaker.isHandshakeComplete()) {
+						handshaker.finishHandshake(channel(), response);
+					}
+				}
+				catch (WebSocketHandshakeException wshe) {
+					onInboundError(wshe);
 				}
 
 				parentContext().fireContextActive(this);

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerWSOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerWSOperations.java
@@ -42,6 +42,7 @@ import reactor.ipc.netty.http.websocket.WebsocketOutbound;
  * Conversion between Netty types  and Reactor types ({@link HttpOperations}
  *
  * @author Stephane Maldini
+ * @author Simon Baslé
  */
 final class HttpServerWSOperations extends HttpServerOperations
 		implements WebsocketInbound, WebsocketOutbound, BiConsumer<Void, Throwable> {
@@ -151,6 +152,11 @@ final class HttpServerWSOperations extends HttpServerOperations
 	@Override
 	public boolean isWebsocket() {
 		return true;
+	}
+
+	@Override
+	public String selectedSubprotocol() {
+		return handshaker.selectedSubprotocol();
 	}
 
 	static final AtomicIntegerFieldUpdater<HttpServerWSOperations> CLOSE_SENT =

--- a/src/main/java/reactor/ipc/netty/http/websocket/WebsocketInbound.java
+++ b/src/main/java/reactor/ipc/netty/http/websocket/WebsocketInbound.java
@@ -25,9 +25,18 @@ import reactor.ipc.netty.NettyInbound;
  * A websocket framed inbound
  *
  * @author Stephane Maldini
+ * @author Simon Baslé
  * @since 0.6
  */
 public interface WebsocketInbound extends NettyInbound {
+
+	/**
+	 * Returns the websocket subprotocol negotiated by the client and server during
+	 * the websocket handshake, or null if none was requested.
+	 *
+	 * @return the subprotocol, or null
+	 */
+	String selectedSubprotocol();
 
 	/**
 	 * Turn this {@link WebsocketInbound} into aggregating mode which will only produce

--- a/src/main/java/reactor/ipc/netty/http/websocket/WebsocketOutbound.java
+++ b/src/main/java/reactor/ipc/netty/http/websocket/WebsocketOutbound.java
@@ -27,9 +27,18 @@ import reactor.ipc.netty.NettyOutbound;
  * A websocket framed outbound
  *
  * @author Stephane Maldini
+ * @author Simon Baslé
  * @since 0.6
  */
 public interface WebsocketOutbound extends NettyOutbound {
+
+	/**
+	 * Returns the websocket subprotocol negotiated by the client and server during
+	 * the websocket handshake, or null if none was requested.
+	 *
+	 * @return the subprotocol, or null
+	 */
+	String selectedSubprotocol();
 
 	@Override
 	default NettyOutbound sendString(Publisher<? extends String> dataStream,

--- a/src/test/java/reactor/ipc/netty/http/WebsocketTests.java
+++ b/src/test/java/reactor/ipc/netty/http/WebsocketTests.java
@@ -18,7 +18,9 @@ package reactor.ipc.netty.http;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
@@ -27,8 +29,11 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.ReplayProcessor;
 import reactor.ipc.netty.NettyContext;
 import reactor.ipc.netty.http.client.HttpClient;
+import reactor.ipc.netty.http.client.HttpClientResponse;
 import reactor.ipc.netty.http.server.HttpServer;
 import reactor.test.StepVerifier;
+
+import static org.hamcrest.CoreMatchers.is;
 
 /**
  * @author tjreactive
@@ -38,26 +43,22 @@ public class WebsocketTests {
 
 	static final String auth = "bearer abc";
 
+	NettyContext httpServer = null;
+
+	@After
+	public void disposeHttpServer() {
+		if (httpServer != null)
+			httpServer.dispose();
+	}
+
 	@Test
 	public void simpleTest() {
-		NettyContext httpServer = HttpServer.create(0)
-		                                    .newHandler((in, out) -> out.sendWebsocket((i, o) -> o.sendString(
-				                                    Mono.just("test"))))
-		                                    .block();
+		httpServer = HttpServer.create(0)
+		                       .newHandler((in, out) -> out.sendWebsocket((i, o) -> o.sendString(
+				                       Mono.just("test"))))
+		                       .block();
 
 		String res = HttpClient.create(httpServer.address()
-		                                         .getPort())
-		                       .get("/test",
-				                       out -> out.addHeader("Authorization", auth)
-				                                 .sendWebsocket())
-		                       .flatMap(in -> in.receive()
-		                                        .asString())
-		                       .log()
-		                       .collectList()
-		                       .block()
-		                       .get(0);
-
-		res = HttpClient.create(httpServer.address()
 		                                  .getPort())
 		                .get("/test",
 				                out -> out.addHeader("Authorization", auth)
@@ -69,24 +70,20 @@ public class WebsocketTests {
 		                .block()
 		                .get(0);
 
-		if (!res.equals("test")) {
-			throw new IllegalStateException("test");
-		}
-
-		httpServer.dispose();
+		Assert.assertThat(res, is("test"));
 	}
 
 	@Test
 	public void unidirectional() {
 		int c = 10;
-		NettyContext httpServer = HttpServer.create(0)
-		                                    .newHandler((in, out) -> out.sendWebsocket(
-		                                    		(i, o) -> o.options(opt -> opt.flushOnEach())
-				                                               .sendString(
-				                                    Flux.just("test")
-				                                        .delayMillis(100)
-				                                        .repeat())))
-		                                    .block();
+		httpServer = HttpServer.create(0)
+		                       .newHandler((in, out) -> out.sendWebsocket(
+				                       (i, o) -> o.options(opt -> opt.flushOnEach())
+				                                  .sendString(
+						                                  Flux.just("test")
+						                                      .delayMillis(100)
+						                                      .repeat())))
+		                       .block();
 
 		Flux<String> ws = HttpClient.create(httpServer.address()
 		                                              .getPort())
@@ -103,8 +100,6 @@ public class WebsocketTests {
 		                                    .toIterable())
 		            .expectComplete()
 		            .verify();
-
-		httpServer.dispose();
 	}
 
 	@Test
@@ -124,13 +119,13 @@ public class WebsocketTests {
 		client.log("client")
 		      .subscribe(v -> clientLatch.countDown());
 
-		NettyContext httpServer = HttpServer.create(0)
-		                                    .newHandler((in, out) -> out.sendWebsocket((i, o) -> o.sendString(
-				                                    i.receive()
-				                                     .asString()
-				                                     .take(c)
-				                                     .subscribeWith(server))))
-		                                    .block();
+		httpServer = HttpServer.create(0)
+		                       .newHandler((in, out) -> out.sendWebsocket((i, o) -> o.sendString(
+				                       i.receive()
+				                        .asString()
+				                        .take(c)
+				                        .subscribeWith(server))))
+		                       .block();
 
 		Flux.intervalMillis(200)
 		    .map(Object::toString)
@@ -150,64 +145,52 @@ public class WebsocketTests {
 		Assert.assertTrue(clientLatch.await(10, TimeUnit.SECONDS));
 	}
 
-
-
 	@Test
 	public void simpleSubprotocolServerNoSubprotocol() throws Exception {
-		NettyContext httpServer = HttpServer.create(0)
+		httpServer = HttpServer.create(0)
 		                                    .newHandler((in, out) -> out.sendWebsocket((i, o) -> o.sendString(
 				                                    Mono.just("test"))))
 		                                    .block();
 
-		try {
-			StepVerifier.create(
-					HttpClient.create(
-							httpServer.address().getPort())
-					          .get("/test",
-							          out -> out.addHeader("Authorization", auth)
-							                    .sendWebsocket("SUBPROTOCOL,OTHER"))
-					          .flatMap(in -> in.receive().asString())
-			)
-			            .verifyErrorMessage("Invalid subprotocol. Actual: null. Expected one of: SUBPROTOCOL,OTHER");
-		}
-		finally {
-			httpServer.dispose();
-		}
+		StepVerifier.create(
+				HttpClient.create(
+						httpServer.address().getPort())
+				          .get("/test",
+						          out -> out.addHeader("Authorization", auth)
+						                    .sendWebsocket("SUBPROTOCOL,OTHER"))
+				          .flatMap(in -> in.receive().asString())
+		)
+		            .verifyErrorMessage("Invalid subprotocol. Actual: null. Expected one of: SUBPROTOCOL,OTHER");
 	}
 
 	@Test
 	public void simpleSubprotocolServerNotSupported() throws Exception {
-		NettyContext httpServer = HttpServer.create(0)
-		                                    .newHandler((in, out) -> out.sendWebsocket(
-				                                    "protoA,protoB",
-				                                    (i, o) -> o.sendString(Mono.just("test"))))
-		                                    .block();
+		httpServer = HttpServer.create(0)
+		                       .newHandler((in, out) -> out.sendWebsocket(
+				                       "protoA,protoB",
+				                       (i, o) -> o.sendString(Mono.just("test"))))
+		                       .block();
 
-		try {
-			StepVerifier.create(
-					HttpClient.create(
-							httpServer.address().getPort())
-					          .get("/test",
-							          out -> out.addHeader("Authorization", auth)
-							                    .sendWebsocket("SUBPROTOCOL,OTHER"))
-					          .flatMap(in -> in.receive().asString())
-			)
-			            //the SERVER returned null which means that it couldn't select a protocol
-			            .verifyErrorMessage("Invalid subprotocol. Actual: null. Expected one of: SUBPROTOCOL,OTHER");
-		}
-		finally {
-			httpServer.dispose();
-		}
+		StepVerifier.create(
+				HttpClient.create(
+						httpServer.address().getPort())
+				          .get("/test",
+						          out -> out.addHeader("Authorization", auth)
+						                    .sendWebsocket("SUBPROTOCOL,OTHER"))
+				          .flatMap(in -> in.receive().asString())
+		)
+		            //the SERVER returned null which means that it couldn't select a protocol
+		            .verifyErrorMessage("Invalid subprotocol. Actual: null. Expected one of: SUBPROTOCOL,OTHER");
 	}
 
 	@Test
 	public void simpleSubprotocolServerSupported() throws Exception {
-		NettyContext httpServer = HttpServer.create(0)
-		                                    .newHandler((in, out) -> out.sendWebsocket(
-		                                    		"SUBPROTOCOL",
-		                                    		(i, o) -> o.sendString(
-				                                    Mono.just("test"))))
-		                                    .block();
+		httpServer = HttpServer.create(0)
+		                       .newHandler((in, out) -> out.sendWebsocket(
+				                       "SUBPROTOCOL",
+				                       (i, o) -> o.sendString(
+						                       Mono.just("test"))))
+		                       .block();
 
 		String res = HttpClient.create(httpServer.address().getPort())
 		                       .get("/test",
@@ -215,14 +198,111 @@ public class WebsocketTests {
 				                          .sendWebsocket("SUBPROTOCOL,OTHER"))
 		                .flatMap(in -> in.receive().asString()).log().collectList().block().get(0);
 
-		if (!res.equals("test")) {
-			throw new IllegalStateException("test");
-		}
-
-		httpServer.dispose();
+		Assert.assertThat(res, is("test"));
 	}
 
+	@Test
+	public void simpleSubprotocolSelected() throws Exception {
+		httpServer = HttpServer.create(0)
+		                       .newHandler((in, out) -> out.sendWebsocket(
+				                       "NOT, Common",
+				                       (i, o) -> o.sendString(
+						                       Mono.just("SERVER:" + o.selectedSubprotocol()))))
+		                       .block();
 
+		String res = HttpClient.create(httpServer.address().getPort())
+		                       .get("/test",
+				                out -> out.addHeader("Authorization", auth)
+				                          .sendWebsocket("Common,OTHER"))
+		                       .map(HttpClientResponse::receiveWebsocket)
+		                       .flatMap(in -> in.receive().asString()
+				                       .map(srv -> "CLIENT:" + in.selectedSubprotocol() + "-" + srv))
+		                       .log().collectList().block().get(0);
 
+		Assert.assertThat(res, is("CLIENT:Common-SERVER:Common"));
+	}
+
+	@Test
+	public void noSubprotocolSelected() {
+		httpServer = HttpServer.create(0)
+		                       .newHandler((in, out) -> out.sendWebsocket((i, o) -> o.sendString(
+				                       Mono.just("SERVER:" + o.selectedSubprotocol()))))
+		                       .block();
+
+		String res = HttpClient.create(httpServer.address()
+		                                         .getPort())
+		                       .get("/test",
+				                       out -> out.addHeader("Authorization", auth)
+				                                 .sendWebsocket())
+		                       .map(HttpClientResponse::receiveWebsocket)
+		                       .flatMap(in -> in.receive()
+		                                        .asString()
+		                                        .map(srv -> "CLIENT:" + in.selectedSubprotocol() + "-" + srv))
+		                       .log()
+		                       .collectList()
+		                       .block()
+		                       .get(0);
+
+		Assert.assertThat(res, is("CLIENT:null-SERVER:null"));
+	}
+
+	@Test
+	public void anySubprotocolSelectsFirstClientProvided() {
+		httpServer = HttpServer.create(0)
+		                       .newHandler((in, out) -> out.sendWebsocket("proto2,*", (i, o) -> o.sendString(
+				                       Mono.just("SERVER:" + o.selectedSubprotocol()))))
+		                       .block();
+
+		String res = HttpClient.create(httpServer.address()
+		                                         .getPort())
+		                       .get("/test",
+				                       out -> out.addHeader("Authorization", auth)
+				                                 .sendWebsocket("proto1, proto2"))
+		                       .map(HttpClientResponse::receiveWebsocket)
+		                       .flatMap(in -> in.receive()
+		                                        .asString()
+		                                        .map(srv -> "CLIENT:" + in.selectedSubprotocol() + "-" + srv))
+		                       .log()
+		                       .collectList()
+		                       .block()
+		                       .get(0);
+
+		Assert.assertThat(res, is("CLIENT:proto1-SERVER:proto1"));
+	}
+
+	@Test
+	public void sendToWebsocketSubprotocol() throws InterruptedException {
+		AtomicReference<String> serverSelectedProtocol = new AtomicReference<>();
+		AtomicReference<String> clientSelectedProtocol = new AtomicReference<>();
+		AtomicReference<String> clientSelectedProtocolWhenSimplyUpgrading = new AtomicReference<>();
+
+		httpServer = HttpServer.create(0)
+		                       .newHandler((in, out) -> out.sendWebsocket(
+		                       		"not,proto1", (i, o) -> {
+					                       serverSelectedProtocol.set(i.selectedSubprotocol());
+					                       return i.receive()
+					                               .asString()
+					                               .doOnNext(System.err::println)
+					                               .then();
+				                       })
+		                       )
+		                       .block();
+
+		HttpClient.create(httpServer.address()
+		                            .getPort())
+		          .ws("/test", "proto1,proto2")
+		          .then(in -> {
+			          clientSelectedProtocolWhenSimplyUpgrading.set(in.receiveWebsocket().selectedSubprotocol());
+			          return in.receiveWebsocket((i, o) -> {
+				          clientSelectedProtocol.set(o.selectedSubprotocol());
+				          return o.sendString(Mono.just("HELLO" + o.selectedSubprotocol()));
+			          });
+		          })
+	              .block();
+
+		Assert.assertThat(serverSelectedProtocol.get(), is("proto1"));
+		Assert.assertThat(clientSelectedProtocol.get(), is("proto1"));
+		Assert.assertThat(clientSelectedProtocolWhenSimplyUpgrading.get(), is("proto1"));
+	}
 
 }


### PR DESCRIPTION
@smaldini can you double-check how I handled the `WebSocketHandshakeException`?

I'm also wondering how we could expose the selected subprotocol to clients, which could come in handy in case they accept several protocols (comma-separated), since the server has to chose one compatible protocol...