### PR TITLE
fix #235: Allow setting followRedirect per HttpClient

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
@@ -17,7 +17,6 @@ package reactor.ipc.netty.http.client;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.Channel;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -33,7 +32,6 @@ import reactor.ipc.netty.Connection;
 import reactor.ipc.netty.NettyOutbound;
 import reactor.ipc.netty.channel.BootstrapHandlers;
 import reactor.ipc.netty.channel.ChannelOperations;
-import reactor.ipc.netty.http.HttpResources;
 import reactor.ipc.netty.resources.PoolResources;
 import reactor.ipc.netty.tcp.TcpClient;
 import reactor.ipc.netty.tcp.TcpServer;
@@ -248,6 +246,15 @@ public abstract class HttpClient {
 	}
 
 	/**
+	 * Enable http status 301/302 auto-redirect support
+	 *
+	 * @return a new {@link HttpClient}
+	 */
+	public final HttpClient followRedirect() {
+		return tcpConfiguration(FOLLOW_REDIRECT_ATTR_CONFIG);
+	}
+
+	/**
 	 * HTTP DELETE to connect the {@link HttpClient}.
 	 *
 	 * @return a {@link RequestSender} ready to prepare the content for response
@@ -338,6 +345,15 @@ public abstract class HttpClient {
 	 */
 	public final HttpClient noCompression() {
 		return tcpConfiguration(COMPRESS_ATTR_DISABLE).headers(COMPRESS_HEADERS_DISABLE);
+	}
+
+	/**
+	 * Disable http status 301/302 auto-redirect support
+	 *
+	 * @return a new {@link HttpClient}
+	 */
+	public final HttpClient noRedirection() {
+		return tcpConfiguration(FOLLOW_REDIRECT_ATTR_DISABLE);
 	}
 
 	/**
@@ -505,14 +521,23 @@ public abstract class HttpClient {
 
 	static final LoggingHandler LOGGING_HANDLER = new LoggingHandler(HttpClient.class);
 
-	static final AttributeKey<Boolean>          ACCEPT_GZIP          =
+	static final AttributeKey<Boolean>          ACCEPT_GZIP                  =
 			AttributeKey.newInstance("acceptGzip");
 
-	static final Function<TcpClient, TcpClient> COMPRESS_ATTR_CONFIG =
+	static final AttributeKey<Boolean>          FOLLOW_REDIRECT              =
+			AttributeKey.newInstance("followRedirect");
+
+	static final Function<TcpClient, TcpClient> COMPRESS_ATTR_CONFIG         =
 			tcp -> tcp.attr(ACCEPT_GZIP, true);
 
-	static final Function<TcpClient, TcpClient> COMPRESS_ATTR_DISABLE =
+	static final Function<TcpClient, TcpClient> COMPRESS_ATTR_DISABLE        =
 			tcp -> tcp.attr(ACCEPT_GZIP, null);
+
+	static final Function<TcpClient, TcpClient> FOLLOW_REDIRECT_ATTR_CONFIG  =
+			tcp -> tcp.attr(FOLLOW_REDIRECT, true);
+
+	static final Function<TcpClient, TcpClient> FOLLOW_REDIRECT_ATTR_DISABLE =
+			tcp -> tcp.attr(FOLLOW_REDIRECT, null);
 
 	static final Consumer<? super HttpHeaders> COMPRESS_HEADERS = h ->
 			h.add(HttpHeaderNames.ACCEPT_ENCODING, HttpHeaderValues.GZIP);

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
@@ -242,10 +242,8 @@ class HttpClientOperations extends HttpOperations<HttpClientResponse, HttpClient
 		return Collections.emptyMap();
 	}
 
-	@Override
-	public HttpClientRequest followRedirect() {
-		redirectable = true;
-		return this;
+	public void followRedirect(boolean redirectable) {
+		this.redirectable = redirectable;
 	}
 
 	@Override

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientRequest.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientRequest.java
@@ -76,13 +76,6 @@ public interface HttpClientRequest extends NettyOutbound, HttpInfos {
 	}
 
 	/**
-	 * Enable http status 302 auto-redirect support
-	 *
-	 * @return {@literal this}
-	 */
-	HttpClientRequest followRedirect();
-
-	/**
 	 * Return  true if headers and status have been sent to the client
 	 *
 	 * @return true if headers and status have been sent to the client

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientOperationsTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientOperationsTest.java
@@ -138,7 +138,7 @@ public class HttpClientOperationsTest {
 
 		HttpClientOperations ops1 = new HttpClientOperations(() -> channel,
 				ConnectionEvents.emptyListener());
-		ops1.followRedirect();
+		ops1.followRedirect(true);
 
 		HttpClientOperations ops2 = new HttpClientOperations(ops1);
 

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
@@ -296,10 +296,9 @@ public class HttpClientTest {
 				                                                                   .host("127.0.0.1")
 				                                                                   .port(8888)))
 				          .wiretap()
-				          .request(HttpMethod.GET)
+				          .followRedirect()
+				          .get()
 				          .uri("https://projectreactor.io")
-				          .send((req, out) -> req.followRedirect()
-				                                 .sendHeaders())
 				          .responseContent()
 				          .retain()
 				          .asString()
@@ -318,19 +317,17 @@ public class HttpClientTest {
 				                                                                   .port(8888)
 				                                                                   .nonProxyHosts("spring.io")))
 				          .wiretap();
-		Mono<String> remote1 = client.request(HttpMethod.GET)
+		Mono<String> remote1 = client.followRedirect()
+		                             .get()
 		                             .uri("https://projectreactor.io")
-		                             .send((c, out) -> c.followRedirect()
-		                                                .sendHeaders())
 		                             .responseContent()
 		                             .retain()
 		                             .asString()
 		                             .limitRate(1)
 		                             .reduce(String::concat);
-		Mono<String> remote2 = client.request(HttpMethod.GET)
+		Mono<String> remote2 = client.followRedirect()
+		                             .get()
 		                             .uri("https://spring.io")
-		                             .send((c, out) -> c.followRedirect()
-		                             .sendHeaders())
 		                             .responseContent()
 		                             .retain()
 		                             .asString()
@@ -371,10 +368,9 @@ public class HttpClientTest {
 		res = HttpClient.prepare()
 		                .tcpConfiguration(tcpClient -> tcpClient.host("google.com"))
 		                .wiretap()
-		                .request(HttpMethod.GET)
+		                .followRedirect()
+		                .get()
 		                .uri("/search")
-		                .send((c, out) -> c.followRedirect()
-		                                   .sendHeaders())
 		                .responseSingle((r, out) -> Mono.just(r.status().code()))
 		                .log()
 		                .block(Duration.ofSeconds(30));
@@ -401,10 +397,9 @@ public class HttpClientTest {
 	}
 
 	private void doSimpleTest404(HttpClient client) {
-		int res = client.request(HttpMethod.GET)
+		int res = client.followRedirect()
+				        .get()
 				        .uri("/unsupportedURI")
-				        .send((c, out) -> c.followRedirect()
-				                           .sendHeaders())
 				        .responseSingle((r, buf) -> Mono.just(r.status().code()))
 				        .log()
 				        .block(Duration.ofSeconds(30));
@@ -586,9 +581,9 @@ public class HttpClientTest {
 		                  .wiretap()
 		                  .headers(h -> h.add("Accept-Encoding", "gzip")
 		                                 .add("Accept-Encoding", "deflate"))
-		                  .request(HttpMethod.GET)
+		                  .followRedirect()
+		                  .get()
 		                  .uri("http://www.httpwatch.com")
-		                  .send((req, out) -> req.followRedirect().sendHeaders())
 		                  .response((r, buf) -> buf.asString()
 		                                           .elementAt(0)
 		                                           .map(s -> s.substring(0, Math.min(s.length() -1, 100)))
@@ -607,13 +602,13 @@ public class HttpClientTest {
 		StepVerifier.create(
 				HttpClient.prepare()
 				          .wiretap()
+				          .followRedirect()
 				          .request(HttpMethod.GET)
 				          .uri("http://www.httpwatch.com")
 				          .send((req, out) ->
 					          req.withConnection(c -> c.addHandlerFirst
 							          ("gzipDecompressor", new
 							          HttpContentDecompressor()))
-					             .followRedirect()
 					             .addHeader
 							          ("Accept-Encoding", "gzip")
 					                    .addHeader("Accept-Encoding", "deflate")

--- a/src/test/java/reactor/ipc/netty/http/client/HttpRedirectTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpRedirectTest.java
@@ -72,9 +72,9 @@ public class HttpRedirectTest {
 
 		try {
 			Flux.range(0, this.numberOfTests)
-			    .concatMap(i -> client.post()
+			    .concatMap(i -> client.followRedirect()
+			                          .post()
 			                          .uri("/login")
-					                  .send((r, out) -> r.followRedirect())
 			                          .responseContent()
 			                          .then())
 			    .blockLast(Duration.ofSeconds(30));
@@ -109,9 +109,9 @@ public class HttpRedirectTest {
 				          .wiretap();
 
 		String value =
-				client.request(HttpMethod.GET)
+				client.followRedirect()
+				      .get()
 				      .uri("/1")
-				      .send((req, out) -> req.followRedirect().sendHeaders())
 				      .responseContent()
 				      .aggregate()
 				      .asString()
@@ -126,9 +126,9 @@ public class HttpRedirectTest {
 		              .block(Duration.ofSeconds(30));
 		Assertions.assertThat(value).isNull();
 
-		value = client.request(HttpMethod.GET)
+		value = client.followRedirect()
+		              .get()
 		              .uri("/2")
-		              .send((req, out) -> req.followRedirect().sendHeaders())
 		              .responseContent()
 		              .aggregate()
 		              .asString()

--- a/src/test/java/reactor/ipc/netty/http/server/HttpServerTests.java
+++ b/src/test/java/reactor/ipc/netty/http/server/HttpServerTests.java
@@ -957,9 +957,9 @@ public class HttpServerTests {
 
 		try {
 			Flux.range(0, this.numberOfTests)
-			    .concatMap(i -> client.post()
+			    .concatMap(i -> client.followRedirect()
+			                          .post()
 					                  .uri("/login")
-					                  .send((r, out) -> r.followRedirect())
 			                          .responseContent()
 			                          .log("reactor.req."+i)
 			                          .then())


### PR DESCRIPTION
The support for `followRedirect` per `HttpClientRequest` is removed.