### PR TITLE
fix #231: Ensure error signal is propagated

### DIFF
--- a/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
@@ -592,7 +592,13 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 						eventLoop.execute(() -> parent.pendingWriteOffer.test(f, PENDING_WRITES));
 					}
 				}
-				f.addListener(this);
+				f.addListener(future -> {
+					if (!future.isSuccess()) {
+						promise.setFailure(Exceptions.addSuppressed(future.cause(), t));
+						return;
+					}
+					promise.setFailure(t);
+				});
 			}
 			else {
 				promise.setFailure(t);


### PR DESCRIPTION
When the writing Publisher completes with an error,
the error signal must be propagated to the subscriber.