### PR TITLE
fix #329 Change the dependency to netty-transport-native-epoll

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,7 @@ configure(rootProject) { project ->
 	compile "io.netty:netty-handler:${nettyVersion}"
 	compile "io.netty:netty-handler-proxy:${nettyVersion}"
 	compile "io.netty:netty-codec-http:${nettyVersion}"
-	compile "io.netty:netty-transport-native-epoll:${nettyVersion}"
+	compile "io.netty:netty-transport-native-epoll:${nettyVersion}:linux-x86_64"
 	optional "io.netty:netty-transport-native-kqueue:${nettyVersion}"
 
 	// Testing

--- a/src/main/java/reactor/ipc/netty/NettyOutbound.java
+++ b/src/main/java/reactor/ipc/netty/NettyOutbound.java
@@ -32,6 +32,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.DefaultFileRegion;
+import io.netty.channel.nio.NioEventLoop;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedInput;
 import io.netty.handler.stream.ChunkedNioFile;
@@ -222,7 +223,9 @@ public interface NettyOutbound extends Publisher<Void> {
 	 */
 	default NettyOutbound sendFile(Path file, long position, long count) {
 		Objects.requireNonNull(file);
-		if (context().channel().pipeline().get(SslHandler.class) != null) {
+		if ((context().channel().pipeline().get(SslHandler.class) != null) ||
+				(!(context().channel().eventLoop() instanceof NioEventLoop) &&
+						!"file".equals(file.toUri().getScheme()))) {
 			return sendFileChunked(file, position, count);
 		}
 


### PR DESCRIPTION
Change the dependency to netty-transport-native-epoll to the one with linux-x86_64 classifier