### PR TITLE
fix #71 bump to core 3.1.0.M2, migrate then/flatMap/toProcessor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
   gradleVersion = '3.3'
   gradleScriptDir = "${rootProject.projectDir}/gradle"
 
-  reactorCoreVersion = "3.0.7.RELEASE"
+  reactorCoreVersion = "3.1.0.M2"
   reactorIpcVersion = "0.6.2.RELEASE"
 
   // Languages
@@ -206,7 +206,7 @@ configure(rootProject) { project ->
 	testCompile "org.apache.httpcomponents:fluent-hc:4.3.6"
 	testCompile "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
 	testCompile "io.reactivex:rxjava:$rxJavaVersion"
-	testCompile "io.projectreactor.addons:reactor-test:$testAddonVersion"
+	testCompile "io.projectreactor:reactor-test:$testAddonVersion"
 
 	testRuntime "org.slf4j:jcl-over-slf4j:$slf4jVersion"
 

--- a/src/main/java/reactor/ipc/netty/http/multipart/MultipartParser.java
+++ b/src/main/java/reactor/ipc/netty/http/multipart/MultipartParser.java
@@ -102,7 +102,10 @@ final class MultipartParser
 
 				WIP.getAndIncrement(this);
 
-				w = UnicastProcessor.create(QueueSupplier.<ByteBuf>unbounded().get(), this);
+				w = UnicastProcessor.<ByteBuf>builder()
+				                    .queue(QueueSupplier.<ByteBuf>unbounded().get())
+				                    .onTerminate(this)
+				                    .build();
 
 				window = w;
 

--- a/src/test/groovy/reactor/ipc/netty/http/HttpCookieHandlingSpec.groovy
+++ b/src/test/groovy/reactor/ipc/netty/http/HttpCookieHandlingSpec.groovy
@@ -40,7 +40,7 @@ class HttpCookieHandlingSpec extends Specification {
 
 	def cookieResponse = HttpClient.create("localhost", server.address().port).
 			get('/test')
-			.then({ replies -> Mono.just(replies.cookies()) }
+			.flatMap({ replies -> Mono.just(replies.cookies()) }
 					as Function<HttpClientResponse, Mono<Map<CharSequence, Set<Cookie>>>>)
 			.doOnSuccess {
 	  			println it

--- a/src/test/groovy/reactor/ipc/netty/http/HttpResponseStatusCodesHandlingSpec.groovy
+++ b/src/test/groovy/reactor/ipc/netty/http/HttpResponseStatusCodesHandlingSpec.groovy
@@ -47,7 +47,7 @@ class HttpResponseStatusCodesHandlingSpec extends Specification {
 			  .just("Hello")
 			  .log('client-send'))
 	}
-	.flatMap { replies ->
+	.flatMapMany { replies ->
 	  //successful request, listen for replies
 	  replies
 			  .receive()

--- a/src/test/groovy/reactor/ipc/netty/http/HttpSpec.groovy
+++ b/src/test/groovy/reactor/ipc/netty/http/HttpSpec.groovy
@@ -59,7 +59,7 @@ class HttpSpec extends Specification {
 	  //return a producing stream to send some data along the request
 	  req.sendString(Mono.just("Hello").log('client-send'))
 
-	}.then({
+	}.flatMap({
 	  replies
 		->
 		//successful request, listen for the first returned next reply and pass it downstream
@@ -111,7 +111,7 @@ class HttpSpec extends Specification {
 	  req.sendString(Flux.just("Hello")
 			  .log('client-send'))
 
-	}.then( { replies ->
+	}.flatMap( { replies ->
 		//successful request, listen for the first returned next reply and pass it downstream
 		replies.receive()
 				.aggregate()
@@ -169,7 +169,7 @@ class HttpSpec extends Specification {
 	//prepare an http post request-reply flow
 	client
 			.get('/test')
-			.then({ replies ->
+			.flatMap({ replies ->
 	  Mono.just(replies.status().code())
 			  .log("received-status-1")
 	} as Function)
@@ -185,9 +185,8 @@ class HttpSpec extends Specification {
 	//prepare an http post request-reply flow
 	def content = client
 			.get('/test2')
-			.flatMapMany { replies -> replies.receive().log("received-status-2")
-	}
-	.next()
+			.flatMapMany { replies -> replies.receive().log("received-status-2") }
+			.next()
 			.block(Duration.ofSeconds(30))
 
 	then: "data was recieved"
@@ -200,7 +199,7 @@ class HttpSpec extends Specification {
 	client
 			.get('/test3')
 			.flatMapMany { replies ->
-	  Flux.just(replies.status().code)
+	  Flux.just(replies.status().code())
 			  .log("received-status-3")
 	}
 	.next()
@@ -261,7 +260,7 @@ class HttpSpec extends Specification {
 				.range(1, 1000)
 				.log('client-send')
 				.map { it.toString() })
-	}.flatMap {
+	}.flatMapMany {
 	  replies
 		->
 		//successful handshake, listen for the first returned next replies and pass it downstream

--- a/src/test/java/reactor/ipc/netty/http/ClientServerHttpTests.java
+++ b/src/test/java/reactor/ipc/netty/http/ClientServerHttpTests.java
@@ -252,7 +252,7 @@ public class ClientServerHttpTests {
 	private void setupFakeProtocolListener() throws Exception {
 		broadcaster = TopicProcessor.create();
 		final Processor<List<String>, List<String>> processor =
-				WorkQueueProcessor.create(false);
+				WorkQueueProcessor.<List<String>>builder().autoCancel(false).build();
 		Flux.from(broadcaster)
 		    .buffer(5)
 		    .subscribe(processor);
@@ -282,13 +282,13 @@ public class ClientServerHttpTests {
 		                                                                 .getPort());
 
 		return httpClient.get("/data")
-		                 .flatMap(s -> s.receive()
+		                 .flatMapMany(s -> s.receive()
 		                                .asString()
 		                                .log("client")
 		                                .next())
 		                 .collectList()
 		                 .cache()
-		                 .subscribe();
+		                 .toProcessor();
 	}
 
 	private List<List<String>> getClientDatas(int threadCount, Sender sender, int count)

--- a/src/test/java/reactor/ipc/netty/http/HttpServerTests.java
+++ b/src/test/java/reactor/ipc/netty/http/HttpServerTests.java
@@ -107,7 +107,7 @@ public class HttpServerTests {
 		NettyContext c = HttpServer.create(0)
 		                           .newHandler((req, resp) -> resp.header(HttpHeaderNames.CONTENT_LENGTH, "1")
 		                                                          .sendString(Mono.just(i.incrementAndGet())
-		                                                                          .then(d -> Mono.delay(
+		                                                                          .flatMap(d -> Mono.delay(
 				                                                                          Duration.ofSeconds(
 						                                                                          4 - d))
 		                                                                                         .map(x -> d + "\n"))))

--- a/src/test/java/reactor/ipc/netty/http/SmokeTests.java
+++ b/src/test/java/reactor/ipc/netty/http/SmokeTests.java
@@ -245,8 +245,8 @@ public class SmokeTests {
 
 	private void setupFakeProtocolListener() throws Exception {
 
-		processor = TopicProcessor.create(false);
-		workProcessor = WorkQueueProcessor.create(false);
+		processor = TopicProcessor.<ByteBuf>builder().autoCancel(false).build();
+		workProcessor = WorkQueueProcessor.<ByteBuf>builder().autoCancel(false).build();
 		Flux<ByteBuf> bufferStream = Flux.from(processor)
 		                                 .window(windowBatch)
 		                                 .doOnNext(d -> windows.getAndIncrement())
@@ -300,7 +300,7 @@ public class SmokeTests {
 						                                        .getPort()));
 
 		Mono<List<String>> content = httpClient.get("/data")
-		                                       .then(f -> f.receive()
+		                                       .flatMap(f -> f.receive()
 		                                                   .asString()
 		                                                   .collectList())
 		                                       .cache();

--- a/src/test/java/reactor/ipc/netty/http/client/WebsocketTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/WebsocketTest.java
@@ -64,7 +64,7 @@ public class WebsocketTest {
 		                .get("/test",
 				                out -> out.addHeader("Authorization", auth)
 				                          .sendWebsocket())
-		                .flatMap(in -> in.receive()
+		                .flatMapMany(in -> in.receive()
 		                                 .asString())
 		                .log()
 		                .collectList()
@@ -97,7 +97,7 @@ public class WebsocketTest {
 //		                       .get("/test",
 //				                       out -> out.addHeader("Authorization", auth)
 //				                                 .sendWebsocket())
-//		                       .flatMap(in -> in.receiveWebsocket()
+//		                       .flatMapMany(in -> in.receiveWebsocket()
 //		                                        .receive()
 //		                                        .asByteArray())
 //		                       .doOnNext(d -> System.out.println(d.length))
@@ -122,7 +122,7 @@ public class WebsocketTest {
 		Flux<String> ws = HttpClient.create(httpServer.address()
 		                                              .getPort())
 		                            .ws("/")
-		                            .flatMap(in -> in.receiveWebsocket()
+		                            .flatMapMany(in -> in.receiveWebsocket()
 		                                             .aggregateFrames()
 		                                             .receive()
 		                                             .asString());
@@ -152,7 +152,7 @@ public class WebsocketTest {
 		Flux<String> ws = HttpClient.create(httpServer.address()
 		                                              .getPort())
 		                            .ws("/")
-		                            .flatMap(in -> in.receiveWebsocket()
+		                            .flatMapMany(in -> in.receiveWebsocket()
 		                                             .aggregateFrames()
 		                                             .receive()
 		                                             .asString());
@@ -198,7 +198,7 @@ public class WebsocketTest {
 		HttpClient.create(httpServer.address()
 		                            .getPort())
 		          .ws("/test")
-		          .then(in -> in.receiveWebsocket((i, o) -> o.options(opt -> opt.flushOnEach())
+		          .flatMap(in -> in.receiveWebsocket((i, o) -> o.options(opt -> opt.flushOnEach())
 		                                                     .sendString(i.receive()
 		                                                                  .asString()
 		                                                                  .subscribeWith(
@@ -222,7 +222,7 @@ public class WebsocketTest {
 				          .get("/test",
 						          out -> out.addHeader("Authorization", auth)
 						                    .sendWebsocket("SUBPROTOCOL,OTHER"))
-				          .flatMap(in -> in.receive().asString())
+				          .flatMapMany(in -> in.receive().asString())
 		)
 		            .verifyErrorMessage("Invalid subprotocol. Actual: null. Expected one of: SUBPROTOCOL,OTHER");
 	}
@@ -241,7 +241,7 @@ public class WebsocketTest {
 				          .get("/test",
 						          out -> out.addHeader("Authorization", auth)
 						                    .sendWebsocket("SUBPROTOCOL,OTHER"))
-				          .flatMap(in -> in.receive().asString())
+				          .flatMapMany(in -> in.receive().asString())
 		)
 		            //the SERVER returned null which means that it couldn't select a protocol
 		            .verifyErrorMessage("Invalid subprotocol. Actual: null. Expected one of: SUBPROTOCOL,OTHER");
@@ -260,7 +260,7 @@ public class WebsocketTest {
 		                       .get("/test",
 				                out -> out.addHeader("Authorization", auth)
 				                          .sendWebsocket("SUBPROTOCOL,OTHER"))
-		                .flatMap(in -> in.receive().asString()).log().collectList().block(Duration.ofSeconds(30)).get(0);
+		                .flatMapMany(in -> in.receive().asString()).log().collectList().block(Duration.ofSeconds(30)).get(0);
 
 		Assert.assertThat(res, is("test"));
 	}
@@ -279,7 +279,7 @@ public class WebsocketTest {
 				                out -> out.addHeader("Authorization", auth)
 				                          .sendWebsocket("Common,OTHER"))
 		                       .map(HttpClientResponse::receiveWebsocket)
-		                       .flatMap(in -> in.receive().asString()
+		                       .flatMapMany(in -> in.receive().asString()
 				                       .map(srv -> "CLIENT:" + in.selectedSubprotocol() + "-" + srv))
 		                       .log().collectList().block(Duration.ofSeconds(30)).get(0);
 
@@ -299,7 +299,7 @@ public class WebsocketTest {
 				                       out -> out.addHeader("Authorization", auth)
 				                                 .sendWebsocket())
 		                       .map(HttpClientResponse::receiveWebsocket)
-		                       .flatMap(in -> in.receive()
+		                       .flatMapMany(in -> in.receive()
 		                                        .asString()
 		                                        .map(srv -> "CLIENT:" + in.selectedSubprotocol() + "-" + srv))
 		                       .log()
@@ -323,7 +323,7 @@ public class WebsocketTest {
 				                       out -> out.addHeader("Authorization", auth)
 				                                 .sendWebsocket("proto1, proto2"))
 		                       .map(HttpClientResponse::receiveWebsocket)
-		                       .flatMap(in -> in.receive()
+		                       .flatMapMany(in -> in.receive()
 		                                        .asString()
 		                                        .map(srv -> "CLIENT:" + in.selectedSubprotocol() + "-" + srv))
 		                       .log()
@@ -357,7 +357,7 @@ public class WebsocketTest {
 		HttpClient.create(httpServer.address()
 		                            .getPort())
 		          .ws("/test", "proto1,proto2")
-		          .then(in -> {
+		          .flatMap(in -> {
 			          clientSelectedProtocolWhenSimplyUpgrading.set(in.receiveWebsocket().selectedSubprotocol());
 			          return in.receiveWebsocket((i, o) -> {
 				          clientSelectedProtocol.set(o.selectedSubprotocol());

--- a/src/test/java/reactor/ipc/netty/tcp/TcpClientTests.java
+++ b/src/test/java/reactor/ipc/netty/tcp/TcpClientTests.java
@@ -367,7 +367,7 @@ public class TcpClientTests {
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		System.out.println(client.get("http://www.google.com/?q=test%20d%20dq")
-		                         .then(r -> r.receive()
+		                         .flatMap(r -> r.receive()
 		                                     .asString()
 		                                     .collectList())
 		                         .doOnSuccess(v -> latch.countDown())

--- a/src/test/java/reactor/ipc/netty/tcp/TcpServerTests.java
+++ b/src/test/java/reactor/ipc/netty/tcp/TcpServerTests.java
@@ -247,11 +247,11 @@ public class TcpServerTests {
 	public void test5() throws Exception {
 		//Hot stream of data, could be injected from anywhere
 		EmitterProcessor<String> broadcaster =
-				EmitterProcessor.<String>create().connect();
+				EmitterProcessor.<String>create();
 
 		//Get a reference to the tail of the operation pipeline (microbatching + partitioning)
 		final Processor<List<String>, List<String>> processor =
-				WorkQueueProcessor.create(false);
+				WorkQueueProcessor.<List<String>>builder().autoCancel(false).build();
 
 		broadcaster
 
@@ -327,7 +327,7 @@ public class TcpServerTests {
 				(in, out) -> HttpClient.create()
 				                       .get("foaas.herokuapp.com/life/" + in.param(
 						                       "search"))
-				                       .flatMap(repliesOut -> out.send(repliesOut.receive()))))
+				                       .flatMapMany(repliesOut -> out.send(repliesOut.receive()))))
 		      .block(Duration.ofSeconds(30))
 		      .onClose()
 		      .block(Duration.ofSeconds(30));
@@ -342,7 +342,7 @@ public class TcpServerTests {
 				                       .get("ws://localhost:3000",
 						                       requestOut -> requestOut.sendWebsocket()
 						                                               .sendString(Mono.just("ping")))
-				                       .flatMap(repliesOut -> out.sendGroups(repliesOut.receive()
+				                       .flatMapMany(repliesOut -> out.sendGroups(repliesOut.receive()
 				                                                                       .window(100)))))
 		      .block(Duration.ofSeconds(30))
 		      .onClose()


### PR DESCRIPTION
This commit bumps the 0.7 dependency to core 3.1.0.M2 and fixes usages
of the following Mono APIs:
 - otherwise has become onErrorResume
 - flatMap has become flatMapMany
 - then has become flatMap
 - subscribe() returns a Disposable, use toProcessor() for old behavior

It also fixes a usage of `Flux.then(Supplier)` to use `Flux.then()` and
a defer instead.