### PR TITLE
Simplify the creation of a proxy configuration

### DIFF
--- a/src/main/java/reactor/ipc/netty/channel/ClientContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ClientContextHandler.java
@@ -91,7 +91,7 @@ final class ClientContextHandler<CHANNEL extends Channel>
 	}
 
 	static void addProxyHandler(ClientOptions clientOptions, ChannelPipeline pipeline, SocketAddress providedAddress) {
-		ProxyHandler proxy = clientOptions.useProxy(providedAddress) ? clientOptions.proxyOptions().getProxyHandler() : null;
+		ProxyHandler proxy = clientOptions.useProxy(providedAddress) ? clientOptions.getProxyOptions().newProxyHandler() : null;
 		if (proxy != null) {
 			pipeline.addFirst(NettyPipeline.ProxyHandler, proxy);
 			if(log.isDebugEnabled()){

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
@@ -20,6 +20,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.handler.ssl.SslContext;
@@ -46,15 +47,6 @@ public final class HttpClientOptions extends ClientOptions {
 	@SuppressWarnings("unchecked")
 	public static HttpClientOptions.Builder builder() {
 		return new HttpClientOptions.Builder();
-	}
-
-	/**
-	 * Create a new ClientProxyOptions.Builder for an HTTP proxy
-	 *
-	 * @return a new ClientProxyOptions.Builder for an HTTP proxy
-	 */
-	public static ClientProxyOptions.Builder httpProxyBuilder() {
-		return ClientProxyOptions.builder().type(Proxy.HTTP);
 	}
 
 	private final boolean acceptGzip;
@@ -180,6 +172,17 @@ public final class HttpClientOptions extends ClientOptions {
 		 */
 		public final Builder compression(boolean enabled) {
 			this.acceptGzip = enabled;
+			return get();
+		}
+
+		/**
+		 * The HTTP proxy configuration
+		 *
+		 * @param proxyOptions the HTTP proxy configuration
+		 * @return {@code this}
+		 */
+		public final Builder httpProxy(Consumer<? super ClientProxyOptions.Builder> proxyOptions) {
+			super.proxy(proxyOptions.andThen(ops -> ((ClientProxyOptions.Builder) ops).type(Proxy.HTTP)));
 			return get();
 		}
 

--- a/src/main/java/reactor/ipc/netty/options/ClientProxyOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/ClientProxyOptions.java
@@ -77,7 +77,7 @@ public class ClientProxyOptions {
 	 *
 	 * @return The proxy type
 	 */
-	public final Proxy type() {
+	public final Proxy getType() {
 		return this.type;
 	}
 
@@ -86,7 +86,7 @@ public class ClientProxyOptions {
 	 *
 	 * @return The supplier for the address to connect to.
 	 */
-	public final Supplier<? extends InetSocketAddress> address() {
+	public final Supplier<? extends InetSocketAddress> getAddress() {
 		return this.address;
 	}
 
@@ -98,7 +98,7 @@ public class ClientProxyOptions {
 	 * a configured list of hosts that should be reached directly, bypassing the
 	 * proxy.
 	 */
-	public final Pattern nonProxyHosts() {
+	public final Pattern getNonProxyHosts() {
 		return this.nonProxyHosts;
 	}
 
@@ -107,7 +107,7 @@ public class ClientProxyOptions {
 	 *
 	 * @return a new eventual {@link ProxyHandler}
 	 */
-	public final ProxyHandler getProxyHandler() {
+	public final ProxyHandler newProxyHandler() {
 		if (Objects.isNull(this.type) || Objects.isNull(this.address)) {
 			return null;
 		}
@@ -141,14 +141,14 @@ public class ClientProxyOptions {
 
 
 	public String asSimpleString() {
-		return "proxy=" + type() +
-				"(" + (address() == null ? null : address().get()) + ")";
+		return "proxy=" + this.type +
+				"(" + (this.address == null ? null : this.address.get()) + ")";
 	}
 
 	public String asDetailedString() {
-		return "address=" + (address() == null ? null : address().get()) +
-				", nonProxyHosts=" + nonProxyHosts() +
-				", type=" + type();
+		return "address=" + (this.address == null ? null : this.address.get()) +
+				", nonProxyHosts=" + this.nonProxyHosts +
+				", type=" + this.type;
 	}
 
 	@Override

--- a/src/test/java/reactor/ipc/netty/channel/ClientContextHandlerTest.java
+++ b/src/test/java/reactor/ipc/netty/channel/ClientContextHandlerTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import io.netty.channel.embedded.EmbeddedChannel;
 import reactor.ipc.netty.NettyPipeline;
 import reactor.ipc.netty.options.ClientOptions;
-import reactor.ipc.netty.options.ClientProxyOptions;
 import reactor.ipc.netty.options.ClientProxyOptions.Proxy;
 
 public class ClientContextHandlerTest {
@@ -39,10 +38,9 @@ public class ClientContextHandlerTest {
 				new InetSocketAddress("localhost", 8080));
 		assertThat(channel.pipeline().get(NettyPipeline.ProxyHandler)).isNull();
 
-		builder.proxyOptions(ClientProxyOptions.builder()
-		                                       .type(Proxy.HTTP)
-		                                       .host("proxy")
-		                                       .port(8080).build());
+		builder.proxy(ops -> ops.type(Proxy.HTTP)
+		                        .host("proxy")
+		                        .port(8080));
 		ClientContextHandler.addProxyHandler(builder.build(), channel.pipeline(),
 				new InetSocketAddress("localhost", 8080));
 		assertThat(channel.pipeline().get(NettyPipeline.ProxyHandler)).isNull();

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
@@ -22,19 +22,18 @@ import reactor.ipc.netty.options.ClientProxyOptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.function.Consumer;
+
 public class HttpClientOptionsTest {
 	private HttpClientOptions.Builder builder;
-	private ClientProxyOptions proxyOptions;
+	private Consumer<? super ClientProxyOptions.Builder> proxyOptions;
 
 	@Before
 	public void setUp() {
 		this.builder = HttpClientOptions.builder();
-		this.proxyOptions =
-				ClientProxyOptions.builder()
-				                  .type(ClientProxyOptions.Proxy.SOCKS4)
-				                  .host("http://proxy")
-				                  .port(456)
-				                  .build();
+		this.proxyOptions = ops -> ops.type(ClientProxyOptions.Proxy.SOCKS4)
+		                              .host("http://proxy")
+		                              .port(456);
 	}
 
 	@Test
@@ -42,7 +41,7 @@ public class HttpClientOptionsTest {
 		assertThat(this.builder.build().asSimpleString()).isEqualTo("connecting to no base address");
 
 		//proxy
-		this.builder.proxyOptions(proxyOptions);
+		this.builder.proxy(proxyOptions);
 		assertThat(this.builder.build().asSimpleString()).isEqualTo("connecting to no base address through SOCKS4 proxy");
 
 		//address
@@ -61,7 +60,7 @@ public class HttpClientOptionsTest {
 				.endsWith(", acceptGzip=false");
 
 		//proxy
-		this.builder.proxyOptions(proxyOptions);
+		this.builder.proxy(proxyOptions);
 		assertThat(this.builder.build().asDetailedString())
 				.startsWith("connectAddress=null, proxy=SOCKS4(http://proxy:456)")
 				.endsWith(", acceptGzip=false");
@@ -83,7 +82,7 @@ public class HttpClientOptionsTest {
 	public void toStringContainsAsDetailedString() {
 		this.builder.host("http://google.com")
 		            .port(123)
-		            .proxyOptions(proxyOptions)
+		            .proxy(proxyOptions)
 		            .compression(true);
 		assertThat(this.builder.build().toString())
 				.startsWith("HttpClientOptions{connectAddress=http://google.com:123, proxy=SOCKS4(http://proxy:456)")

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
@@ -48,7 +48,6 @@ import reactor.ipc.netty.FutureMono;
 import reactor.ipc.netty.NettyContext;
 import reactor.ipc.netty.channel.AbortedException;
 import reactor.ipc.netty.http.server.HttpServer;
-import reactor.ipc.netty.options.ClientProxyOptions;
 import reactor.ipc.netty.options.ClientProxyOptions.Proxy;
 import reactor.ipc.netty.resources.PoolResources;
 import reactor.ipc.netty.tcp.TcpServer;
@@ -222,11 +221,9 @@ public class HttpClientTest {
 	@Test
 	@Ignore
 	public void proxy() throws Exception {
-		Mono<HttpClientResponse> remote = HttpClient.create(o -> o.proxyOptions(ClientProxyOptions.builder()
-		                                                                                          .type(Proxy.HTTP)
-		                                                                                          .host("127.0.0.1")
-		                                                                                          .port(8888)
-		                                                                                          .build()))
+		Mono<HttpClientResponse> remote = HttpClient.create(o -> o.proxy(ops -> ops.type(Proxy.HTTP)
+		                                                                           .host("127.0.0.1")
+		                                                                           .port(8888)))
 		          .get("https://projectreactor.io",
 				          c -> c.followRedirect()
 				                .sendHeaders());
@@ -244,12 +241,10 @@ public class HttpClientTest {
 	@Test
 	@Ignore
 	public void nonProxyHosts() throws Exception {
-		HttpClient client = HttpClient.create(o -> o.proxyOptions(ClientProxyOptions.builder()
-		                                                                            .type(Proxy.HTTP)
-		                                                                            .nonProxyHosts("spring.io")
-		                                                                            .host("127.0.0.1")
-		                                                                            .port(8888)
-		                                                                            .build()));
+		HttpClient client = HttpClient.create(o -> o.proxy(ops -> ops.type(Proxy.HTTP)
+		                                                             .nonProxyHosts("spring.io")
+		                                                             .host("127.0.0.1")
+		                                                             .port(8888)));
 		Mono<HttpClientResponse> remote1 = client.get("https://projectreactor.io",
 		                                                 c -> c.followRedirect()
 		                                                       .sendHeaders());

--- a/src/test/java/reactor/ipc/netty/options/ClientProxyOptionsTests.java
+++ b/src/test/java/reactor/ipc/netty/options/ClientProxyOptionsTests.java
@@ -82,14 +82,14 @@ public class ClientProxyOptionsTests {
 	@Test
 	public void getProxyHandlerTypeNotSpecified() {
 		ClientProxyOptions.Builder builder = ClientProxyOptions.builder();
-		assertThat(builder.build().getProxyHandler()).isNull();
+		assertThat(builder.build().newProxyHandler()).isNull();
 	}
 
 	@Test
 	public void getProxyHandlerAddressNotSpecified() {
 		ClientProxyOptions.Builder builder = ClientProxyOptions.builder();
 		builder.type(Proxy.HTTP);
-		assertThat(builder.build().getProxyHandler()).isNull();
+		assertThat(builder.build().newProxyHandler()).isNull();
 	}
 
 	@Test
@@ -99,15 +99,15 @@ public class ClientProxyOptionsTests {
 		       .port(456)
 		       .type(Proxy.HTTP);
 
-		assertThat(builder.build().getProxyHandler()).isInstanceOf(HttpProxyHandler.class);
-		assertThat(builder.build().getProxyHandler().proxyAddress().toString()).isEqualTo("http://proxy:456");
+		assertThat(builder.build().newProxyHandler()).isInstanceOf(HttpProxyHandler.class);
+		assertThat(builder.build().newProxyHandler().proxyAddress().toString()).isEqualTo("http://proxy:456");
 
 		builder.username("test1");
-		assertThat(((HttpProxyHandler) builder.build().getProxyHandler()).username()).isNull();
+		assertThat(((HttpProxyHandler) builder.build().newProxyHandler()).username()).isNull();
 
 		builder.password(name -> "test2");
-		assertThat(((HttpProxyHandler) builder.build().getProxyHandler()).username()).isEqualTo("test1");
-		assertThat(((HttpProxyHandler) builder.build().getProxyHandler()).password()).isEqualTo("test2");
+		assertThat(((HttpProxyHandler) builder.build().newProxyHandler()).username()).isEqualTo("test1");
+		assertThat(((HttpProxyHandler) builder.build().newProxyHandler()).password()).isEqualTo("test2");
 	}
 
 	@Test
@@ -117,11 +117,11 @@ public class ClientProxyOptionsTests {
 		       .port(456)
 		       .type(Proxy.SOCKS4);
 
-		assertThat(builder.build().getProxyHandler()).isInstanceOf(Socks4ProxyHandler.class);
-		assertThat(builder.build().getProxyHandler().proxyAddress().toString()).isEqualTo("http://proxy:456");
+		assertThat(builder.build().newProxyHandler()).isInstanceOf(Socks4ProxyHandler.class);
+		assertThat(builder.build().newProxyHandler().proxyAddress().toString()).isEqualTo("http://proxy:456");
 
 		builder.username("test1");
-		assertThat(((Socks4ProxyHandler) builder.build().getProxyHandler()).username()).isEqualTo("test1");
+		assertThat(((Socks4ProxyHandler) builder.build().newProxyHandler()).username()).isEqualTo("test1");
 	}
 
 	@Test
@@ -131,14 +131,14 @@ public class ClientProxyOptionsTests {
 		       .port(456)
 		       .type(Proxy.SOCKS5);
 
-		assertThat(builder.build().getProxyHandler()).isInstanceOf(Socks5ProxyHandler.class);
-		assertThat(builder.build().getProxyHandler().proxyAddress().toString()).isEqualTo("http://proxy:456");
+		assertThat(builder.build().newProxyHandler()).isInstanceOf(Socks5ProxyHandler.class);
+		assertThat(builder.build().newProxyHandler().proxyAddress().toString()).isEqualTo("http://proxy:456");
 
 		builder.username("test1");
-		assertThat(((Socks5ProxyHandler) builder.build().getProxyHandler()).username()).isNull();
+		assertThat(((Socks5ProxyHandler) builder.build().newProxyHandler()).username()).isNull();
 
 		builder.password(name -> "test2");
-		assertThat(((Socks5ProxyHandler) builder.build().getProxyHandler()).username()).isEqualTo("test1");
-		assertThat(((Socks5ProxyHandler) builder.build().getProxyHandler()).password()).isEqualTo("test2");
+		assertThat(((Socks5ProxyHandler) builder.build().newProxyHandler()).username()).isEqualTo("test1");
+		assertThat(((Socks5ProxyHandler) builder.build().newProxyHandler()).password()).isEqualTo("test2");
 	}
 }


### PR DESCRIPTION
Replace `proxyOptions(ClientProxyOptions)` with `proxy(Consumer<? super ClientProxyOptions.Builder>)` 

Thus instead of this:
```
...proxyOptions(ClientProxyOptions.builder()
                                  .host()
                                  ...
                                  .build())
```

one can configure the proxy with:
```
...proxy(ops -> ops.host(...).port(...))
```