### PR TITLE
Add port to HttpClient host header

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/MonoHttpClientResponse.java
+++ b/src/main/java/reactor/ipc/netty/http/client/MonoHttpClientResponse.java
@@ -95,13 +95,18 @@ final class MonoHttpClientResponse extends Mono<HttpClientResponse> {
 			try {
 				URI uri = bridge.activeURI;
 				HttpClientOperations ch = (HttpClientOperations) in;
+				String host = uri.getHost();
+				int port = uri.getPort();
+				if (port != 80 && port != 443) {
+					host = host + ':' + port;
+				}
 				ch.getNettyRequest()
 				  .setUri(uri.getPath() + (uri.getQuery() == null ? "" :
 						  "?" + uri.getRawQuery()))
 				  .setMethod(parent.method)
 				  .setProtocolVersion(HttpVersion.HTTP_1_1)
 				  .headers()
-				  .add(HttpHeaderNames.HOST, uri.getHost())
+				  .add(HttpHeaderNames.HOST, host)
 				  .add(HttpHeaderNames.ACCEPT, ALL);
 
 				if (parent.method == HttpMethod.GET || parent.method == HttpMethod.HEAD) {

--- a/src/main/java/reactor/ipc/netty/http/client/MonoHttpClientResponse.java
+++ b/src/main/java/reactor/ipc/netty/http/client/MonoHttpClientResponse.java
@@ -97,7 +97,7 @@ final class MonoHttpClientResponse extends Mono<HttpClientResponse> {
 				HttpClientOperations ch = (HttpClientOperations) in;
 				String host = uri.getHost();
 				int port = uri.getPort();
-				if (port != 80 && port != 443) {
+				if (port != -1 && port != 80 && port != 443) {
 					host = host + ':' + port;
 				}
 				ch.getNettyRequest()


### PR DESCRIPTION
When making http request to server on non standard port, host header should contain port number.