### PR TITLE
fix #126 Correctly use base hostname in HttpClientOptions even if proxy

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
@@ -102,18 +102,25 @@ public final class HttpClientOptions extends ClientOptions {
 			else {
 				schemeBuilder.append(isSecure() ? HttpClient.HTTPS_SCHEME : HttpClient.HTTP_SCHEME);
 			}
+
 			final String scheme = schemeBuilder.append("://").toString();
 			if (url.startsWith("/")) {
+				//consider relative URL, use the base hostname/port or fallback to localhost
 				SocketAddress remote = getAddress();
 
-				if (remote != null && remote instanceof InetSocketAddress) {
+				if (remote instanceof InetSocketAddress) {
 					InetSocketAddress inet = (InetSocketAddress) remote;
 
 					return scheme + inet.getHostName() + ":" + inet.getPort() + url;
 				}
-				return scheme + "localhost" + url;
+				else {
+					return scheme + "localhost" + url;
+				}
 			}
-			return scheme + url;
+			else {
+				//consider absolute URL
+				return scheme + url;
+			}
 		}
 		else {
 			return url;

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
@@ -106,7 +106,7 @@ public final class HttpClientOptions extends ClientOptions {
 			if (url.startsWith("/")) {
 				SocketAddress remote = getAddress();
 
-				if (remote != null && !useProxy(remote) && remote instanceof InetSocketAddress) {
+				if (remote != null && remote instanceof InetSocketAddress) {
 					InetSocketAddress inet = (InetSocketAddress) remote;
 
 					return scheme + inet.getHostName() + ":" + inet.getPort() + url;

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
@@ -157,6 +157,17 @@ public class HttpClientOptionsTest {
 	}
 
 	@Test
+	public void formatSchemeAndHostRelativeAndProxy() {
+		String test = this.builder.proxyOptions(proxyOptions)
+				.host("google.com")
+				.port(80)
+				.build()
+				.formatSchemeAndHost("/foo", false);
+
+		assertThat(test).isEqualTo("http://google.com:80/foo");
+	}
+
+	@Test
 	public void formatSchemeAndHostAbsoluteHttp() throws Exception {
 		String test1 = this.builder.build()
 		                           .formatSchemeAndHost("https://localhost/foo", false);

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
@@ -158,7 +158,7 @@ public class HttpClientOptionsTest {
 
 	@Test
 	public void formatSchemeAndHostRelativeAndProxy() {
-		String test = this.builder.proxyOptions(proxyOptions)
+		String test = this.builder.proxy(proxyOptions)
 				.host("google.com")
 				.port(80)
 				.build()


### PR DESCRIPTION
This commit fixes the HttpClientOptions to correctly derive relative
urls from the base url, even when a proxy is configured. It would
previously wrongly replace the hostname with `localhost`.