### PR TITLE
fix #289 Register pool-releasing close listener only if acquired

### DIFF
--- a/src/main/java/reactor/ipc/netty/channel/PooledClientContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/PooledClientContextHandler.java
@@ -200,6 +200,9 @@ final class PooledClientContextHandler<CHANNEL extends Channel>
 		if (createOperations(c, null) == null) {
 			setFuture(pool.acquire());
 		}
+		else {
+			c.closeFuture().addListener(ff -> pool.release(c));
+		}
 	}
 
 	@Override

--- a/src/main/java/reactor/ipc/netty/channel/PooledClientContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/PooledClientContextHandler.java
@@ -189,7 +189,6 @@ final class PooledClientContextHandler<CHANNEL extends Channel>
 		if (!c.isActive()) {
 			log.debug("Immediately aborted pooled channel, re-acquiring new " + "channel: {}",
 					c.toString());
-			release(c);
 			setFuture(pool.acquire());
 			return;
 		}
@@ -200,10 +199,9 @@ final class PooledClientContextHandler<CHANNEL extends Channel>
 		if (createOperations(c, null) == null) {
 			setFuture(pool.acquire());
 		}
-		else {
-			c.closeFuture().addListener(ff -> pool.release(c));
-		}
 	}
+
+
 
 	@Override
 	@SuppressWarnings("unchecked")

--- a/src/main/java/reactor/ipc/netty/resources/DefaultPoolResources.java
+++ b/src/main/java/reactor/ipc/netty/resources/DefaultPoolResources.java
@@ -161,6 +161,7 @@ final class DefaultPoolResources implements PoolResources {
 
 		@Override
 		public void channelCreated(Channel ch) throws Exception {
+			activeConnections.incrementAndGet();
 			/*
 				Sometimes the Channel can be notified as created (by FixedChannelPool) but
 				it actually fails to connect and the FixedChannelPool will decrement its
@@ -172,6 +173,7 @@ final class DefaultPoolResources implements PoolResources {
 
 				see https://github.com/reactor/reactor-netty/issues/289
 			 */
+
 			if (log.isDebugEnabled()) {
 				log.debug("Created new pooled channel {}, now {} active connections",
 						ch.toString(),

--- a/src/main/java/reactor/ipc/netty/resources/DefaultPoolResources.java
+++ b/src/main/java/reactor/ipc/netty/resources/DefaultPoolResources.java
@@ -157,8 +157,6 @@ final class DefaultPoolResources implements PoolResources {
 						ch.toString(),
 						activeConnections);
 			}
-			ch.closeFuture()
-			  .addListener(ff -> pool.release(ch).get());
 		}
 
 		@Override
@@ -170,12 +168,12 @@ final class DefaultPoolResources implements PoolResources {
 				still invoked, which can lead to double-decrement and an assertion error.
 
 				As such, it is best to only register the close handler on the channel in
-				`channelAcquired`.
+				`PooledClientContextHandler`.
 
 				see https://github.com/reactor/reactor-netty/issues/289
 			 */
 			if (log.isDebugEnabled()) {
-				log.debug("Created new pooled channel {}, pending channelAcquired, had {} active connections",
+				log.debug("Created new pooled channel {}, now {} active connections",
 						ch.toString(),
 						activeConnections);
 			}


### PR DESCRIPTION
Instead of setting up the close listener in the ChannelPoolHandler
channelCreated method, set it up in the PooledClientContextHandler.

This should prevent the listener to be invoked after a FixedChannelPool
has determined the channel was not healthy and has already decremented
its internal acquire counter (which would lead to a second decrement of
said counter and an assertion error).