### PR TITLE
improve client cancellation flow

### DIFF
--- a/src/main/java/reactor/ipc/netty/channel/ChannelOperations.java
+++ b/src/main/java/reactor/ipc/netty/channel/ChannelOperations.java
@@ -333,7 +333,7 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 	/**
 	 * React on inbound cancel (receive() subscriber cancelled)
 	 */
-	protected void onInboundCancel() {
+	protected void afterInboundCancel() {
 
 	}
 

--- a/src/main/java/reactor/ipc/netty/channel/CloseableContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/CloseableContextHandler.java
@@ -104,7 +104,7 @@ abstract class CloseableContextHandler<CHANNEL extends Channel>
 	}
 
 	@Override
-	public final void dispose() {
+	public void dispose() {
 		if (f == null){
 			return;
 		}

--- a/src/main/java/reactor/ipc/netty/channel/ContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ContextHandler.java
@@ -32,6 +32,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.concurrent.Future;
 import org.reactivestreams.Publisher;
 import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
 import reactor.ipc.netty.NettyContext;
@@ -298,6 +299,10 @@ public abstract class ContextHandler<CHANNEL extends Channel>
 	@Override
 	protected void initChannel(CHANNEL ch) throws Exception {
 		accept(ch);
+	}
+
+	protected Disposable.Swap disposable() {
+		return Disposables.swap();
 	}
 
 	/**

--- a/src/main/java/reactor/ipc/netty/channel/PooledClientContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/PooledClientContextHandler.java
@@ -126,7 +126,6 @@ final class PooledClientContextHandler<CHANNEL extends Channel>
 	@Override
 	@SuppressWarnings("unchecked")
 	protected void terminateChannel(Channel channel) {
-		onCancel.dispose();
 		release((CHANNEL) channel);
 	}
 

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
@@ -252,7 +252,7 @@ class HttpClientOperations extends HttpOperations<HttpClientResponse, HttpClient
 	}
 
 	@Override
-	protected void onInboundCancel() {
+	protected void afterInboundCancel() {
 		channel().close();
 	}
 

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientWSOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientWSOperations.java
@@ -184,7 +184,7 @@ final class HttpClientWSOperations extends HttpClientOperations
 	}
 
 	@Override
-	protected void onInboundCancel() {
+	protected void afterInboundCancel() {
 		if (log.isDebugEnabled()) {
 			log.debug("Cancelling Websocket inbound. Closing Websocket");
 		}

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientOperationsTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientOperationsTest.java
@@ -187,7 +187,6 @@ public class HttpClientOperationsTest {
 		assertSame(ops1.nettyRequest, ops2.nettyRequest);
 		assertSame(ops1.responseState, ops2.responseState);
 		assertSame(ops1.redirectable, ops2.redirectable);
-		assertSame(ops1.inboundPrefetch, ops2.inboundPrefetch);
 		assertSame(ops1.requestHeaders, ops2.requestHeaders);
 		assertSame(ops1.clientError, ops2.clientError);
 		assertSame(ops1.serverError, ops2.serverError);

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
@@ -361,6 +361,7 @@ public class HttpClientTest {
 				                                 c -> c.chunkedTransfer(false)
 				                                       .failOnClientError(false)
 				                                       .sendString(Flux.just("hello")))
+		                                 .doOnNext(x -> x.receive().subscribe())
 		                                 .block(Duration.ofSeconds(30));
 
 		FutureMono.from(r.context()
@@ -379,6 +380,7 @@ public class HttpClientTest {
 				                                 c -> c.chunkedTransfer(false)
 				                                       .failOnClientError(false)
 				                                       .keepAlive(false))
+		                                 .doOnNext(x -> x.receive().subscribe())
 		                                 .block(Duration.ofSeconds(30));
 
 		FutureMono.from(r.context()
@@ -398,13 +400,16 @@ public class HttpClientTest {
 		                                 .get("http://google.com/unsupportedURI",
 				                                 c -> c.failOnClientError(false)
 				                                       .sendHeaders())
+		                                 .doOnNext(x -> x.receive().subscribe())
 		                                 .block(Duration.ofSeconds(30));
 
 		HttpClientResponse r2 = HttpClient.create(opts -> opts.poolResources(p))
 		                                  .get("http://google.com/unsupportedURI",
 				                                  c -> c.failOnClientError(false)
 				                                        .sendHeaders())
+		                                  .doOnNext(x -> x.receive().subscribe())
 		                                  .block(Duration.ofSeconds(30));
+
 		Assert.assertTrue(r.context()
 		                   .channel() == r2.context()
 		                                   .channel());
@@ -420,6 +425,7 @@ public class HttpClientTest {
 		                                 .get("/unsupportedURI",
 				                                 c -> c.chunkedTransfer(false)
 				                                       .failOnClientError(false))
+		                                 .doOnNext(x -> x.receive().subscribe())
 		                                 .block(Duration.ofSeconds(30));
 
 		FutureMono.from(r.context()
@@ -439,6 +445,7 @@ public class HttpClientTest {
 				                                 c -> c.header("content-length", "1")
 				                                       .failOnClientError(false)
 				                                       .sendString(Mono.just(" ")))
+		                                 .doOnNext(x -> x.receive().subscribe())
 		                                 .block(Duration.ofSeconds(30));
 
 		HttpClientResponse r1 = HttpClient.create(opts -> opts.poolResources(fixed))
@@ -446,6 +453,7 @@ public class HttpClientTest {
 				                                  c -> c.header("content-length", "1")
 				                                        .failOnClientError(false)
 				                                        .sendString(Mono.just(" ")))
+		                                  .doOnNext(x -> x.receive().subscribe())
 		                                  .block(Duration.ofSeconds(30));
 
 		Assert.assertTrue(r.status() == HttpResponseStatus.BAD_REQUEST);

--- a/src/test/java/reactor/ipc/netty/http/server/HttpServerTests.java
+++ b/src/test/java/reactor/ipc/netty/http/server/HttpServerTests.java
@@ -378,36 +378,43 @@ public class HttpServerTests {
 		HttpClientResponse response0 = HttpClient.create(c.address()
 		                                                  .getPort())
 		                                         .get("/test/index.html")
+		                                         .doOnNext(r -> r.receive().subscribe())
 		                                         .block(Duration.ofSeconds(30));
 
 		HttpClientResponse response1 = HttpClient.create(c.address()
 		                                                  .getPort())
 		                                         .get("/test/test.css")
+		                                         .doOnNext(r -> r.receive().subscribe())
 		                                         .block(Duration.ofSeconds(30));
 
 		HttpClientResponse response2 = HttpClient.create(c.address()
 		                                                  .getPort())
 		                                         .get("/test/test1.css")
+		                                         .doOnNext(r -> r.receive().subscribe())
 		                                         .block(Duration.ofSeconds(30));
 
 		HttpClientResponse response3 = HttpClient.create(c.address()
 		                                                  .getPort())
 		                                         .get("/test/test2.css")
+		                                         .doOnNext(r -> r.receive().subscribe())
 		                                         .block(Duration.ofSeconds(30));
 
 		HttpClientResponse response4 = HttpClient.create(c.address()
 		                                                  .getPort())
 		                                         .get("/test/test3.css")
+		                                         .doOnNext(r -> r.receive().subscribe())
 		                                         .block(Duration.ofSeconds(30));
 
 		HttpClientResponse response5 = HttpClient.create(c.address()
 		                                                  .getPort())
 		                                         .get("/test/test4.css")
+		                                         .doOnNext(r -> r.receive().subscribe())
 		                                         .block(Duration.ofSeconds(30));
 
 		HttpClientResponse response6 = HttpClient.create(opts -> opts.port(c.address().getPort())
 		                                                             .disablePool())
 		                                         .get("/test/test5.css")
+		                                         .doOnNext(r -> r.receive().subscribe())
 		                                         .block(Duration.ofSeconds(30));
 
 		Assert.assertEquals(response0.channel(), response1.channel());


### PR DESCRIPTION
- avoid double release (and subsequent channel pool exception)
- discard already available FluxReceive in connect cancellation race

for review @violetagg (also need to try on spring)