### PR TITLE
Fix #134: Handle pending writes when outbound completion is reached

### DIFF
--- a/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
@@ -81,7 +81,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 	@SuppressWarnings("unchecked")
 	ChannelOperationsHandler(ContextHandler<?> contextHandler) {
 		this.inner = new PublisherSender(this);
-		this.prefetch = 32;
+		this.prefetch = 1;
 		this.encoder = NOOP_ENCODER;
 		this.lastContext = null;
 		this.originContext = contextHandler; // only set if parent context is closable,

--- a/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
@@ -378,7 +378,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 
 				v = pendingWrites.poll();
 
-				if (!innerActive && v instanceof PendingWritesOnCompletion) {
+				if (!innerActive && v == PublisherSender.PENDING_WRITES) {
 					boolean last = pendingWrites.isEmpty();
 					if (!future.isDone() && hasPendingWriteBytes()) {
 						ctx.flush();

--- a/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
@@ -487,7 +487,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 
 			if (f != null) {
 				if (!f.isDone() && parent.hasPendingWriteBytes()) {
-					parent.pendingWriteOffer.test(f, new PendingWritesOnCompletion());
+					parent.pendingWriteOffer.test(f, PENDING_WRITES);
 				}
 				f.addListener(this);
 			}
@@ -519,7 +519,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 
 			if (f != null) {
 				if (!f.isDone() && parent.hasPendingWriteBytes()) {
-					parent.pendingWriteOffer.test(f, new PendingWritesOnCompletion());
+					parent.pendingWriteOffer.test(f, PENDING_WRITES);
 				}
 				f.addListener(this);
 			}
@@ -748,6 +748,8 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 		@SuppressWarnings("rawtypes")
 		static final AtomicIntegerFieldUpdater<PublisherSender> WIP                 =
 				AtomicIntegerFieldUpdater.newUpdater(PublisherSender.class, "wip");
+
+		private static final PendingWritesOnCompletion PENDING_WRITES = new PendingWritesOnCompletion();
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/src/test/java/reactor/ipc/netty/channel/ChannelOperationsHandlerTest.java
+++ b/src/test/java/reactor/ipc/netty/channel/ChannelOperationsHandlerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.ipc.netty.channel;
+
+import java.time.Duration;
+
+import org.junit.Test;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.ipc.netty.NettyContext;
+import reactor.ipc.netty.http.client.HttpClient;
+import reactor.ipc.netty.http.client.HttpClientResponse;
+import reactor.ipc.netty.http.server.HttpServer;
+import reactor.test.StepVerifier;
+
+public class ChannelOperationsHandlerTest {
+
+	@Test
+	public void publisherSenderOnCompleteFlushInProgress() {
+		NettyContext server =
+				HttpServer.create(0)
+				          .newHandler((req, res) ->
+				                  req.receive()
+				                     .asString()
+				                     .doOnNext(System.err::println)
+				                     .then(res.status(200).sendHeaders().then()))
+				          .block(Duration.ofSeconds(30));
+
+		Flux<String> flux = Flux.range(1, 257).map(count -> count + "");
+		Mono<HttpClientResponse> client =
+				HttpClient.create(server.address().getPort())
+				          .post("/", req -> req.sendString(flux));
+
+		StepVerifier.create(client)
+		            .expectNextMatches(res -> res.status().code() == 200)
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(30));
+	}
+}

--- a/src/test/java/reactor/ipc/netty/channel/ChannelOperationsHandlerTest.java
+++ b/src/test/java/reactor/ipc/netty/channel/ChannelOperationsHandlerTest.java
@@ -64,12 +64,12 @@ public class ChannelOperationsHandlerTest {
 		channel.config().setWriteBufferLowWaterMark(1024)
 		                .setWriteBufferHighWaterMark(1024);
 
-		assertThat(handler.prefetch == (handler.inner.requested - handler.inner.produced));
+		assertThat(handler.prefetch == (handler.inner.requested - handler.inner.produced)).isTrue();
 
 		StepVerifier.create(FutureMono.deferFuture(() -> channel.writeAndFlush(Flux.range(0, 70))))
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(30));
 
-		assertThat(handler.prefetch == (handler.inner.requested - handler.inner.produced));
+		assertThat(handler.prefetch == (handler.inner.requested - handler.inner.produced)).isTrue();
 	}
 }

--- a/src/test/java/reactor/ipc/netty/channel/ChannelOperationsHandlerTest.java
+++ b/src/test/java/reactor/ipc/netty/channel/ChannelOperationsHandlerTest.java
@@ -57,12 +57,21 @@ public class ChannelOperationsHandlerTest {
 	}
 
 	@Test
-	public void keepPrefetchSizeConstant() {
+	public void keepPrefetchSizeConstantEqualsWriteBufferLowHighWaterMark() {
+		doTestPrefetchSize(1024, 1024);
+	}
+
+	@Test
+	public void keepPrefetchSizeConstantDifferentWriteBufferLowHighWaterMark() {
+		doTestPrefetchSize(0, 1024);
+	}
+
+	private void doTestPrefetchSize(int writeBufferLowWaterMark, int writeBufferHighWaterMark) {
 		ChannelOperationsHandler handler = new ChannelOperationsHandler(null);
 
 		EmbeddedChannel channel = new EmbeddedChannel(handler);
-		channel.config().setWriteBufferLowWaterMark(1024)
-		                .setWriteBufferHighWaterMark(1024);
+		channel.config().setWriteBufferLowWaterMark(writeBufferLowWaterMark)
+		                .setWriteBufferHighWaterMark(writeBufferHighWaterMark);
 
 		assertThat(handler.prefetch == (handler.inner.requested - handler.inner.produced)).isTrue();
 


### PR DESCRIPTION
In some use cases it may appear that the last flush operation that
is performed by PublisherSender#onComplete/onError will not able
to flush the data completely. In these cases the underlaying Netty
implementation will schedule an additional task which will try to
flush the remaining data. This additional flush operation will call
ChannelPipeline#flush. Extend ChannelOperationsHandler#drain so that
it is able to handle these additional callbacks.