### PR TITLE
Add support for Forwarded / X-Forwarded-* headers

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/server/ConnectionInfo.java
+++ b/src/main/java/reactor/ipc/netty/http/server/ConnectionInfo.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.ipc.netty.http.server;
+
+import java.net.InetSocketAddress;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.ssl.SslHandler;
+import reactor.ipc.netty.options.InetSocketAddressUtil;
+
+/**
+ * Resolve information about the current connection, including the
+ * host (server) address, the remote (client) address and the scheme.
+ *
+ * <p>Depending on the chosen factory method, the information
+ * can be retrieved directly from the channel or additionally
+ * using the {@code "Forwarded"}, or {@code "X-Forwarded-*"}
+ * HTTP request headers.
+ *
+ * @author Brian Clozel
+ * @since 0.8
+ * @see <a href="https://tools.ietf.org/html/rfc7239">rfc7239</a>
+ */
+public final class ConnectionInfo {
+
+	private static final String FORWARDED_HEADER = "Forwarded";
+	private static final Pattern FORWARDED_HOST_PATTERN = Pattern.compile("host=\"?([^;,\"]+)\"?");
+	private static final Pattern FORWARDED_PROTO_PATTERN = Pattern.compile("proto=\"?([^;,\"]+)\"?");
+	private static final Pattern FORWARDED_FOR_PATTERN = Pattern.compile("for=\"?([^;,\"]+)\"?");
+
+	private static final String XFORWARDED_IP_HEADER = "X-Forwarded-For";
+	private static final String XFORWARDED_HOST_HEADER = "X-Forwarded-Host";
+	private static final String XFORWARDED_PORT_HEADER = "X-Forwarded-Port";
+	private static final String XFORWARDED_PROTO_HEADER = "X-Forwarded-Proto";
+
+	private final InetSocketAddress hostAddress;
+
+	private final InetSocketAddress remoteAddress;
+
+	private final String scheme;
+
+	/**
+	 * Retrieve the connection information from the current connection directly
+	 * @param request the current server request
+	 * @param channel the current channel
+	 * @return the connection information
+	 */
+	public static ConnectionInfo newConnectionInfo(HttpServerRequest request, SocketChannel channel) {
+		InetSocketAddress hostAddress = channel.localAddress();
+		InetSocketAddress remoteAddress = channel.remoteAddress();
+		String scheme = channel.pipeline().get(SslHandler.class) != null ? "https" : "http";
+		return new ConnectionInfo(hostAddress, remoteAddress, scheme);
+	}
+
+	/**
+	 * Retrieve the connection information from the {@code "Forwarded"}/{@code "X-Forwarded-*"}
+	 * HTTP request headers, or from the current connection directly if none are found.
+	 * @param request the current server request
+	 * @param channel the current channel
+	 * @return the connection information
+	 */
+	public static ConnectionInfo newForwardedConnectionInfo(HttpServerRequest request, SocketChannel channel) {
+		if (request.requestHeaders().contains(FORWARDED_HEADER)) {
+			return parseForwardedInfo(request, channel);
+		}
+		else {
+			return parseXForwardedInfo(request, channel);
+		}
+	}
+
+	private static ConnectionInfo parseForwardedInfo(HttpServerRequest request, SocketChannel channel) {
+		InetSocketAddress hostAddress = channel.localAddress();
+		InetSocketAddress remoteAddress = channel.remoteAddress();
+		String scheme = channel.pipeline().get(SslHandler.class) != null ? "https" : "http";
+
+		String forwarded = request.requestHeaders().get(FORWARDED_HEADER).split(",")[0];
+		Matcher hostMatcher = FORWARDED_HOST_PATTERN.matcher(forwarded);
+		if (hostMatcher.find()) {
+			hostAddress = parseAddress(hostMatcher.group(1), hostAddress.getPort());
+		}
+		Matcher protoMatcher = FORWARDED_PROTO_PATTERN.matcher(forwarded);
+		if (protoMatcher.find()) {
+			scheme = protoMatcher.group(1).trim();
+		}
+		Matcher forMatcher = FORWARDED_FOR_PATTERN.matcher(forwarded);
+		if(forMatcher.find()) {
+			remoteAddress = parseAddress(forMatcher.group(1).trim(), remoteAddress.getPort());
+		}
+		return new ConnectionInfo(hostAddress, remoteAddress, scheme);
+	}
+
+	private static InetSocketAddress parseAddress(String address, int defaultPort) {
+		int portSeparatorIdx = address.lastIndexOf(":");
+		if (portSeparatorIdx > address.lastIndexOf("]")) {
+			return InetSocketAddressUtil.createUnresolved(address.substring(0, portSeparatorIdx),
+					Integer.parseInt(address.substring(portSeparatorIdx + 1)));
+		}
+		else {
+			return InetSocketAddressUtil.createUnresolved(address, defaultPort);
+		}
+	}
+
+	private static ConnectionInfo parseXForwardedInfo(HttpServerRequest request, SocketChannel channel) {
+		InetSocketAddress hostAddress = channel.localAddress();
+		InetSocketAddress remoteAddress = channel.remoteAddress();
+		String scheme = channel.pipeline().get(SslHandler.class) != null ? "https" : "http";
+		if (request.requestHeaders().contains(XFORWARDED_IP_HEADER)) {
+			String hostValue = request.requestHeaders().get(XFORWARDED_IP_HEADER).split(",")[0];
+			hostAddress = parseAddress(hostValue, hostAddress.getPort());
+		}
+		else if(request.requestHeaders().contains(XFORWARDED_HOST_HEADER)) {
+			if(request.requestHeaders().contains(XFORWARDED_PORT_HEADER)) {
+				hostAddress = InetSocketAddressUtil.createUnresolved(
+						request.requestHeaders().get(XFORWARDED_HOST_HEADER).split(",")[0].trim(),
+						Integer.parseInt(request.requestHeaders().get(XFORWARDED_PORT_HEADER).split(",")[0].trim()));
+			}
+			else {
+				hostAddress = InetSocketAddressUtil.createUnresolved(
+						request.requestHeaders().get(XFORWARDED_HOST_HEADER).split(",")[0].trim(),
+						channel.localAddress().getPort());
+			}
+		}
+		if (request.requestHeaders().contains(XFORWARDED_PROTO_HEADER)) {
+			scheme = request.requestHeaders().get(XFORWARDED_PROTO_HEADER).trim();
+		}
+		return new ConnectionInfo(hostAddress, remoteAddress, scheme);
+	}
+
+	private ConnectionInfo(InetSocketAddress hostAddress, InetSocketAddress remoteAddress, String scheme) {
+		this.hostAddress = hostAddress;
+		this.remoteAddress = remoteAddress;
+		this.scheme = scheme;
+	}
+
+	public InetSocketAddress getHostAddress() {
+		return hostAddress;
+	}
+
+	public InetSocketAddress getRemoteAddress() {
+		return remoteAddress;
+	}
+
+	public String getScheme() {
+		return scheme;
+	}
+}

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServer.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServer.java
@@ -188,6 +188,16 @@ public abstract class HttpServer {
 	}
 
 	/**
+	 * Enable support for the {@code "Forwarded"} and {@code "X-Forwarded-*"}
+	 * HTTP request headers for deriving information about the connection.
+	 *
+	 * @return a new {@link HttpServer}
+	 */
+	public final HttpServer forwarded() {
+		return tcpConfiguration(tcp -> tcp.attr(HttpServerOperations.USE_FORWARDED, true));
+	}
+
+	/**
 	 * Enable GZip response compression if the client request presents accept encoding
 	 * headers
 	 * AND the response reaches a minimum threshold
@@ -233,6 +243,16 @@ public abstract class HttpServer {
 	 */
 	public final HttpServer noCompression() {
 		return tcpConfiguration(COMPRESS_ATTR_DISABLE);
+	}
+
+	/**
+	 * Disable support for the {@code "Forwarded"} and {@code "X-Forwarded-*"}
+	 * HTTP request headers.
+	 *
+	 * @return a new {@link HttpServer}
+	 */
+	public final HttpServer noForwarded() {
+		return tcpConfiguration(tcp -> tcp.attr(HttpServerOperations.USE_FORWARDED, false));
 	}
 
 	/**

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerRequest.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerRequest.java
@@ -16,6 +16,7 @@
 
 package reactor.ipc.netty.http.server;
 
+import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -78,10 +79,31 @@ public interface HttpServerRequest extends NettyInbound, HttpInfos {
 	}
 
 	/**
+	 * Return the address of the host peer.
+	 *
+	 * @return the host's address
+	 */
+	InetSocketAddress hostAddress();
+
+	/**
+	 * Return the address of the remote peer.
+	 *
+	 * @return the peer's address
+	 */
+	InetSocketAddress remoteAddress();
+
+	/**
 	 * Return inbound {@link HttpHeaders}
 	 *
 	 * @return inbound {@link HttpHeaders}
 	 */
 	HttpHeaders requestHeaders();
+
+	/**
+	 * Return the current scheme
+	 *
+	 * @return the protocol scheme
+	 */
+	String scheme();
 
 }

--- a/src/test/java/reactor/ipc/netty/http/server/ConnectionInfoTests.java
+++ b/src/test/java/reactor/ipc/netty/http/server/ConnectionInfoTests.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.ipc.netty.http.server;
+
+
+import java.util.function.Consumer;
+
+import org.junit.After;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.ipc.netty.Connection;
+import reactor.ipc.netty.http.client.HttpClient;
+import reactor.ipc.netty.http.client.HttpClientRequest;
+import reactor.ipc.netty.http.client.HttpClientResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConnectionInfo}
+ *
+ * @author Brian Clozel
+ */
+public class ConnectionInfoTests {
+
+	private Connection connection;
+
+	@Test
+	public void noHeaders() {
+		testClientRequest(
+				clientRequest -> {
+				},
+				serverRequest -> {
+					assertThat(serverRequest.hostAddress().getHostString()).isIn("0:0:0:0:0:0:0:1", "127.0.0.1");
+					assertThat(serverRequest.hostAddress().getPort()).isEqualTo(this.connection.address().getPort());
+				});
+	}
+
+	@Test
+	public void forwardedHost() {
+		testClientRequest(
+				clientRequest -> {
+					clientRequest.addHeader("Forwarded", "host=192.168.0.1");
+				},
+				serverRequest -> {
+					assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("192.168.0.1");
+					assertThat(serverRequest.hostAddress().getPort()).isEqualTo(this.connection.address().getPort());
+				});
+	}
+
+	@Test
+	public void forwardedHostIpV6() {
+		testClientRequest(
+				clientRequest -> {
+					clientRequest.addHeader("Forwarded", "host=[1abc:2abc:3abc::5ABC:6abc]");
+				},
+				serverRequest -> {
+					assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
+					assertThat(serverRequest.hostAddress().getPort()).isEqualTo(this.connection.address().getPort());
+				});
+	}
+
+	@Test
+	public void xForwardedFor() {
+		testClientRequest(
+				clientRequest -> {
+					clientRequest.addHeader("X-Forwarded-For", "[1abc:2abc:3abc::5ABC:6abc]:8080, 192.168.0.1");
+				},
+				serverRequest -> {
+					assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
+					assertThat(serverRequest.hostAddress().getPort()).isEqualTo(8080);
+				});
+	}
+
+	@Test
+	public void xForwardedHost() {
+		testClientRequest(
+				clientRequest -> {
+					clientRequest.addHeader("X-Forwarded-Host", "[1abc:2abc:3abc::5ABC:6abc], 192.168.0.1");
+				},
+				serverRequest -> {
+					assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
+					assertThat(serverRequest.hostAddress().getPort()).isEqualTo(this.connection.address().getPort());
+				});
+	}
+
+	@Test
+	public void xForwardedHostAndPort() {
+		testClientRequest(
+				clientRequest -> {
+					clientRequest.addHeader("X-Forwarded-Host", "192.168.0.1");
+					clientRequest.addHeader("X-Forwarded-Port", "8080");
+				},
+				serverRequest -> {
+					assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("192.168.0.1");
+					assertThat(serverRequest.hostAddress().getPort()).isEqualTo(8080);
+				});
+	}
+
+	@Test
+	public void forwardedMultipleHosts() {
+		testClientRequest(
+				clientRequest -> {
+					clientRequest.addHeader("Forwarded", "host=a.example.com,host=b.example.com, host=c.example.com");
+				},
+				serverRequest -> {
+					assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("a.example.com");
+					assertThat(serverRequest.hostAddress().getPort()).isEqualTo(this.connection.address().getPort());
+				});
+	}
+
+	@Test
+	public void forwardedAllDirectives() {
+		testClientRequest(
+				clientRequest -> {
+					clientRequest.addHeader("Forwarded", "host=a.example.com:443;proto=https");
+				},
+				serverRequest -> {
+					assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("a.example.com");
+					assertThat(serverRequest.hostAddress().getPort()).isEqualTo(443);
+					assertThat(serverRequest.scheme()).isEqualTo("https");
+				});
+	}
+
+	@Test
+	public void forwardedAllDirectivesQuoted() {
+		testClientRequest(
+				clientRequest -> {
+					clientRequest.addHeader("Forwarded", "host=\"a.example.com:443\";proto=\"https\"");
+				},
+				serverRequest -> {
+					assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("a.example.com");
+					assertThat(serverRequest.hostAddress().getPort()).isEqualTo(443);
+					assertThat(serverRequest.scheme()).isEqualTo("https");
+				});
+	}
+
+	@Test
+	public void forwardedMultipleHeaders() {
+		testClientRequest(
+				clientRequest -> {
+					clientRequest.addHeader("Forwarded", "host=a.example.com:443;proto=https");
+					clientRequest.addHeader("Forwarded", "host=b.example.com");
+				},
+				serverRequest -> {
+					assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("a.example.com");
+					assertThat(serverRequest.hostAddress().getPort()).isEqualTo(443);
+					assertThat(serverRequest.scheme()).isEqualTo("https");
+				});
+	}
+
+	@Test
+	public void forwardedForHostname() {
+		testClientRequest(
+				clientRequest -> {
+					clientRequest.addHeader("Forwarded", "for=\"_gazonk\"");
+				},
+				serverRequest -> {
+					assertThat(serverRequest.remoteAddress().getHostString()).isEqualTo("_gazonk");
+					assertThat(serverRequest.remoteAddress().getPort()).isPositive();
+				});
+	}
+
+	@Test
+	public void forwardedForIp() {
+		testClientRequest(
+				clientRequest -> {
+					clientRequest.addHeader("Forwarded", "for=192.0.2.60;proto=http;by=203.0.113.43");
+				},
+				serverRequest -> {
+					assertThat(serverRequest.remoteAddress().getHostString()).isEqualTo("192.0.2.60");
+					assertThat(serverRequest.remoteAddress().getPort()).isPositive();
+					assertThat(serverRequest.scheme()).isEqualTo("http");
+				});
+	}
+
+	@Test
+	public void forwardedForIpV6() {
+		testClientRequest(
+				clientRequest -> {
+					clientRequest.addHeader("Forwarded", "for=\"[2001:db8:cafe::17]:4711\"");
+				},
+				serverRequest -> {
+					assertThat(serverRequest.remoteAddress().getHostString()).isEqualTo("2001:db8:cafe:0:0:0:0:17");
+					assertThat(serverRequest.remoteAddress().getPort()).isEqualTo(4711);
+				});
+	}
+
+
+	private void testClientRequest(Consumer<HttpClientRequest> clientConsumer,
+			Consumer<HttpServerRequest> serverConsumer) {
+
+		this.connection = HttpServer.create().forwarded().port(0).handler((req, res) -> {
+			try {
+				serverConsumer.accept(req);
+				return res.status(200).sendString(Mono.just("OK"));
+			}
+			catch (Throwable e) {
+				return res.status(500).sendString(Mono.just(e.getMessage()));
+			}
+		}).bindNow();
+
+		HttpClientResponse response = HttpClient.create(this.connection.address().getPort())
+				.get("/test", req -> {
+					clientConsumer.accept(req);
+					return req.send();
+				}).block();
+
+		assertThat(response.receive().aggregate().asString().block()).isEqualTo("OK");
+	}
+
+	@After
+	public void tearDown() {
+		this.connection.dispose();
+	}
+
+}


### PR DESCRIPTION
This is a proposal for gh-220.

This implementation supports both the standard header `"Forward"`, but also non-standard but quite common ones, such as `"X-Forwarded-For"`, `"X-Forwarded-Host"`, `"X-Forwarded-Port"` and `"X-Forwarded-Proto"`.

I've made available that information directly in the `HttpServerRequest`. Of course this feature is opt-in and disabled by default.

Possible improvements:
* support trusted proxies; the current implementation considers only the first information provided in the list of values. We could configure trusted proxies, walk back the listed values and stop at the first unknown proxy
* refine the configuration; it's currently an on/off thing, but we could only enable support for the rfc or the non-standard `X-Forwarded-*`