### PR TITLE
Enable hostname verification in client SSL config

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
@@ -22,13 +22,19 @@ import java.net.URI;
 import java.util.Objects;
 import java.util.function.Function;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslHandler;
 import io.netty.util.NetUtil;
 import reactor.ipc.netty.options.ClientOptions;
 import reactor.ipc.netty.options.ClientProxyOptions;
 import reactor.ipc.netty.options.ClientProxyOptions.Proxy;
+import reactor.util.function.Tuple2;
 
 /**
  * An http client connector builder with low-level connection options including
@@ -79,6 +85,16 @@ public final class HttpClientOptions extends ClientOptions {
 		// TODO: find out whether the remote address should be resolved using blocking operation at this point
 		boolean shouldResolveAddress = !useProxy(uri.getHost());
 		return createInetSocketAddress(uri.getHost(), port, shouldResolveAddress);
+	}
+
+	@Override
+	public SslHandler getSslHandler(ByteBufAllocator allocator, Tuple2<String, Integer> sniInfo) {
+		SslHandler handler =  super.getSslHandler(allocator, sniInfo);
+		SSLEngine sslEngine = handler.engine();
+		SSLParameters sslParameters = sslEngine.getSSLParameters();
+		sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
+		sslEngine.setSSLParameters(sslParameters);
+		return handler;
 	}
 
 	/**

--- a/src/main/java/reactor/ipc/netty/options/NettyOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/NettyOptions.java
@@ -168,7 +168,7 @@ public abstract class NettyOptions<BOOTSTRAP extends AbstractBootstrap<BOOTSTRAP
 	 * @param sniInfo {@link Tuple2} with hostname and port for SNI (any null will skip SNI).
 	 * @return a new eventual {@link SslHandler} with SNI activated
 	 */
-	public final SslHandler getSslHandler(ByteBufAllocator allocator,
+	public SslHandler getSslHandler(ByteBufAllocator allocator,
 			Tuple2<String, Integer> sniInfo) {
 		SslContext sslContext =
 				this.sslContext == null ? defaultSslContext() : this.sslContext;


### PR DESCRIPTION
This is a draft PR for gh-222.

Netty client doesn't enable hostname verification in its client SSL Context by default (see [this warning](https://netty.io/4.1/api/io/netty/handler/ssl/SslContext.html#newHandler-io.netty.buffer.ByteBufAllocator-)).

I've just tested that change against badssl.com - but I'm willing to improve that PR in any way you'd like. 