### PR TITLE
Compatibility with current 3.1.0 snapshots

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerOperations.java
@@ -453,7 +453,7 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 
 			if (replace(ops)) {
 				return FutureMono.from(ops.handshakerResult)
-				                 .then(() -> Mono.from(websocketHandler.apply(ops, ops)))
+				                 .then(Mono.defer(() -> Mono.from(websocketHandler.apply(ops, ops))))
 				                 .doAfterTerminate(ops);
 			}
 		}

--- a/src/test/groovy/reactor/ipc/netty/http/HttpSpec.groovy
+++ b/src/test/groovy/reactor/ipc/netty/http/HttpSpec.groovy
@@ -21,7 +21,6 @@ import reactor.core.scheduler.Schedulers
 import reactor.ipc.netty.http.client.HttpClient
 import reactor.ipc.netty.http.client.HttpClientException
 import reactor.ipc.netty.http.server.HttpServer
-import reactor.util.Loggers
 import spock.lang.Specification
 
 import java.time.Duration
@@ -186,7 +185,7 @@ class HttpSpec extends Specification {
 	//prepare an http post request-reply flow
 	def content = client
 			.get('/test2')
-			.flatMap { replies -> replies.receive().log("received-status-2")
+			.flatMapMany { replies -> replies.receive().log("received-status-2")
 	}
 	.next()
 			.block(Duration.ofSeconds(30))
@@ -200,7 +199,7 @@ class HttpSpec extends Specification {
 	//prepare an http post request-reply flow
 	client
 			.get('/test3')
-			.flatMap { replies ->
+			.flatMapMany { replies ->
 	  Flux.just(replies.status().code)
 			  .log("received-status-3")
 	}


### PR DESCRIPTION
Fix remaining cases of using reactor-core methods deprecated in 3.0.7 but removed in 3.1.0 that make reactor-netty not usable with reactor-core 3.1.0. 

The two have been out of sync for about a week, since Apr 19 with https://github.com/reactor/reactor-core/commit/df2c6cc64b6d867b7ff662e83e7fd02ecfd10238, but for some reason the Spring Framework build only [started failing](https://build.spring.io/browse/SPR-PUB-4770) today. Perhaps the 3.1.0 snapshots were stale?

Note I did not change all tests to be 3.1.0 compatible since flatMap is deprecated in 3.0.7 but actually needs to be used with 3.1.0 as a replacement for `then`.