### PR TITLE
Do not close the channel directly but mark it for closing

### DIFF
--- a/src/main/java/reactor/ipc/netty/channel/AbortedException.java
+++ b/src/main/java/reactor/ipc/netty/channel/AbortedException.java
@@ -17,6 +17,7 @@
 package reactor.ipc.netty.channel;
 
 import java.io.IOException;
+import java.net.SocketException;
 
 /**
  * An exception marking prematurely or unexpectedly closed inbound
@@ -57,10 +58,14 @@ public class AbortedException extends RuntimeException {
 	 * @return true if connection has been simply aborted on a tcp level
 	 */
 	public static boolean isConnectionReset(Throwable err) {
-		return err.getClass()
-		          .equals(AbortedException.class) || (err instanceof IOException && (err.getMessage() == null || err.getMessage()
-		                                                                                                            .contains("Broken pipe") || err.getMessage()
-		                                                                                                                                           .contains(
-				                                                                                                                                           "Connection reset by peer")));
+		return err instanceof AbortedException ||
+		       (err instanceof IOException && (err.getMessage() == null ||
+		                                       err.getMessage()
+		                                          .contains("Broken pipe") ||
+		                                       err.getMessage()
+		                                          .contains("Connection reset by peer"))) ||
+		       (err instanceof SocketException && err.getMessage() != null &&
+		                                          err.getMessage()
+		                                             .contains("Connection reset by peer"));
 	}
 }

--- a/src/main/java/reactor/ipc/netty/channel/FluxReceive.java
+++ b/src/main/java/reactor/ipc/netty/channel/FluxReceive.java
@@ -356,7 +356,7 @@ final class FluxReceive extends Flux<Object> implements Subscription, Disposable
 		this.inboundDone = true;
 
 		if(channel.isActive()){
-			channel.close();
+			parent.markPersistent(false);
 		}
 		if (receiverFastpath && receiver != null) {
 			parent.context.fireContextError(err);


### PR DESCRIPTION
The channel will be closed while releasing it.
The original exception that is received is `Connection reset by peer`,
but as a result of a direct close invocation, `SSLEngine closed already`
is forwarded to the user:

```
    at reactor.ipc.netty.http.client.HttpClientOperations.onOutboundError(HttpClientOperations.java:530)
    at reactor.ipc.netty.channel.ChannelOperations.onError(ChannelOperations.java:234)
    at reactor.core.publisher.Operators$MonoSubscriber.onError(Operators.java:1126)
    at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreInner.onError(MonoIgnoreThen.java:234)
    at reactor.ipc.netty.FutureMono$FutureSubscription.operationComplete(FutureMono.java:298)
    ...
    at io.netty.handler.ssl.SslHandler.wrap(SslHandler.java:830)
    at io.netty.handler.ssl.SslHandler.wrapAndFlush(SslHandler.java:793)
    at io.netty.handler.ssl.SslHandler.flush(SslHandler.java:774)
    at io.netty.handler.ssl.SslHandler.flush(SslHandler.java:1647)
    at io.netty.handler.ssl.SslHandler.closeOutboundAndChannel(SslHandler.java:1615)
    at io.netty.handler.ssl.SslHandler.close(SslHandler.java:732)
    ...
    at io.netty.channel.AbstractChannel.close(AbstractChannel.java:238)
    at reactor.ipc.netty.channel.FluxReceive.onInboundError(FluxReceive.java:359)
    at reactor.ipc.netty.channel.ChannelOperations.onInboundError(ChannelOperations.java:429)
    at reactor.ipc.netty.channel.ChannelOperationsHandler.exceptionCaught(ChannelOperationsHandler.java:182)
    at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:285)
    ...
```