### PR TITLE
fix #94 : Allow setting chunkedTransfer per HttpClient

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClient.java
@@ -255,6 +255,15 @@ public abstract class HttpClient {
 	}
 
 	/**
+	 * Enable transfer-encoding
+	 *
+	 * @return a new {@link HttpClient}
+	 */
+	public final HttpClient chunkedTransfer() {
+		return tcpConfiguration(CHUNKED_ATTR_CONFIG);
+	}
+
+	/**
 	 * HTTP DELETE to connect the {@link HttpClient}.
 	 *
 	 * @return a {@link RequestSender} ready to prepare the content for response
@@ -354,6 +363,15 @@ public abstract class HttpClient {
 	 */
 	public final HttpClient noRedirection() {
 		return tcpConfiguration(FOLLOW_REDIRECT_ATTR_DISABLE);
+	}
+
+	/**
+	 * Disable transfer-encoding
+	 *
+	 * @return a new {@link HttpClient}
+	 */
+	public final HttpClient noChunkedTransfer() {
+		return tcpConfiguration(CHUNKED_ATTR_DISABLE);
 	}
 
 	/**
@@ -527,11 +545,20 @@ public abstract class HttpClient {
 	static final AttributeKey<Boolean>          FOLLOW_REDIRECT              =
 			AttributeKey.newInstance("followRedirect");
 
+	static final AttributeKey<Boolean>          CHUNKED                      =
+			AttributeKey.newInstance("chunkedTransfer");
+
 	static final Function<TcpClient, TcpClient> COMPRESS_ATTR_CONFIG         =
 			tcp -> tcp.attr(ACCEPT_GZIP, true);
 
 	static final Function<TcpClient, TcpClient> COMPRESS_ATTR_DISABLE        =
 			tcp -> tcp.attr(ACCEPT_GZIP, null);
+
+	static final Function<TcpClient, TcpClient> CHUNKED_ATTR_CONFIG          =
+			tcp -> tcp.attr(CHUNKED, true);
+
+	static final Function<TcpClient, TcpClient> CHUNKED_ATTR_DISABLE         =
+			tcp -> tcp.attr(CHUNKED, false);
 
 	static final Function<TcpClient, TcpClient> FOLLOW_REDIRECT_ATTR_CONFIG  =
 			tcp -> tcp.attr(FOLLOW_REDIRECT, true);

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientConnect.java
@@ -132,6 +132,8 @@ final class HttpClientConnect extends HttpClient {
 
 		boolean followRedirect = attrs.get(FOLLOW_REDIRECT) != null && (Boolean) attrs.get(FOLLOW_REDIRECT);
 
+		Object chunkedTransfer = attrs.get(CHUNKED);
+
 
 		String uri = (String)attrs.get(URI);
 
@@ -143,12 +145,13 @@ final class HttpClientConnect extends HttpClient {
 						delegate.isSecure());
 
 		HttpClientHandler handler =
-				new HttpClientHandler(attrs, reconnectableUriEndpoint, compress, followRedirect);
+				new HttpClientHandler(attrs, reconnectableUriEndpoint, compress, followRedirect, chunkedTransfer);
 
 		reconnectableUriEndpoint.init(uri, handler.method);
 
 		b.attr(ACCEPT_GZIP, null)
 		 .attr(FOLLOW_REDIRECT, null)
+		 .attr(CHUNKED, null)
 		 .attr(BODY, null)
 		 .attr(HEADERS, null)
 		 .attr(URI, null)
@@ -210,10 +213,11 @@ final class HttpClientConnect extends HttpClient {
 		                                                                                           defaultHeaders;
 		final BiFunction<? super HttpClientRequest, ? super NettyOutbound, ? extends NettyOutbound>handler;
 		final boolean                                                                              followRedirect;
+		final Object                                                                               chunkedTransfer;
 
 		@SuppressWarnings("unchecked")
 		HttpClientHandler(Map<AttributeKey<?>, Object> attrs, ReconnectableUriEndpoint bridge,
-						  boolean compress, boolean followRedirect) {
+						  boolean compress, boolean followRedirect, Object chunkedTransfer) {
 			this.method = (HttpMethod) attrs.get(METHOD);
 			HttpHeaders defaultHeaders = (HttpHeaders) attrs.get(HttpClientConnect.HEADERS);
 
@@ -233,6 +237,7 @@ final class HttpClientConnect extends HttpClient {
 			this.handler = requestHandler;
 			this.bridge = bridge;
 			this.followRedirect = followRedirect;
+			this.chunkedTransfer = chunkedTransfer;
 		}
 
 		@Override
@@ -255,6 +260,10 @@ final class HttpClientConnect extends HttpClient {
 				}
 				else {
 					ch.chunkedTransfer(true);
+				}
+
+				if (chunkedTransfer != null) {
+					ch.chunkedTransfer((Boolean) chunkedTransfer);
 				}
 
 				if (defaultHeaders != null) {

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
@@ -217,13 +217,11 @@ class HttpClientOperations extends HttpOperations<HttpClientResponse, HttpClient
 		return ((SocketChannel) channel()).remoteAddress();
 	}
 
-	@Override
-	public HttpClientRequest chunkedTransfer(boolean chunked) {
+	public void chunkedTransfer(boolean chunked) {
 		if (!hasSentHeaders() && HttpUtil.isTransferEncodingChunked(nettyRequest) != chunked) {
 			requestHeaders.remove(HttpHeaderNames.TRANSFER_ENCODING);
 			HttpUtil.setTransferEncodingChunked(nettyRequest, chunked);
 		}
-		return this;
 	}
 
 	@Override

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientRequest.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientRequest.java
@@ -60,15 +60,6 @@ public interface HttpClientRequest extends NettyOutbound, HttpInfos {
 	 */
 	HttpClientRequest addHeader(CharSequence name, CharSequence value);
 
-	/**
-	 * Set transfer-encoding header
-	 *
-	 * @param chunked true if transfer-encoding:chunked
-	 *
-	 * @return this outbound
-	 */
-	HttpClientRequest chunkedTransfer(boolean chunked);
-
 	@Override
 	default HttpClientRequest options(Consumer<? super NettyPipeline.SendOptions> configurator){
 		NettyOutbound.super.options(configurator);

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
@@ -415,10 +415,10 @@ public class HttpClientTest {
 				HttpClient.prepare()
 				          .tcpConfiguration(tcpClient -> tcpClient.host("google.com"))
 				          .wiretap()
+				          .noChunkedTransfer()
 				          .request(HttpMethod.GET)
 				          .uri("/unsupportedURI")
-				          .send((c, out) -> c.chunkedTransfer(false)
-				                             .sendString(Flux.just("hello")))
+				          .send(ByteBufFlux.fromString(Flux.just("hello")))
 				          .responseSingle((res, buf) -> Mono.just(res.status()))
 				          .block(Duration.ofSeconds(30));
 
@@ -431,10 +431,10 @@ public class HttpClientTest {
 				HttpClient.prepare()
 				          .tcpConfiguration(tcpClient -> tcpClient.host("google.com"))
 				          .wiretap()
+				          .noChunkedTransfer()
 				          .request(HttpMethod.GET)
 				          .uri("/unsupportedURI")
-				          .send((c, out) -> c.chunkedTransfer(false)
-				                             .keepAlive(false))
+				          .send((c, out) -> c.keepAlive(false))
 				          .responseSingle((res, buf) -> Mono.just(res.status()))
 				          .block(Duration.ofSeconds(30));
 
@@ -484,9 +484,9 @@ public class HttpClientTest {
 				HttpClient.prepare()
 				          .tcpConfiguration(tcpClient -> tcpClient.host("google.com"))
 				          .wiretap()
-				          .request(HttpMethod.GET)
+				          .noChunkedTransfer()
+				          .get()
 				          .uri("/unsupportedURI")
-				          .send((c, out) -> c.chunkedTransfer(false))
 				          .responseSingle((res, buf) -> Mono.just(res.status()))
 				          .block(Duration.ofSeconds(30));
 


### PR DESCRIPTION
The support for chunkedTransfer per HttpClientRequest is removed.