### PR TITLE
fix #80 Add NettyContext config callback, rework Channel config options

### DIFF
--- a/src/main/java/reactor/ipc/netty/channel/ContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ContextHandler.java
@@ -29,7 +29,6 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.pool.ChannelPool;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import org.reactivestreams.Publisher;
 import reactor.core.Disposable;
@@ -231,11 +230,19 @@ public abstract class ContextHandler<CHANNEL extends Channel>
 					return null;
 				}
 
+				if (this.options.afterNettyContextInit() != null) {
+					try {
+						this.options.afterNettyContextInit().accept(op.context());
+					}
+					catch (Throwable t) {
+						log.error("Could not apply afterNettyContextInit callback {}", t.toString());
+					}
+				}
+
 				channel.pipeline()
 				       .get(ChannelOperationsHandler.class).lastContext = this;
 
-				channel.eventLoop()
-				       .execute(op::onHandlerStart);
+				channel.eventLoop().execute(op::onHandlerStart);
 			}
 			return op;
 		}

--- a/src/test/java/reactor/ipc/netty/options/NettyOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/options/NettyOptionsTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.ipc.netty.options;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.ipc.netty.NettyContext;
+import reactor.ipc.netty.http.client.HttpClient;
+import reactor.ipc.netty.http.client.HttpClientResponse;
+import reactor.ipc.netty.http.server.HttpServer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NettyOptionsTest {
+
+	@Test
+	public void afterChannelInit() {
+		List<Channel> initializedChannels = new ArrayList<>();
+
+		NettyContext nettyContext =
+				HttpServer.create(opt -> opt.afterChannelInit(initializedChannels::add))
+				          .start((req, resp) -> resp.sendNotFound())
+				          .getContext();
+
+		assertThat(initializedChannels).hasSize(0);
+
+		Mono.when(
+				HttpClient.create(nettyContext.address().getPort())
+				          .get("/", req -> req.failOnClientError(false).send()),
+				HttpClient.create(nettyContext.address().getPort())
+				          .get("/", req -> req.failOnClientError(false).send()))
+		    .block();
+
+		assertThat(initializedChannels)
+				.hasSize(2)
+				.doesNotContain(nettyContext.channel());
+	}
+
+	@Test
+	public void afterChannelInitThenChannelGroup() {
+		ChannelGroup group = new DefaultChannelGroup(null);
+		List<Channel> initializedChannels = new ArrayList<>();
+
+		NettyContext nettyContext =
+				HttpServer.create(opt -> opt
+						.afterChannelInit(initializedChannels::add)
+						.channelGroup(group)
+				)
+				          .start((req, resp) -> resp.sendNotFound())
+				          .getContext();
+
+		Mono.when(
+				HttpClient.create(nettyContext.address().getPort())
+				          .get("/", req -> req.failOnClientError(false).send())
+				,
+				HttpClient.create(nettyContext.address().getPort())
+				          .get("/", req -> req.failOnClientError(false).send())
+		)
+		    .block();
+
+		assertThat(initializedChannels).hasSize(2);
+		assertThat((Iterable<Channel>) group)
+				.hasSameElementsAs(initializedChannels)
+				.doesNotContain(nettyContext.channel());
+	}
+
+	@Test
+	public void afterChannelInitAfterChannelGroup() {
+		//this test only differs from afterChannelInitThenChannelGroup in the order of the options
+		ChannelGroup group = new DefaultChannelGroup(null);
+		List<Channel> initializedChannels = new ArrayList<>();
+
+		NettyContext nettyContext =
+				HttpServer.create(opt -> opt
+						.channelGroup(group)
+						.afterChannelInit(initializedChannels::add)
+				)
+				          .start((req, resp) -> resp.sendNotFound())
+				          .getContext();
+
+		Mono.when(
+				HttpClient.create(nettyContext.address().getPort())
+				          .get("/", req -> req.failOnClientError(false).send())
+				,
+				HttpClient.create(nettyContext.address().getPort())
+				          .get("/", req -> req.failOnClientError(false).send())
+		)
+		    .block();
+
+		assertThat(initializedChannels).hasSize(2);
+		assertThat((Iterable<Channel>) group)
+				.hasSameElementsAs(initializedChannels)
+				.doesNotContain(nettyContext.channel());
+	}
+
+	@Test
+	public void channelIsAddedToChannelGroup() {
+		//create a ChannelGroup that never removes disconnected channels
+		ChannelGroup group = new DefaultChannelGroup(null) {
+			@Override
+			public boolean remove(Object o) {
+				System.err.println("removed " + o);
+				return false;
+			}
+		};
+
+		NettyContext nettyContext =
+				HttpServer.create(opt -> opt.channelGroup(group))
+				          .start((req, resp) -> resp.sendNotFound())
+				          .getContext();
+
+		Mono.when(
+				HttpClient.create(nettyContext.address().getPort())
+				          .get("/", req -> req.failOnClientError(false).send()),
+				HttpClient.create(nettyContext.address().getPort())
+				          .get("/", req -> req.failOnClientError(false).send()))
+		    .block();
+
+		assertThat((Iterable<Channel>) group)
+				//the main NettyContext channel is not impacted by pipeline options
+				.doesNotContain(nettyContext.channel())
+				//both GET triggered a Channel added to the group
+				.hasSize(2);
+	}
+
+	@Test
+	public void afterNettyContextInit() {
+		AtomicInteger readCount = new AtomicInteger();
+		ChannelInboundHandlerAdapter handler = new ChannelInboundHandlerAdapter() {
+			@Override
+			public void channelRead(ChannelHandlerContext ctx, Object msg)
+					throws Exception {
+				readCount.incrementAndGet();
+				super.channelRead(ctx, msg);
+			}
+		};
+		String handlerName = "test";
+
+		NettyContext nettyContext =
+				HttpServer.create(opt -> opt.afterNettyContextInit(c -> c.addHandlerFirst(handlerName, handler)))
+				          .start((req, resp) -> resp.sendNotFound())
+				          .getContext();
+
+		HttpClientResponse response1 = HttpClient.create(nettyContext.address().getPort())
+		                                         .get("/", req -> req.failOnClientError(false).send())
+		                                         .block();
+
+		assertThat(response1.status().code()).isEqualTo(404);
+
+		//the "main" context doesn't get enriched with handlers from options...
+		assertThat(nettyContext.channel().pipeline().names()).doesNotContain(handlerName);
+		//...but the child channels that are created for requests are
+		assertThat(readCount.get()).isEqualTo(1);
+
+		HttpClientResponse response2 = HttpClient.create(nettyContext.address().getPort())
+		                                         .get("/", req -> req.failOnClientError(false).send())
+		                                         .block();
+
+		assertThat(response2.status().code()).isEqualTo(404); //reactor handler was applied and produced a response
+		assertThat(readCount.get()).isEqualTo(1); //BUT channelHandler wasn't applied a second time since not Shareable
+	}
+
+}

--- a/src/test/java/reactor/ipc/netty/options/NettyOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/options/NettyOptionsTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class NettyOptionsTest {
 
 	@Test
-	public void afterChannelInit() {
+	public void afterChannelInit() throws InterruptedException {
 		List<Channel> initializedChannels = new ArrayList<>();
 
 		NettyContext nettyContext =
@@ -46,15 +46,12 @@ public class NettyOptionsTest {
 
 		assertThat(initializedChannels).hasSize(0);
 
-		Mono.when(
-				HttpClient.create(nettyContext.address().getPort())
-				          .get("/", req -> req.failOnClientError(false).send()),
-				HttpClient.create(nettyContext.address().getPort())
-				          .get("/", req -> req.failOnClientError(false).send()))
-		    .block();
+		HttpClient.create(nettyContext.address().getPort())
+		          .get("/", req -> req.failOnClientError(false).send())
+		          .block();
 
 		assertThat(initializedChannels)
-				.hasSize(2)
+				.hasSize(1)
 				.doesNotContain(nettyContext.channel());
 	}
 
@@ -71,17 +68,12 @@ public class NettyOptionsTest {
 				          .start((req, resp) -> resp.sendNotFound())
 				          .getContext();
 
-		Mono.when(
-				HttpClient.create(nettyContext.address().getPort())
-				          .get("/", req -> req.failOnClientError(false).send())
-				,
-				HttpClient.create(nettyContext.address().getPort())
-				          .get("/", req -> req.failOnClientError(false).send())
-		)
-		    .block();
+		HttpClient.create(nettyContext.address().getPort())
+		          .get("/", req -> req.failOnClientError(false).send())
+		          .block();
 
-		assertThat(initializedChannels).hasSize(2);
 		assertThat((Iterable<Channel>) group)
+				.hasSize(1)
 				.hasSameElementsAs(initializedChannels)
 				.doesNotContain(nettyContext.channel());
 	}
@@ -100,17 +92,12 @@ public class NettyOptionsTest {
 				          .start((req, resp) -> resp.sendNotFound())
 				          .getContext();
 
-		Mono.when(
-				HttpClient.create(nettyContext.address().getPort())
-				          .get("/", req -> req.failOnClientError(false).send())
-				,
-				HttpClient.create(nettyContext.address().getPort())
-				          .get("/", req -> req.failOnClientError(false).send())
-		)
-		    .block();
+		HttpClient.create(nettyContext.address().getPort())
+		          .get("/", req -> req.failOnClientError(false).send())
+		          .block();
 
-		assertThat(initializedChannels).hasSize(2);
 		assertThat((Iterable<Channel>) group)
+				.hasSize(1)
 				.hasSameElementsAs(initializedChannels)
 				.doesNotContain(nettyContext.channel());
 	}
@@ -131,18 +118,15 @@ public class NettyOptionsTest {
 				          .start((req, resp) -> resp.sendNotFound())
 				          .getContext();
 
-		Mono.when(
-				HttpClient.create(nettyContext.address().getPort())
-				          .get("/", req -> req.failOnClientError(false).send()),
-				HttpClient.create(nettyContext.address().getPort())
-				          .get("/", req -> req.failOnClientError(false).send()))
-		    .block();
+		HttpClient.create(nettyContext.address().getPort())
+		          .get("/", req -> req.failOnClientError(false).send())
+		          .block();
 
 		assertThat((Iterable<Channel>) group)
 				//the main NettyContext channel is not impacted by pipeline options
 				.doesNotContain(nettyContext.channel())
-				//both GET triggered a Channel added to the group
-				.hasSize(2);
+				//the GET triggered a Channel added to the group
+				.hasSize(1);
 	}
 
 	@Test


### PR DESCRIPTION
This commit adds a configuration callback to NettyOptions that deals
with newly initialized NettyContexts rather than just with the Channel.
This allows to get access to the handler management API for easier
insertion of handlers in the pipelines that have reactor-netty handlers.

Additionally, this commit does a bit of rework and cleanup around other
options that deal with pipeline configuration, notably afterChannelInit,
onChannelInit and channelGroup.