### PR TITLE
fix #218 add predicate based http server compression

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/HttpOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/HttpOperations.java
@@ -130,8 +130,7 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 					msg = outboundHttpMessage();
 				}
 
-
-				checkIfNotPersistent();
+				preSendHeadersAndStatus();
 
 				return channel().writeAndFlush(msg);
 			}
@@ -141,10 +140,7 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 		});
 	}
 
-	protected void checkIfNotPersistent(){
-		//default doesn't imply anything - only server usually implies if connection
-		// should default persist (keep-alive) when response is not self defined
-	}
+	protected abstract void preSendHeadersAndStatus();
 
 	protected abstract HttpMessage newFullEmptyBodyMessage();
 

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
@@ -492,6 +492,11 @@ class HttpClientOperations extends HttpOperations<HttpClientResponse, HttpClient
 	}
 
 	@Override
+	protected void preSendHeadersAndStatus() {
+		//Noop
+	}
+
+	@Override
 	protected void onHandlerStart() {
 		applyHandler();
 	}

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerOptions.java
@@ -16,6 +16,9 @@
 
 package reactor.ipc.netty.http.server;
 
+import java.util.Objects;
+import java.util.function.BiPredicate;
+
 import io.netty.bootstrap.ServerBootstrap;
 import reactor.ipc.netty.options.ServerOptions;
 
@@ -37,6 +40,8 @@ public final class HttpServerOptions extends ServerOptions {
 		return new HttpServerOptions.Builder();
 	}
 
+	private final BiPredicate<HttpServerRequest, HttpServerResponse> compressionPredicate;
+
 	private final int minCompressionResponseSize;
 	private final int maxInitialLineLength;
 	private final int maxHeaderSize;
@@ -52,6 +57,17 @@ public final class HttpServerOptions extends ServerOptions {
 		this.maxChunkSize = builder.maxChunkSize;
 		this.validateHeaders = builder.validateHeaders;
 		this.initialBufferSize = builder.initialBufferSize;
+		this.compressionPredicate = builder.compressionPredicate;
+	}
+
+	/**
+	 * Returns the compression predicate returning true to compress the response.
+	 * By default the compression is disabled.
+	 *
+	 * @return Returns the compression predicate returning true to compress the response.
+	 */
+	public BiPredicate<HttpServerRequest, HttpServerResponse> compressionPredicate() {
+		return compressionPredicate;
 	}
 
 	/**
@@ -153,6 +169,8 @@ public final class HttpServerOptions extends ServerOptions {
 		public static final boolean DEFAULT_VALIDATE_HEADERS    = true;
 		public static final int DEFAULT_INITIAL_BUFFER_SIZE     = 128;
 
+		private BiPredicate<HttpServerRequest, HttpServerResponse> compressionPredicate;
+
 		private int minCompressionResponseSize = -1;
 		private int maxInitialLineLength = DEFAULT_MAX_INITIAL_LINE_LENGTH;
 		private int maxHeaderSize = DEFAULT_MAX_HEADER_SIZE;
@@ -173,6 +191,27 @@ public final class HttpServerOptions extends ServerOptions {
 		 */
 		public final Builder compression(boolean enabled) {
 			this.minCompressionResponseSize = enabled ? 0 : -1;
+			return get();
+		}
+
+		/**
+		 * Enable GZip response compression if the client request presents accept encoding
+		 * headers and the passed {@link java.util.function.Predicate} matches.
+		 * <p>
+		 *     note the passed {@link HttpServerRequest} and {@link HttpServerResponse}
+		 *     should be considered read-only and the implement SHOULD NOT consume or
+		 *     write the request/response in this predicate.
+		 * @param predicate that returns true to compress the response.
+		 *
+		 *
+		 * @return {@code this}
+		 */
+		public final Builder compression(BiPredicate<HttpServerRequest, HttpServerResponse> predicate) {
+			Objects.requireNonNull(predicate, "compressionPredicate");
+			if (this.minCompressionResponseSize < 0) {
+				this.minCompressionResponseSize = 0;
+			}
+			this.compressionPredicate = predicate;
 			return get();
 		}
 


### PR DESCRIPTION
HttpServerBuilder now exposes a compression(BiPredicate<Req,Res>).
The predicate is evaluated before committing response header/status.
If the predicate is true, compression is enabled for the given response.
The minimum compression threshold now uses content-length predicate.