### PR TITLE
Use port from HttpServer's builder also when options are present

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/server/HttpServer.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServer.java
@@ -121,11 +121,10 @@ public final class HttpServer
 
 	private HttpServer(HttpServer.Builder builder) {
 		HttpServerOptions.Builder serverOptionsBuilder = HttpServerOptions.builder();
-		if (Objects.isNull(builder.options)) {
-			serverOptionsBuilder.host(builder.bindAddress)
-			                    .port(builder.port);
-		}
-		else {
+		serverOptionsBuilder
+				.host(builder.bindAddress)
+				.port(builder.port);
+		if (Objects.nonNull(builder.options)) {
 			builder.options.accept(serverOptionsBuilder);
 		}
 		if (!serverOptionsBuilder.isLoopAvailable()) {

--- a/src/test/java/reactor/ipc/netty/http/server/HttpServerTests.java
+++ b/src/test/java/reactor/ipc/netty/http/server/HttpServerTests.java
@@ -118,6 +118,24 @@ public class HttpServerTests {
 	}
 
 	@Test
+	public void httpPortInBuilderFieldIsUsedWhenOptionsAreProvided() {
+		HttpServer.Builder builder = HttpServer.builder()
+				.options(o -> {})
+				.port(9080);
+		HttpServer binding = builder.build();
+		BlockingNettyContext blockingFacade = binding.start((req, resp) -> resp.sendNotFound());
+		blockingFacade.shutdown();
+
+		assertThat(blockingFacade.getPort())
+				.isEqualTo(9080)
+				.isEqualTo(blockingFacade.getContext().address().getPort());
+
+		assertThat(binding.options().getAddress())
+				.isInstanceOf(InetSocketAddress.class)
+				.hasFieldOrPropertyWithValue("port", 9080);
+	}
+
+	@Test
 	public void sendFileSecure()
 			throws CertificateException, SSLException, URISyntaxException {
 		Path largeFile = Paths.get(getClass().getResource("/largeFile.txt").toURI());


### PR DESCRIPTION
This PR fixes a problem that the port given to `HttpServer.builder()` wasn't used after specifying some options. For example, in this case, a random port was used instead of the given port `12345`

```
        HttpServer httpServer = HttpServer.builder()
                 .options(options -> options.option(ChannelOption.TCP_NODELAY, false))
                 .port(12345)
                 .build();
```