### PR TITLE
fix #106 Take HttpServerOptions.compression(int) threshold into account

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerOptions.java
@@ -201,7 +201,7 @@ public final class HttpServerOptions extends ServerOptions {
 	 */
 	public HttpServerOptions compression(int minResponseSize) {
 		if (minResponseSize < 0) {
-			throw new IllegalArgumentException("minResponseSize should be strictly positive");
+			throw new IllegalArgumentException("minResponseSize must be positive");
 		}
 		this.minCompressionResponseSize = minResponseSize;
 		return this;

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerOptions.java
@@ -201,9 +201,9 @@ public final class HttpServerOptions extends ServerOptions {
 	 */
 	public HttpServerOptions compression(int minResponseSize) {
 		if (minResponseSize < 0) {
-			throw new IllegalArgumentException("minResponseSize should be non-negative");
+			throw new IllegalArgumentException("minResponseSize should be strictly positive");
 		}
-		this.minCompressionResponseSize = 0;
+		this.minCompressionResponseSize = minResponseSize;
 		return this;
 	}
 

--- a/src/test/java/reactor/ipc/netty/http/server/HttpServerOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/http/server/HttpServerOptionsTest.java
@@ -1,0 +1,35 @@
+package reactor.ipc.netty.http.server;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class HttpServerOptionsTest {
+
+	@Test
+	public void minResponseForCompressionNegative() {
+		HttpServerOptions options = HttpServerOptions.create();
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> options.compression(-1))
+				.withMessage("minResponseSize must be positive");
+	}
+
+	@Test
+	public void minResponseForCompressionZero() {
+		HttpServerOptions options = HttpServerOptions.create();
+		options.compression(0);
+
+		assertThat(options.minCompressionResponseSize).isZero();
+	}
+
+	@Test
+	public void minResponseForCompressionPositive() {
+		HttpServerOptions options = HttpServerOptions.create();
+		options.compression(10);
+
+		assertThat(options.minCompressionResponseSize).isEqualTo(10);
+	}
+
+}


### PR DESCRIPTION
Rework the tests so that they correctly surface the issue, fix the
option ignoring the threshold and always activating compression.