### PR TITLE
Create LoopResources/PoolResources only in case the user does not specify their own.

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
@@ -132,10 +132,12 @@ public class HttpClient implements NettyConnector<HttpClientResponse, HttpClient
 
 	private HttpClient(HttpClient.Builder builder) {
 		HttpClientOptions.Builder clientOptionsBuilder = HttpClientOptions.builder();
-		clientOptionsBuilder.loopResources(HttpResources.get())
-		                    .poolResources(HttpResources.get());
 		if (Objects.nonNull(builder.options)) {
 			builder.options.accept(clientOptionsBuilder);
+		}
+		clientOptionsBuilder.loopResources(HttpResources.get());
+		if (!clientOptionsBuilder.isPoolDisabled()) {
+			clientOptionsBuilder.poolResources(HttpResources.get());
 		}
 		this.options = clientOptionsBuilder.build();
 		this.client = new TcpBridgeClient(options);

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServer.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServer.java
@@ -121,7 +121,6 @@ public final class HttpServer
 
 	private HttpServer(HttpServer.Builder builder) {
 		HttpServerOptions.Builder serverOptionsBuilder = HttpServerOptions.builder();
-		serverOptionsBuilder.loopResources(HttpResources.get());
 		if (Objects.isNull(builder.options)) {
 			serverOptionsBuilder.host(builder.bindAddress)
 			                    .port(builder.port);
@@ -129,6 +128,7 @@ public final class HttpServer
 		else {
 			builder.options.accept(serverOptionsBuilder);
 		}
+		serverOptionsBuilder.loopResources(HttpResources.get());
 		this.options = serverOptionsBuilder.build();
 		this.server = new TcpBridgeServer(this.options);
 	}

--- a/src/main/java/reactor/ipc/netty/options/ClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/ClientOptions.java
@@ -252,6 +252,7 @@ public class ClientOptions extends NettyOptions<Bootstrap, ClientOptions> {
 	public static class Builder<BUILDER extends Builder<BUILDER>>
 			extends NettyOptions.Builder<Bootstrap, ClientOptions, BUILDER> {
 		private PoolResources poolResources;
+		private boolean poolDisabled = false;
 		private InternetProtocolFamily protocolFamily;
 		private String host;
 		private int port = -1;
@@ -299,6 +300,7 @@ public class ClientOptions extends NettyOptions<Bootstrap, ClientOptions> {
 		 */
 		public final BUILDER poolResources(PoolResources poolResources) {
 			this.poolResources = Objects.requireNonNull(poolResources, "poolResources");
+			this.poolDisabled = false;
 			return get();
 		}
 
@@ -309,7 +311,12 @@ public class ClientOptions extends NettyOptions<Bootstrap, ClientOptions> {
 		 */
 		public BUILDER disablePool() {
 			this.poolResources = null;
+			this.poolDisabled = true;
 			return get();
+		}
+
+		public final boolean isPoolDisabled() {
+			return poolDisabled;
 		}
 
 		/**

--- a/src/main/java/reactor/ipc/netty/tcp/TcpClient.java
+++ b/src/main/java/reactor/ipc/netty/tcp/TcpClient.java
@@ -118,10 +118,12 @@ public class TcpClient implements NettyConnector<NettyInbound, NettyOutbound> {
 
 	protected TcpClient(TcpClient.Builder builder) {
 		ClientOptions.Builder<?> clientOptionsBuilder = ClientOptions.builder();
-		clientOptionsBuilder.loopResources(TcpResources.get())
-		                    .poolResources(TcpResources.get());
 		if (Objects.nonNull(builder.options)) {
 			builder.options.accept(clientOptionsBuilder);
+		}
+		clientOptionsBuilder.loopResources(TcpResources.get());
+		if (!clientOptionsBuilder.isPoolDisabled()) {
+			clientOptionsBuilder.poolResources(TcpResources.get());
 		}
 		this.options = clientOptionsBuilder.build();
 	}

--- a/src/main/java/reactor/ipc/netty/tcp/TcpServer.java
+++ b/src/main/java/reactor/ipc/netty/tcp/TcpServer.java
@@ -133,7 +133,6 @@ public class TcpServer implements NettyConnector<NettyInbound, NettyOutbound> {
 
 	protected TcpServer(TcpServer.Builder builder) {
 		ServerOptions.Builder<?> serverOptionsBuilder = ServerOptions.builder();
-		serverOptionsBuilder.loopResources(TcpResources.get());
 		if (Objects.isNull(builder.options)) {
 			serverOptionsBuilder.host(builder.bindAddress)
 			                    .port(builder.port);
@@ -141,6 +140,7 @@ public class TcpServer implements NettyConnector<NettyInbound, NettyOutbound> {
 		else {
 			builder.options.accept(serverOptionsBuilder);
 		}
+		serverOptionsBuilder.loopResources(TcpResources.get());
 		this.options = serverOptionsBuilder.build();
 	}
 

--- a/src/main/java/reactor/ipc/netty/udp/UdpClient.java
+++ b/src/main/java/reactor/ipc/netty/udp/UdpClient.java
@@ -120,10 +120,10 @@ final public class UdpClient implements NettyConnector<UdpInbound, UdpOutbound> 
 
 	private UdpClient(UdpClient.Builder builder) {
 		UdpClientOptions.Builder clientOptionsBuilder = UdpClientOptions.builder();
-		clientOptionsBuilder.loopResources(DEFAULT_UDP_LOOPS);
 		if (Objects.nonNull(builder.options)) {
 			builder.options.accept(clientOptionsBuilder);
 		}
+		clientOptionsBuilder.loopResources(DEFAULT_UDP_LOOPS);
 		this.options = clientOptionsBuilder.build();
 	}
 


### PR DESCRIPTION
Fixes #168 