### PR TITLE
fix #24 Allow shutdown of global TcpResources

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/HttpResources.java
+++ b/src/main/java/reactor/ipc/netty/http/HttpResources.java
@@ -64,11 +64,19 @@ public final class HttpResources extends TcpResources {
 	 * @return the global HTTP resources
 	 */
 	public static HttpResources reset() {
+		shutdown();
+		return getOrCreate(httpResources, null, null, ON_HTTP_NEW, "http");
+	}
+
+	/**
+	 * Shutdown the global {@link HttpResources} without resetting them,
+	 * effectively cleaning up associated resources without creating new ones.
+	 */
+	public static void shutdown() {
 		HttpResources resources = httpResources.getAndSet(null);
 		if (resources != null) {
 			resources._dispose();
 		}
-		return getOrCreate(httpResources, null, null, ON_HTTP_NEW, "http");
 	}
 
 	HttpResources(LoopResources loops, PoolResources pools) {

--- a/src/main/java/reactor/ipc/netty/tcp/TcpResources.java
+++ b/src/main/java/reactor/ipc/netty/tcp/TcpResources.java
@@ -72,11 +72,15 @@ public class TcpResources implements PoolResources, LoopResources {
 	 * @return the global HTTP resources
 	 */
 	public static TcpResources reset() {
+		shutdown();
+		return getOrCreate(tcpResources, null, null, ON_TCP_NEW, "tcp");
+	}
+
+	public static void shutdown() {
 		TcpResources resources = tcpResources.getAndSet(null);
 		if (resources != null) {
 			resources._dispose();
 		}
-		return getOrCreate(tcpResources, null, null, ON_TCP_NEW, "tcp");
 	}
 
 	final PoolResources defaultPools;
@@ -95,6 +99,7 @@ public class TcpResources implements PoolResources, LoopResources {
 	/**
 	 * Dispose underlying resources
 	 */
+	//TODO make public?
 	protected void _dispose(){
 		defaultPools.dispose();
 		defaultLoops.dispose();

--- a/src/main/java/reactor/ipc/netty/tcp/TcpResources.java
+++ b/src/main/java/reactor/ipc/netty/tcp/TcpResources.java
@@ -76,6 +76,10 @@ public class TcpResources implements PoolResources, LoopResources {
 		return getOrCreate(tcpResources, null, null, ON_TCP_NEW, "tcp");
 	}
 
+	/**
+	 * Shutdown the global {@link TcpResources} without resetting them,
+	 * effectively cleaning up associated resources without creating new ones.
+	 */
 	public static void shutdown() {
 		TcpResources resources = tcpResources.getAndSet(null);
 		if (resources != null) {


### PR DESCRIPTION
This commit allows to just shut down the currently set global
TcpResource without replacing it with a new one. It disposes underlying
resources, which helps in server shutdown scenarios.