### PR TITLE
Fix X-Forwarded-For support

### DIFF
--- a/src/main/java/reactor/netty/http/server/ConnectionInfo.java
+++ b/src/main/java/reactor/netty/http/server/ConnectionInfo.java
@@ -130,8 +130,8 @@ final class ConnectionInfo {
 		InetSocketAddress remoteAddress = channel.remoteAddress();
 		String scheme = channel.pipeline().get(SslHandler.class) != null ? "https" : "http";
 		if (request.headers().contains(XFORWARDED_IP_HEADER)) {
-			String hostValue = request.headers().get(XFORWARDED_IP_HEADER).split(",")[0];
-			hostAddress = parseAddress(hostValue, hostAddress.getPort());
+			String remoteIpValue = request.headers().get(XFORWARDED_IP_HEADER).split(",")[0];
+			remoteAddress = parseAddress(remoteIpValue, remoteAddress.getPort());
 		}
 		else if(request.headers().contains(XFORWARDED_HOST_HEADER)) {
 			if(request.headers().contains(XFORWARDED_PORT_HEADER)) {

--- a/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -73,8 +73,8 @@ public class ConnectionInfoTests {
 				clientRequestHeaders -> clientRequestHeaders.add("X-Forwarded-For",
 						"[1abc:2abc:3abc::5ABC:6abc]:8080, 192.168.0.1"),
 				serverRequest -> {
-					Assertions.assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
-					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(8080);
+					Assertions.assertThat(serverRequest.remoteAddress().getHostString()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
+					Assertions.assertThat(serverRequest.remoteAddress().getPort()).isEqualTo(8080);
 				});
 	}
 


### PR DESCRIPTION
The "X-Forwarded-For" request header is about the remote host
information, not the server host information.