### PR TITLE
Enable errorprone compiler plugin in build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ configure(rootProject) { project ->
   apply plugin: 'propdeps'
   apply plugin: 'osgi'
   apply from: "${gradleScriptDir}/ide.gradle"
+  apply from: "${gradleScriptDir}/errorprone.gradle"
 
   jacoco {
 	toolVersion = '0.7.7.201606060606'

--- a/gradle/errorprone.gradle
+++ b/gradle/errorprone.gradle
@@ -1,0 +1,25 @@
+buildscript {
+	repositories {
+		maven {
+			url "https://plugins.gradle.org/m2/"
+		}
+	}
+	dependencies {
+		classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
+	}
+}
+
+apply plugin: net.ltgt.gradle.errorprone.ErrorPronePlugin
+
+dependencies {
+	errorprone 'com.google.errorprone:error_prone_core:2.3.1'
+	errorprone 'com.google.guava:guava:23.5-jre' // prevents conflicts with guava versions of other gradle plugins
+}
+
+// Change all errorprone errors to warnings
+// TODO: remove when warning have been resolved
+project.afterEvaluate {
+	tasks.withType(JavaCompile) {
+		options.compilerArgs << '-XepAllErrorsAsWarnings'
+	}
+}


### PR DESCRIPTION
- enable [errorprone](http://errorprone.info/) compiler plugin in build
- for now, errorprone errors are converted to warnings with the [`-XepAllErrorsAsWarnings` flag](http://errorprone.info/docs/flags)