### PR TITLE
Netty FixedChannelPool does not recognize -1 as a way to unbound maxC…

### DIFF
--- a/src/main/java/reactor/ipc/netty/resources/PoolResources.java
+++ b/src/main/java/reactor/ipc/netty/resources/PoolResources.java
@@ -132,7 +132,7 @@ public interface PoolResources extends Disposable {
 						checker,
 						FixedChannelPool.AcquireTimeoutAction.FAIL,
 						acquireTimeout,
-						maxConnections,
+						maxConnections == -1 ? Integer.MAX_VALUE : maxConnections,
 						Integer.MAX_VALUE
 						));
 	}


### PR DESCRIPTION
tag: Obvious Fix

According to the doc tag on PoolResources (https://github.com/reactor/reactor-netty/blob/master/src/main/java/reactor/ipc/netty/resources/PoolResources.java#L41) passing the maxConnection value -1 is meant to make the connection pool unbounded,

Due to the netty implementation of FixedChannelPool this would never happen (https://github.com/mitermayer/netty/blob/4.1/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java#L150)

This fixes issue https://github.com/reactor/reactor-netty/issues/95