### PR TITLE
fix #25 Allow listen until LoopResource/PoolResources disposal

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/HttpResources.java
+++ b/src/main/java/reactor/ipc/netty/http/HttpResources.java
@@ -19,6 +19,7 @@ package reactor.ipc.netty.http;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
+import reactor.core.publisher.Mono;
 import reactor.ipc.netty.resources.LoopResources;
 import reactor.ipc.netty.resources.PoolResources;
 import reactor.ipc.netty.tcp.TcpResources;
@@ -77,6 +78,21 @@ public final class HttpResources extends TcpResources {
 		if (resources != null) {
 			resources._dispose();
 		}
+	}
+
+	/**
+	 * Prepare to shutdown the global {@link TcpResources} without resetting them,
+	 * effectively cleaning up associated resources without creating new ones. This only
+	 * occurs when the returned {@link Mono} is subscribed to.
+	 *
+	 * @return a {@link Mono} triggering the {@link #shutdown()} when subscribed to.
+	 */
+	public static Mono<Void> shutdownDeferred() {
+		HttpResources resources = httpResources.getAndSet(null);
+		if (resources != null) {
+			return resources._disposeDeferred();
+		}
+		return Mono.empty();
 	}
 
 	HttpResources(LoopResources loops, PoolResources pools) {

--- a/src/main/java/reactor/ipc/netty/http/HttpResources.java
+++ b/src/main/java/reactor/ipc/netty/http/HttpResources.java
@@ -87,12 +87,14 @@ public final class HttpResources extends TcpResources {
 	 *
 	 * @return a {@link Mono} triggering the {@link #shutdown()} when subscribed to.
 	 */
-	public static Mono<Void> shutdownDeferred() {
-		HttpResources resources = httpResources.getAndSet(null);
-		if (resources != null) {
-			return resources._disposeDeferred();
-		}
-		return Mono.empty();
+	public static Mono<Void> shutdownLater() {
+		return Mono.defer(() -> {
+			HttpResources resources = httpResources.getAndSet(null);
+			if (resources != null) {
+				return resources._disposeLater();
+			}
+			return Mono.empty();
+		});
 	}
 
 	HttpResources(LoopResources loops, PoolResources pools) {

--- a/src/main/java/reactor/ipc/netty/resources/DefaultPoolResources.java
+++ b/src/main/java/reactor/ipc/netty/resources/DefaultPoolResources.java
@@ -32,6 +32,7 @@ import io.netty.channel.pool.ChannelPoolHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.PlatformDependent;
+import reactor.core.publisher.Mono;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
@@ -187,13 +188,22 @@ final class DefaultPoolResources implements PoolResources {
 
 	@Override
 	public void dispose() {
-		Pool pool;
-		for (SocketAddress key: channelPools.keySet()) {
-			pool = channelPools.remove(key);
-			if(pool != null){
-				pool.close();
+		disposeDeferred().subscribe();
+	}
+
+	@Override
+	public Mono<Void> disposeDeferred() {
+		return Mono.defer(() -> {
+
+			Pool pool;
+			for (SocketAddress key: channelPools.keySet()) {
+				pool = channelPools.remove(key);
+				if(pool != null){
+					pool.close();
+				}
 			}
-		}
+			return Mono.empty();
+		});
 	}
 
 	static final Logger log = Loggers.getLogger(DefaultPoolResources.class);

--- a/src/main/java/reactor/ipc/netty/resources/DefaultPoolResources.java
+++ b/src/main/java/reactor/ipc/netty/resources/DefaultPoolResources.java
@@ -193,7 +193,7 @@ final class DefaultPoolResources implements PoolResources {
 
 	@Override
 	public Mono<Void> disposeLater() {
-		return Mono.defer(() -> {
+		return Mono.fromRunnable(() -> {
 			Pool pool;
 			for (SocketAddress key: channelPools.keySet()) {
 				pool = channelPools.remove(key);
@@ -201,7 +201,6 @@ final class DefaultPoolResources implements PoolResources {
 					pool.close();
 				}
 			}
-			return Mono.empty();
 		});
 	}
 

--- a/src/main/java/reactor/ipc/netty/resources/DefaultPoolResources.java
+++ b/src/main/java/reactor/ipc/netty/resources/DefaultPoolResources.java
@@ -188,13 +188,12 @@ final class DefaultPoolResources implements PoolResources {
 
 	@Override
 	public void dispose() {
-		disposeDeferred().subscribe();
+		disposeLater().subscribe();
 	}
 
 	@Override
-	public Mono<Void> disposeDeferred() {
+	public Mono<Void> disposeLater() {
 		return Mono.defer(() -> {
-
 			Pool pool;
 			for (SocketAddress key: channelPools.keySet()) {
 				pool = channelPools.remove(key);
@@ -204,6 +203,13 @@ final class DefaultPoolResources implements PoolResources {
 			}
 			return Mono.empty();
 		});
+	}
+
+	@Override
+	public boolean isDisposed() {
+		return channelPools.isEmpty() || channelPools.values()
+		                                             .stream()
+		                                             .allMatch(AtomicBoolean::get);
 	}
 
 	static final Logger log = Loggers.getLogger(DefaultPoolResources.class);

--- a/src/main/java/reactor/ipc/netty/resources/LoopResources.java
+++ b/src/main/java/reactor/ipc/netty/resources/LoopResources.java
@@ -218,19 +218,15 @@ public interface LoopResources extends Disposable {
 	@Override
 	default void dispose() {
 		//noop default
-		disposeDeferred().subscribe();
+		disposeLater().subscribe();
 	}
 
 	/**
 	 * Returns a Mono that triggers the disposal of underlying resources when subscribed to.
-	 * Note that if the resources cleanup process was started in the meantime, the last
-	 * Mono subscribed will immediately terminate, even if the first one subscribed is
-	 * still finishing cleanup.
 	 *
-	 * @return a Mono representing the cleanup (first one to be subscribed represents the
-	 * actual cleanup, others terminate immediately).
+	 * @return a Mono representing the completion of resources disposal.
 	 **/
-	default Mono<Void> disposeDeferred() {
+	default Mono<Void> disposeLater() {
 		return Mono.empty(); //noop default
 	}
 }

--- a/src/main/java/reactor/ipc/netty/resources/LoopResources.java
+++ b/src/main/java/reactor/ipc/netty/resources/LoopResources.java
@@ -25,6 +25,7 @@ import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
 
 /**
  * An {@link EventLoopGroup} selector with associated
@@ -217,5 +218,19 @@ public interface LoopResources extends Disposable {
 	@Override
 	default void dispose() {
 		//noop default
+		disposeDeferred().subscribe();
+	}
+
+	/**
+	 * Returns a Mono that triggers the disposal of underlying resources when subscribed to.
+	 * Note that if the resources cleanup process was started in the meantime, the last
+	 * Mono subscribed will immediately terminate, even if the first one subscribed is
+	 * still finishing cleanup.
+	 *
+	 * @return a Mono representing the cleanup (first one to be subscribed represents the
+	 * actual cleanup, others terminate immediately).
+	 **/
+	default Mono<Void> disposeDeferred() {
+		return Mono.empty(); //noop default
 	}
 }

--- a/src/main/java/reactor/ipc/netty/resources/PoolResources.java
+++ b/src/main/java/reactor/ipc/netty/resources/PoolResources.java
@@ -27,6 +27,7 @@ import io.netty.channel.pool.ChannelPool;
 import io.netty.channel.pool.FixedChannelPool;
 import io.netty.channel.pool.SimpleChannelPool;
 import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
 
 /**
  * A {@link io.netty.channel.pool.ChannelPool} selector with associated factories.
@@ -160,5 +161,19 @@ public interface PoolResources extends Disposable {
 	@Override
 	default void dispose() {
 		//noop default
+		disposeDeferred().subscribe();
+	}
+
+	/**
+	 * Returns a Mono that triggers the disposal of underlying resources when subscribed to.
+	 * Note that if the resources cleanup process was started in the meantime, the last
+	 * Mono subscribed will immediately terminate, even if the first one subscribed is
+	 * still finishing cleanup.
+	 *
+	 * @return a Mono representing the cleanup (first one to be subscribed represents the
+	 * actual cleanup, others terminate immediately).
+	 **/
+	default Mono<Void> disposeDeferred() {
+		return Mono.empty(); //noop default
 	}
 }

--- a/src/main/java/reactor/ipc/netty/resources/PoolResources.java
+++ b/src/main/java/reactor/ipc/netty/resources/PoolResources.java
@@ -161,19 +161,15 @@ public interface PoolResources extends Disposable {
 	@Override
 	default void dispose() {
 		//noop default
-		disposeDeferred().subscribe();
+		disposeLater().subscribe();
 	}
 
 	/**
 	 * Returns a Mono that triggers the disposal of underlying resources when subscribed to.
-	 * Note that if the resources cleanup process was started in the meantime, the last
-	 * Mono subscribed will immediately terminate, even if the first one subscribed is
-	 * still finishing cleanup.
 	 *
-	 * @return a Mono representing the cleanup (first one to be subscribed represents the
-	 * actual cleanup, others terminate immediately).
+	 * @return a Mono representing the completion of resources disposal.
 	 **/
-	default Mono<Void> disposeDeferred() {
+	default Mono<Void> disposeLater() {
 		return Mono.empty(); //noop default
 	}
 }

--- a/src/test/java/reactor/ipc/netty/http/HttpResourcesTest.java
+++ b/src/test/java/reactor/ipc/netty/http/HttpResourcesTest.java
@@ -1,0 +1,109 @@
+package reactor.ipc.netty.http;
+
+import java.net.SocketAddress;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.pool.ChannelPool;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.ipc.netty.resources.LoopResources;
+import reactor.ipc.netty.resources.PoolResources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpResourcesTest {
+
+	private AtomicBoolean loopDisposed;
+	private AtomicBoolean poolDisposed;
+	private LoopResources loopResources;
+	private PoolResources poolResources;
+	private HttpResources testResources;
+
+	@Before
+	public void before() {
+		loopDisposed = new AtomicBoolean();
+		poolDisposed = new AtomicBoolean();
+
+		loopResources = new LoopResources() {
+			@Override
+			public EventLoopGroup onServer(boolean useNative) {
+				return null;
+			}
+
+			@Override
+			public Mono<Void> disposeLater() {
+				return Mono.<Void>empty().doOnSuccess(c -> loopDisposed.set(true));
+			}
+
+			@Override
+			public boolean isDisposed() {
+				return loopDisposed.get();
+			}
+		};
+
+		poolResources = new PoolResources() {
+			@Override
+			public ChannelPool selectOrCreate(SocketAddress address,
+					Supplier<? extends Bootstrap> bootstrap,
+					Consumer<? super Channel> onChannelCreate, EventLoopGroup group) {
+				return null;
+			}
+
+			public Mono<Void> disposeLater() {
+				return Mono.<Void>empty().doOnSuccess(c -> poolDisposed.set(true));
+			}
+
+			@Override
+			public boolean isDisposed() {
+				return poolDisposed.get();
+			}
+		};
+
+		testResources = new HttpResources(loopResources, poolResources);
+	}
+
+	@Test
+	public void disposeLaterDefers() {
+		assertThat(testResources.isDisposed()).isFalse();
+
+		testResources.disposeLater();
+		assertThat(testResources.isDisposed()).isFalse();
+
+		testResources.disposeLater()
+		             .doOnSuccess(c -> assertThat(testResources.isDisposed()).isTrue())
+		             .subscribe();
+		//not immediately disposed when subscribing
+		assertThat(testResources.isDisposed()).as("immediate status on disposeLater subscribe").isFalse();
+	}
+
+	@Test
+	public void shutdownLaterDefers() {
+		HttpResources oldHttpResources = HttpResources.httpResources.getAndSet(testResources);
+		HttpResources newHttpResources = HttpResources.httpResources.get();
+
+		try {
+			assertThat(newHttpResources).isSameAs(testResources);
+
+			HttpResources.shutdownLater();
+			assertThat(newHttpResources.isDisposed()).isFalse();
+
+			HttpResources.shutdownLater().block();
+			assertThat(newHttpResources.isDisposed()).as("shutdownLater completion").isTrue();
+
+			assertThat(HttpResources.httpResources.get()).isNull();
+		}
+		finally {
+			if (oldHttpResources != null && !HttpResources.httpResources.compareAndSet(null, oldHttpResources)) {
+				oldHttpResources.dispose();
+			}
+		}
+	}
+
+
+}

--- a/src/test/java/reactor/ipc/netty/http/HttpResourcesTest.java
+++ b/src/test/java/reactor/ipc/netty/http/HttpResourcesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package reactor.ipc.netty.http;
 
 import java.net.SocketAddress;

--- a/src/test/java/reactor/ipc/netty/resources/DefaultLoopResourcesTest.java
+++ b/src/test/java/reactor/ipc/netty/resources/DefaultLoopResourcesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package reactor.ipc.netty.resources;
 
 import java.time.Duration;

--- a/src/test/java/reactor/ipc/netty/resources/DefaultLoopResourcesTest.java
+++ b/src/test/java/reactor/ipc/netty/resources/DefaultLoopResourcesTest.java
@@ -1,0 +1,43 @@
+package reactor.ipc.netty.resources;
+
+import java.time.Duration;
+
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultLoopResourcesTest {
+
+	@Test
+	public void disposeLaterDefers() {
+		DefaultLoopResources loopResources = new DefaultLoopResources(
+				"test", 0, false);
+
+		Mono<Void> disposer = loopResources.disposeLater();
+		assertThat(loopResources.isDisposed()).isFalse();
+
+		disposer.subscribe();
+		assertThat(loopResources.isDisposed()).isTrue();
+	}
+
+	@Test
+	public void disposeLaterSubsequentIsQuick() {
+		DefaultLoopResources loopResources = new DefaultLoopResources(
+				"test", 0, false);
+
+		assertThat(loopResources.isDisposed()).isFalse();
+
+		Duration firstInvocation = StepVerifier.create(loopResources.disposeLater())
+		                                       .verifyComplete();
+		assertThat(loopResources.isDisposed()).isTrue();
+		assertThat(loopResources.serverLoops.isTerminated()).isTrue();
+
+		Duration secondInvocation = StepVerifier.create(loopResources.disposeLater())
+		                                        .verifyComplete();
+
+		assertThat(secondInvocation).isLessThan(firstInvocation);
+	}
+
+}

--- a/src/test/java/reactor/ipc/netty/resources/DefaultPoolResourcesTest.java
+++ b/src/test/java/reactor/ipc/netty/resources/DefaultPoolResourcesTest.java
@@ -1,0 +1,100 @@
+package reactor.ipc.netty.resources;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultPoolResourcesTest {
+
+	private AtomicInteger closed;
+	private ChannelPool channelPool;
+
+	@Before
+	public void before() {
+		closed = new AtomicInteger();
+		channelPool = new ChannelPool() {
+			@Override
+			public Future<Channel> acquire() {
+				return null;
+			}
+
+			@Override
+			public Future<Channel> acquire(Promise<Channel> promise) {
+				return null;
+			}
+
+			@Override
+			public Future<Void> release(Channel channel) {
+				return null;
+			}
+
+			@Override
+			public Future<Void> release(Channel channel, Promise<Void> promise) {
+				return null;
+			}
+
+			@Override
+			public void close() {
+				closed.incrementAndGet();
+			}
+		};
+	}
+
+	@Test
+	public void disposeLaterDefers() {
+		DefaultPoolResources.Pool pool = new DefaultPoolResources.Pool(
+				new Bootstrap(),
+				(b, handler, checker) -> channelPool,
+				null, new DefaultEventLoopGroup());
+
+		DefaultPoolResources poolResources = new DefaultPoolResources("test",
+				(b, handler, checker) -> channelPool);
+		//"register" our fake Pool
+		poolResources.channelPools.put(
+				InetSocketAddress.createUnresolved("localhost", 80),
+				pool);
+
+		Mono<Void> disposer = poolResources.disposeLater();
+		assertThat(closed.get()).as("pool closed by disposeLater()").isEqualTo(0);
+
+		disposer.subscribe();
+		assertThat(closed.get()).as("pool closed by disposer subscribe()").isEqualTo(1);
+	}
+
+	@Test
+	public void disposeOnlyOnce() {
+		DefaultPoolResources.Pool pool = new DefaultPoolResources.Pool(
+				new Bootstrap(),
+				(b, handler, checker) -> channelPool,
+				null, new DefaultEventLoopGroup());
+
+		DefaultPoolResources poolResources = new DefaultPoolResources("test",
+				(b, handler, checker) -> channelPool);
+		//"register" our fake Pool
+		poolResources.channelPools.put(
+				InetSocketAddress.createUnresolved("localhost", 80),
+				pool);
+
+		poolResources.dispose();
+		assertThat(closed.get()).as("pool closed by dispose()").isEqualTo(1);
+
+		Mono<Void> disposer = poolResources.disposeLater();
+		disposer.subscribe();
+		poolResources.disposeLater().subscribe();
+		poolResources.dispose();
+
+		assertThat(closed.get()).as("pool closed only once").isEqualTo(1);
+	}
+
+}

--- a/src/test/java/reactor/ipc/netty/resources/DefaultPoolResourcesTest.java
+++ b/src/test/java/reactor/ipc/netty/resources/DefaultPoolResourcesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package reactor.ipc.netty.resources;
 
 import java.net.InetSocketAddress;

--- a/src/test/java/reactor/ipc/netty/tcp/TcpResourcesTest.java
+++ b/src/test/java/reactor/ipc/netty/tcp/TcpResourcesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package reactor.ipc.netty.tcp;
 
 import java.net.SocketAddress;

--- a/src/test/java/reactor/ipc/netty/tcp/TcpResourcesTest.java
+++ b/src/test/java/reactor/ipc/netty/tcp/TcpResourcesTest.java
@@ -1,0 +1,108 @@
+package reactor.ipc.netty.tcp;
+
+import java.net.SocketAddress;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.pool.ChannelPool;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.ipc.netty.resources.LoopResources;
+import reactor.ipc.netty.resources.PoolResources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TcpResourcesTest {
+
+	private AtomicBoolean loopDisposed;
+	private AtomicBoolean poolDisposed;
+	private LoopResources loopResources;
+	private PoolResources poolResources;
+	private TcpResources tcpResources;
+
+	@Before
+	public void before() {
+		loopDisposed = new AtomicBoolean();
+		poolDisposed = new AtomicBoolean();
+
+		loopResources = new LoopResources() {
+			@Override
+			public EventLoopGroup onServer(boolean useNative) {
+				return null;
+			}
+
+			@Override
+			public Mono<Void> disposeLater() {
+				return Mono.<Void>empty().doOnSuccess(c -> loopDisposed.set(true));
+			}
+
+			@Override
+			public boolean isDisposed() {
+				return loopDisposed.get();
+			}
+		};
+
+		poolResources = new PoolResources() {
+			@Override
+			public ChannelPool selectOrCreate(SocketAddress address,
+					Supplier<? extends Bootstrap> bootstrap,
+					Consumer<? super Channel> onChannelCreate, EventLoopGroup group) {
+				return null;
+			}
+
+			public Mono<Void> disposeLater() {
+				return Mono.<Void>empty().doOnSuccess(c -> poolDisposed.set(true));
+			}
+
+			@Override
+			public boolean isDisposed() {
+				return poolDisposed.get();
+			}
+		};
+
+		tcpResources = new TcpResources(loopResources, poolResources);
+	}
+
+	@Test
+	public void disposeLaterDefers() {
+		assertThat(tcpResources.isDisposed()).isFalse();
+
+		tcpResources.disposeLater();
+		assertThat(tcpResources.isDisposed()).isFalse();
+
+		tcpResources.disposeLater()
+		            .doOnSuccess(c -> assertThat(tcpResources.isDisposed()).isTrue())
+		            .subscribe();
+		//not immediately disposed when subscribing
+		assertThat(tcpResources.isDisposed()).as("immediate status on disposeLater subscribe").isFalse();
+	}
+
+	@Test
+	public void shutdownLaterDefers() {
+		TcpResources oldTcpResources = TcpResources.tcpResources.getAndSet(tcpResources);
+		TcpResources newTcpResources = TcpResources.tcpResources.get();
+
+		try {
+			assertThat(newTcpResources).isSameAs(tcpResources);
+
+			TcpResources.shutdownLater();
+			assertThat(newTcpResources.isDisposed()).isFalse();
+
+			TcpResources.shutdownLater().block();
+			assertThat(newTcpResources.isDisposed()).as("shutdownLater completion").isTrue();
+
+			assertThat(TcpResources.tcpResources.get()).isNull();
+		}
+		finally {
+			if (oldTcpResources != null && !TcpResources.tcpResources.compareAndSet(null, oldTcpResources)) {
+				oldTcpResources.dispose();
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
This commit adds a disposeAndListen method to both LoopResources and
PoolResources that allow to dispose these but also get a notification of
when the disposal is done, in a best effort fashion.

Subsequent calls however are not guaranteed to return a relevant Mono,
which could complete sooner than the actual disposal as triggered by the
first invocation.