### PR TITLE
Fix #223 Allow custom websocket maxFramePayloadLength

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -703,11 +703,35 @@ public abstract class HttpClient {
 	 * @return a {@link WebsocketSender} ready to consume for response
 	 */
 	public final WebsocketSender websocket(String subprotocols) {
-		Objects.requireNonNull(subprotocols, "subprotocols");
-		TcpClient tcpConfiguration = tcpConfiguration().bootstrap(b -> HttpClientConfiguration.websocketSubprotocols(b, subprotocols));
-		return new WebsocketFinalizer(tcpConfiguration);
+		return websocket(subprotocols, 65536);
 	}
 
+	/**
+	 * HTTP Websocket to connect the {@link HttpClient}.
+	 *
+	 * @param maxFramePayloadLength maximum allowable frame payload length
+	 *
+	 * @return a {@link WebsocketSender} ready to consume for response
+	 */
+	public final WebsocketSender websocket(int maxFramePayloadLength) {
+		return websocket("", maxFramePayloadLength);
+	}
+
+	/**
+	 * HTTP Websocket to connect the {@link HttpClient}.
+	 *
+	 * @param subprotocols a websocket subprotocol comma separated list
+	 * @param maxFramePayloadLength maximum allowable frame payload length
+	 *
+	 * @return a {@link WebsocketSender} ready to consume for response
+	 */
+	public final WebsocketSender websocket(String subprotocols, int maxFramePayloadLength) {
+		Objects.requireNonNull(subprotocols, "subprotocols");
+		TcpClient tcpConfiguration = tcpConfiguration()
+				.bootstrap(b -> HttpClientConfiguration.websocketSubprotocols(b, subprotocols))
+				.bootstrap(b -> HttpClientConfiguration.websocketMaxFramePayloadLength(b, maxFramePayloadLength));
+		return new WebsocketFinalizer(tcpConfiguration);
+	}
 
 	/**
 	 * Get a TcpClient from the parent {@link HttpClient} chain to use with {@link

--- a/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
@@ -50,6 +50,7 @@ final class HttpClientConfiguration {
 	HttpHeaders  headers               = null;
 	HttpMethod   method                = HttpMethod.GET;
 	String       websocketSubprotocols = null;
+	int          websocketMaxFramePayloadLength = 65536;
 	int                    protocols         = h11;
 
 	ClientCookieEncoder cookieEncoder = ClientCookieEncoder.STRICT;
@@ -70,6 +71,7 @@ final class HttpClientConfiguration {
 		this.headers = from.headers;
 		this.method = from.method;
 		this.websocketSubprotocols = from.websocketSubprotocols;
+		this.websocketMaxFramePayloadLength = from.websocketMaxFramePayloadLength;
 		this.body = from.body;
 	}
 
@@ -197,6 +199,11 @@ final class HttpClientConfiguration {
 
 	static Bootstrap websocketSubprotocols(Bootstrap b, String websocketSubprotocols) {
 		getOrCreate(b).websocketSubprotocols = websocketSubprotocols;
+		return b;
+	}
+
+	static Bootstrap websocketMaxFramePayloadLength(Bootstrap b, int websocketMaxFramePayloadLength) {
+		getOrCreate(b).websocketMaxFramePayloadLength = websocketMaxFramePayloadLength;
 		return b;
 	}
 

--- a/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -597,13 +597,13 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 		}
 	}
 
-	final void withWebsocketSupport(String protocols) {
+	final void withWebsocketSupport(String protocols, int maxFramePayloadLength) {
 		URI url = websocketUri();
 		//prevent further header to be sent for handshaking
 		if (markSentHeaders()) {
 			addHandlerFirst(NettyPipeline.HttpAggregator, new HttpObjectAggregator(8192));
 
-			WebsocketClientOperations ops = new WebsocketClientOperations(url, protocols, this);
+			WebsocketClientOperations ops = new WebsocketClientOperations(url, protocols, maxFramePayloadLength, this);
 
 			if(!rebind(ops)) {
 				log.error(format(channel(), "Error while rebinding websocket in channel attribute: " +

--- a/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
@@ -56,6 +56,7 @@ final class WebsocketClientOperations extends HttpClientOperations
 
 	WebsocketClientOperations(URI currentURI,
 			String protocols,
+			int maxFramePayloadLength,
 			HttpClientOperations replaced) {
 		super(replaced);
 		Channel channel = channel();
@@ -65,7 +66,8 @@ final class WebsocketClientOperations extends HttpClientOperations
 					protocols.isEmpty() ? null : protocols,
 					true,
 					replaced.requestHeaders()
-					        .remove(HttpHeaderNames.HOST));
+					        .remove(HttpHeaderNames.HOST),
+					maxFramePayloadLength);
 
 		handshaker.handshake(channel)
 		          .addListener(f -> {


### PR DESCRIPTION
Our current use case requires overriding the default value and as #223 shows there is no way to do this from HttpClient API.