### PR TITLE
fix #370 Remove TcpServer/HttpServer API for using ssl with self singed certificate

### DIFF
--- a/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
@@ -49,7 +50,7 @@ import reactor.util.Loggers;
  * {@code
  * HttpServer.create()
  *           .host("0.0.0.0")
- *           .secure()
+ *           .secureSelfSigned()
  *           .handle((req, res) -> res.sendString(Flux.just("hello"))
  *           .bind()
  *           .block();
@@ -292,29 +293,27 @@ public abstract class HttpServer {
 	}
 
 	/**
-	 * Enable default sslContext support. The default {@link SslContext} will be
-	 * assigned to
-	 * with a default value of {@code 10} seconds handshake timeout unless
-	 * the environment property {@code reactor.netty.tcp.sslHandshakeTimeout} is set.
-	 *
-	 * @return a new {@link HttpServer}
-	 */
-	public final HttpServer secure() {
-		return new HttpServerSecure(this, null);
-	}
-
-	/**
 	 * Apply an SSL configuration customization via the passed builder. The builder
 	 * will produce the {@link SslContext} to be passed to with a default value of
 	 * {@code 10} seconds handshake timeout unless the environment property {@code
 	 * reactor.netty.tcp.sslHandshakeTimeout} is set.
+	 *
+	 * If {@link SelfSignedCertificate} needs to be used, the sample below can be
+	 * used. Note that {@link SelfSignedCertificate} should not be used in production.
+	 * <pre>
+	 * {@code
+	 *     SelfSignedCertificate cert = new SelfSignedCertificate();
+	 *     SslContextBuilder sslContextBuilder =
+	 *             SslContextBuilder.forServer(cert.certificate(), cert.privateKey());
+	 *     secure(sslContextSpec -> sslContextSpec.sslContext(sslContextBuilder));
+	 * }
 	 *
 	 * @param sslProviderBuilder builder callback for further customization of SslContext.
 	 *
 	 * @return a new {@link HttpServer}
 	 */
 	public final HttpServer secure(Consumer<? super SslProvider.SslContextSpec> sslProviderBuilder) {
-		return HttpServerSecure.secure(this, sslProviderBuilder);
+		return new HttpServerSecure(this, sslProviderBuilder);
 	}
 
 	/**

--- a/src/main/java/reactor/netty/tcp/TcpServer.java
+++ b/src/main/java/reactor/netty/tcp/TcpServer.java
@@ -33,6 +33,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.AttributeKey;
 import io.netty.util.NetUtil;
 import org.reactivestreams.Publisher;
@@ -65,7 +66,7 @@ import reactor.util.Loggers;
  *          .doOnUnbound(stopMetrics)
  *          .host("127.0.0.1")
  *          .port(1234)
- *          .secure()
+ *          .secureSelfSigned()
  *          .bind()
  *          .block()
  * }
@@ -431,20 +432,19 @@ public abstract class TcpServer {
 	}
 
 	/**
-	 * Enable default sslContext support. The default {@link SslContext} will be assigned
-	 * to with a default value of {@code 10} seconds handshake timeout unless the
-	 * environment property {@code reactor.netty.tcp.sslHandshakeTimeout} is set.
-	 *
-	 * @return a new {@link TcpServer}
-	 */
-	public final TcpServer secure() {
-		return secure(SslProvider.DEFAULT_SERVER_SPEC);
-	}
-
-	/**
 	 * Apply an SSL configuration customization via the passed {@link SslContext}. with a
 	 * default value of {@code 10} seconds handshake timeout unless the environment
 	 * property {@code reactor.netty.tcp.sslHandshakeTimeout} is set.
+	 *
+	 * If {@link SelfSignedCertificate} needs to be used, the sample below can be
+	 * used. Note that {@link SelfSignedCertificate} should not be used in production.
+	 * <pre>
+	 * {@code
+	 *     SelfSignedCertificate cert = new SelfSignedCertificate();
+	 *     SslContextBuilder sslContextBuilder =
+	 *             SslContextBuilder.forServer(cert.certificate(), cert.privateKey());
+	 *     secure(sslContextBuilder.build());
+	 * }
 	 *
 	 * @param sslContext The context to set when configuring SSL
 	 *
@@ -459,6 +459,16 @@ public abstract class TcpServer {
 	 * will produce the {@link SslContext} to be passed to with a default value of
 	 * {@code 10} seconds handshake timeout unless the environment property {@code
 	 * reactor.netty.tcp.sslHandshakeTimeout} is set.
+	 *
+	 * If {@link SelfSignedCertificate} needs to be used, the sample below can be
+	 * used. Note that {@link SelfSignedCertificate} should not be used in production.
+	 * <pre>
+	 * {@code
+	 *     SelfSignedCertificate cert = new SelfSignedCertificate();
+	 *     SslContextBuilder sslContextBuilder =
+	 *             SslContextBuilder.forServer(cert.certificate(), cert.privateKey());
+	 *     secure(sslContextSpec -> sslContextSpec.sslContext(sslContextBuilder));
+	 * }
 	 *
 	 * @param sslProviderBuilder builder callback for further customization of SslContext.
 	 *

--- a/src/test/java/reactor/netty/tcp/TcpServerTests.java
+++ b/src/test/java/reactor/netty/tcp/TcpServerTests.java
@@ -110,10 +110,15 @@ public class TcpServerTests {
 	public void tcpServerHandlesJsonPojosOverSsl() throws Exception {
 		final CountDownLatch latch = new CountDownLatch(2);
 
+		SelfSignedCertificate cert = new SelfSignedCertificate();
+		SslContextBuilder serverOptions = SslContextBuilder.forServer(cert.certificate(), cert.privateKey());
 		SslContext clientOptions = SslContextBuilder.forClient()
 		                                            .trustManager(InsecureTrustManagerFactory.INSTANCE)
 		                                            .build();
-		final TcpServer server = TcpServer.create().host("localhost").secure();
+		final TcpServer server =
+				TcpServer.create()
+				         .host("localhost")
+				         .secure(sslContextSpec -> sslContextSpec.sslContext(serverOptions));
 
 		ObjectMapper m = new ObjectMapper();
 


### PR DESCRIPTION
Document in javadoc how ssl with self singed certificate can be used.
Expose API for choosing the default SslContext configuration

Related to issue #382