### PR TITLE
fix #340 When compression is enabled do not send file with zero copy

### DIFF
--- a/src/main/java/reactor/ipc/netty/NettyOutbound.java
+++ b/src/main/java/reactor/ipc/netty/NettyOutbound.java
@@ -224,6 +224,7 @@ public interface NettyOutbound extends Publisher<Void> {
 	default NettyOutbound sendFile(Path file, long position, long count) {
 		Objects.requireNonNull(file);
 		if ((context().channel().pipeline().get(SslHandler.class) != null) ||
+				context().channel().pipeline().get(NettyPipeline.CompressionHandler) != null ||
 				(!(context().channel().eventLoop() instanceof NioEventLoop) &&
 						!"file".equals(file.toUri().getScheme()))) {
 			return sendFileChunked(file, position, count);


### PR DESCRIPTION
When compression is enabled do not send file with zero copy instead
use chunking