### PR TITLE
fix #90 Auto clean global connectionProvider on server.dispose

### DIFF
--- a/src/main/java/reactor/netty/http/HttpResources.java
+++ b/src/main/java/reactor/netty/http/HttpResources.java
@@ -65,7 +65,7 @@ public final class HttpResources extends TcpResources {
 	 * @return the global HTTP resources
 	 */
 	public static HttpResources reset() {
-		shutdown();
+		disposeLoopsAndConnections();
 		return getOrCreate(httpResources, null, null, ON_HTTP_NEW, "http");
 	}
 
@@ -73,7 +73,7 @@ public final class HttpResources extends TcpResources {
 	 * Shutdown the global {@link HttpResources} without resetting them,
 	 * effectively cleaning up associated resources without creating new ones.
 	 */
-	public static void shutdown() {
+	public static void disposeLoopsAndConnections() {
 		HttpResources resources = httpResources.getAndSet(null);
 		if (resources != null) {
 			resources._dispose();
@@ -81,13 +81,13 @@ public final class HttpResources extends TcpResources {
 	}
 
 	/**
-	 * Prepare to shutdown the global {@link TcpResources} without resetting them,
+	 * Prepare to shutdown the global {@link HttpResources} without resetting them,
 	 * effectively cleaning up associated resources without creating new ones. This only
 	 * occurs when the returned {@link Mono} is subscribed to.
 	 *
-	 * @return a {@link Mono} triggering the {@link #shutdown()} when subscribed to.
+	 * @return a {@link Mono} triggering the {@link #disposeLoopsAndConnections()} when subscribed to.
 	 */
-	public static Mono<Void> shutdownLater() {
+	public static Mono<Void> disposeLoopsAndConnectionsLater() {
 		return Mono.defer(() -> {
 			HttpResources resources = httpResources.getAndSet(null);
 			if (resources != null) {

--- a/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -16,6 +16,8 @@
 
 package reactor.netty.resources;
 
+import java.net.SocketAddress;
+
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.pool.FixedChannelPool;
 import io.netty.channel.pool.SimpleChannelPool;
@@ -23,6 +25,7 @@ import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.ReactorNetty;
+import reactor.util.annotation.NonNull;
 
 /**
  * A {@link ConnectionProvider} will produce {@link Connection}
@@ -153,6 +156,10 @@ public interface ConnectionProvider extends Disposable {
 	 * @return an existing or new {@link Mono} of {@link Connection}
 	 */
 	Mono<? extends Connection> acquire(Bootstrap bootstrap);
+
+
+	default void disposeWhen(@NonNull SocketAddress address) {
+	}
 
 	@Override
 	default void dispose() {

--- a/src/main/java/reactor/netty/tcp/TcpServerBind.java
+++ b/src/main/java/reactor/netty/tcp/TcpServerBind.java
@@ -37,6 +37,7 @@ import reactor.netty.ConnectionObserver;
 import reactor.netty.DisposableServer;
 import reactor.netty.channel.BootstrapHandlers;
 import reactor.netty.channel.ChannelOperations;
+import reactor.netty.http.HttpResources;
 import reactor.netty.resources.LoopResources;
 
 import static reactor.netty.ReactorNetty.format;
@@ -163,6 +164,10 @@ final class TcpServerBind extends TcpServer {
 
 				f.channel()
 				 .close();
+
+				HttpResources.get()
+				             .disposeWhen(bootstrap.config()
+				                                   .localAddress());
 			}
 			else if (!f.isDone()) {
 				f.cancel(true);

--- a/src/test/java/reactor/netty/http/HttpResourcesTest.java
+++ b/src/test/java/reactor/netty/http/HttpResourcesTest.java
@@ -100,11 +100,11 @@ public class HttpResourcesTest {
 		try {
 			assertThat(newHttpResources).isSameAs(testResources);
 
-			HttpResources.shutdownLater();
+			HttpResources.disposeLoopsAndConnectionsLater();
 			assertThat(newHttpResources.isDisposed()).isFalse();
 
-			HttpResources.shutdownLater().block();
-			assertThat(newHttpResources.isDisposed()).as("shutdownLater completion").isTrue();
+			HttpResources.disposeLoopsAndConnectionsLater().block();
+			assertThat(newHttpResources.isDisposed()).as("disposeLoopsAndConnectionsLater completion").isTrue();
 
 			assertThat(HttpResources.httpResources.get()).isNull();
 		}

--- a/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -56,7 +56,6 @@ import reactor.netty.ChannelBindException;
 import reactor.netty.Connection;
 import reactor.netty.DisposableServer;
 import reactor.netty.FutureMono;
-import reactor.netty.http.HttpResources;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.tcp.TcpClient;
@@ -146,16 +145,15 @@ public class HttpServerTests {
 		                     .wiretap()
 		                     .get()
 		                     .uri("/")
-		                     .responseSingle((res, buf) -> Mono.just(res.status().code()))
+		                     .response()
+		                     .map(res -> res.status().code())
+//		                     .responseSingle((res, buf) -> Mono.just(res.status().code()))
 		                     .block();
 
 		// checking the response status, OK
 		assertThat(code).isEqualTo(200);
 		// dispose the Netty context and wait for the channel close
 		context.disposeNow();
-
-		//REQUIRED - bug pool does not detect/translate properly lifecycle
-		HttpResources.reset();
 
 		// create a totally new server instance, with a different handler that answers HTTP 201
 		context = HttpServer.create()

--- a/src/test/java/reactor/netty/tcp/TcpResourcesTest.java
+++ b/src/test/java/reactor/netty/tcp/TcpResourcesTest.java
@@ -107,11 +107,11 @@ public class TcpResourcesTest {
 		try {
 			assertThat(newTcpResources).isSameAs(tcpResources);
 
-			TcpResources.shutdownLater();
+			TcpResources.disposeLoopsAndConnectionsLater();
 			assertThat(newTcpResources.isDisposed()).isFalse();
 
-			TcpResources.shutdownLater().block();
-			assertThat(newTcpResources.isDisposed()).as("shutdownLater completion").isTrue();
+			TcpResources.disposeLoopsAndConnectionsLater().block();
+			assertThat(newTcpResources.isDisposed()).as("disposeLoopsAndConnectionsLater completion").isTrue();
 
 			assertThat(TcpResources.tcpResources.get()).isNull();
 		}


### PR DESCRIPTION
Add address-matching ConnectionProvider#disposeWhen(SocketAddress).
This will be used by global resource holders to selectively close
stateful connection providers such as PooledConnectionProvider.

Rename shutdown to disposeLoopsAndConnections to align with dispose
semantics.

Minor tweak to release state lifecycle in PooledConnectionProvider