### PR TITLE
Ensure accept gzip is applied when there is no handler provided

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
@@ -422,13 +422,15 @@ public class HttpClient implements NettyConnector<HttpClientResponse, HttpClient
 
 	static Function<? super HttpClientRequest, ? extends Publisher<Void>> handler(Function<? super HttpClientRequest, ? extends Publisher<Void>> h,
 			HttpClientOptions opts) {
-		if (h == null) {
-			return null;
-		}
-
 		if (opts.acceptGzip()) {
-			return req -> h.apply(req.header(HttpHeaderNames.ACCEPT_ENCODING,
-					HttpHeaderValues.GZIP));
+			if (h != null) {
+				return req -> h.apply(req.header(HttpHeaderNames.ACCEPT_ENCODING,
+						HttpHeaderValues.GZIP));
+			}
+			else {
+				return req -> req.header(HttpHeaderNames.ACCEPT_ENCODING,
+						HttpHeaderValues.GZIP);
+			}
 		}
 		else {
 			return h;

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
@@ -505,6 +505,32 @@ public class HttpClientTest {
 	}
 
 	@Test
+	public void gzipEnabled() {
+		doTestGzip(true);
+	}
+
+	@Test
+	public void gzipDisabled() {
+		doTestGzip(false);
+	}
+
+	private void doTestGzip(boolean gzipEnabled) {
+		String expectedResponse = gzipEnabled ? "gzip" : "no gzip";
+		NettyContext server = HttpServer.create(0)
+		          .newHandler((req,res) -> res.sendString(
+		                  Mono.just(req.requestHeaders().get(HttpHeaderNames.ACCEPT_ENCODING, "no gzip"))))
+		          .block(Duration.ofSeconds(30));
+		StepVerifier.create(
+		        HttpClient.create(ops -> ops.port(server.address().getPort()).compression(gzipEnabled))
+		                  .get("/")
+		                  .flatMap(r -> r.receive().asString().elementAt(0))
+		        )
+		            .expectNextMatches(str -> expectedResponse.equals(str))
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(30));
+	}
+
+	@Test
 	public void testUserAgent() {
 		NettyContext c = HttpServer.create(0)
 		                           .newHandler((req, resp) -> {


### PR DESCRIPTION
Ensure that accept gzip configuration is applied when the
HttpClient request is made without a handler