### PR TITLE
Don't send chunked transfer for DELETE requests

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/MonoHttpClientResponse.java
+++ b/src/main/java/reactor/ipc/netty/http/client/MonoHttpClientResponse.java
@@ -109,7 +109,9 @@ final class MonoHttpClientResponse extends Mono<HttpClientResponse> {
 				  .add(HttpHeaderNames.HOST, host)
 				  .add(HttpHeaderNames.ACCEPT, ALL);
 
-				if (parent.method == HttpMethod.GET || parent.method == HttpMethod.HEAD) {
+				if (parent.method == HttpMethod.GET
+						|| parent.method == HttpMethod.HEAD
+						|| parent.method == HttpMethod.DELETE) {
 					ch.chunkedTransfer(false);
 				}
 


### PR DESCRIPTION
This commit adds `DELETE` requests to the list of HTTP methods which
shouldn't send `Transfer-Encoding: chunked` request headers by default.

The HTTP specification states that for `GET`, `HEAD` and `DELETE`
requests, a payload has "no defined semantics" and "might cause existing
implementations to reject the request".
See https://tools.ietf.org/html/rfc7231#section-4.3.5

This commit aligns the `DELETE` behavior on other, similar HTTP methods.

See https://jira.spring.io/browse/SPR-15947 for background information.