### PR TITLE
Omit filling stack trace for RedirectClientException

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/RedirectClientException.java
+++ b/src/main/java/reactor/ipc/netty/http/client/RedirectClientException.java
@@ -35,4 +35,9 @@ final class RedirectClientException extends HttpClientException {
 		                                          .get(HttpHeaderNames.LOCATION));
 	}
 
+	@Override
+	public synchronized Throwable fillInStackTrace() {
+		// omit stacktrace for this exception
+		return this;
+	}
 }


### PR DESCRIPTION
- there is no use for the stack trace of `reactor.ipc.netty.http.client.RedirectClientException`