### PR TITLE
issue #89: Update pendingResponses in the event for termination

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerHandler.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerHandler.java
@@ -158,10 +158,6 @@ final class HttpServerHandler extends ChannelDuplexHandler
 				}
 				promise.addListener(ChannelFutureListener.CLOSE);
 			}
-			else if(mustRecycleEncoder) {
-				mustRecycleEncoder = false;
-				pendingResponses -= 1;
-			}
 		}
 		ctx.write(msg, promise);
 	}


### PR DESCRIPTION
Problem: pendingResponses variable is decreased when
`r.i.n.h.server.HttpServerHandler#write` is invoked with `LastHttpContent`,
but the channel attributes are cleared in the event for termination
`r.i.n.channel.ChannelOperations#onHandlerTerminate`.
New request can be received after invocation of the write operation and
before event for termination.
`r.i.n.h.server.HttpServerHandler#channelRead`
In this situation instead of pipelining the new request the implementation
will check the channel attributes and as they are still not cleared the
request will not be processed.