### PR TITLE
Adapt to CoreSubscriber & Context change in reactor-core

### DIFF
--- a/src/main/java/reactor/ipc/netty/ByteBufFlux.java
+++ b/src/main/java/reactor/ipc/netty/ByteBufFlux.java
@@ -19,7 +19,6 @@ package reactor.ipc.netty;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
@@ -30,11 +29,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufHolder;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
+import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxOperator;
 import reactor.core.publisher.Mono;
-import reactor.util.context.Context;
 
 /**
  * A decorating {@link Flux} {@link NettyInbound} with various {@link ByteBuf} related
@@ -239,8 +237,8 @@ public final class ByteBufFlux extends FluxOperator<ByteBuf, ByteBuf> {
 	}
 
 	@Override
-	public void subscribe(Subscriber<? super ByteBuf> s, Context ctx) {
-		source.subscribe(s, ctx);
+	public void subscribe(CoreSubscriber<? super ByteBuf> s) {
+		source.subscribe(s);
 	}
 
 	/**

--- a/src/main/java/reactor/ipc/netty/ByteBufMono.java
+++ b/src/main/java/reactor/ipc/netty/ByteBufMono.java
@@ -24,10 +24,9 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
-import org.reactivestreams.Subscriber;
+import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoOperator;
-import reactor.util.context.Context;
 
 /**
  * A decorating {@link Mono} {@link NettyInbound} with various {@link ByteBuf} related
@@ -99,8 +98,8 @@ public final class ByteBufMono extends MonoOperator<ByteBuf, ByteBuf> {
 	}
 
 	@Override
-	public void subscribe(Subscriber<? super ByteBuf> actual, Context context) {
-		source.subscribe(actual, context);
+	public void subscribe(CoreSubscriber<? super ByteBuf> actual) {
+		source.subscribe(actual);
 	}
 
 	protected ByteBufMono(Mono<?> source) {

--- a/src/main/java/reactor/ipc/netty/FutureMono.java
+++ b/src/main/java/reactor/ipc/netty/FutureMono.java
@@ -22,10 +22,9 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import reactor.core.Exceptions;
+import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
-import reactor.util.context.Context;
 
 /**
  * Convert Netty Future into void {@link Mono}.
@@ -76,7 +75,7 @@ public abstract class FutureMono extends Mono<Void> {
 		}
 
 		@Override
-		public final void subscribe(final Subscriber<? super Void> s, Context ctx) {
+		public final void subscribe(final CoreSubscriber<? super Void> s) {
 			if(future.isDone()){
 				if(future.isSuccess()){
 					Operators.complete(s);
@@ -103,7 +102,7 @@ public abstract class FutureMono extends Mono<Void> {
 		}
 
 		@Override
-		public void subscribe(Subscriber<? super Void> s, Context ctx) {
+		public void subscribe(CoreSubscriber<? super Void> s) {
 			F f = deferredFuture.get();
 
 			if (f == null) {

--- a/src/main/java/reactor/ipc/netty/channel/ChannelOperations.java
+++ b/src/main/java/reactor/ipc/netty/channel/ChannelOperations.java
@@ -29,8 +29,8 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -52,7 +52,7 @@ import reactor.util.Loggers;
  * @since 0.6
  */
 public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends NettyOutbound>
-		implements NettyInbound, NettyOutbound, NettyContext, Subscriber<Void> {
+		implements NettyInbound, NettyOutbound, NettyContext, CoreSubscriber<Void> {
 
 	/**
 	 * Create a new {@link ChannelOperations} attached to the {@link Channel} attribute

--- a/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
@@ -38,8 +38,8 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.FileRegion;
 import io.netty.util.ReferenceCountUtil;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Operators;
 import reactor.ipc.netty.NettyOutbound;
@@ -405,7 +405,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 	}
 
 	static final class PublisherSender
-			implements Subscriber<Object>, Subscription, ChannelFutureListener {
+			implements CoreSubscriber<Object>, Subscription, ChannelFutureListener {
 
 		final ChannelOperationsHandler parent;
 

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
@@ -57,7 +57,7 @@ import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
+import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -73,9 +73,6 @@ import reactor.ipc.netty.http.websocket.WebsocketInbound;
 import reactor.ipc.netty.http.websocket.WebsocketOutbound;
 import reactor.util.Logger;
 import reactor.util.Loggers;
-import reactor.util.context.Context;
-
-import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 
 /**
  * @author Stephane Maldini
@@ -736,20 +733,20 @@ class HttpClientOperations extends HttpOperations<HttpClientResponse, HttpClient
 		}
 
 		@Override
-		public void subscribe(Subscriber<? super Long> s, Context context) {
+		public void subscribe(CoreSubscriber<? super Long> s) {
 			if (parent.channel()
 			          .eventLoop()
 			          .inEventLoop()) {
-				_subscribe(s, context);
+				_subscribe(s);
 			}
 			else {
 				parent.channel()
 				      .eventLoop()
-				      .execute(() -> _subscribe(s, context));
+				      .execute(() -> _subscribe(s));
 			}
 		}
 
-		void _subscribe(Subscriber<? super Long> s, Context context) {
+		void _subscribe(CoreSubscriber<? super Long> s) {
 			if (!parent.markSentHeaders()) {
 				Operators.error(s,
 						new IllegalStateException("headers have already " + "been sent"));
@@ -805,7 +802,7 @@ class HttpClientOperations extends HttpOperations<HttpClientResponse, HttpClient
 					          .cast(Long.class)
 					          .switchIfEmpty(Mono.just(encoder.length()))
 					          .flux()
-					          .subscribe(s, context);
+					          .subscribe(s);
 				}
 
 

--- a/src/main/java/reactor/ipc/netty/http/client/MonoHttpClientResponse.java
+++ b/src/main/java/reactor/ipc/netty/http/client/MonoHttpClientResponse.java
@@ -29,13 +29,12 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AsciiString;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
+import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 import reactor.ipc.netty.NettyInbound;
 import reactor.ipc.netty.NettyOutbound;
 import reactor.ipc.netty.channel.AbortedException;
-import reactor.util.context.Context;
 
 /**
  * @author Stephane Maldini
@@ -67,8 +66,7 @@ final class MonoHttpClientResponse extends Mono<HttpClientResponse> {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void subscribe(final Subscriber<? super HttpClientResponse> subscriber,
-			Context ctx) {
+	public void subscribe(final CoreSubscriber<? super HttpClientResponse> subscriber) {
 		ReconnectableBridge bridge = new ReconnectableBridge();
 		bridge.activeURI = startURI;
 
@@ -78,7 +76,7 @@ final class MonoHttpClientResponse extends Mono<HttpClientResponse> {
 				bridge))
 		    .retry(bridge)
 		    .cast(HttpClientResponse.class)
-		    .subscribe(subscriber, ctx);
+		    .subscribe(subscriber);
 	}
 
 	static final class HttpClientHandler

--- a/src/main/java/reactor/ipc/netty/http/multipart/MultipartDecoder.java
+++ b/src/main/java/reactor/ipc/netty/http/multipart/MultipartDecoder.java
@@ -18,11 +18,10 @@ package reactor.ipc.netty.http.multipart;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import org.reactivestreams.Subscriber;
+import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxOperator;
 import reactor.ipc.netty.ByteBufFlux;
-import reactor.util.context.Context;
 
 /**
  * @author Ben Hale
@@ -39,8 +38,8 @@ final class MultipartDecoder extends FluxOperator<ByteBuf, ByteBufFlux> {
 	}
 
 	@Override
-	public void subscribe(Subscriber<? super ByteBufFlux> subscriber, Context ctx) {
+	public void subscribe(CoreSubscriber<? super ByteBufFlux> subscriber) {
 		this.source.subscribe(new MultipartTokenizer(this.boundary,
-				new MultipartParser(subscriber, alloc)), ctx);
+				new MultipartParser(subscriber, alloc)));
 	}
 }


### PR DESCRIPTION
This commit adapts to the CoreSubscriber change in core by replacing
`subscribe(Subscriber, Context)` methods by `subscribe(CoreSubscriber)`.