### PR TITLE
fix #109 Make HttpClient SSL work on relative GET

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
@@ -360,8 +360,14 @@ public final class HttpClientOptions extends ClientOptions {
 
 	final String formatSchemeAndHost(String url, boolean ws) {
 		if (!url.startsWith(HttpClient.HTTP_SCHEME) && !url.startsWith(HttpClient.WS_SCHEME)) {
-			final String scheme =
-					(ws ? HttpClient.WS_SCHEME : HttpClient.HTTP_SCHEME) + "://";
+			StringBuilder schemeBuilder = new StringBuilder();
+			if (ws) {
+				schemeBuilder.append(isSecure() ? HttpClient.WSS_SCHEME : HttpClient.WS_SCHEME);
+			}
+			else {
+				schemeBuilder.append(isSecure() ? HttpClient.HTTPS_SCHEME : HttpClient.HTTP_SCHEME);
+			}
+			final String scheme = schemeBuilder.append("://").toString();
 			if (url.startsWith("/")) {
 				SocketAddress remote = getAddress();
 

--- a/src/main/java/reactor/ipc/netty/options/NettyOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/NettyOptions.java
@@ -168,6 +168,16 @@ public abstract class NettyOptions<BOOSTRAP extends AbstractBootstrap<BOOSTRAP, 
 	}
 
 	/**
+	 * Checks if these options denotes secured communication, ie. a {@link javax.net.ssl.SSLContext}
+	 * was set other than the default one.
+	 *
+	 * @return true if the options denote secured communication (SSL is active)
+	 */
+	public boolean isSecure() {
+		return sslContext != null;
+	}
+
+	/**
 	 * Provide an {@link EventLoopGroup} supplier.
 	 * Note that server might call it twice for both their selection and io loops.
 	 *

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
@@ -64,4 +64,107 @@ public class HttpClientOptionsTest {
 				.endsWith(", acceptGzip=true}");
 	}
 
+	@Test
+	public void formatSchemeAndHostRelative() throws Exception {
+		String test1 = HttpClientOptions.create()
+		                                .formatSchemeAndHost("/foo", false);
+		String test2 = HttpClientOptions.create()
+		                                .formatSchemeAndHost("/foo", true);
+
+		assertThat(test1).isEqualTo("http://localhost/foo");
+		assertThat(test2).isEqualTo("ws://localhost/foo");
+	}
+
+	@Test
+	public void formatSchemeAndHostRelativeSslSupport() throws Exception {
+		String test1 = HttpClientOptions.create()
+		                                .sslSupport()
+		                                .formatSchemeAndHost("/foo", false);
+		String test2 = HttpClientOptions.create()
+		                                .sslSupport()
+		                                .formatSchemeAndHost("/foo", true);
+
+		assertThat(test1).isEqualTo("https://localhost/foo");
+		assertThat(test2).isEqualTo("wss://localhost/foo");
+	}
+
+	@Test
+	public void formatSchemeAndHostRelativeNoLeadingSlash() throws Exception {
+		String test1 = HttpClientOptions.create()
+		                                .formatSchemeAndHost("foo:8080/bar", false);
+		String test2 = HttpClientOptions.create()
+		                                .formatSchemeAndHost("foo:8080/bar", true);
+
+		assertThat(test1).isEqualTo("http://foo:8080/bar");
+		assertThat(test2).isEqualTo("ws://foo:8080/bar");
+	}
+
+	@Test
+	public void formatSchemeAndHostRelativeAddress() throws Exception {
+		String test1 = HttpClientOptions.create()
+		                                .connect("127.0.0.1", 8080)
+		                                .formatSchemeAndHost("/foo", false);
+		String test2 = HttpClientOptions.create()
+		                                .connect("127.0.0.1", 8080)
+		                                .formatSchemeAndHost("/foo", true);
+
+		assertThat(test1).isEqualTo("http://127.0.0.1:8080/foo");
+		assertThat(test2).isEqualTo("ws://127.0.0.1:8080/foo");
+	}
+
+	@Test
+	public void formatSchemeAndHostRelativeAddressSsl() throws Exception {
+		String test1 = HttpClientOptions.create()
+		                                .connect("example", 8080)
+		                                .sslSupport()
+		                                .formatSchemeAndHost("/foo", false);
+		String test2 = HttpClientOptions.create()
+		                                .connect("example", 8080)
+		                                .sslSupport()
+		                                .formatSchemeAndHost("/foo", true);
+
+		assertThat(test1).isEqualTo("https://example:8080/foo");
+		assertThat(test2).isEqualTo("wss://example:8080/foo");
+	}
+
+	@Test
+	public void formatSchemeAndHostAbsoluteHttp() throws Exception {
+		String test1 = HttpClientOptions.create()
+		                                .formatSchemeAndHost("https://localhost/foo", false);
+		String test2 = HttpClientOptions.create()
+		                                .formatSchemeAndHost("http://localhost/foo", true);
+
+		String test3 = HttpClientOptions.create()
+		                                .sslSupport()
+		                                .formatSchemeAndHost("http://localhost/foo", false);
+		String test4 = HttpClientOptions.create()
+		                                .sslSupport()
+		                                .formatSchemeAndHost("https://localhost/foo", true);
+
+		assertThat(test1).isEqualTo("https://localhost/foo");
+		assertThat(test2).isEqualTo("http://localhost/foo");
+		assertThat(test3).isEqualTo("http://localhost/foo");
+		assertThat(test4).isEqualTo("https://localhost/foo");
+	}
+
+	@Test
+	public void formatSchemeAndHostAbsoluteWs() throws Exception {
+		String test1 = HttpClientOptions.create()
+		                                .formatSchemeAndHost("wss://localhost/foo", false);
+		String test2 = HttpClientOptions.create()
+		                                .formatSchemeAndHost("ws://localhost/foo", true);
+
+		String test3 = HttpClientOptions.create()
+		                                .sslSupport()
+		                                .formatSchemeAndHost("ws://localhost/foo", false);
+		String test4 = HttpClientOptions.create()
+		                                .sslSupport()
+		                                .formatSchemeAndHost("wss://localhost/foo", true);
+
+		assertThat(test1).isEqualTo("wss://localhost/foo");
+		assertThat(test2).isEqualTo("ws://localhost/foo");
+		assertThat(test3).isEqualTo("ws://localhost/foo");
+		assertThat(test4).isEqualTo("wss://localhost/foo");
+	}
+
 }


### PR DESCRIPTION
This commit fixes HttpClient not correctly working with SSL activated
when performing a request (eg. get) on a relative url/path.

This was due to HttpClientOptions.formatSchemeAndHostRelative not taking
the SslContext configuration into account when creating a full URL for
such a request, resulting in HTTP requests being performed on a HTTPS
connection.