### PR TITLE
fix #66 Expose duplicate of options for TCP/HTTP Client and Server

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
@@ -331,6 +331,20 @@ public class HttpClient implements NettyConnector<HttpClientResponse, HttpClient
 				});
 	}
 
+	/**
+	 * Get a copy of the {@link HttpClientOptions} currently in effect.
+	 *
+	 * @return the http client options
+	 */
+	public HttpClientOptions options() {
+		return options.duplicate();
+	}
+
+	@Override
+	public String toString() {
+		return "HttpClient: " + options.asSimpleString();
+	}
+
 	static final HttpMethod     WS             = new HttpMethod("WS");
 	final static String         WS_SCHEME      = "ws";
 	final static String         WSS_SCHEME     = "wss";

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
@@ -379,6 +379,21 @@ public final class HttpClientOptions extends ClientOptions {
 		}
 	}
 
+	@Override
+	public String asSimpleString() {
+		return super.asSimpleString() + (acceptGzip ? " with gzip" : "");
+	}
+
+	@Override
+	public String asDetailedString() {
+		return super.asDetailedString() + ", acceptGzip=" + acceptGzip;
+	}
+
+	@Override
+	public String toString() {
+		return "HttpClientOptions{" + asDetailedString() + "}";
+	}
+
 	static boolean isSecure(URI uri) {
 		return uri.getScheme() != null && (uri.getScheme()
 		                                      .toLowerCase()

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServer.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServer.java
@@ -37,7 +37,6 @@ import reactor.ipc.netty.NettyOutbound;
 import reactor.ipc.netty.NettyPipeline;
 import reactor.ipc.netty.channel.ContextHandler;
 import reactor.ipc.netty.http.HttpResources;
-import reactor.ipc.netty.options.NettyOptions;
 import reactor.ipc.netty.options.ServerOptions;
 import reactor.ipc.netty.tcp.TcpServer;
 
@@ -119,6 +118,20 @@ public final class HttpServer
 	HttpServer(HttpServerOptions options) {
 		this.server = new TcpBridgeServer(options);
 		this.options = options;
+	}
+
+	/**
+	 * Get a copy of the {@link HttpServerOptions} currently in effect.
+	 *
+	 * @return the http server options
+	 */
+	public final HttpServerOptions options() {
+		return this.options.duplicate();
+	}
+
+	@Override
+	public String toString() {
+		return "HttpServer: " + options.asSimpleString();
 	}
 
 	@Override

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerOptions.java
@@ -207,4 +207,28 @@ public final class HttpServerOptions extends ServerOptions {
 		return this;
 	}
 
+	@Override
+	public String asSimpleString() {
+		StringBuilder s = new StringBuilder(super.asSimpleString());
+
+		if (minCompressionResponseSize >= 0) {
+			s.append(", gzip");
+			if (minCompressionResponseSize > 0) {
+				s.append( " over ").append(minCompressionResponseSize).append(" bytes");
+			}
+		}
+
+		return s.toString();
+	}
+
+	@Override
+	public String asDetailedString() {
+		return super.asDetailedString() +
+				", minCompressionResponseSize=" + minCompressionResponseSize;
+	}
+
+	@Override
+	public String toString() {
+		return "HttpServerOptions{" + asDetailedString() + "}";
+	}
 }

--- a/src/main/java/reactor/ipc/netty/options/ClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/ClientOptions.java
@@ -467,4 +467,36 @@ public class ClientOptions extends NettyOptions<Bootstrap, ClientOptions> {
 			bootstrap.channel(loops.onChannel(elg));
 		}
 	}
+
+
+	@Override
+	public String asSimpleString() {
+		StringBuilder s = new StringBuilder();
+		if (getAddress() == null) {
+			s.append("connecting to no base address");
+		}
+		else {
+			s.append("connecting to ").append(getAddress());
+		}
+		if (proxyType != null) {
+			s.append(" through ").append(proxyType).append(" proxy");
+		}
+		return s.toString();
+	}
+
+	@Override
+	public String asDetailedString() {
+		if (proxyType == null) {
+			return "connectAddress=" + getAddress() + ", proxy=null, " + super.asDetailedString();
+		}
+		return "connectAddress=" + getAddress() +
+				", proxy=" + proxyType +
+				"(" + proxyAddress.get() + "), " +
+				super.asDetailedString();
+	}
+
+	@Override
+	public String toString() {
+		return "ClientOptions{" + asDetailedString() + "}";
+	}
 }

--- a/src/main/java/reactor/ipc/netty/options/NettyOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/NettyOptions.java
@@ -367,9 +367,23 @@ public abstract class NettyOptions<BOOSTRAP extends AbstractBootstrap<BOOSTRAP, 
 		return (SO) this;
 	}
 
+	public String asSimpleString() {
+		return this.asDetailedString();
+	}
+
+	public String asDetailedString() {
+		return "bootstrapTemplate=" + bootstrapTemplate +
+				", sslHandshakeTimeoutMillis=" + sslHandshakeTimeoutMillis +
+				", sslContext=" + sslContext +
+				", preferNative=" + preferNative +
+				", afterChannelInit=" + afterChannelInit +
+				", onChannelInit=" + onChannelInit +
+				", loopResources=" + loopResources;
+	}
+
 	@Override
 	public String toString() {
-		return "NettyOptions{" + "bootstrapTemplate=" + bootstrapTemplate + ", sslHandshakeTimeoutMillis=" + sslHandshakeTimeoutMillis + ", sslContext=" + sslContext + ", preferNative=" + preferNative + ", afterChannelInit=" + afterChannelInit + ", onChannelInit=" + onChannelInit + ", loopResources=" + loopResources + '}';
+		return "NettyOptions{" + asDetailedString() + "}";
 	}
 
 	static final boolean DEFAULT_NATIVE =

--- a/src/main/java/reactor/ipc/netty/options/ServerOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/ServerOptions.java
@@ -274,5 +274,20 @@ public class ServerOptions extends NettyOptions<ServerBootstrap, ServerOptions> 
 		         .channel(loops.onServerChannel(elg));
 	}
 
+	@Override
+	public String asSimpleString() {
+		return "listening on " + this.getAddress();
+	}
+
+	@Override
+	public String asDetailedString() {
+		return "address=" + getAddress() + ", " + super.asDetailedString();
+	}
+
+	@Override
+	public String toString() {
+		return "ServerOptions{" + asDetailedString() + "}";
+	}
+
 	final static InetSocketAddress LOCALHOST_AUTO_PORT = new InetSocketAddress(0);
 }

--- a/src/main/java/reactor/ipc/netty/tcp/TcpClient.java
+++ b/src/main/java/reactor/ipc/netty/tcp/TcpClient.java
@@ -117,24 +117,24 @@ public class TcpClient implements NettyConnector<NettyInbound, NettyOutbound> {
 		this.options = Objects.requireNonNull(options, "options");
 	}
 
-	/**
-	 * Get the {@link ClientOptions} currently in effect.
-	 *
-	 * @return the client options
-	 */
-	public final ClientOptions options() {
-		return this.options;
-	}
-
 	@Override
 	public final Mono<? extends NettyContext> newHandler(BiFunction<? super NettyInbound, ? super NettyOutbound, ? extends Publisher<Void>> handler) {
 		Objects.requireNonNull(handler, "handler");
 		return newHandler(handler, null, true, null);
 	}
 
+	/**
+	 * Get a copy of the {@link ClientOptions} currently in effect.
+	 *
+	 * @return the client options
+	 */
+	public final ClientOptions options() {
+		return this.options.duplicate();
+	}
+
 	@Override
 	public String toString() {
-		return "TcpClient:" + options.toString();
+		return "TcpClient: " + options.asSimpleString();
 	}
 
 	/**

--- a/src/main/java/reactor/ipc/netty/tcp/TcpServer.java
+++ b/src/main/java/reactor/ipc/netty/tcp/TcpServer.java
@@ -16,7 +16,6 @@
 
 package reactor.ipc.netty.tcp;
 
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -153,9 +152,18 @@ public class TcpServer implements NettyConnector<NettyInbound, NettyOutbound> {
 		});
 	}
 
+	/**
+	 * Get a copy of the {@link ServerOptions} currently in effect.
+	 *
+	 * @return the server options
+	 */
+	public ServerOptions options() {
+		return this.options.duplicate();
+	}
+
 	@Override
 	public String toString() {
-		return "TcpServer:" + options.toString();
+		return "TcpServer: " + options.asSimpleString();
 	}
 
 	/**

--- a/src/main/java/reactor/ipc/netty/udp/UdpClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/udp/UdpClientOptions.java
@@ -51,4 +51,9 @@ final class UdpClientOptions extends ClientOptions {
 	public ClientOptions connect(@Nonnull String host, int port) {
 		return connect(new InetSocketAddress(host, port));
 	}
+
+	@Override
+	public String toString() {
+		return "UdpClientOptions{" + asDetailedString() + "}";
+	}
 }

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
@@ -1,0 +1,67 @@
+package reactor.ipc.netty.http.client;
+
+import org.junit.Test;
+import reactor.ipc.netty.options.ClientOptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpClientOptionsTest {
+
+	@Test
+	public void asSimpleString() {
+		HttpClientOptions opt = HttpClientOptions.create();
+
+		assertThat(opt.asSimpleString()).isEqualTo("connecting to no base address");
+
+		//proxy
+		opt.proxy(ClientOptions.Proxy.SOCKS4, "http://proxy", 456);
+		assertThat(opt.asSimpleString()).isEqualTo("connecting to no base address through SOCKS4 proxy");
+
+		//address
+		opt.connect("http://google.com", 123);
+		assertThat(opt.asSimpleString()).isEqualTo("connecting to http://google.com:123 through SOCKS4 proxy");
+
+		//gzip
+		opt.compression(true);
+		assertThat(opt.asSimpleString()).isEqualTo("connecting to http://google.com:123 through SOCKS4 proxy with gzip");
+	}
+
+	@Test
+	public void asDetailedString() {
+		HttpClientOptions opt = HttpClientOptions.create();
+
+		assertThat(opt.asDetailedString())
+				.startsWith("connectAddress=null, proxy=null")
+				.endsWith(", acceptGzip=false");
+
+		//proxy
+		opt.proxy(ClientOptions.Proxy.SOCKS4, "http://proxy", 456);
+		assertThat(opt.asDetailedString())
+				.startsWith("connectAddress=null, proxy=SOCKS4(http://proxy:456)")
+				.endsWith(", acceptGzip=false");
+
+		//address
+		opt.connect("http://google.com", 123);
+		assertThat(opt.asDetailedString())
+				.startsWith("connectAddress=http://google.com:123, proxy=SOCKS4(http://proxy:456)")
+				.endsWith(", acceptGzip=false");
+
+		//gzip
+		opt.compression(true);
+		assertThat(opt.asDetailedString())
+				.startsWith("connectAddress=http://google.com:123, proxy=SOCKS4(http://proxy:456)")
+				.endsWith(", acceptGzip=true");
+	}
+
+	@Test
+	public void toStringContainsAsDetailedString() {
+		HttpClientOptions opt = HttpClientOptions.create()
+		                                         .connect("http://google.com", 123)
+		                                         .proxy(ClientOptions.Proxy.SOCKS4, "http://proxy", 456)
+		                                         .compression(true);
+		assertThat(opt.toString())
+				.startsWith("HttpClientOptions{connectAddress=http://google.com:123, proxy=SOCKS4(http://proxy:456)")
+				.endsWith(", acceptGzip=true}");
+	}
+
+}

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
@@ -43,6 +43,8 @@ import reactor.ipc.netty.resources.PoolResources;
 import reactor.ipc.netty.tcp.TcpServer;
 import reactor.test.StepVerifier;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Stephane Maldini
  * @since 0.6
@@ -474,4 +476,19 @@ public class HttpClientTest {
 		c.dispose();
 	}
 
+	@Test
+	public void toStringShowsOptions() {
+		HttpClient client = HttpClient.create(opt -> opt.connect("foo", 123)
+		                                                .compression(true));
+
+		assertThat(client.toString()).isEqualTo("HttpClient: connecting to foo:123 with gzip");
+	}
+
+	@Test
+	public void gettingOptionsDuplicates() {
+		HttpClient client = HttpClient.create(opt -> opt.connect("foo", 123).compression(true));
+		assertThat(client.options())
+				.isNotSameAs(client.options)
+				.isNotSameAs(client.options());
+	}
 }

--- a/src/test/java/reactor/ipc/netty/http/server/HttpServerOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/http/server/HttpServerOptionsTest.java
@@ -32,4 +32,60 @@ public class HttpServerOptionsTest {
 		assertThat(options.minCompressionResponseSize).isEqualTo(10);
 	}
 
+	@Test
+	public void asSimpleString() {
+		HttpServerOptions opt = HttpServerOptions.create();
+
+		assertThat(opt.asSimpleString()).isEqualTo("listening on 0.0.0.0/0.0.0.0:0");
+
+		//address
+		opt.listen("foo", 123);
+		assertThat(opt.asSimpleString()).isEqualTo("listening on foo:123");
+
+		//gzip
+		opt.compression(true);
+		assertThat(opt.asSimpleString()).isEqualTo("listening on foo:123, gzip");
+
+		//gzip with threshold
+		opt.compression(534);
+		assertThat(opt.asSimpleString()).isEqualTo("listening on foo:123, gzip over 534 bytes");
+	}
+
+	@Test
+	public void asDetailedString() {
+		HttpServerOptions opt = HttpServerOptions.create();
+
+		assertThat(opt.asDetailedString())
+				.startsWith("address=0.0.0.0/0.0.0.0:0")
+				.endsWith(", minCompressionResponseSize=-1");
+
+		//address
+		opt.listen("foo", 123);
+		assertThat(opt.asDetailedString())
+				.startsWith("address=foo:123")
+				.endsWith(", minCompressionResponseSize=-1");
+
+		//gzip
+		opt.compression(true);
+		assertThat(opt.asDetailedString())
+				.startsWith("address=foo:123")
+				.endsWith(", minCompressionResponseSize=0");
+
+		//gzip with threshold
+		opt.compression(534);
+		assertThat(opt.asDetailedString())
+				.startsWith("address=foo:123")
+				.endsWith(", minCompressionResponseSize=534");
+	}
+
+	@Test
+	public void toStringContainsAsDetailedString() {
+		HttpServerOptions opt = HttpServerOptions.create()
+		                                         .listen("http://google.com", 123)
+		                                         .compression(534);
+		assertThat(opt.toString())
+				.startsWith("HttpServerOptions{address=http://google.com:123")
+				.endsWith(", minCompressionResponseSize=534}");
+	}
+
 }

--- a/src/test/java/reactor/ipc/netty/http/server/HttpServerTests.java
+++ b/src/test/java/reactor/ipc/netty/http/server/HttpServerTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package reactor.ipc.netty.http;
+package reactor.ipc.netty.http.server;
 
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -36,9 +36,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.ipc.netty.ByteBufFlux;
 import reactor.ipc.netty.NettyContext;
+import reactor.ipc.netty.http.HttpResources;
 import reactor.ipc.netty.http.client.HttpClient;
 import reactor.ipc.netty.http.client.HttpClientResponse;
-import reactor.ipc.netty.http.server.HttpServer;
 import reactor.ipc.netty.resources.PoolResources;
 import reactor.ipc.netty.tcp.TcpClient;
 import reactor.test.StepVerifier;
@@ -228,4 +228,20 @@ public class HttpServerTests {
 		HttpResources.reset();
 	}
 
+
+	@Test
+	public void toStringShowsOptions() {
+		HttpServer server = HttpServer.create(opt -> opt.listen("foo", 123)
+		                                                .compression(987));
+
+		Assertions.assertThat(server.toString()).isEqualTo("HttpServer: listening on foo:123, gzip over 987 bytes");
+	}
+
+	@Test
+	public void gettingOptionsDuplicates() {
+		HttpServer server = HttpServer.create(opt -> opt.listen("foo", 123).compression(true));
+		Assertions.assertThat(server.options())
+		          .isNotSameAs(server.options)
+		          .isNotSameAs(server.options());
+	}
 }

--- a/src/test/java/reactor/ipc/netty/options/ClientOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/options/ClientOptionsTest.java
@@ -1,0 +1,52 @@
+package reactor.ipc.netty.options;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClientOptionsTest {
+
+	@Test
+	public void asSimpleString() {
+		ClientOptions opt = ClientOptions.create();
+
+		assertThat(opt.asSimpleString()).isEqualTo("connecting to no base address");
+
+		//proxy
+		opt.proxy(ClientOptions.Proxy.SOCKS4, "http://proxy", 456);
+		assertThat(opt.asSimpleString()).isEqualTo("connecting to no base address through SOCKS4 proxy");
+
+		//address
+		opt.connect("http://google.com", 123);
+		assertThat(opt.asSimpleString()).isEqualTo("connecting to http://google.com:123 through SOCKS4 proxy");
+	}
+
+	@Test
+	public void asDetailedString() {
+		ClientOptions opt = ClientOptions.create();
+
+		assertThat(opt.asDetailedString())
+				.startsWith("connectAddress=null, proxy=null");
+
+		//proxy
+		opt.proxy(ClientOptions.Proxy.SOCKS4, "http://proxy", 456);
+		assertThat(opt.asDetailedString())
+				.startsWith("connectAddress=null, proxy=SOCKS4(http://proxy:456)");
+
+		//address
+		opt.connect("http://google.com", 123);
+		assertThat(opt.asDetailedString())
+				.startsWith("connectAddress=http://google.com:123, proxy=SOCKS4(http://proxy:456)");
+	}
+
+	@Test
+	public void toStringContainsAsDetailedString() {
+		ClientOptions opt = ClientOptions.create()
+		                                         .connect("http://google.com", 123)
+		                                         .proxy(ClientOptions.Proxy.SOCKS4, "http://proxy", 456);
+		assertThat(opt.toString())
+				.startsWith("ClientOptions{connectAddress=http://google.com:123, proxy=SOCKS4(http://proxy:456)")
+				.endsWith("}");
+	}
+
+}

--- a/src/test/java/reactor/ipc/netty/tcp/TcpClientTests.java
+++ b/src/test/java/reactor/ipc/netty/tcp/TcpClientTests.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.netty.handler.codec.LineBasedFrameDecoder;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -374,6 +375,21 @@ public class TcpClientTests {
 		                         .block(Duration.ofSeconds(30)));
 
 		assertTrue("Latch didn't time out", latch.await(15, TimeUnit.SECONDS));
+	}
+
+	@Test
+	public void toStringShowsOptions() {
+		TcpClient client = TcpClient.create(opt -> opt.connect("foo", 123));
+
+		Assertions.assertThat(client.toString()).isEqualTo("TcpClient: connecting to foo:123");
+	}
+
+	@Test
+	public void gettingOptionsDuplicates() {
+		TcpClient client = TcpClient.create(opt -> opt.connect("foo", 123));
+		Assertions.assertThat(client.options())
+		          .isNotSameAs(client.options)
+		          .isNotSameAs(client.options());
 	}
 
 	private static final class EchoServer

--- a/src/test/java/reactor/ipc/netty/tcp/TcpServerTests.java
+++ b/src/test/java/reactor/ipc/netty/tcp/TcpServerTests.java
@@ -33,6 +33,7 @@ import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -347,6 +348,21 @@ public class TcpServerTests {
 		      .block(Duration.ofSeconds(30))
 		      .onClose()
 		      .block(Duration.ofSeconds(30));
+	}
+
+	@Test
+	public void toStringShowsOptions() {
+		TcpServer server = TcpServer.create(opt -> opt.listen("foo", 123));
+
+		Assertions.assertThat(server.toString()).isEqualTo("TcpServer: listening on foo:123");
+	}
+
+	@Test
+	public void gettingOptionsDuplicates() {
+		TcpServer server = TcpServer.create(opt -> opt.listen("foo", 123));
+		Assertions.assertThat(server.options())
+		          .isNotSameAs(server.options)
+		          .isNotSameAs(server.options());
 	}
 
 	public static class Pojo {


### PR DESCRIPTION
This is useful when the handler cannot be created, to get the original
configuration of the Client/Server object.

The toString() methods for Client/Servers and Options have been aligned,
and each option type has 2 additional String representations (one
detailed as used in toString, the other simplified, as used by the
client/server's toString).