### PR TITLE
Expose connect() method for websocket connections

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -263,6 +263,17 @@ public abstract class HttpClient {
 	 * {@link Publisher#subscribe(Subscriber)}.
 	 */
 	public interface WebsocketReceiver<S extends WebsocketReceiver<?>> extends UriConfiguration<S>  {
+		/**
+		 * Negotiate a websocket upgrade and return a {@link Mono} of {@link Connection}. If
+		 * {@link Mono} is cancelled, the underlying connection will be aborted. Once the
+		 * {@link Connection} has been emitted and is not necessary anymore, disposing must be
+		 * done by the user via {@link Connection#dispose()}.
+		 *
+		 * If update configuration phase fails, a {@link Mono#error(Throwable)} will be returned
+		 *
+		 * @return a {@link Mono} of {@link Connection}
+		 */
+		Mono<? extends Connection> connect();
 
 		/**
 		 * Negotiate a websocket upgrade and extract a flux from the given

--- a/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
+++ b/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
@@ -59,7 +59,7 @@ final class WebsocketFinalizer extends HttpClient implements HttpClient.Websocke
 	}
 
 	@SuppressWarnings("unchecked")
-	Mono<WebsocketClientOperations> connect() {
+	public Mono<WebsocketClientOperations> connect() {
 		return (Mono<WebsocketClientOperations>)cachedConfiguration.connect();
 	}
 


### PR DESCRIPTION
Having access to the underlying Connection for websocket/http2 as in TCP makes it more natural to implement DuplexConnection in RSocket. So instead of having to use the 'handle' method and cast:

`.<DuplexConnection>handle((in, out) -> Mono.just(new WebsocketDuplexConnection((Connection) in)))`

We can instead do:

`.connect().map(WebsocketDuplexConnection::new);`