### PR TITLE
fix #321: Handle the delayed writes when onComplete/onError event is sent

### DIFF
--- a/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
@@ -527,7 +527,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 			if (p != 0L) {
 				produced = 0L;
 				produced(p);
-				if (parent.pendingBytes > 0L || parent.hasPendingWriteBytes()) {
+				if (parent.pendingBytes > 0L || parent.hasPendingWriteBytes() || !lastThreadInEventLoop) {
 					if (parent.ctx.channel()
 					              .isActive()) {
 						parent.pendingBytes = 0L;
@@ -548,7 +548,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 			}
 
 			if (f != null) {
-				if (!f.isDone() && parent.hasPendingWriteBytes()) {
+				if (!f.isDone() && (parent.hasPendingWriteBytes() || !lastThreadInEventLoop)) {
 					EventLoop eventLoop = parent.ctx.channel().eventLoop();
 					if (eventLoop.inEventLoop()) {
 						parent.pendingWriteOffer.test(f, PENDING_WRITES);
@@ -592,7 +592,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 			}
 
 			if (f != null) {
-				if (!f.isDone() && parent.hasPendingWriteBytes()) {
+				if (!f.isDone() && (parent.hasPendingWriteBytes() || !lastThreadInEventLoop)) {
 					EventLoop eventLoop = parent.ctx.channel().eventLoop();
 					if (eventLoop.inEventLoop()) {
 						parent.pendingWriteOffer.test(f, PENDING_WRITES);

--- a/src/test/java/reactor/ipc/netty/http/server/HttpsSendFileTests.java
+++ b/src/test/java/reactor/ipc/netty/http/server/HttpsSendFileTests.java
@@ -56,10 +56,4 @@ public class HttpsSendFileTests extends HttpSendFileTests {
 			throw new RuntimeException(e);
 		}
 	}
-
-	@Override
-	protected void doTestSendFileAsync(int chunk) throws IOException, URISyntaxException {
-		// TODO: FIX THIS FOR SSL, remove this overridden method that disables the currently failing tests
-		// https://github.com/reactor/reactor-netty/issues/321
-	}
 }


### PR DESCRIPTION
When onNext event is sent and the previous thread was not in an event loop then
the write will be delayed. Then when onComplete/onError event is sent, the
implementation need to check the pending writes and also the delayed.