### PR TITLE
fix #293 support expect 100-continue

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/HttpOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/HttpOperations.java
@@ -48,7 +48,6 @@ import reactor.ipc.netty.NettyContext;
 import reactor.ipc.netty.NettyInbound;
 import reactor.ipc.netty.NettyOutbound;
 import reactor.ipc.netty.NettyPipeline;
-import reactor.ipc.netty.channel.AbortedException;
 import reactor.ipc.netty.channel.ChannelOperations;
 import reactor.ipc.netty.channel.ContextHandler;
 import reactor.ipc.netty.channel.data.AbstractFileChunkedStrategy;
@@ -147,16 +146,19 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 					                     .remove(HttpHeaderNames.TRANSFER_ENCODING);
 				}
 
-				if (!HttpUtil.isTransferEncodingChunked(outboundHttpMessage()) && !HttpUtil.isContentLengthSet(
-						outboundHttpMessage())) {
-					markPersistent(false);
-				}
+				checkIfNotPersistent();
+
 				return channel().writeAndFlush(outboundHttpMessage());
 			}
 			else {
 				return channel().newSucceededFuture();
 			}
 		});
+	}
+
+	protected void checkIfNotPersistent(){
+		//default doesn't imply anything - only server usually implies if connection
+		// should default persist (keep-alive) when response is not self defined
 	}
 
 	protected abstract HttpMessage newFullEmptyBodyMessage();

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
@@ -272,6 +272,17 @@ class HttpClientOperations extends HttpOperations<HttpClientResponse, HttpClient
 	}
 
 	@Override
+	public NettyOutbound sendObject(Publisher<?> dataStream) {
+		if (!HttpUtil.isTransferEncodingChunked(nettyRequest) &&
+				!HttpUtil.isContentLengthSet(nettyRequest) &&
+				!method().equals(HttpMethod.HEAD) &&
+				!hasSentHeaders()) {
+			HttpUtil.setTransferEncodingChunked(nettyRequest, true);
+		}
+		return super.sendObject(dataStream);
+	}
+
+	@Override
 	public HttpClientRequest header(CharSequence name, CharSequence value) {
 		if (!hasSentHeaders()) {
 			this.requestHeaders.set(name, value);

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerHandler.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerHandler.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.ReferenceCountUtil;
@@ -167,7 +168,7 @@ final class HttpServerHandler extends ChannelDuplexHandler
 				setKeepAlive(response, false);
 			}
 
-			if (isInformational(response)) {
+			if (response.status().equals(HttpResponseStatus.CONTINUE)) {
 				ctx.write(msg, promise);
 				return;
 			}

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerHandler.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerHandler.java
@@ -166,6 +166,11 @@ final class HttpServerHandler extends ChannelDuplexHandler
 			if (!shouldKeepAlive()) {
 				setKeepAlive(response, false);
 			}
+
+			if (isInformational(response)) {
+				ctx.write(msg, promise);
+				return;
+			}
 		}
 		if (msg instanceof LastHttpContent) {
 			if (!shouldKeepAlive()) {

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerOperations.java
@@ -250,7 +250,13 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		//       No need to notify the upstream handlers - just log.
 		//       If decoding a response, just throw an error.
 		if (HttpUtil.is100ContinueExpected(nettyRequest)) {
-			return FutureMono.deferFuture(() -> channel().writeAndFlush(CONTINUE))
+			return FutureMono.deferFuture(() -> {
+						if(!hasSentHeaders()) {
+							return channel().writeAndFlush(CONTINUE);
+						}
+						return channel().newSucceededFuture();
+					})
+
 			                 .thenMany(super.receiveObject());
 		}
 		else {

--- a/src/test/java/reactor/ipc/netty/resources/DefaultPoolResourcesTest.java
+++ b/src/test/java/reactor/ipc/netty/resources/DefaultPoolResourcesTest.java
@@ -174,7 +174,7 @@ public class DefaultPoolResourcesTest {
 
 			assertThat(end - start)
 					.as("channel4 acquire blocked until channel1 released")
-					.isGreaterThan(500);
+					.isGreaterThanOrEqualTo(500);
 
 			pool.release(channel3).get();
 			pool.release(channel4).get();


### PR DESCRIPTION
HttpServerHandler now write informational response separately.
In order to fully work the fix correctly defers header sending on subscribe.
This can give precedence to the expect100Continue logic in receiveObject()