### PR TITLE
Do not add PENDING_WRITES to the queue if future is DONE

### DIFF
--- a/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
@@ -590,9 +590,11 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 					}
 					else {
 						eventLoop.execute(() -> {
-							if (!parent.pendingWriteOffer.test(f, PENDING_WRITES) && f instanceof ChannelPromise) {
-								// Returned value is deliberately ignored
-								((ChannelPromise) f).setFailure(new IllegalStateException("Send Queue full?!"));
+							if (!f.isDone() && parent.hasPendingWriteBytes()) {
+								if (!parent.pendingWriteOffer.test(f, PENDING_WRITES) && f instanceof ChannelPromise) {
+									// Returned value is deliberately ignored
+									((ChannelPromise) f).setFailure(new IllegalStateException("Send Queue full?!"));
+								}
 							}
 						});
 					}


### PR DESCRIPTION
When adding to the queue is scheduled operation, check again whether
future is DONE and there are pending write bytes.