### PR TITLE
Fix and suppress compilation and build warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ configure(rootProject) { project ->
 														   "-Xlint:-serial",      // intentionally disabled
 														   "-Xlint:-options",     // intentionally disabled
 														   "-Xlint:-fallthrough", // intentionally disabled
-														   "-Xlint:-rawtypes"     // TODO enable and fix warnings
+														   "-Xlint:rawtypes"
   ]
 
   compileJava {

--- a/src/docs/asciidoc/index.asciidoc
+++ b/src/docs/asciidoc/index.asciidoc
@@ -9,5 +9,4 @@ ifndef::host-github[:ext-relative: {outfilesuffix}]
 include::net.adoc[]
 include::net-tcp.adoc[]
 include::net-http.adoc[]
-include::net-e2e.adoc[]
 

--- a/src/main/java/reactor/ipc/netty/NettyOutbound.java
+++ b/src/main/java/reactor/ipc/netty/NettyOutbound.java
@@ -94,7 +94,7 @@ public interface NettyOutbound extends Publisher<Void> {
 		return this;
 	}
 
-	default FileChunkedStrategy getFileChunkedStrategy() {
+	default FileChunkedStrategy<?> getFileChunkedStrategy() {
 		return FILE_CHUNKED_STRATEGY_BUFFER;
 	}
 
@@ -242,7 +242,7 @@ public interface NettyOutbound extends Publisher<Void> {
 
 	default NettyOutbound sendFileChunked(Path file, long position, long count) {
 		Objects.requireNonNull(file);
-		final FileChunkedStrategy strategy = getFileChunkedStrategy();
+		final FileChunkedStrategy<?> strategy = getFileChunkedStrategy();
 		strategy.preparePipeline(context());
 
 		return then(Mono.using(() -> FileChannel.open(file, StandardOpenOption.READ),

--- a/src/main/java/reactor/ipc/netty/channel/ChannelOperations.java
+++ b/src/main/java/reactor/ipc/netty/channel/ChannelOperations.java
@@ -106,7 +106,7 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 	}
 
 	static ChannelOperations<?, ?> tryGetAndSet(Channel ch, ChannelOperations<?, ?> ops) {
-		Attribute<ChannelOperations> attr = ch.attr(ChannelOperations.OPERATIONS_KEY);
+		Attribute<ChannelOperations<?, ?>> attr = ch.attr(ChannelOperations.OPERATIONS_KEY);
 		for (; ; ) {
 			ChannelOperations<?, ?> op = attr.get();
 			if (op != null) {
@@ -475,10 +475,11 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 	/**
 	 * The attribute in {@link Channel} to store the current {@link ChannelOperations}
 	 */
-	protected static final AttributeKey<ChannelOperations> OPERATIONS_KEY = AttributeKey.newInstance("nettyOperations");
+	protected static final AttributeKey<ChannelOperations<?, ?>> OPERATIONS_KEY = AttributeKey.newInstance("nettyOperations");
 	static final Logger     log  = Loggers.getLogger(ChannelOperations.class);
-	static final BiFunction PING = (i, o) -> Flux.empty();
+	static final BiFunction<? super NettyInbound, ? super NettyOutbound, ? extends Publisher<Void>> PING = (i, o) -> Flux.empty();
 
+	@SuppressWarnings("rawtypes")
 	static final AtomicReferenceFieldUpdater<ChannelOperations, Subscription>
 			OUTBOUND_CLOSE = AtomicReferenceFieldUpdater.newUpdater(ChannelOperations.class,
 			Subscription.class,

--- a/src/main/java/reactor/ipc/netty/channel/ContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ContextHandler.java
@@ -221,7 +221,7 @@ public abstract class ContextHandler<CHANNEL extends Channel>
 					channelOpFactory.create((CHANNEL) channel, this, msg);
 
 			if (op != null) {
-				ChannelOperations old = ChannelOperations.tryGetAndSet(channel, op);
+				ChannelOperations<?, ?> old = ChannelOperations.tryGetAndSet(channel, op);
 
 				if (old != null) {
 					if (log.isDebugEnabled()) {

--- a/src/main/java/reactor/ipc/netty/channel/PooledClientContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/PooledClientContextHandler.java
@@ -55,12 +55,13 @@ final class PooledClientContextHandler<CHANNEL extends Channel>
 
 	volatile Future<CHANNEL> future;
 
+	@SuppressWarnings("rawtypes")
 	static final AtomicReferenceFieldUpdater<PooledClientContextHandler, Future> FUTURE =
 			AtomicReferenceFieldUpdater.newUpdater(PooledClientContextHandler.class,
 					Future.class,
 					"future");
 
-	static final Future DISPOSED = new SucceededFuture<>(null, null);
+	static final Future<?> DISPOSED = new SucceededFuture<>(null, null);
 
 	PooledClientContextHandler(ChannelOperations.OnNew<CHANNEL> channelOpFactory,
 			ClientOptions options,

--- a/src/main/java/reactor/ipc/netty/http/HttpOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/HttpOperations.java
@@ -168,7 +168,7 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 	}
 
 	@Override
-	public FileChunkedStrategy getFileChunkedStrategy() {
+	public FileChunkedStrategy<?> getFileChunkedStrategy() {
 		return new AbstractFileChunkedStrategy<HttpContent>() {
 			@Override
 			public ChunkedInput<HttpContent> chunkFile(FileChannel fileChannel, long offset, long length, int chunkSize) {
@@ -263,6 +263,7 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 	 */
 	protected abstract HttpMessage outboundHttpMessage();
 
+	@SuppressWarnings("rawtypes")
 	final static AtomicIntegerFieldUpdater<HttpOperations> HTTP_STATE =
 			AtomicIntegerFieldUpdater.newUpdater(HttpOperations.class,
 					"statusAndHeadersSent");

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
@@ -83,7 +83,7 @@ import reactor.util.Loggers;
 class HttpClientOperations extends HttpOperations<HttpClientResponse, HttpClientRequest>
 		implements HttpClientResponse, HttpClientRequest {
 
-	static HttpOperations bindHttp(Channel channel,
+	static HttpClientOperations bindHttp(Channel channel,
 			BiFunction<? super HttpClientResponse, ? super HttpClientRequest, ? extends Publisher<Void>> handler,
 			ContextHandler<?> context) {
 		return new HttpClientOperations(channel, handler, context);

--- a/src/main/java/reactor/ipc/netty/resources/DefaultLoopResources.java
+++ b/src/main/java/reactor/ipc/netty/resources/DefaultLoopResources.java
@@ -92,6 +92,7 @@ final class DefaultLoopResources extends AtomicLong implements LoopResources {
 		return !running.get();
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public Mono<Void> disposeLater() {
 		return Mono.defer(() -> {

--- a/src/main/java/reactor/ipc/netty/tcp/TcpClient.java
+++ b/src/main/java/reactor/ipc/netty/tcp/TcpClient.java
@@ -226,7 +226,7 @@ public class TcpClient implements NettyConnector<NettyInbound, NettyOutbound> {
 						(ch, c, msg) -> ChannelOperations.bind(ch, handler, c));
 	}
 
-	protected static final ChannelOperations.OnNew EMPTY = (a,b,c) -> null;
+	protected static final ChannelOperations.OnNew<SocketChannel> EMPTY = (a,b,c) -> null;
 
 	static final LoggingHandler loggingHandler = new LoggingHandler(TcpClient.class);
 

--- a/src/test/java/reactor/ipc/netty/NettyOutboundTest.java
+++ b/src/test/java/reactor/ipc/netty/NettyOutboundTest.java
@@ -114,7 +114,7 @@ public class NettyOutboundTest {
 			}
 
 			@Override
-			public FileChunkedStrategy getFileChunkedStrategy() {
+			public FileChunkedStrategy<?> getFileChunkedStrategy() {
 				return FILE_CHUNKED_STRATEGY_NOPIPELINE;
 			}
 		};
@@ -182,7 +182,7 @@ public class NettyOutboundTest {
 			}
 
 			@Override
-			public FileChunkedStrategy getFileChunkedStrategy() {
+			public FileChunkedStrategy<?> getFileChunkedStrategy() {
 				return FILE_CHUNKED_STRATEGY_NOPIPELINE;
 			}
 		};
@@ -248,7 +248,7 @@ public class NettyOutboundTest {
 			}
 
 			@Override
-			public FileChunkedStrategy getFileChunkedStrategy() {
+			public FileChunkedStrategy<?> getFileChunkedStrategy() {
 				return FILE_CHUNKED_STRATEGY_NOPIPELINE;
 			}
 		};
@@ -277,7 +277,7 @@ public class NettyOutboundTest {
 		assertThat(channel.finishAndReleaseAll()).isTrue();
 	}
 
-	private static final FileChunkedStrategy FILE_CHUNKED_STRATEGY_NOPIPELINE =
+	private static final FileChunkedStrategy<ByteBuf> FILE_CHUNKED_STRATEGY_NOPIPELINE =
 			new FileChunkedStrategy<ByteBuf>() {
 				@Override
 				public ChunkedInput<ByteBuf> chunkFile(FileChannel fileChannel, long offset, long length, int chunkSize) {

--- a/src/test/java/reactor/ipc/netty/http/server/UriPathTemplateTest.java
+++ b/src/test/java/reactor/ipc/netty/http/server/UriPathTemplateTest.java
@@ -20,6 +20,8 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 import reactor.ipc.netty.http.server.HttpPredicate.UriPathTemplate;
 
+import java.util.Arrays;
+
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -59,7 +61,7 @@ public class UriPathTemplateTest {
     public void parametrizedPathWithMultipleParametersShouldBeMatched() {
         UriPathTemplate template = new UriPathTemplate("/{collection}/{id}");
         assertThat(template.matches("/comments/1"), is(true));
-        assertThat(template.match("/comments/1"), allOf(hasEntry("id", "1"), hasEntry("collection", "comments")));
+        assertThat(template.match("/comments/1"), allOf(Arrays.asList(hasEntry("id", "1"), hasEntry("collection", "comments"))));
     }
 
     @Test

--- a/src/test/java/reactor/ipc/netty/tcp/TcpClientTests.java
+++ b/src/test/java/reactor/ipc/netty/tcp/TcpClientTests.java
@@ -200,7 +200,7 @@ public class TcpClientTests {
 
 	@Test
 	public void tcpClientHandlesLineFeedDataFixedPool() throws InterruptedException {
-		Consumer<Channel> channelInit = c -> c
+		Consumer<? super Channel> channelInit = c -> c
 				.pipeline()
 				.addBefore(NettyPipeline.ReactiveBridge,
 						"codec",
@@ -216,7 +216,7 @@ public class TcpClientTests {
 
 	@Test
 	public void tcpClientHandlesLineFeedDataElasticPool() throws InterruptedException {
-		Consumer<Channel> channelInit = c -> c
+		Consumer<? super Channel> channelInit = c -> c
 				.pipeline()
 				.addBefore(NettyPipeline.ReactiveBridge,
 						"codec",
@@ -230,7 +230,7 @@ public class TcpClientTests {
 		);
 	}
 
-	private void tcpClientHandlesLineFeedData(Consumer<? super ClientOptions.Builder> opsBuilder) throws InterruptedException {
+	private void tcpClientHandlesLineFeedData(Consumer<? super ClientOptions.Builder<?>> opsBuilder) throws InterruptedException {
 		final int messages = 100;
 		final CountDownLatch latch = new CountDownLatch(messages);
 		final List<String> strings = new ArrayList<>();
@@ -272,7 +272,7 @@ public class TcpClientTests {
 		      .block(Duration.ofSeconds(30));
 	}
 
-	private void connectionWillRetryConnectionAttemptWhenItFails(Consumer<ClientOptions.Builder> opsBuilder)
+	private void connectionWillRetryConnectionAttemptWhenItFails(Consumer<ClientOptions.Builder<?>> opsBuilder)
 			throws InterruptedException {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicLong totalDelay = new AtomicLong();


### PR DESCRIPTION
- suppress unchecked warnings in disposeLater method
- fix warning in asciidoc rendering about missing file
- fix unchecked warnings in tests
- enable rawtypes linting
- resolve or suppress warnings related to rawtypes 