### PR TITLE
Do not specify SO_LINGER timeout, JVM default will be used

### DIFF
--- a/src/main/java/reactor/ipc/netty/options/ServerOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/ServerOptions.java
@@ -153,7 +153,6 @@ public class ServerOptions extends NettyOptions<ServerBootstrap, ServerOptions> 
 			         .childOption(ChannelOption.SO_SNDBUF, 1024 * 1024)
 			         .childOption(ChannelOption.AUTO_READ, false)
 			         .childOption(ChannelOption.SO_KEEPALIVE, true)
-			         .childOption(ChannelOption.SO_LINGER, 0)
 			         .childOption(ChannelOption.TCP_NODELAY, true)
 			         .childOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, 30000);
 		}


### PR DESCRIPTION
When `SO_LINGER >= 0` this will specify a timeout value, in seconds (linger interval).
The linger interval is the timeout for the close method to **block**
while the OS attempts to transmit the unsent data. When **0** the OS will not attempt
to transmit the unsend data.
When `SO_LINGER < 0`, then the close method does not wait until unsent data is
transmitted, but if possible the OS will transmit any unsent data before
the connection is closed.
More information `StandardSocketOptions#SO_LINGER`