### PR TITLE
Prevent unwanted reverse DNS lookup calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,14 @@ configure(rootProject) { project ->
   }
 
   project.tasks.withType(Test).all {
+	// run tests with IPv4 only when IPv6 is available
+	if (project.hasProperty('preferIPv4Stack')) {
+		systemProperty("java.net.preferIPv4Stack", "true")
+	}
+	// run tests with preferring IPv6 addresses
+	if (project.hasProperty('preferIPv6Addresses')) {
+		systemProperty("java.net.preferIPv6Addresses", "true")
+	}
 	systemProperty("java.awt.headless", "true")
 	systemProperty("reactor.trace.cancel", "true")
 	systemProperty("reactor.trace.nocapacity", "true")

--- a/src/main/java/reactor/ipc/netty/channel/ClientContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ClientContextHandler.java
@@ -79,7 +79,7 @@ final class ClientContextHandler<CHANNEL extends Channel>
 	protected Tuple2<String, Integer> getSNI() {
 		if (providedAddress instanceof InetSocketAddress) {
 			InetSocketAddress ipa = (InetSocketAddress) providedAddress;
-			return Tuples.of(ipa.getHostName(), ipa.getPort());
+			return Tuples.of(ipa.getHostString(), ipa.getPort());
 		}
 		return null;
 	}

--- a/src/main/java/reactor/ipc/netty/channel/PooledClientContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/PooledClientContextHandler.java
@@ -290,7 +290,7 @@ final class PooledClientContextHandler<CHANNEL extends Channel>
 	protected Tuple2<String, Integer> getSNI() {
 		if (providedAddress instanceof InetSocketAddress) {
 			InetSocketAddress ipa = (InetSocketAddress) providedAddress;
-			return Tuples.of(ipa.getHostName(), ipa.getPort());
+			return Tuples.of(ipa.getHostString(), ipa.getPort());
 		}
 		return null;
 	}

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
@@ -105,7 +105,7 @@ public class HttpClient implements NettyConnector<HttpClientResponse, HttpClient
 	 * @return a simple HTTP client bound on the provided address and port
 	 */
 	public static HttpClient create(String address, int port) {
-		return create(opts -> opts.connectAddress(() -> InetSocketAddress.createUnresolved(address, port)));
+		return create(opts -> opts.host(address).port(port));
 	}
 
 	/**

--- a/src/main/java/reactor/ipc/netty/options/ClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/ClientOptions.java
@@ -95,10 +95,10 @@ public class ClientOptions extends NettyOptions<Bootstrap, ClientOptions> {
 		if (Objects.isNull(builder.connectAddress)) {
 			if (builder.port >= 0) {
 				if (Objects.isNull(builder.host)) {
-					this.connectAddress = () -> new InetSocketAddress(NetUtil.LOCALHOST.getHostAddress(), builder.port);
+					this.connectAddress = () -> new InetSocketAddress(NetUtil.LOCALHOST, builder.port);
 				}
 				else {
-					this.connectAddress = () -> InetSocketAddress.createUnresolved(builder.host, builder.port);
+					this.connectAddress = () -> InetSocketAddressUtil.createUnresolved(builder.host, builder.port);
 				}
 			}
 			else {
@@ -163,7 +163,7 @@ public class ClientOptions extends NettyOptions<Bootstrap, ClientOptions> {
 		if (this.proxyOptions != null) { 
 			if (this.proxyOptions.getNonProxyHosts() != null && 
 					address instanceof InetSocketAddress) {
-				String hostName = ((InetSocketAddress) address).getHostName();
+				String hostName = ((InetSocketAddress) address).getHostString();
 				return !this.proxyOptions.getNonProxyHosts().matcher(hostName).matches();
 			}
 			return true;
@@ -247,6 +247,10 @@ public class ClientOptions extends NettyOptions<Bootstrap, ClientOptions> {
 	@Override
 	public String toString() {
 		return "ClientOptions{" + asDetailedString() + "}";
+	}
+
+	protected InetSocketAddress createInetSocketAddress(String hostname, int port, boolean resolve) {
+		return InetSocketAddressUtil.createInetSocketAddress(hostname, port, resolve);
 	}
 
 	public static class Builder<BUILDER extends Builder<BUILDER>>

--- a/src/main/java/reactor/ipc/netty/options/ClientProxyOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/ClientProxyOptions.java
@@ -53,7 +53,7 @@ public class ClientProxyOptions {
 		this.username = builder.username;
 		this.password = builder.password;
 		if (Objects.isNull(builder.address)) {
-			this.address = () -> new InetSocketAddress(builder.host, builder.port);
+			this.address = () -> InetSocketAddressUtil.createResolved(builder.host, builder.port);
 		}
 		else {
 			this.address = builder.address;
@@ -187,10 +187,7 @@ public class ClientProxyOptions {
 		@Override
 		public final Builder address(InetSocketAddress address) {
 			Objects.requireNonNull(address, "address");
-			this.address = address.isUnresolved() ?
-					() -> new InetSocketAddress(address.getHostName(),
-							address.getPort()) :
-					() -> address;
+			this.address = () -> InetSocketAddressUtil.replaceWithResolved(address);
 			return this;
 		}
 

--- a/src/main/java/reactor/ipc/netty/options/InetSocketAddressUtil.java
+++ b/src/main/java/reactor/ipc/netty/options/InetSocketAddressUtil.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.ipc.netty.options;
+
+import java.net.*;
+
+import io.netty.util.NetUtil;
+
+/**
+ * Internal class that creates unresolved or resolved InetSocketAddress instances
+ *
+ * Numeric IPv4 and IPv6 addresses will be detected and parsed by using Netty's
+ * {@link NetUtil#createByteArrayFromIpAddressString} utility method and the
+ * InetSocketAddress instances will created in a way that these instances are resolved
+ * initially. This removes the need to do unnecessary reverse DNS lookups.
+ *
+ */
+class InetSocketAddressUtil {
+
+	/**
+	 * Creates unresolved InetSocketAddress. Numeric IP addresses will be detected and
+	 * resolved.
+	 * 
+	 * @param hostname ip-address or hostname
+	 * @param port port number
+	 * @return InetSocketAddress for given parameters
+	 */
+	public static InetSocketAddress createUnresolved(String hostname, int port) {
+		return createInetSocketAddress(hostname, port, false);
+	}
+
+	/**
+	 * Creates InetSocketAddress that is always resolved. Numeric IP addresses will be
+	 * detected and resolved without doing reverse DNS lookups.
+	 * 
+	 * @param hostname ip-address or hostname
+	 * @param port port number
+	 * @return InetSocketAddress for given parameters
+	 */
+	public static InetSocketAddress createResolved(String hostname, int port) {
+		return createInetSocketAddress(hostname, port, true);
+	}
+
+	/**
+	 * Creates InetSocketAddress instance. Numeric IP addresses will be detected and
+	 * resolved without doing reverse DNS lookups.
+	 *
+	 * @param hostname ip-address or hostname
+	 * @param port port number
+	 * @param resolve when true, resolve given hostname at instance creation time
+	 * @return InetSocketAddress for given parameters
+	 */
+	public static InetSocketAddress createInetSocketAddress(String hostname, int port,
+			boolean resolve) {
+		InetSocketAddress inetAddressForIpString = createForIpString(hostname, port);
+		if (inetAddressForIpString != null) {
+			return inetAddressForIpString;
+		}
+		else {
+			return resolve ? new InetSocketAddress(hostname, port)
+					: InetSocketAddress.createUnresolved(hostname, port);
+		}
+	}
+
+	private static InetSocketAddress createForIpString(String hostname, int port) {
+		InetAddress inetAddressForIpString = attemptParsingIpString(hostname);
+		if (inetAddressForIpString != null) {
+			return new InetSocketAddress(inetAddressForIpString, port);
+		}
+		return null;
+	}
+
+	/**
+	 * Replaces an unresolved InetSocketAddress with a resolved instance in the case that
+	 * the passed address is unresolved.
+	 *
+	 * @param inetSocketAddress socket address instance to process
+	 * @return resolved instance with same host string and port
+	 */
+	public static InetSocketAddress replaceWithResolved(
+			InetSocketAddress inetSocketAddress) {
+		if (!inetSocketAddress.isUnresolved()) {
+			return inetSocketAddress;
+		}
+		inetSocketAddress = replaceUnresolvedNumericIp(inetSocketAddress);
+		if (!inetSocketAddress.isUnresolved()) {
+			return inetSocketAddress;
+		}
+		else {
+			return new InetSocketAddress(inetSocketAddress.getHostString(),
+					inetSocketAddress.getPort());
+		}
+	}
+
+	/**
+	 * Replaces an unresolved InetSocketAddress with a resolved instance in the case that
+	 * the passed address is a numeric IP address (both IPv4 and IPv6 are supported).
+	 *
+	 * @param inetSocketAddress socket address instance to process
+	 * @return processed socket address instance
+	 */
+	public static InetSocketAddress replaceUnresolvedNumericIp(
+			InetSocketAddress inetSocketAddress) {
+		if (!inetSocketAddress.isUnresolved()) {
+			return inetSocketAddress;
+		}
+		InetSocketAddress inetAddressForIpString = createForIpString(
+				inetSocketAddress.getHostString(), inetSocketAddress.getPort());
+		if (inetAddressForIpString != null) {
+			return inetAddressForIpString;
+		}
+		else {
+			return inetSocketAddress;
+		}
+	}
+
+	private static InetAddress attemptParsingIpString(String hostname) {
+		byte[] ipAddressBytes = NetUtil.createByteArrayFromIpAddressString(hostname);
+
+		if (ipAddressBytes != null) {
+			try {
+				if (ipAddressBytes.length == 4) {
+					return Inet4Address.getByAddress(ipAddressBytes);
+				}
+				else {
+					return Inet6Address.getByAddress(null, ipAddressBytes, -1);
+				}
+			}
+			catch (UnknownHostException e) {
+				throw new RuntimeException(e); // Should never happen
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/src/main/java/reactor/ipc/netty/options/ServerOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/ServerOptions.java
@@ -75,11 +75,13 @@ public class ServerOptions extends NettyOptions<ServerBootstrap, ServerOptions> 
 				this.localAddress = new InetSocketAddress(builder.port);
 			}
 			else {
-				this.localAddress = new InetSocketAddress(builder.host, builder.port);
+				this.localAddress = InetSocketAddressUtil.createResolved(builder.host, builder.port);
 			}
 		}
 		else {
-			this.localAddress = builder.listenAddress;
+			this.localAddress = builder.listenAddress instanceof InetSocketAddress
+					? InetSocketAddressUtil.replaceWithResolved((InetSocketAddress) builder.listenAddress)
+					: builder.listenAddress;
 		}
 	}
 

--- a/src/test/groovy/reactor/ipc/netty/tcp/netty/NettyTcpServerSpec.groovy
+++ b/src/test/groovy/reactor/ipc/netty/tcp/netty/NettyTcpServerSpec.groovy
@@ -146,7 +146,7 @@ class NettyTcpServerSpec extends Specification {
 			  .log('flatmap-retry'))
 	}.block(Duration.ofSeconds(30))
 
-	def client = TcpClient.create("localhost", server.address().port)
+	def client = TcpClient.create({ opts -> opts.connectAddress({ -> server.address() }) })
 	client.newHandler { i, o ->
 	  i.receive()
 			  .asString()
@@ -190,7 +190,7 @@ class NettyTcpServerSpec extends Specification {
 	@Override
 	void run() {
 	  def ch = SocketChannel.
-			  open(new InetSocketAddress(NetUtil.LOCALHOST.getHostAddress(), port))
+			  open(new InetSocketAddress(NetUtil.LOCALHOST, port))
 	  def len = ch.write(ByteBuffer.wrap(output.getBytes(Charset.defaultCharset())))
 	  assert ch.connected
 	  data = ByteBuffer.allocate(len)

--- a/src/test/java/reactor/ipc/netty/http/HttpCompressionClientServerTests.java
+++ b/src/test/java/reactor/ipc/netty/http/HttpCompressionClientServerTests.java
@@ -299,7 +299,6 @@ public class HttpCompressionClientServerTests {
 	}
 
 	private InetSocketAddress address(NettyContext nettyContext) {
-		return new InetSocketAddress(nettyContext.address()
-		                                         .getPort());
+		return nettyContext.address();
 	}
 }

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
@@ -140,6 +140,21 @@ public class HttpClientOptionsTest {
 	}
 
 	@Test
+	public void formatSchemeAndHostIPv6Address() throws Exception {
+		String test1 = this.builder.host("::1")
+				.port(8080)
+				.build()
+				.formatSchemeAndHost("/foo", false);
+		String test2 = this.builder.host("::1")
+				.port(8080)
+				.build()
+				.formatSchemeAndHost("/foo", true);
+
+		assertThat(test1).isEqualTo("http://[::1]:8080/foo");
+		assertThat(test2).isEqualTo("ws://[::1]:8080/foo");
+	}
+
+	@Test
 	public void formatSchemeAndHostRelativeAddressSsl() throws Exception {
 		String test1 = this.builder.host("example")
 		                           .port(8080)

--- a/src/test/java/reactor/ipc/netty/http/server/HttpServerOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/http/server/HttpServerOptionsTest.java
@@ -52,7 +52,8 @@ public class HttpServerOptionsTest {
 	public void asSimpleString() {
 		HttpServerOptions.Builder builder = HttpServerOptions.builder();
 
-		assertThat(builder.build().asSimpleString()).isEqualTo("listening on 0.0.0.0/0.0.0.0:0");
+		assertThat(builder.build().asSimpleString())
+				.matches("^listening on (0\\.0\\.0\\.0/0\\.0\\.0\\.0:0|/0:0:0:0:0:0:0:1.*)$");
 
 		//address
 		builder.host("foo").port(123);
@@ -72,7 +73,7 @@ public class HttpServerOptionsTest {
 		HttpServerOptions.Builder builder = HttpServerOptions.builder();
 
 		assertThat(builder.build().asDetailedString())
-				.startsWith("address=0.0.0.0/0.0.0.0:0")
+				.matches("^address=(0\\.0\\.0\\.0/0\\.0\\.0\\.0:0|/0:0:0:0:0:0:0:1).*")
 				.endsWith(", minCompressionResponseSize=-1");
 
 		//address

--- a/src/test/java/reactor/ipc/netty/http/server/HttpServerTests.java
+++ b/src/test/java/reactor/ipc/netty/http/server/HttpServerTests.java
@@ -190,7 +190,7 @@ public class HttpServerTests {
 
 
 		HttpClientResponse response =
-				HttpClient.create(opt -> opt.port(context.address().getPort()))
+				HttpClient.create(opt -> opt.connectAddress(() -> context.address()))
 				          .get("/foo")
 				          .block(Duration.ofSeconds(120));
 
@@ -463,20 +463,19 @@ public class HttpServerTests {
 				                           .get("/304-2", (req, res) -> res.status(HttpResponseStatus.NOT_MODIFIED)))
 				          .block(Duration.ofSeconds(30));
 
-		int port = server.address().getPort();
-		checkResponse("/204-1", port);
-		checkResponse("/204-2", port);
-		checkResponse("/205-1", port);
-		checkResponse("/205-2", port);
-		checkResponse("/304-1", port);
-		checkResponse("/304-2", port);
+		checkResponse("/204-1", server.address());
+		checkResponse("/204-2", server.address());
+		checkResponse("/205-1", server.address());
+		checkResponse("/205-2", server.address());
+		checkResponse("/304-1", server.address());
+		checkResponse("/304-2", server.address());
 
 		server.dispose();
 	}
 
-	private void checkResponse(String url, int port) {
+	private void checkResponse(String url, InetSocketAddress address) {
 		Mono<HttpClientResponse> response =
-				HttpClient.create(ops -> ops.port(port))
+				HttpClient.create(ops -> ops.connectAddress(() -> address))
 				          .get(url);
 
 		StepVerifier.create(response)

--- a/src/test/java/reactor/ipc/netty/options/InetSocketAddressUtilTest.java
+++ b/src/test/java/reactor/ipc/netty/options/InetSocketAddressUtilTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.ipc.netty.options;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetSocketAddress;
+
+import org.junit.Test;
+
+public class InetSocketAddressUtilTest {
+
+	@Test
+	public void shouldCreateResolvedNumericIPv4Address() {
+		InetSocketAddress socketAddress = InetSocketAddressUtil
+				.createResolved("127.0.0.1", 8080);
+		assertThat(socketAddress.isUnresolved()).isFalse();
+		assertThat(socketAddress.getAddress().getHostAddress()).isEqualTo("127.0.0.1");
+		assertThat(socketAddress.getPort()).isEqualTo(8080);
+		assertThat(socketAddress.getHostString()).isEqualTo("127.0.0.1");
+	}
+
+	@Test
+	public void shouldCreateResolvedNumericIPv6Address() {
+		InetSocketAddress socketAddress = InetSocketAddressUtil.createResolved("::1",
+				8080);
+		assertThat(socketAddress.isUnresolved()).isFalse();
+		assertThat(socketAddress.getAddress().getHostAddress())
+				.isEqualTo("0:0:0:0:0:0:0:1");
+		assertThat(socketAddress.getPort()).isEqualTo(8080);
+		assertThat(socketAddress.getHostString()).isEqualTo("0:0:0:0:0:0:0:1");
+	}
+
+	@Test
+	public void shouldCreateUnresolvedAddressByHostName() {
+		InetSocketAddress socketAddress = InetSocketAddressUtil
+				.createUnresolved("google.com", 80);
+		assertThat(socketAddress.isUnresolved()).isTrue();
+		assertThat(socketAddress.getPort()).isEqualTo(80);
+		assertThat(socketAddress.getHostString()).isEqualTo("google.com");
+	}
+
+	@Test
+	public void shouldAlwaysCreateResolvedNumberIPAddress() {
+		InetSocketAddress socketAddress = InetSocketAddressUtil
+				.createUnresolved("127.0.0.1", 8080);
+		assertThat(socketAddress.isUnresolved()).isFalse();
+		assertThat(socketAddress.getAddress().getHostAddress()).isEqualTo("127.0.0.1");
+		assertThat(socketAddress.getPort()).isEqualTo(8080);
+		assertThat(socketAddress.getHostString()).isEqualTo("127.0.0.1");
+	}
+
+	@Test
+	public void shouldReplaceNumericIPAddressWithResolvedInstance() {
+		InetSocketAddress socketAddress = InetSocketAddress.createUnresolved("127.0.0.1",
+				8080);
+		InetSocketAddress replacedAddress = InetSocketAddressUtil
+				.replaceUnresolvedNumericIp(socketAddress);
+		assertThat(replacedAddress).isNotSameAs(socketAddress);
+		assertThat(socketAddress.isUnresolved()).isTrue();
+		assertThat(replacedAddress.isUnresolved()).isFalse();
+		assertThat(replacedAddress.getAddress().getHostAddress()).isEqualTo("127.0.0.1");
+		assertThat(replacedAddress.getPort()).isEqualTo(8080);
+		assertThat(replacedAddress.getHostString()).isEqualTo("127.0.0.1");
+	}
+
+	@Test
+	public void shouldNotReplaceIfNonNumeric() {
+		InetSocketAddress socketAddress = InetSocketAddress.createUnresolved("google.com",
+				80);
+		InetSocketAddress processedAddress = InetSocketAddressUtil
+				.replaceUnresolvedNumericIp(socketAddress);
+		assertThat(processedAddress).isSameAs(socketAddress);
+	}
+
+	@Test
+	public void shouldNotReplaceIfAlreadyResolvedWhenCallingReplaceUnresolveNumericIp() {
+		InetSocketAddress socketAddress = new InetSocketAddress("127.0.0.1", 80);
+		InetSocketAddress processedAddress = InetSocketAddressUtil
+				.replaceUnresolvedNumericIp(socketAddress);
+		assertThat(processedAddress).isSameAs(socketAddress);
+	}
+
+	@Test
+	public void shouldResolveUnresolvedAddress() {
+		InetSocketAddress socketAddress = InetSocketAddress.createUnresolved("google.com",
+				80);
+		InetSocketAddress processedAddress = InetSocketAddressUtil
+				.replaceWithResolved(socketAddress);
+		assertThat(processedAddress).isNotSameAs(socketAddress);
+		assertThat(processedAddress.isUnresolved()).isFalse();
+	}
+
+	@Test
+	public void shouldNotReplaceIfAlreadyResolved() {
+		InetSocketAddress socketAddress = new InetSocketAddress("google.com", 80);
+		InetSocketAddress processedAddress = InetSocketAddressUtil
+				.replaceWithResolved(socketAddress);
+		assertThat(processedAddress).isSameAs(socketAddress);
+	}
+}

--- a/src/test/java/reactor/ipc/netty/options/NettyOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/options/NettyOptionsTest.java
@@ -46,7 +46,7 @@ public class NettyOptionsTest {
 
 		assertThat(initializedChannels).hasSize(0);
 
-		HttpClient.create(nettyContext.address().getPort())
+		HttpClient.create(opt -> opt.connectAddress(() -> nettyContext.address()))
 		          .get("/", req -> req.failOnClientError(false).send())
 		          .block();
 
@@ -68,7 +68,7 @@ public class NettyOptionsTest {
 				          .start((req, resp) -> resp.sendNotFound())
 				          .getContext();
 
-		HttpClient.create(nettyContext.address().getPort())
+		HttpClient.create(opt -> opt.connectAddress(() -> nettyContext.address()))
 		          .get("/", req -> req.failOnClientError(false).send())
 		          .block();
 
@@ -92,7 +92,7 @@ public class NettyOptionsTest {
 				          .start((req, resp) -> resp.sendNotFound())
 				          .getContext();
 
-		HttpClient.create(nettyContext.address().getPort())
+		HttpClient.create(opt -> opt.connectAddress(() -> nettyContext.address()))
 		          .get("/", req -> req.failOnClientError(false).send())
 		          .block();
 
@@ -118,7 +118,7 @@ public class NettyOptionsTest {
 				          .start((req, resp) -> resp.sendNotFound())
 				          .getContext();
 
-		HttpClient.create(nettyContext.address().getPort())
+		HttpClient.create(opt -> opt.connectAddress(() -> nettyContext.address()))
 		          .get("/", req -> req.failOnClientError(false).send())
 		          .block();
 
@@ -147,7 +147,7 @@ public class NettyOptionsTest {
 				          .start((req, resp) -> resp.sendNotFound())
 				          .getContext();
 
-		HttpClientResponse response1 = HttpClient.create(nettyContext.address().getPort())
+		HttpClientResponse response1 = HttpClient.create(opt -> opt.connectAddress(() -> nettyContext.address()))
 		                                         .get("/", req -> req.failOnClientError(false).send())
 		                                         .block();
 
@@ -158,7 +158,7 @@ public class NettyOptionsTest {
 		//...but the child channels that are created for requests are
 		assertThat(readCount.get()).isEqualTo(1);
 
-		HttpClientResponse response2 = HttpClient.create(nettyContext.address().getPort())
+		HttpClientResponse response2 = HttpClient.create(opt -> opt.connectAddress(() -> nettyContext.address()))
 		                                         .get("/", req -> req.failOnClientError(false).send())
 		                                         .block();
 


### PR DESCRIPTION
- use InetSocketAddress.getHostString instead of getHostName
  where applicable
- detect numeric IP addresses and construct them in a way that prevents
  reverse DNS lookup calls when InetSocketAddress.getAddress is called
- add possibility to pass InetSocketAddress instance to the builder
  of HttpServer and TcpServer
    - Binding to localhost can utilize NetUtil.LOCALHOST
      InetSocketAddress instance
    - Binding to wildcard address can be done by passing an instance
      of InetSocketAddress created with the "int port" constructor
- fixes some problems in tests when using IPv6 local address
  - NetUtil.LOCALHOST points to IPv6 local address when IPv6 is
    preferred
  - adds ability to run tests with java.net.preferIPv4Stack and
    java.net.preferIPv6Addresses settings enabled to compare
    differences in IPv4 and IPv6 handling