### PR TITLE
fix #125 Allow configuration of hosts that bypass the proxy

### DIFF
--- a/src/main/java/reactor/ipc/netty/channel/ClientContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ClientContextHandler.java
@@ -87,11 +87,11 @@ final class ClientContextHandler<CHANNEL extends Channel>
 	@Override
 	protected void doPipeline(Channel ch) {
 		addSslAndLogHandlers(clientOptions, this, loggingHandler, secure, getSNI(), ch.pipeline());
-		addProxyHandler(clientOptions, ch.pipeline());
+		addProxyHandler(clientOptions, ch.pipeline(), providedAddress);
 	}
 
-	static void addProxyHandler(ClientOptions clientOptions, ChannelPipeline pipeline) {
-		ProxyHandler proxy = clientOptions.useProxy() ? clientOptions.proxyOptions().getProxyHandler() : null;
+	static void addProxyHandler(ClientOptions clientOptions, ChannelPipeline pipeline, SocketAddress providedAddress) {
+		ProxyHandler proxy = clientOptions.useProxy(providedAddress) ? clientOptions.proxyOptions().getProxyHandler() : null;
 		if (proxy != null) {
 			pipeline.addFirst(NettyPipeline.ProxyHandler, proxy);
 			if(log.isDebugEnabled()){

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
@@ -73,7 +73,7 @@ public final class HttpClientOptions extends ClientOptions {
 	 * Return a new {@link InetSocketAddress} from the URI.
 	 * <p>
 	 * If the port is undefined (-1), a default port is used (80 or 443 depending on
-	 * whether the URI is secure or not). If {@link #useProxy() a proxy} is used, the
+	 * whether the URI is secure or not). If {@link #useProxy(String) a proxy} is used, the
 	 * returned address is provided unresolved.
 	 *
 	 * @param uri {@link URI} to extract host and port information from
@@ -83,7 +83,7 @@ public final class HttpClientOptions extends ClientOptions {
 		Objects.requireNonNull(uri, "uri");
 		boolean secure = isSecure(uri);
 		int port = uri.getPort() != -1 ? uri.getPort() : (secure ? 443 : 80);
-		return useProxy() ? InetSocketAddress.createUnresolved(uri.getHost(), port) :
+		return useProxy(uri.getHost()) ? InetSocketAddress.createUnresolved(uri.getHost(), port) :
 				new InetSocketAddress(uri.getHost(), port);
 	}
 
@@ -114,7 +114,7 @@ public final class HttpClientOptions extends ClientOptions {
 			if (url.startsWith("/")) {
 				SocketAddress remote = getAddress();
 
-				if (remote != null && !useProxy() && remote instanceof InetSocketAddress) {
+				if (remote != null && !useProxy(remote) && remote instanceof InetSocketAddress) {
 					InetSocketAddress inet = (InetSocketAddress) remote;
 
 					return scheme + inet.getHostName() + ":" + inet.getPort() + url;

--- a/src/main/java/reactor/ipc/netty/options/ClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/ClientOptions.java
@@ -151,12 +151,41 @@ public class ClientOptions extends NettyOptions<Bootstrap, ClientOptions> {
 	}
 
 	/**
-	 * Return true if proxy options have been set
+	 * Return true if proxy options have been set and the host is not
+	 * configured to bypass the proxy.
 	 *
-	 * @return true if proxy options have been set
+	 * @param address The address to which this client should connect.
+	 * @return true if proxy options have been set and the host is not
+	 * configured to bypass the proxy.
 	 */
-	public boolean useProxy() {
-		return this.proxyOptions != null;
+	public boolean useProxy(SocketAddress address) {
+		if (this.proxyOptions != null) { 
+			if (this.proxyOptions.nonProxyHosts() != null && 
+					address instanceof InetSocketAddress) {
+				String hostName = ((InetSocketAddress) address).getHostName();
+				return !this.proxyOptions.nonProxyHosts().matcher(hostName).matches();
+			}
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Return true if proxy options have been set and the host is not
+	 * configured to bypass the proxy.
+	 *
+	 * @param hostName The host name to which this client should connect.
+	 * @return true if proxy options have been set and the host is not
+	 * configured to bypass the proxy.
+	 */
+	public boolean useProxy(String hostName) {
+		if (this.proxyOptions != null) { 
+			if (this.proxyOptions.nonProxyHosts() != null && hostName != null) {
+				return !this.proxyOptions.nonProxyHosts().matcher(hostName).matches();
+			}
+			return true;
+		}
+		return false;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/reactor/ipc/netty/options/ClientProxyOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/ClientProxyOptions.java
@@ -20,6 +20,7 @@ import java.net.InetSocketAddress;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import io.netty.handler.proxy.HttpProxyHandler;
 import io.netty.handler.proxy.ProxyHandler;
@@ -45,6 +46,7 @@ public class ClientProxyOptions {
 	private final String username;
 	private final Function<? super String, ? extends String> password;
 	private final Supplier<? extends InetSocketAddress> address;
+	private final Pattern nonProxyHosts;
 	private final Proxy type;
 
 	private ClientProxyOptions(ClientProxyOptions.Builder builder) {
@@ -60,6 +62,12 @@ public class ClientProxyOptions {
 		}
 		else {
 			this.address = builder.address;
+		}
+		if (builder.nonProxyHosts != null) {
+			this.nonProxyHosts = Pattern.compile(builder.nonProxyHosts, Pattern.CASE_INSENSITIVE);
+		}
+		else {
+			this.nonProxyHosts = null;
 		}
 		this.type = builder.type;
 	}
@@ -80,6 +88,18 @@ public class ClientProxyOptions {
 	 */
 	public final Supplier<? extends InetSocketAddress> address() {
 		return this.address;
+	}
+
+	/**
+	 * Regular expression (<code>using java.util.regex</code>) for a configured
+	 * list of hosts that should be reached directly, bypassing the proxy.
+	 *
+	 * @return Regular expression (<code>using java.util.regex</code>) for
+	 * a configured list of hosts that should be reached directly, bypassing the
+	 * proxy.
+	 */
+	public final Pattern nonProxyHosts() {
+		return this.nonProxyHosts;
 	}
 
 	/**
@@ -127,6 +147,7 @@ public class ClientProxyOptions {
 
 	public String asDetailedString() {
 		return "address=" + (address() == null ? null : address().get()) +
+				", nonProxyHosts=" + nonProxyHosts() +
 				", type=" + type();
 	}
 
@@ -141,6 +162,7 @@ public class ClientProxyOptions {
 		private String host;
 		private int port;
 		private Supplier<? extends InetSocketAddress> address;
+		private String nonProxyHosts;
 		private Proxy type;
 
 		private Builder() {
@@ -213,6 +235,19 @@ public class ClientProxyOptions {
 		 */
 		public final Builder address(Supplier<? extends InetSocketAddress> addressSupplier) {
 			this.address = Objects.requireNonNull(addressSupplier, "addressSupplier");
+			return this;
+		}
+
+		/**
+		 * Regular expression (<code>using java.util.regex</code>) for a configured
+		 * list of hosts that should be reached directly, bypassing the proxy.
+		 *
+		 * @param nonProxyHostsPattern Regular expression (<code>using java.util.regex</code>)
+		 * for a configured list of hosts that should be reached directly, bypassing the proxy.
+		 * @return {@code this}
+		 */
+		public final Builder nonProxyHosts(String nonProxyHostsPattern) {
+			this.nonProxyHosts = nonProxyHostsPattern;
 			return this;
 		}
 

--- a/src/test/java/reactor/ipc/netty/channel/ClientContextHandlerTest.java
+++ b/src/test/java/reactor/ipc/netty/channel/ClientContextHandlerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.ipc.netty.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetSocketAddress;
+
+import org.junit.Test;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import reactor.ipc.netty.NettyPipeline;
+import reactor.ipc.netty.options.ClientOptions;
+import reactor.ipc.netty.options.ClientProxyOptions;
+import reactor.ipc.netty.options.ClientProxyOptions.Proxy;
+
+public class ClientContextHandlerTest {
+
+	@Test
+	public void addProxyHandler() {
+		ClientOptions.Builder<?> builder = ClientOptions.builder();
+		EmbeddedChannel channel = new EmbeddedChannel();
+
+		ClientContextHandler.addProxyHandler(builder.build(), channel.pipeline(),
+				new InetSocketAddress("localhost", 8080));
+		assertThat(channel.pipeline().get(NettyPipeline.ProxyHandler)).isNull();
+
+		builder.proxyOptions(ClientProxyOptions.builder()
+		                                       .type(Proxy.HTTP)
+		                                       .host("proxy")
+		                                       .port(8080).build());
+		ClientContextHandler.addProxyHandler(builder.build(), channel.pipeline(),
+				new InetSocketAddress("localhost", 8080));
+		assertThat(channel.pipeline().get(NettyPipeline.ProxyHandler)).isNull();
+	}
+}

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
@@ -271,8 +271,15 @@ public class HttpClientTest {
 				               .limitRate(1))
 				.reduce(String::concat);
 
-		page1.block(Duration.ofSeconds(30));
-		page2.block(Duration.ofSeconds(30));
+		StepVerifier.create(page1)
+		            .expectNextMatches(s -> s.contains("<title>Project Reactor</title>"))
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(30));
+
+		StepVerifier.create(page2)
+		            .expectNextMatches(s -> s.contains("<title>Spring</title>"))
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(30));
 	}
 
 	//@Test

--- a/src/test/java/reactor/ipc/netty/options/ClientOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/options/ClientOptionsTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.InetSocketAddress;
+
 public class ClientOptionsTest {
 	private ClientOptions.Builder<?> builder;
 	private ClientProxyOptions proxyOptions;
@@ -76,4 +78,29 @@ public class ClientOptionsTest {
 				.endsWith("}");
 	}
 
+	@Test
+	public void useProxy() {
+		ClientProxyOptions.Builder proxyBuilder = ClientProxyOptions.builder()
+		                                             .type(ClientProxyOptions.Proxy.SOCKS4)
+		                                             .host("http://proxy")
+		                                             .port(456);
+
+		ClientOptions.Builder<?> opsBuilder = ClientOptions.builder();
+
+		assertThat(opsBuilder.build().useProxy("hostName")).isFalse();
+		assertThat(opsBuilder.build().useProxy(new InetSocketAddress("google.com", 123))).isFalse();
+
+		opsBuilder.proxyOptions(proxyBuilder.build());
+		assertThat(opsBuilder.build().useProxy("hostName")).isTrue();
+		assertThat(opsBuilder.build().useProxy(new InetSocketAddress("google.com", 123))).isTrue();
+
+		proxyBuilder.nonProxyHosts("localhost");
+		opsBuilder.proxyOptions(proxyBuilder.build());
+		assertThat(opsBuilder.build().useProxy((String) null)).isTrue();
+		assertThat(opsBuilder.build().useProxy((InetSocketAddress) null)).isTrue();
+		assertThat(opsBuilder.build().useProxy("hostName")).isTrue();
+		assertThat(opsBuilder.build().useProxy(new InetSocketAddress("google.com", 123))).isTrue();
+		assertThat(opsBuilder.build().useProxy("localhost")).isFalse();
+		assertThat(opsBuilder.build().useProxy(new InetSocketAddress("localhost", 8080))).isFalse();
+	}
 }

--- a/src/test/java/reactor/ipc/netty/options/ClientOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/options/ClientOptionsTest.java
@@ -102,5 +102,6 @@ public class ClientOptionsTest {
 		assertThat(opsBuilder.build().useProxy(new InetSocketAddress("google.com", 123))).isTrue();
 		assertThat(opsBuilder.build().useProxy("localhost")).isFalse();
 		assertThat(opsBuilder.build().useProxy(new InetSocketAddress("localhost", 8080))).isFalse();
+		assertThat(opsBuilder.build().useProxy(new InetSocketAddress("127.0.0.1", 8080))).isFalse();
 	}
 }

--- a/src/test/java/reactor/ipc/netty/options/ClientProxyOptionsTests.java
+++ b/src/test/java/reactor/ipc/netty/options/ClientProxyOptionsTests.java
@@ -48,16 +48,24 @@ public class ClientProxyOptionsTests {
 	public void asDetailedString() {
 		ClientProxyOptions.Builder builder = ClientProxyOptions.builder();
 
-		assertThat(builder.build().asDetailedString()).isEqualTo("address=null, type=null");
+		assertThat(builder.build().asDetailedString())
+				.isEqualTo("address=null, nonProxyHosts=null, type=null");
 
 		builder.type(Proxy.HTTP);
-		assertThat(builder.build().asDetailedString()).isEqualTo("address=null, type=HTTP");
+		assertThat(builder.build().asDetailedString())
+				.isEqualTo("address=null, nonProxyHosts=null, type=HTTP");
 
 		builder.host("http://proxy").port(456);
-		assertThat(builder.build().asDetailedString()).isEqualTo("address=http://proxy:456, type=HTTP");
+		assertThat(builder.build().asDetailedString())
+				.isEqualTo("address=http://proxy:456, nonProxyHosts=null, type=HTTP");
 
 		builder.address(() -> new InetSocketAddress("http://another.proxy", 123));
-		assertThat(builder.build().asSimpleString()).isEqualTo("proxy=HTTP(http://another.proxy:123)");
+		assertThat(builder.build().asDetailedString())
+				.isEqualTo("address=http://another.proxy:123, nonProxyHosts=null, type=HTTP");
+
+		builder.nonProxyHosts("localhost");
+		assertThat(builder.build().asDetailedString())
+				.isEqualTo("address=http://another.proxy:123, nonProxyHosts=localhost, type=HTTP");
 	}
 
 	@Test
@@ -67,7 +75,8 @@ public class ClientProxyOptionsTests {
 		       .port(456)
 		       .type(Proxy.HTTP)
 		       .build();
-		assertThat(builder.build().toString()).isEqualTo("ClientProxyOptions{address=http://proxy:456, type=HTTP}");
+		assertThat(builder.build().toString()).isEqualTo(
+				"ClientProxyOptions{address=http://proxy:456, nonProxyHosts=null, type=HTTP}");
 	}
 
 	@Test


### PR DESCRIPTION
New configuration is added ClientProxyOptions.Builder.nonProxyHosts
that can be used to specify via regular expression
(using java.util.regex) the hosts that should bypass the proxy.