### PR TITLE
conditional HTTP compression

### DIFF
--- a/src/main/java/reactor/ipc/netty/NettyPipeline.java
+++ b/src/main/java/reactor/ipc/netty/NettyPipeline.java
@@ -59,12 +59,15 @@ public interface NettyPipeline {
 	String ReactiveBridge     = RIGHT + "reactiveBridge";
 	String HttpEncoder        = LEFT + "httpEncoder";
 	String HttpDecoder        = LEFT + "httpDecoder";
+	String HttpDecompressor   = LEFT + "decompressor";
+	String HttpCompressor     = LEFT + "compressor";
 	String HttpAggregator     = LEFT + "httpAggregator";
 	String HttpServerHandler  = LEFT + "httpServerHandler";
 	String OnChannelWriteIdle = LEFT + "onChannelWriteIdle";
 	String OnChannelReadIdle  = LEFT + "onChannelReadIdle";
 	String ChunkedWriter      = LEFT + "chunkedWriter";
 	String LoggingHandler     = LEFT + "loggingHandler";
+	String CompressionHandler = LEFT + "compressionHandler";
 
 	/**
 	 * A builder for sending strategy, similar prefixed methods being mutually exclusive
@@ -134,5 +137,9 @@ public interface NettyPipeline {
 	 */
 	static Object handlerTerminatedEvent() {
 		return ReactorNetty.TERMINATED;
+	}
+
+	static Object responseWriteCompletedEvent() {
+		return ReactorNetty.RESPONSE_WRITE_COMPLETED;
 	}
 }

--- a/src/main/java/reactor/ipc/netty/ReactorNetty.java
+++ b/src/main/java/reactor/ipc/netty/ReactorNetty.java
@@ -225,6 +225,13 @@ final class ReactorNetty {
 		}
 	}
 
+	static final class ResponseWriteCompleted {
+		@Override
+		public String toString() {
+			return "[Response Write Completed]";
+		}
+	}
+
 	/**
 	 * An appending write that delegates to its origin context and append the passed
 	 * publisher after the origin success if any.
@@ -297,6 +304,7 @@ final class ReactorNetty {
 	}
 
 	static final Object TERMINATED = new TerminatedHandlerEvent();
+	static final Object RESPONSE_WRITE_COMPLETED = new ResponseWriteCompleted();
 	static final Logger log        = Loggers.getLogger(ReactorNetty.class);
 
 	/**

--- a/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
@@ -444,6 +444,8 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 
 		@Override
 		public void onComplete() {
+			parent.ctx.pipeline()
+					.fireUserEventTriggered(NettyPipeline.responseWriteCompletedEvent());
 			long p = produced;
 			ChannelFuture f = lastWrite;
 			parent.innerActive = false;

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
@@ -34,6 +34,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpRequestEncoder;
 import io.netty.handler.codec.http.HttpResponseDecoder;
+import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.logging.LoggingHandler;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
@@ -372,12 +373,13 @@ public class HttpClient implements NettyConnector<HttpClientResponse, HttpClient
 					} : EMPTY).onPipeline(this);
 		}
 
-		@Override
-		public void accept(ChannelPipeline pipeline, ContextHandler<Channel> c) {
-			pipeline.addLast(NettyPipeline.HttpDecoder, new HttpResponseDecoder())
-			        .addLast(NettyPipeline.HttpEncoder, new HttpRequestEncoder());
-		}
-	}
+        @Override
+        public void accept(ChannelPipeline pipeline, ContextHandler<Channel> c) {
+            pipeline.addLast(NettyPipeline.HttpDecompressor, new HttpContentDecompressor())
+                    .addLast(NettyPipeline.HttpDecoder, new HttpResponseDecoder())
+                    .addLast(NettyPipeline.HttpEncoder, new HttpRequestEncoder());
+        }
+    }
 
 	static String reactorNettyVersion() {
 		return Optional.ofNullable(HttpClient.class.getPackage().getImplementationVersion())

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
@@ -375,8 +375,10 @@ public class HttpClient implements NettyConnector<HttpClientResponse, HttpClient
 
         @Override
         public void accept(ChannelPipeline pipeline, ContextHandler<Channel> c) {
-            pipeline.addLast(NettyPipeline.HttpDecompressor, new HttpContentDecompressor())
-                    .addLast(NettyPipeline.HttpDecoder, new HttpResponseDecoder())
+			if (options.supportsCompression()) {
+				pipeline.addLast(NettyPipeline.HttpDecompressor, new HttpContentDecompressor());
+			}
+			pipeline.addLast(NettyPipeline.HttpDecoder, new HttpResponseDecoder())
                     .addLast(NettyPipeline.HttpEncoder, new HttpRequestEncoder());
         }
     }

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
@@ -375,11 +375,12 @@ public class HttpClient implements NettyConnector<HttpClientResponse, HttpClient
 
         @Override
         public void accept(ChannelPipeline pipeline, ContextHandler<Channel> c) {
-			if (options.supportsCompression()) {
-				pipeline.addLast(NettyPipeline.HttpDecompressor, new HttpContentDecompressor());
-			}
 			pipeline.addLast(NettyPipeline.HttpDecoder, new HttpResponseDecoder())
                     .addLast(NettyPipeline.HttpEncoder, new HttpRequestEncoder());
+			if (options.supportsCompression()) {
+				pipeline.addAfter(NettyPipeline.HttpDecoder,
+                        NettyPipeline.HttpDecompressor, new HttpContentDecompressor());
+			}
         }
     }
 

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
@@ -52,6 +52,8 @@ import reactor.ipc.netty.resources.PoolResources;
  */
 public final class HttpClientOptions extends ClientOptions {
 
+	private boolean enabled;
+
 	/**
 	 * Create new {@link HttpClientOptions}.
 	 *
@@ -64,8 +66,9 @@ public final class HttpClientOptions extends ClientOptions {
 	HttpClientOptions() {
 	}
 
-	HttpClientOptions(ClientOptions options) {
+	HttpClientOptions(HttpClientOptions options) {
 		super(options);
+		this.enabled = options.enabled;
 	}
 
 	@Override
@@ -124,6 +127,15 @@ public final class HttpClientOptions extends ClientOptions {
 	public HttpClientOptions eventLoopGroup(EventLoopGroup eventLoopGroup) {
 		super.eventLoopGroup(eventLoopGroup);
 		return this;
+	}
+
+	public HttpClientOptions supportsCompression(boolean enabled) {
+		this.enabled = enabled;
+		return this;
+	}
+
+	public boolean supportsCompression() {
+		return enabled;
 	}
 
 	/**

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
@@ -52,7 +52,7 @@ import reactor.ipc.netty.resources.PoolResources;
  */
 public final class HttpClientOptions extends ClientOptions {
 
-	private boolean enabled;
+	private Compression compression = new Compression.Builder().build();
 
 	/**
 	 * Create new {@link HttpClientOptions}.
@@ -68,7 +68,7 @@ public final class HttpClientOptions extends ClientOptions {
 
 	HttpClientOptions(HttpClientOptions options) {
 		super(options);
-		this.enabled = options.enabled;
+		this.compression = options.compression;
 	}
 
 	@Override
@@ -129,13 +129,21 @@ public final class HttpClientOptions extends ClientOptions {
 		return this;
 	}
 
-	public HttpClientOptions supportsCompression(boolean enabled) {
-		this.enabled = enabled;
+	/**
+	 * @param compression configures compression support
+	 * @return {@code this}
+	 */
+	public HttpClientOptions compression(Compression compression) {
+		Objects.requireNonNull(compression, "compression");
+		this.compression = compression;
 		return this;
 	}
 
-	public boolean supportsCompression() {
-		return enabled;
+	/**
+	 * @return compression configuration
+	 */
+	public Compression getCompression() {
+		return compression;
 	}
 
 	/**
@@ -397,5 +405,56 @@ public final class HttpClientOptions extends ClientOptions {
 			sslContext = null;
 		}
 		DEFAULT_SSL_CONTEXT = sslContext;
+	}
+
+	public static class Compression {
+		private final boolean isEnabled;
+		private final boolean includeAcceptEncodingGzip;
+
+		Compression(boolean isEnabled, boolean includeAcceptEncodingGzip) {
+			this.isEnabled = isEnabled;
+			this.includeAcceptEncodingGzip = includeAcceptEncodingGzip;
+		}
+
+		/**
+		 * @return true if support for http compression is enabled, false otherwise
+		 */
+		public boolean isEnabled() {
+			return isEnabled;
+		}
+
+		/**
+		 * @return true if "Accept-Encoding:gzip" header is added to every request, false otherwise
+		 */
+		public boolean includeAcceptEncoding() {
+			return includeAcceptEncodingGzip;
+		}
+
+		public static class Builder {
+            private boolean isEnabled;
+            private boolean acceptEncoding;
+
+			/**
+			 * @param isEnabled add support for http compression
+			 * @return {@code this}
+			 */
+			public Builder setEnabled(boolean isEnabled) {
+                this.isEnabled = isEnabled;
+                return this;
+            }
+
+			/**
+			 * @param includeAcceptEncoding add "Accept-Encoding:gzip" header to every request
+			 * @return {@code this}
+			 */
+			public Builder setIncludeAcceptEncoding(boolean includeAcceptEncoding) {
+                this.acceptEncoding = includeAcceptEncoding;
+                return this;
+            }
+
+            public Compression build() {
+                return new Compression(isEnabled, acceptEncoding);
+            }
+        }
 	}
 }

--- a/src/main/java/reactor/ipc/netty/http/server/CompressionHandler.java
+++ b/src/main/java/reactor/ipc/netty/http/server/CompressionHandler.java
@@ -1,0 +1,122 @@
+package reactor.ipc.netty.http.server;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpMessage;
+import reactor.ipc.netty.NettyPipeline;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+/**
+ * @author mostroverkhov
+ */
+class CompressionHandler extends ChannelDuplexHandler {
+
+    private final HttpServerOptions.Compression compression;
+    private int bodyCompressThreshold;
+    private final Queue<Object> messages = new ArrayDeque<>();
+
+    CompressionHandler(HttpServerOptions.Compression compression) {
+        this.compression = compression;
+        this.bodyCompressThreshold = compression.getMinResponseSize();
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (compression.isEnabled()) {
+            if (msg instanceof ByteBuf) {
+                offerByteBuf(ctx, msg, promise);
+            } else if (msg instanceof HttpMessage) {
+                offerHttpMessage(msg, promise);
+            }
+        } else {
+            super.write(ctx, msg, promise);
+        }
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt == NettyPipeline.responseWriteCompletedEvent()) {
+            if (bodyCompressThreshold > 0 || !messages.isEmpty()) {
+                while (!messages.isEmpty()) {
+                    Object msg = messages.poll();
+                    writeSkipCompress(ctx, msg);
+                }
+            }
+        }
+        super.userEventTriggered(ctx, evt);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        releaseMsgs();
+        super.exceptionCaught(ctx, cause);
+    }
+
+    @Override
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        releaseMsgs();
+        super.close(ctx, promise);
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        ChannelPipeline cp = ctx.pipeline();
+        if (compression.isEnabled()) {
+            addCompressionHandlerOnce(ctx, cp);
+        }
+    }
+
+    private void offerHttpMessage(Object msg, ChannelPromise p) {
+        messages.offer(msg);
+        p.setSuccess();
+    }
+
+    private void offerByteBuf(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        ByteBuf byteBuf = (ByteBuf) msg;
+        messages.offer(byteBuf);
+        if (bodyCompressThreshold > 0) {
+            bodyCompressThreshold -= byteBuf.readableBytes();
+        }
+        drain(ctx, promise);
+    }
+
+    private void drain(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        if (bodyCompressThreshold <= 0) {
+            while (!messages.isEmpty()) {
+                Object message = messages.poll();
+                writeCompress(ctx, message, promise);
+            }
+        }
+    }
+
+    private void writeCompress(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        ctx.write(msg, promise);
+    }
+
+    private void writeSkipCompress(ChannelHandlerContext ctx, Object msg) throws Exception {
+        ctx.write(FilteringHttpContentCompressor.FilterMessage.wrap(msg));
+    }
+
+    private void releaseMsgs() {
+        while (!(messages.isEmpty())) {
+            Object msg = messages.poll();
+            if (msg instanceof ByteBuf) {
+                ((ByteBuf) msg).release();
+            }
+        }
+    }
+
+    private void addCompressionHandlerOnce(ChannelHandlerContext ctx, ChannelPipeline cp) {
+        if (cp.get(FilteringHttpContentCompressor.class) == null) {
+            ctx.pipeline().addBefore(NettyPipeline.CompressionHandler, NettyPipeline.HttpCompressor,
+                    new FilteringHttpContentCompressor());
+        }
+    }
+}
+
+

--- a/src/main/java/reactor/ipc/netty/http/server/CompressionHandler.java
+++ b/src/main/java/reactor/ipc/netty/http/server/CompressionHandler.java
@@ -32,6 +32,8 @@ class CompressionHandler extends ChannelDuplexHandler {
                 offerByteBuf(ctx, msg, promise);
             } else if (msg instanceof HttpMessage) {
                 offerHttpMessage(msg, promise);
+            } else {
+                super.write(ctx, msg, promise);
             }
         } else {
             super.write(ctx, msg, promise);

--- a/src/main/java/reactor/ipc/netty/http/server/FilteringHttpContentCompressor.java
+++ b/src/main/java/reactor/ipc/netty/http/server/FilteringHttpContentCompressor.java
@@ -1,7 +1,9 @@
 package reactor.ipc.netty.http.server;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.HttpContentCompressor;
 
 /**
@@ -18,6 +20,9 @@ public class FilteringHttpContentCompressor extends HttpContentCompressor {
             FilterMessage filterMsg = (FilterMessage) msg;
             ctx.write(filterMsg.unwrap(), promise);
         } else {
+            if (msg instanceof ByteBuf) {
+              msg = new DefaultHttpContent((ByteBuf) msg);
+            }
             super.write(ctx, msg, promise);
         }
     }

--- a/src/main/java/reactor/ipc/netty/http/server/FilteringHttpContentCompressor.java
+++ b/src/main/java/reactor/ipc/netty/http/server/FilteringHttpContentCompressor.java
@@ -1,0 +1,40 @@
+package reactor.ipc.netty.http.server;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpContentCompressor;
+
+/**
+ * @author mostroverkhov
+ */
+public class FilteringHttpContentCompressor extends HttpContentCompressor {
+
+    public FilteringHttpContentCompressor() {
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (msg instanceof FilterMessage) {
+            FilterMessage filterMsg = (FilterMessage) msg;
+            ctx.write(filterMsg.unwrap(), promise);
+        } else {
+            super.write(ctx, msg, promise);
+        }
+    }
+
+    static final class FilterMessage {
+        private final Object message;
+
+        static FilterMessage wrap(Object msg){
+            return new FilterMessage(msg);
+        }
+
+        FilterMessage(Object message) {
+            this.message = message;
+        }
+
+        Object unwrap() {
+            return message;
+        }
+    }
+}

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServer.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServer.java
@@ -164,12 +164,13 @@ public final class HttpServer
 			                     .autoCreateOperations(false);
 		}
 
-		@Override
-		public void accept(ChannelPipeline p, ContextHandler<Channel> c) {
-			p.addLast(NettyPipeline.HttpDecoder, new HttpRequestDecoder())
-			 .addLast(NettyPipeline.HttpEncoder, new HttpResponseEncoder())
-			 .addLast(NettyPipeline.HttpServerHandler, new HttpServerHandler(c));
-		}
+        @Override
+        public void accept(ChannelPipeline p, ContextHandler<Channel> c) {
+            p.addLast(NettyPipeline.HttpDecoder, new HttpRequestDecoder())
+                    .addLast(NettyPipeline.HttpEncoder,new HttpResponseEncoder())
+                    .addLast(NettyPipeline.CompressionHandler, new CompressionHandler(options.compression()))
+                    .addLast(NettyPipeline.HttpServerHandler, new HttpServerHandler(c));
+        }
 
 		@Override
 		protected LoggingHandler loggingHandler() {

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerOptions.java
@@ -18,6 +18,7 @@ package reactor.ipc.netty.http.server;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -38,6 +39,8 @@ import reactor.ipc.netty.options.ServerOptions;
  */
 public final class HttpServerOptions extends ServerOptions {
 
+    Compression compression = new Compression.CompressionBuilder().build();
+
 	/**
 	 * Create a new server builder
 	 * @return a new server builder
@@ -49,9 +52,10 @@ public final class HttpServerOptions extends ServerOptions {
 	HttpServerOptions(){
 	}
 
-	HttpServerOptions(HttpServerOptions options){
-		super(options);
-	}
+    HttpServerOptions(HttpServerOptions options) {
+        super(options);
+        this.compression = options.compression();
+    }
 
 	@Override
 	public HttpServerOptions afterChannelInit(Consumer<? super Channel> afterChannelInit) {
@@ -166,9 +170,77 @@ public final class HttpServerOptions extends ServerOptions {
 		return this;
 	}
 
-	@Override
-	public HttpServerOptions sslSelfSigned() {
-		super.sslSelfSigned();
-		return this;
-	}
+    @Override
+    public HttpServerOptions sslSelfSigned() {
+        super.sslSelfSigned();
+        return this;
+    }
+
+	/**
+	 *Set response compression options
+	 * @param compression options for {@link Compression}
+	 * @return {@code this}
+	 */
+    public HttpServerOptions compression(Compression compression) {
+        Objects.requireNonNull(compression, "compression");
+        this.compression = compression;
+        return this;
+    }
+
+	/**
+	 * @return response compression options
+	 */
+    public Compression compression() {
+        return compression;
+    }
+
+    public static class Compression {
+        private final boolean enabled;
+        private final int minResponseSize;
+
+        /**
+         * @param enabled true if compression is enabled, false otherwise
+         * @param minResponseSize compression is performed once response size exceeds given value
+         */
+        Compression(boolean enabled,
+                    int minResponseSize) {
+            this.enabled = enabled;
+            this.minResponseSize = minResponseSize;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public int getMinResponseSize() {
+            return minResponseSize;
+        }
+
+
+        public static class CompressionBuilder {
+            private boolean enabled;
+            private int minResponseSize;
+
+            public CompressionBuilder setEnabled(boolean enabled) {
+                this.enabled = enabled;
+                return this;
+            }
+
+            public CompressionBuilder setMinResponseSize(int minResponseSize) {
+                if (minResponseSize < 0) {
+                    throw new IllegalArgumentException("minResponseSize should be non-negative");
+                }
+                this.minResponseSize = minResponseSize;
+                return this;
+            }
+
+            public Compression build() {
+                if (!enabled) {
+                    minResponseSize = 0;
+                }
+                return new Compression(enabled, minResponseSize);
+            }
+        }
+    }
+
 }

--- a/src/test/java/reactor/ipc/netty/http/HttpCompressionClientServerTests.java
+++ b/src/test/java/reactor/ipc/netty/http/HttpCompressionClientServerTests.java
@@ -11,6 +11,7 @@ import reactor.ipc.netty.http.client.HttpClientResponse;
 import reactor.ipc.netty.http.server.HttpServer;
 import reactor.ipc.netty.http.server.HttpServerOptions;
 
+import java.net.InetSocketAddress;
 import java.time.Duration;
 
 /**
@@ -26,7 +27,9 @@ public class HttpCompressionClientServerTests {
                 Mono.just("reply"))).block(Duration.ofMillis(10_000));
 
 
-        HttpClient client = HttpClient.create(port(nettyContext));
+        HttpClient client = HttpClient.create(o -> o
+                .supportsCompression(true)
+                .connect(address(nettyContext)));
         HttpClientResponse resp = client.get("/test", req ->
                 req.header("Accept-Encoding", "gzip"))
                 .block();
@@ -51,7 +54,9 @@ public class HttpCompressionClientServerTests {
                 Mono.just("reply"))).block(Duration.ofMillis(10_000));
 
 
-        HttpClient client = HttpClient.create(port(nettyContext));
+        HttpClient client = HttpClient.create(o -> o
+                .supportsCompression(true)
+                .connect(address(nettyContext)));
         HttpClientResponse resp = client.get("/test", req ->
                 req.header("Accept-Encoding", "gzip"))
                 .block();
@@ -75,7 +80,9 @@ public class HttpCompressionClientServerTests {
                 Mono.just("reply"))).block(Duration.ofMillis(10_000));
 
 
-        HttpClient client = HttpClient.create(port(nettyContext));
+        HttpClient client = HttpClient.create(o -> o
+                .supportsCompression(true)
+                .connect(address(nettyContext)));
         HttpClientResponse resp = client.get("/test", req ->
                 req.header("Accept-Encoding", "gzip"))
                 .block();
@@ -99,7 +106,9 @@ public class HttpCompressionClientServerTests {
                 Mono.just("reply"))).block(Duration.ofMillis(10_000));
 
 
-        HttpClient client = HttpClient.create(port(nettyContext));
+        HttpClient client = HttpClient.create(o -> o
+                .supportsCompression(true)
+                .connect(address(nettyContext)));
         HttpClientResponse resp = client.get("/test", req ->
                 req.header("Accept-Encoding", "gzip"))
                 .block();
@@ -123,7 +132,9 @@ public class HttpCompressionClientServerTests {
                 Mono.just("reply"))).block(Duration.ofMillis(10_000));
 
 
-        HttpClient client = HttpClient.create(port(nettyContext));
+        HttpClient client = HttpClient.create(o -> o
+                .supportsCompression(true)
+                .connect(address(nettyContext)));
         HttpClientResponse resp = client.get("/test", req ->
                 req.header("Accept-Encoding", "gzip"))
                 .block();
@@ -147,7 +158,9 @@ public class HttpCompressionClientServerTests {
                 Mono.empty())).block(Duration.ofMillis(10_000));
 
 
-        HttpClient client = HttpClient.create(port(nettyContext));
+        HttpClient client = HttpClient.create(o -> o
+                .supportsCompression(true)
+                .connect(address(nettyContext)));
         HttpClientResponse resp = client.get("/test", req ->
                 req.header("Accept-Encoding", "gzip"))
                 .block();
@@ -158,7 +171,7 @@ public class HttpCompressionClientServerTests {
         nettyContext.onClose().block();
     }
 
-    private int port(NettyContext nettyContext) {
-        return nettyContext.address().getPort();
+    private InetSocketAddress address(NettyContext nettyContext) {
+        return new InetSocketAddress(nettyContext.address().getPort());
     }
 }

--- a/src/test/java/reactor/ipc/netty/http/HttpCompressionClientServerTests.java
+++ b/src/test/java/reactor/ipc/netty/http/HttpCompressionClientServerTests.java
@@ -1,0 +1,164 @@
+package reactor.ipc.netty.http;
+
+import io.netty.handler.codec.http.HttpHeaders;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.ipc.netty.NettyContext;
+import reactor.ipc.netty.http.client.HttpClient;
+import reactor.ipc.netty.http.client.HttpClientResponse;
+import reactor.ipc.netty.http.server.HttpServer;
+import reactor.ipc.netty.http.server.HttpServerOptions;
+
+import java.time.Duration;
+
+/**
+ * @author mostroverkhov
+ */
+public class HttpCompressionClientServerTests {
+
+    @Test
+    public void compressionDefault() throws Exception {
+        HttpServer server = HttpServer.create(0);
+
+        NettyContext nettyContext = server.newHandler((in, out) -> out.sendString(
+                Mono.just("reply"))).block(Duration.ofMillis(10_000));
+
+
+        HttpClient client = HttpClient.create(port(nettyContext));
+        HttpClientResponse resp = client.get("/test", req ->
+                req.header("Accept-Encoding", "gzip"))
+                .block();
+
+        HttpHeaders headers = resp.responseHeaders();
+        Assert.assertFalse(headers.contains("Content-Encoding", "gzip", true));
+        String reply = resp.receive().asString().blockFirst();
+        Assert.assertEquals("reply", reply);
+        nettyContext.dispose();
+        nettyContext.onClose().block();
+
+    }
+
+    @Test
+    public void compressionDisabled() throws Exception {
+        HttpServer server = HttpServer.create(o -> {
+            o.listen(0).compression(new HttpServerOptions.Compression.CompressionBuilder()
+                    .setEnabled(false).setMinResponseSize(0).build());
+        });
+
+        NettyContext nettyContext = server.newHandler((in, out) -> out.sendString(
+                Mono.just("reply"))).block(Duration.ofMillis(10_000));
+
+
+        HttpClient client = HttpClient.create(port(nettyContext));
+        HttpClientResponse resp = client.get("/test", req ->
+                req.header("Accept-Encoding", "gzip"))
+                .block();
+
+        HttpHeaders headers = resp.responseHeaders();
+        Assert.assertFalse(headers.contains("Content-Encoding", "gzip", true));
+        String reply = resp.receive().asString().blockFirst();
+        Assert.assertEquals("reply", reply);
+        nettyContext.dispose();
+        nettyContext.onClose().block();
+    }
+
+    @Test
+    public void compressionAlwaysEnabled() throws Exception {
+        HttpServer server = HttpServer.create(o -> {
+            o.listen(0).compression(new HttpServerOptions.Compression.CompressionBuilder()
+                    .setEnabled(true).setMinResponseSize(0).build());
+        });
+
+        NettyContext nettyContext = server.newHandler((in, out) -> out.sendString(
+                Mono.just("reply"))).block(Duration.ofMillis(10_000));
+
+
+        HttpClient client = HttpClient.create(port(nettyContext));
+        HttpClientResponse resp = client.get("/test", req ->
+                req.header("Accept-Encoding", "gzip"))
+                .block();
+
+        HttpHeaders headers = resp.responseHeaders();
+        Assert.assertTrue(headers.contains("Content-Encoding", "gzip", true));
+        String reply = resp.receive().asString().blockFirst();
+        Assert.assertEquals("reply", reply);
+        nettyContext.dispose();
+        nettyContext.onClose().block();
+    }
+
+    @Test
+    public void compressionEnabledSmallResponse() throws Exception {
+        HttpServer server = HttpServer.create(o -> {
+            o.listen(0).compression(new HttpServerOptions.Compression.CompressionBuilder()
+                    .setEnabled(true).setMinResponseSize(25).build());
+        });
+
+        NettyContext nettyContext = server.newHandler((in, out) -> out.sendString(
+                Mono.just("reply"))).block(Duration.ofMillis(10_000));
+
+
+        HttpClient client = HttpClient.create(port(nettyContext));
+        HttpClientResponse resp = client.get("/test", req ->
+                req.header("Accept-Encoding", "gzip"))
+                .block();
+
+        HttpHeaders headers = resp.responseHeaders();
+        Assert.assertFalse(headers.contains("Content-Encoding", "gzip", true));
+        String reply = resp.receive().asString().blockFirst();
+        Assert.assertEquals("reply", reply);
+        nettyContext.dispose();
+        nettyContext.onClose().block();
+    }
+
+    @Test
+    public void compressionEnabledBigResponse() throws Exception {
+        HttpServer server = HttpServer.create(o -> {
+            o.listen(0).compression(new HttpServerOptions.Compression.CompressionBuilder()
+                    .setEnabled(true).setMinResponseSize(4).build());
+        });
+
+        NettyContext nettyContext = server.newHandler((in, out) -> out.sendString(
+                Mono.just("reply"))).block(Duration.ofMillis(10_000));
+
+
+        HttpClient client = HttpClient.create(port(nettyContext));
+        HttpClientResponse resp = client.get("/test", req ->
+                req.header("Accept-Encoding", "gzip"))
+                .block();
+
+        HttpHeaders headers = resp.responseHeaders();
+        Assert.assertTrue(headers.contains("Content-Encoding", "gzip", true));
+        String reply = resp.receive().asString().blockFirst();
+        Assert.assertEquals("reply", reply);
+        nettyContext.dispose();
+        nettyContext.onClose().block();
+    }
+
+    @Test
+    public void emptyBody() throws Exception {
+        HttpServer server = HttpServer.create(o -> {
+            o.listen(0).compression(new HttpServerOptions.Compression.CompressionBuilder()
+                    .setEnabled(true).build());
+        });
+
+        NettyContext nettyContext = server.newHandler((in, out) -> out.sendString(
+                Mono.empty())).block(Duration.ofMillis(10_000));
+
+
+        HttpClient client = HttpClient.create(port(nettyContext));
+        HttpClientResponse resp = client.get("/test", req ->
+                req.header("Accept-Encoding", "gzip"))
+                .block();
+
+        HttpHeaders headers = resp.responseHeaders();
+        Assert.assertFalse(headers.contains("Content-Encoding", "gzip", true));
+        nettyContext.dispose();
+        nettyContext.onClose().block();
+    }
+
+    private int port(NettyContext nettyContext) {
+        return nettyContext.address().getPort();
+    }
+}


### PR DESCRIPTION
This PR adds support for HTTP compression. Server is configured with HttpServerOptions.Compression enabled and minResponseSize parameters. Latter controls compression based on response body size, 0 value means all responses with non-empty body are compressed. Client is configured with `HttpClientOptions.supportsCompression(boolean)`. Partially addresses #77. Relates to #98 