### PR TITLE
fix ssl configuration issue for tcp and http clients

### DIFF
--- a/src/main/java/reactor/netty/channel/BootstrapHandlers.java
+++ b/src/main/java/reactor/netty/channel/BootstrapHandlers.java
@@ -136,6 +136,9 @@ public abstract class BootstrapHandlers {
 				if (clazz.isInstance(aRph.consumer)) {
 					return (C) aRph.consumer;
 				}
+				if (clazz.isInstance(aRph.deferredConsumer)) {
+					return (C) aRph.deferredConsumer;
+				}
 			}
 		}
 		return null;

--- a/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -106,7 +106,7 @@ public final class SslProvider {
 	 */
 	@Nullable
 	public static SslProvider findSslSupport(Bootstrap b) {
-		SslSupportConsumer ssl = BootstrapHandlers.findConfiguration(SslSupportConsumer.class, b.config().handler());
+		DeferredSslSupport ssl = BootstrapHandlers.findConfiguration(DeferredSslSupport.class, b.config().handler());
 
 		if (ssl == null) {
 			return null;
@@ -129,6 +129,18 @@ public final class SslProvider {
 			return null;
 		}
 		return ssl.sslProvider;
+	}
+
+	/**
+	 * Remove Ssl support in the given client bootstrap
+	 *
+	 * @param b a bootstrap to search and remove
+	 *
+	 * @return passed {@link Bootstrap}
+	 */
+	public static Bootstrap removeSslSupport(Bootstrap b) {
+		BootstrapHandlers.removeConfiguration(b, NettyPipeline.SslHandler);
+		return b;
 	}
 
 	final SslContext                   sslContext;
@@ -427,29 +439,6 @@ public final class SslProvider {
 		 */
 		Builder forServer();
 
-	}
-
-	@Nullable
-	static SslContext findSslContext(Bootstrap b) {
-		SslSupportConsumer c =
-				BootstrapHandlers.findConfiguration(SslSupportConsumer.class,
-						b.config().handler());
-
-		return c != null ? c.sslProvider.getSslContext() : null;
-	}
-
-	@Nullable
-	static SslContext findSslContext(ServerBootstrap b) {
-		SslSupportConsumer c =
-				BootstrapHandlers.findConfiguration(SslSupportConsumer.class,
-						b.config().childHandler());
-
-		return c != null ? c.sslProvider.getSslContext() : null;
-	}
-
-	static Bootstrap removeSslSupport(Bootstrap b) {
-		BootstrapHandlers.removeConfiguration(b, NettyPipeline.SslHandler);
-		return b;
 	}
 
 	static ServerBootstrap removeSslSupport(ServerBootstrap b) {

--- a/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -328,7 +328,7 @@ public abstract class TcpClient {
 	 * @return true if that {@link TcpClient} secured via SSL transport
 	 */
 	public final boolean isSecure(){
-		return sslContext() != null;
+		return sslProvider() != null;
 	}
 
 
@@ -506,14 +506,14 @@ public abstract class TcpClient {
 	}
 
 	/**
-	 * Return the current {@link SslContext} if that {@link TcpClient} secured via SSL
+	 * Return the current {@link SslProvider} if that {@link TcpClient} secured via SSL
 	 * transport or null
 	 *
-	 * @return he current {@link SslContext} if that {@link TcpClient} secured via SSL
+	 * @return he current {@link SslProvider} if that {@link TcpClient} secured via SSL
 	 * transport or null
 	 */
 	@Nullable
-	public SslContext sslContext(){
+	public SslProvider sslProvider(){
 		return null;
 	}
 

--- a/src/main/java/reactor/netty/tcp/TcpClientConnect.java
+++ b/src/main/java/reactor/netty/tcp/TcpClientConnect.java
@@ -45,8 +45,7 @@ final class TcpClientConnect extends TcpClient {
 
 			TcpClientRunOn.configure(b,
 					LoopResources.DEFAULT_NATIVE,
-					TcpResources.get(),
-					SslProvider.findSslContext(b));
+					TcpResources.get());
 		}
 
 		return provider.acquire(b);

--- a/src/main/java/reactor/netty/tcp/TcpClientOperator.java
+++ b/src/main/java/reactor/netty/tcp/TcpClientOperator.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.handler.ssl.SslContext;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 
@@ -46,8 +45,8 @@ abstract class TcpClientOperator extends TcpClient {
 
 	@Override
 	@Nullable
-	public SslContext sslContext(){
-		return source.sslContext();
+	public SslProvider sslProvider(){
+		return source.sslProvider();
 	}
 
 	@Override

--- a/src/main/java/reactor/netty/tcp/TcpClientRunOn.java
+++ b/src/main/java/reactor/netty/tcp/TcpClientRunOn.java
@@ -17,12 +17,10 @@
 package reactor.netty.tcp;
 
 import java.util.Objects;
-import javax.annotation.Nullable;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.JdkSslContext;
-import io.netty.handler.ssl.SslContext;
 import reactor.netty.resources.LoopResources;
 
 /**
@@ -43,16 +41,19 @@ final class TcpClientRunOn extends TcpClientOperator {
 	public Bootstrap configure() {
 		Bootstrap b = source.configure();
 
-		configure(b, preferNative, loopResources, sslContext());
+		configure(b, preferNative, loopResources);
 
 		return b;
 	}
 
 	static void configure(Bootstrap b,
 			boolean preferNative,
-			LoopResources resources,
-			@Nullable SslContext sslContext) {
-		boolean useNative = preferNative && !(sslContext instanceof JdkSslContext);
+			LoopResources resources) {
+		SslProvider sslProvider =  SslProvider.findSslSupport(b);
+
+		boolean useNative = preferNative &&
+				(sslProvider == null || !(sslProvider.sslContext instanceof JdkSslContext));
+
 		EventLoopGroup elg = resources.onClient(useNative);
 
 		b.group(elg).channel(resources.onChannel(elg));

--- a/src/main/java/reactor/netty/tcp/TcpClientSecure.java
+++ b/src/main/java/reactor/netty/tcp/TcpClientSecure.java
@@ -21,7 +21,6 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.handler.ssl.SslContext;
 
 /**
  * @author Stephane Maldini
@@ -54,8 +53,8 @@ final class TcpClientSecure extends TcpClientOperator {
 	}
 
 	@Override
-	public SslContext sslContext(){
-		return this.sslProvider.getSslContext();
+	public SslProvider sslProvider(){
+		return this.sslProvider;
 	}
 
 }

--- a/src/main/java/reactor/netty/tcp/TcpClientUnsecure.java
+++ b/src/main/java/reactor/netty/tcp/TcpClientUnsecure.java
@@ -19,7 +19,6 @@ package reactor.netty.tcp;
 import javax.annotation.Nullable;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.handler.ssl.SslContext;
 
 /**
  * @author Stephane Maldini
@@ -37,7 +36,7 @@ final class TcpClientUnsecure extends TcpClientOperator {
 
 	@Override
 	@Nullable
-	public SslContext sslContext(){
+	public SslProvider sslProvider(){
 		return null;
 	}
 }

--- a/src/main/java/reactor/netty/tcp/TcpServer.java
+++ b/src/main/java/reactor/netty/tcp/TcpServer.java
@@ -335,7 +335,7 @@ public abstract class TcpServer {
 	 * @return true if that {@link TcpServer} secured via SSL transport
 	 */
 	public final boolean isSecure(){
-		return sslContext() != null;
+		return sslProvider() != null;
 	}
 
 	/**
@@ -501,14 +501,14 @@ public abstract class TcpServer {
 	}
 
 	/**
-	 * Return the current {@link SslContext} if that {@link TcpServer} secured via SSL
+	 * Return the current {@link SslProvider} if that {@link TcpServer} secured via SSL
 	 * transport or null
 	 *
-	 * @return he current {@link SslContext} if that {@link TcpServer} secured via SSL
+	 * @return he current {@link SslProvider} if that {@link TcpServer} secured via SSL
 	 * transport or null
 	 */
 	@Nullable
-	public SslContext sslContext() {
+	public SslProvider sslProvider() {
 		return null;
 	}
 

--- a/src/main/java/reactor/netty/tcp/TcpServerBind.java
+++ b/src/main/java/reactor/netty/tcp/TcpServerBind.java
@@ -49,10 +49,7 @@ final class TcpServerBind extends TcpServer {
 		if (b.config()
 		     .group() == null) {
 
-			TcpServerRunOn.configure(b,
-					LoopResources.DEFAULT_NATIVE,
-					TcpResources.get(),
-					SslProvider.findSslContext(b));
+			TcpServerRunOn.configure(b, LoopResources.DEFAULT_NATIVE, TcpResources.get());
 		}
 
 		return Mono.create(sink -> {

--- a/src/main/java/reactor/netty/tcp/TcpServerOperator.java
+++ b/src/main/java/reactor/netty/tcp/TcpServerOperator.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import reactor.core.publisher.Mono;
 import reactor.netty.DisposableServer;
 
@@ -46,7 +45,7 @@ abstract class TcpServerOperator extends TcpServer {
 
 	@Override
 	@Nullable
-	public SslContext sslContext(){
-		return source.sslContext();
+	public SslProvider sslProvider(){
+		return source.sslProvider();
 	}
 }

--- a/src/main/java/reactor/netty/tcp/TcpServerRunOn.java
+++ b/src/main/java/reactor/netty/tcp/TcpServerRunOn.java
@@ -17,12 +17,10 @@
 package reactor.netty.tcp;
 
 import java.util.Objects;
-import javax.annotation.Nullable;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.JdkSslContext;
-import io.netty.handler.ssl.SslContext;
 import reactor.netty.resources.LoopResources;
 
 /**
@@ -43,16 +41,18 @@ final class TcpServerRunOn extends TcpServerOperator {
 	public ServerBootstrap configure() {
 		ServerBootstrap b = source.configure();
 
-		configure(b, preferNative, loopResources, sslContext());
+		configure(b, preferNative, loopResources);
 
 		return b;
 	}
 
 	static void configure(ServerBootstrap b,
 			boolean preferNative,
-			LoopResources resources,
-			@Nullable SslContext sslContext) {
-		boolean useNative = preferNative && !(sslContext instanceof JdkSslContext);
+			LoopResources resources) {
+		SslProvider sslProvider =  SslProvider.findSslSupport(b);
+
+		boolean useNative = preferNative &&
+				(sslProvider == null || !(sslProvider.sslContext instanceof JdkSslContext));
 		EventLoopGroup selectorGroup = resources.onServerSelect(useNative);
 		EventLoopGroup elg = resources.onServer(useNative);
 

--- a/src/main/java/reactor/netty/tcp/TcpServerSecure.java
+++ b/src/main/java/reactor/netty/tcp/TcpServerSecure.java
@@ -20,7 +20,6 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 
 /**
  * @author Stephane Maldini
@@ -45,7 +44,7 @@ final class TcpServerSecure extends TcpServerOperator {
 	}
 
 	@Override
-	public SslContext sslContext() {
-		return this.sslProvider.getSslContext();
+	public SslProvider sslProvider() {
+		return this.sslProvider;
 	}
 }

--- a/src/main/java/reactor/netty/tcp/TcpServerUnsecure.java
+++ b/src/main/java/reactor/netty/tcp/TcpServerUnsecure.java
@@ -19,7 +19,6 @@ package reactor.netty.tcp;
 import javax.annotation.Nullable;
 
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 
 /**
  * @author Stephane Maldini
@@ -37,7 +36,7 @@ final class TcpServerUnsecure extends TcpServerOperator {
 
 	@Override
 	@Nullable
-	public SslContext sslContext(){
+	public SslProvider sslProvider(){
 		return null;
 	}
 }


### PR DESCRIPTION
* make sure https is used in the uri factory if default secure
* remove ssl if absolute http is used in a redirect
* align server/client ssl conf accessor to expose SslProvider
* expose removeSslSupport in SslProvider
* fix BootstrapHandlers.findConfiguration for deferred confs