### PR TITLE
fix #405 channel reused before old OWNER is cleaned

### DIFF
--- a/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -351,9 +351,6 @@ final class PooledConnectionProvider implements ConnectionProvider {
 				log.debug("Failed cleaning the channel from pool", future.cause());
 			}
 			onTerminate.onComplete();
-			channel.attr(OWNER)
-			       .getAndSet(ConnectionObserver.emptyListener())
-			       .onStateChange(this, State.RELEASED);
 		}
 
 		@Override
@@ -380,6 +377,9 @@ final class PooledConnectionProvider implements ConnectionProvider {
 					log.debug(format(connection.channel(), "Releasing channel"));
 				}
 
+				channel.attr(OWNER)
+						.getAndSet(ConnectionObserver.emptyListener())
+						.onStateChange(this, State.RELEASED);
 				pool.release(channel)
 				    .addListener(this);
 				return;


### PR DESCRIPTION
after channel released *operationComplete* will clean OWNER in channel
but the same channel will be reused once it released, it's not atomic

there will be chance the new subscriber set the OWNER then the old *operationComplete* clean the OWNER in different thread so the new subscriber will never complete.

so I move the clean procedure before release.