### PR TITLE
fix #312 - Add reactor core 3.1.6 non blocking thread marker support

### DIFF
--- a/src/main/java/reactor/ipc/netty/channel/ChannelOperations.java
+++ b/src/main/java/reactor/ipc/netty/channel/ChannelOperations.java
@@ -376,8 +376,14 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 			log.debug("[{}] {} handler is being applied: {}", formatName(), channel
 					(), handler);
 		}
-		Mono.fromDirect(handler.apply((INBOUND) this, (OUTBOUND) this))
-		       .subscribe(this);
+		try {
+			Mono.fromDirect(handler.apply((INBOUND) this, (OUTBOUND) this))
+			    .subscribe(this);
+		}
+		catch (Throwable t) {
+			log.error("", t);
+			channel.close();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Prevent bifunction handler propagation and close the connection.