### PR TITLE
Use HttpClientCodec/HttpServerCodec

### DIFF
--- a/src/main/java/reactor/ipc/netty/NettyPipeline.java
+++ b/src/main/java/reactor/ipc/netty/NettyPipeline.java
@@ -57,8 +57,7 @@ public interface NettyPipeline {
 	String SslLoggingHandler  = LEFT + "sslLoggingHandler";
 	String ProxyHandler       = LEFT + "proxyHandler";
 	String ReactiveBridge     = RIGHT + "reactiveBridge";
-	String HttpEncoder        = LEFT + "httpEncoder";
-	String HttpDecoder        = LEFT + "httpDecoder";
+	String HttpCodec          = LEFT + "httpCodec";
 	String HttpDecompressor   = LEFT + "decompressor";
 	String HttpCompressor     = LEFT + "compressor";
 	String HttpAggregator     = LEFT + "httpAggregator";

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
@@ -29,13 +29,12 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.pool.ChannelPool;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpRequestEncoder;
-import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.logging.LoggingHandler;
 
 import org.reactivestreams.Publisher;
@@ -409,10 +408,9 @@ public class HttpClient implements NettyConnector<HttpClientResponse, HttpClient
 
 		@Override
 		public void accept(ChannelPipeline pipeline, ContextHandler<Channel> c) {
-			pipeline.addLast(NettyPipeline.HttpDecoder, new HttpResponseDecoder())
-			        .addLast(NettyPipeline.HttpEncoder, new HttpRequestEncoder());
+			pipeline.addLast(NettyPipeline.HttpCodec, new HttpClientCodec());
 			if (options.acceptGzip()) {
-				pipeline.addAfter(NettyPipeline.HttpDecoder,
+				pipeline.addAfter(NettyPipeline.HttpCodec,
 						NettyPipeline.HttpDecompressor,
 						new HttpContentDecompressor());
 			}

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientWSOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientWSOperations.java
@@ -26,9 +26,9 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpObjectAggregator;
-import io.netty.handler.codec.http.HttpRequestEncoder;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
@@ -113,10 +113,10 @@ final class HttpClientWSOperations extends HttpClientOperations
 		handshakerResult = channel.newPromise();
 
 		String handlerName = channel.pipeline()
-		                            .context(HttpRequestEncoder.class)
+		                            .context(HttpClientCodec.class)
 		                            .name();
 
-		if (!handlerName.equals(NettyPipeline.HttpEncoder)) {
+		if (!handlerName.equals(NettyPipeline.HttpCodec)) {
 			channel.pipeline()
 			       .remove(handlerName);
 		}

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientWSOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientWSOperations.java
@@ -26,7 +26,6 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
@@ -36,7 +35,6 @@ import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
-import reactor.ipc.netty.NettyPipeline;
 import reactor.ipc.netty.http.websocket.WebsocketInbound;
 import reactor.ipc.netty.http.websocket.WebsocketOutbound;
 
@@ -112,14 +110,6 @@ final class HttpClientWSOperations extends HttpClientOperations
 //		}
 		handshakerResult = channel.newPromise();
 
-		String handlerName = channel.pipeline()
-		                            .context(HttpClientCodec.class)
-		                            .name();
-
-		if (!handlerName.equals(NettyPipeline.HttpCodec)) {
-			channel.pipeline()
-			       .remove(handlerName);
-		}
 		handshaker.handshake(channel)
 		          .addListener(f -> {
 			          markPersistent(false);

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServer.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServer.java
@@ -23,8 +23,7 @@ import java.util.function.Consumer;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.http.HttpRequestDecoder;
-import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.util.NetUtil;
 
@@ -249,8 +248,7 @@ public final class HttpServer
 
         @Override
         public void accept(ChannelPipeline p, ContextHandler<Channel> c) {
-            p.addLast(NettyPipeline.HttpDecoder, new HttpRequestDecoder())
-                    .addLast(NettyPipeline.HttpEncoder,new HttpResponseEncoder());
+            p.addLast(NettyPipeline.HttpCodec, new HttpServerCodec());
 
             if(options.minCompressionResponseSize() >= 0) {
                     p.addLast(NettyPipeline.CompressionHandler, new CompressionHandler(options.minCompressionResponseSize()));

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerHandler.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerHandler.java
@@ -26,7 +26,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.ReferenceCountUtil;
@@ -170,7 +170,7 @@ final class HttpServerHandler extends ChannelDuplexHandler
 				pendingResponses -= 1;
 
 				ctx.pipeline()
-				   .replace(NettyPipeline.HttpEncoder, NettyPipeline.HttpEncoder, new HttpResponseEncoder());
+				   .replace(NettyPipeline.HttpCodec, NettyPipeline.HttpCodec, new HttpServerCodec());
 			}
 
 			if (pipelined != null && !pipelined.isEmpty()) {

--- a/src/test/java/reactor/ipc/netty/NettyContextTest.java
+++ b/src/test/java/reactor/ipc/netty/NettyContextTest.java
@@ -27,8 +27,7 @@ import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.LineBasedFrameDecoder;
-import io.netty.handler.codec.http.HttpRequestDecoder;
-import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.websocketx.Utf8FrameValidator;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,7 +78,7 @@ public class NettyContextTest {
 	public void addByteDecoderWhenNoRight() throws Exception {
 
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpDecoder, new ChannelHandlerAdapter() {
+		       .addLast(NettyPipeline.HttpCodec, new ChannelHandlerAdapter() {
 		       });
 		ChannelHandler decoder = new LineBasedFrameDecoder(12);
 
@@ -89,7 +88,7 @@ public class NettyContextTest {
 
 		assertEquals(channel.pipeline()
 		                    .names(),
-				Arrays.asList(NettyPipeline.HttpDecoder,
+				Arrays.asList(NettyPipeline.HttpCodec,
 						"decoder$extract",
 						"decoder",
 						"DefaultChannelPipeline$TailContext#0"));
@@ -115,8 +114,7 @@ public class NettyContextTest {
 	public void addByteDecoderWhenFullReactorPipeline() throws Exception {
 
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpDecoder, new HttpRequestDecoder())
-		       .addLast(NettyPipeline.HttpEncoder, new HttpResponseEncoder())
+		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec())
 		       .addLast(NettyPipeline.HttpServerHandler, new ChannelDuplexHandler())
 		       .addLast(NettyPipeline.ReactiveBridge, new ChannelHandlerAdapter() {
 		       });
@@ -128,8 +126,7 @@ public class NettyContextTest {
 
 		assertEquals(channel.pipeline()
 		                    .names(),
-				Arrays.asList(NettyPipeline.HttpDecoder,
-						NettyPipeline.HttpEncoder,
+				Arrays.asList(NettyPipeline.HttpCodec,
 						NettyPipeline.HttpServerHandler,
 						"decoder$extract",
 						"decoder",
@@ -159,7 +156,7 @@ public class NettyContextTest {
 	public void addNonByteDecoderWhenNoRight() throws Exception {
 
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpDecoder, new ChannelHandlerAdapter() {
+		       .addLast(NettyPipeline.HttpCodec, new ChannelHandlerAdapter() {
 		       });
 		ChannelHandler decoder = new ChannelHandlerAdapter() {
 		};
@@ -168,7 +165,7 @@ public class NettyContextTest {
 
 		assertEquals(channel.pipeline()
 		                    .names(),
-				Arrays.asList(NettyPipeline.HttpDecoder,
+				Arrays.asList(NettyPipeline.HttpCodec,
 						"decoder",
 						"DefaultChannelPipeline$TailContext#0"));
 	}
@@ -190,8 +187,7 @@ public class NettyContextTest {
 	public void addNonByteDecoderWhenFullReactorPipeline() throws Exception {
 
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpDecoder, new HttpRequestDecoder())
-		       .addLast(NettyPipeline.HttpEncoder, new HttpResponseEncoder())
+		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec())
 		       .addLast(NettyPipeline.HttpServerHandler, new ChannelDuplexHandler())
 		       .addLast(NettyPipeline.ReactiveBridge, new ChannelHandlerAdapter() {
 		       });
@@ -202,8 +198,7 @@ public class NettyContextTest {
 
 		assertEquals(channel.pipeline()
 		                    .names(),
-				Arrays.asList(NettyPipeline.HttpDecoder,
-						NettyPipeline.HttpEncoder,
+				Arrays.asList(NettyPipeline.HttpCodec,
 						NettyPipeline.HttpServerHandler,
 						"decoder",
 						NettyPipeline.ReactiveBridge,
@@ -216,8 +211,7 @@ public class NettyContextTest {
 		ChannelHandler decoder2 = new LineBasedFrameDecoder(13);
 
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpDecoder, new HttpRequestDecoder())
-		       .addLast(NettyPipeline.HttpEncoder, new HttpResponseEncoder())
+		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec())
 		       .addLast(NettyPipeline.HttpServerHandler, new ChannelDuplexHandler())
 		       .addLast(NettyPipeline.ReactiveBridge, new ChannelHandlerAdapter() {
 		       });
@@ -232,8 +226,7 @@ public class NettyContextTest {
 
 		assertEquals(channel.pipeline()
 		                    .names(),
-				Arrays.asList(NettyPipeline.HttpDecoder,
-						NettyPipeline.HttpEncoder,
+				Arrays.asList(NettyPipeline.HttpCodec,
 						NettyPipeline.HttpServerHandler,
 						"decoder1$extract",
 						"decoder1",
@@ -264,7 +257,7 @@ public class NettyContextTest {
 	public void addByteEncoderWhenNoRight() throws Exception {
 
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpDecoder, new ChannelHandlerAdapter() {
+		       .addLast(NettyPipeline.HttpCodec, new ChannelHandlerAdapter() {
 		       });
 		ChannelHandler encoder = new LineBasedFrameDecoder(12);
 
@@ -272,7 +265,7 @@ public class NettyContextTest {
 
 		assertEquals(channel.pipeline()
 		                    .names(),
-				Arrays.asList(NettyPipeline.HttpDecoder,
+				Arrays.asList(NettyPipeline.HttpCodec,
 						"encoder",
 						"DefaultChannelPipeline$TailContext#0"));
 	}
@@ -293,8 +286,7 @@ public class NettyContextTest {
 	public void addByteEncoderWhenFullReactorPipeline() throws Exception {
 
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpDecoder, new HttpRequestDecoder())
-		       .addLast(NettyPipeline.HttpEncoder, new HttpResponseEncoder())
+		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec())
 		       .addLast(NettyPipeline.HttpServerHandler, new ChannelDuplexHandler())
 		       .addLast(NettyPipeline.ReactiveBridge, new ChannelHandlerAdapter() {
 		       });
@@ -304,8 +296,7 @@ public class NettyContextTest {
 
 		assertEquals(channel.pipeline()
 		                    .names(),
-				Arrays.asList(NettyPipeline.HttpDecoder,
-						NettyPipeline.HttpEncoder,
+				Arrays.asList(NettyPipeline.HttpCodec,
 						NettyPipeline.HttpServerHandler,
 						"encoder",
 						NettyPipeline.ReactiveBridge,
@@ -334,7 +325,7 @@ public class NettyContextTest {
 	public void addNonByteEncoderWhenNoRight() throws Exception {
 
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpDecoder, new ChannelHandlerAdapter() {
+		       .addLast(NettyPipeline.HttpCodec, new ChannelHandlerAdapter() {
 		       });
 		ChannelHandler encoder = new ChannelHandlerAdapter() {
 		};
@@ -343,7 +334,7 @@ public class NettyContextTest {
 
 		assertEquals(channel.pipeline()
 		                    .names(),
-				Arrays.asList(NettyPipeline.HttpDecoder,
+				Arrays.asList(NettyPipeline.HttpCodec,
 						"encoder",
 						"DefaultChannelPipeline$TailContext#0"));
 	}
@@ -365,8 +356,7 @@ public class NettyContextTest {
 	public void addNonByteEncoderWhenFullReactorPipeline() throws Exception {
 
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpDecoder, new HttpRequestDecoder())
-		       .addLast(NettyPipeline.HttpEncoder, new HttpResponseEncoder())
+		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec())
 		       .addLast(NettyPipeline.HttpServerHandler, new ChannelDuplexHandler())
 		       .addLast(NettyPipeline.ReactiveBridge, new ChannelHandlerAdapter() {
 		       });
@@ -377,8 +367,7 @@ public class NettyContextTest {
 
 		assertEquals(channel.pipeline()
 		                    .names(),
-				Arrays.asList(NettyPipeline.HttpDecoder,
-						NettyPipeline.HttpEncoder,
+				Arrays.asList(NettyPipeline.HttpCodec,
 						NettyPipeline.HttpServerHandler,
 						"encoder",
 						NettyPipeline.ReactiveBridge,
@@ -391,8 +380,7 @@ public class NettyContextTest {
 		ChannelHandler encoder2 = new LineBasedFrameDecoder(13);
 
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpDecoder, new HttpRequestDecoder())
-		       .addLast(NettyPipeline.HttpEncoder, new HttpResponseEncoder())
+		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec())
 		       .addLast(NettyPipeline.HttpServerHandler, new ChannelDuplexHandler())
 		       .addLast(NettyPipeline.ReactiveBridge, new ChannelHandlerAdapter() {
 		       });
@@ -402,8 +390,7 @@ public class NettyContextTest {
 
 		assertEquals(channel.pipeline()
 		                    .names(),
-				Arrays.asList(NettyPipeline.HttpDecoder,
-						NettyPipeline.HttpEncoder,
+				Arrays.asList(NettyPipeline.HttpCodec,
 						NettyPipeline.HttpServerHandler,
 						"encoder2",
 						"encoder1",


### PR DESCRIPTION
Instead of using separate `HttpRequestEncoder` and `HttpResponseDecoder`
in the client/server pipeline, use `HttpClientCodec`/`HttpServerCodec`.
`HttpClientCodec`/`HttpServerCodec` are a combination of `HttpRequestEncoder`
and `HttpResponseDecoder` which enables specific client/server side HTTP
implementation.
More information
https://github.com/netty/netty/blob/4.1/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
https://github.com/netty/netty/blob/4.1/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java