### PR TITLE
fix #22 Let NettyInbound/NettyOutbound idle handlers replace old ones

### DIFF
--- a/src/main/java/reactor/ipc/netty/NettyInbound.java
+++ b/src/main/java/reactor/ipc/netty/NettyInbound.java
@@ -70,7 +70,7 @@ public interface NettyInbound extends Inbound<ByteBuf> {
 
 	/**
 	 * Assign a {@link Runnable} to be invoked when reads have become idle for the given
-	 * timeout.
+	 * timeout. This replaces any previously set idle callback.
 	 *
 	 * @param idleTimeout the idle timeout
 	 * @param onReadIdle the idle timeout handler
@@ -78,6 +78,7 @@ public interface NettyInbound extends Inbound<ByteBuf> {
 	 * @return {@literal this}
 	 */
 	default NettyInbound onReadIdle(long idleTimeout, Runnable onReadIdle) {
+		context().removeHandler(NettyPipeline.OnChannelReadIdle);
 		context().addHandlerFirst(NettyPipeline.OnChannelReadIdle,
 				new ReactorNetty.InboundIdleStateHandler(idleTimeout, onReadIdle));
 		return this;

--- a/src/main/java/reactor/ipc/netty/NettyOutbound.java
+++ b/src/main/java/reactor/ipc/netty/NettyOutbound.java
@@ -93,7 +93,7 @@ public interface NettyOutbound extends Outbound<ByteBuf>, Publisher<Void> {
 
 	/**
 	 * Assign a {@link Runnable} to be invoked when writes have become idle for the given
-	 * timeout.
+	 * timeout. This replaces any previously set idle callback.
 	 *
 	 * @param idleTimeout the idle timeout
 	 * @param onWriteIdle the idle timeout handler
@@ -101,6 +101,7 @@ public interface NettyOutbound extends Outbound<ByteBuf>, Publisher<Void> {
 	 * @return {@literal this}
 	 */
 	default NettyOutbound onWriteIdle(long idleTimeout, Runnable onWriteIdle) {
+		context().removeHandler(NettyPipeline.OnChannelWriteIdle);
 		context().addHandlerFirst(NettyPipeline.OnChannelWriteIdle,
 				new ReactorNetty.OutboundIdleStateHandler(idleTimeout, onWriteIdle));
 		return this;

--- a/src/test/java/reactor/ipc/netty/NettyInboundTest.java
+++ b/src/test/java/reactor/ipc/netty/NettyInboundTest.java
@@ -1,0 +1,51 @@
+package reactor.ipc.netty;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+/**
+ * @author Simon Baslé
+ */
+public class NettyInboundTest {
+
+	@Test
+	public void onReadIdleReplaces() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel();
+		NettyContext mockContext = () -> channel;
+		NettyInbound inbound = new NettyInbound() {
+			@Override
+			public NettyContext context() {
+				return mockContext;
+			}
+
+			@Override
+			public Flux<?> receiveObject() {
+				return Flux.empty();
+			}
+		};
+
+		AtomicLong idle1 = new AtomicLong();
+		AtomicLong idle2 = new AtomicLong();
+
+		inbound.onReadIdle(100, idle1::incrementAndGet);
+		inbound.onReadIdle(150, idle2::incrementAndGet);
+		ReactorNetty.InboundIdleStateHandler idleStateHandler =
+				(ReactorNetty.InboundIdleStateHandler) channel.pipeline().get(NettyPipeline.OnChannelReadIdle);
+		idleStateHandler.onReadIdle.run();
+
+		assertThat(channel.pipeline().names(), is(Arrays.asList(
+				NettyPipeline.OnChannelReadIdle,
+				"DefaultChannelPipeline$TailContext#0")));
+
+		assertThat(idle1.intValue(), is(0));
+		assertThat(idle2.intValue(), is(1));
+	}
+
+}

--- a/src/test/java/reactor/ipc/netty/NettyOutboundTest.java
+++ b/src/test/java/reactor/ipc/netty/NettyOutboundTest.java
@@ -1,0 +1,42 @@
+package reactor.ipc.netty;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.*;
+
+/**
+ * @author Simon Baslé
+ */
+public class NettyOutboundTest {
+
+	@Test
+	public void onWriteIdleReplaces() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel();
+		NettyContext mockContext = () -> channel;
+		NettyOutbound outbound = () -> mockContext;
+
+		AtomicLong idle1 = new AtomicLong();
+		AtomicLong idle2 = new AtomicLong();
+
+		outbound.onWriteIdle(100, idle1::incrementAndGet);
+		outbound.onWriteIdle(150, idle2::incrementAndGet);
+		ReactorNetty.OutboundIdleStateHandler idleStateHandler =
+				(ReactorNetty.OutboundIdleStateHandler) channel.pipeline().get(NettyPipeline.OnChannelWriteIdle);
+		idleStateHandler.onWriteIdle.run();
+
+		assertThat(channel.pipeline().names(), is(Arrays.asList(
+				NettyPipeline.OnChannelWriteIdle,
+				"DefaultChannelPipeline$TailContext#0")));
+
+		assertThat(idle1.intValue(), is(0));
+		assertThat(idle2.intValue(), is(1));
+	}
+
+}


### PR DESCRIPTION
This commit allows subsequent calls to `onReadIdle` and `onWriteIdle`
APIs with different idle callbacks. Each call will replace the previous
callback by removing any existing idle handler first.

cc @rstoyanchev