### PR TITLE
Enable hostname verification in client SSL config

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
@@ -22,13 +22,19 @@ import java.net.URI;
 import java.util.Objects;
 import java.util.function.Function;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslHandler;
 import io.netty.util.NetUtil;
 import reactor.ipc.netty.options.ClientOptions;
 import reactor.ipc.netty.options.ClientProxyOptions;
 import reactor.ipc.netty.options.ClientProxyOptions.Proxy;
+import reactor.util.function.Tuple2;
 
 /**
  * An http client connector builder with low-level connection options including
@@ -79,6 +85,16 @@ public final class HttpClientOptions extends ClientOptions {
 		// TODO: find out whether the remote address should be resolved using blocking operation at this point
 		boolean shouldResolveAddress = !useProxy(uri.getHost());
 		return createInetSocketAddress(uri.getHost(), port, shouldResolveAddress);
+	}
+
+	@Override
+	public SslHandler getSslHandler(ByteBufAllocator allocator, Tuple2<String, Integer> sniInfo) {
+		SslHandler handler =  super.getSslHandler(allocator, sniInfo);
+		SSLEngine sslEngine = handler.engine();
+		SSLParameters sslParameters = sslEngine.getSSLParameters();
+		sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
+		sslEngine.setSSLParameters(sslParameters);
+		return handler;
 	}
 
 	/**

--- a/src/main/java/reactor/ipc/netty/options/NettyOptions.java
+++ b/src/main/java/reactor/ipc/netty/options/NettyOptions.java
@@ -168,7 +168,7 @@ public abstract class NettyOptions<BOOTSTRAP extends AbstractBootstrap<BOOTSTRAP
 	 * @param sniInfo {@link Tuple2} with hostname and port for SNI (any null will skip SNI).
 	 * @return a new eventual {@link SslHandler} with SNI activated
 	 */
-	public final SslHandler getSslHandler(ByteBufAllocator allocator,
+	public SslHandler getSslHandler(ByteBufAllocator allocator,
 			Tuple2<String, Integer> sniInfo) {
 		SslContext sslContext =
 				this.sslContext == null ? defaultSslContext() : this.sslContext;

--- a/src/test/java/reactor/ipc/netty/ByteBufFluxTest.java
+++ b/src/test/java/reactor/ipc/netty/ByteBufFluxTest.java
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -132,7 +133,8 @@ public class ByteBufFluxTest {
         if (withSecurity) {
             SelfSignedCertificate ssc = new SelfSignedCertificate();
             SslContext sslServer = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
-            SslContext sslClient = SslContextBuilder.forClient().trustManager(ssc.cert()).build();
+            SslContext sslClient = SslContextBuilder.forClient()
+					.trustManager(InsecureTrustManagerFactory.INSTANCE).build();
             serverOptions = ops -> ops.port(serverPort).sslContext(sslServer);
             clientOptions = ops -> ops.port(serverPort).sslContext(sslClient);
         }

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
@@ -40,6 +40,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.CharsetUtil;
 import org.junit.Assert;
@@ -674,8 +675,7 @@ public class HttpClientTest {
 		SslContext sslServer = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
 		                                        .build();
 		SslContext sslClient = SslContextBuilder.forClient()
-		                                        //make the client to trust the self signed certificate
-		                                        .trustManager(ssc.cert())
+		                                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
 		                                        .build();
 
 		NettyContext context =
@@ -701,7 +701,7 @@ public class HttpClientTest {
 		SelfSignedCertificate ssc = new SelfSignedCertificate();
 		SslContext sslServer = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
 		SslContext sslClient = SslContextBuilder.forClient()
-		                                        .trustManager(ssc.cert()).build();
+		                                        .trustManager(InsecureTrustManagerFactory.INSTANCE).build();
 
 		NettyContext context =
 				HttpServer.create(opt -> opt.sslContext(sslServer))
@@ -725,7 +725,8 @@ public class HttpClientTest {
 		Path largeFile = Paths.get(getClass().getResource("/largeFile.txt").toURI());
 		SelfSignedCertificate ssc = new SelfSignedCertificate();
 		SslContext sslServer = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
-		SslContext sslClient = SslContextBuilder.forClient().trustManager(ssc.cert()).build();
+		SslContext sslClient = SslContextBuilder.forClient()
+				.trustManager(InsecureTrustManagerFactory.INSTANCE).build();
 		AtomicReference<String> uploaded = new AtomicReference<>();
 
 		NettyContext context =

--- a/src/test/java/reactor/ipc/netty/http/server/HttpServerTests.java
+++ b/src/test/java/reactor/ipc/netty/http/server/HttpServerTests.java
@@ -58,6 +58,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.ResourceLeakDetector;
 import org.junit.Test;
@@ -166,7 +167,8 @@ public class HttpServerTests {
 		Path largeFile = Paths.get(getClass().getResource("/largeFile.txt").toURI());
 		SelfSignedCertificate ssc = new SelfSignedCertificate();
 		SslContext sslServer = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
-		SslContext sslClient = SslContextBuilder.forClient().trustManager(ssc.cert()).build();
+		SslContext sslClient = SslContextBuilder.forClient()
+				.trustManager(InsecureTrustManagerFactory.INSTANCE).build();
 
 		NettyContext context =
 				HttpServer.create(opt -> opt.sslContext(sslServer))


### PR DESCRIPTION
This is a fix for gh-222.

Netty client doesn't enable hostname verification in its client SSL Context by default (see [this warning](https://netty.io/4.1/api/io/netty/handler/ssl/SslContext.html#newHandler-io.netty.buffer.ByteBufAllocator-)).

I've just tested that change against badssl.com - but I'm willing to improve that PR in any way you'd like.

In order to make other tests pass, I had to use Netty's `InsecureTrustManagerFactory.INSTANCE` and I don't know if this is the right solution vs. using registering the self signed cert as previously. The self signed cert is generated with `"example.com"` as a domain. It looks like hostname verification will resolve the real cert associated with `"example.com"` and won't find a valid cert path between the generated and the real one.

It looks like Netty itself is [doing this when testing SSL-related scenarios](https://github.com/netty/netty/blob/4.1/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java).