### PR TITLE
fix #430 Defer decision for DefaultFileRegion vs ChunkedInput

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/HttpOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/HttpOperations.java
@@ -145,7 +145,7 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 	protected abstract HttpMessage newFullEmptyBodyMessage();
 
 	@Override
-	public NettyOutbound sendFile(Path file, long position, long count) {
+	public final NettyOutbound sendFile(Path file, long position, long count) {
 		Objects.requireNonNull(file);
 
 		if (hasSentHeaders()) {

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerOperations.java
@@ -310,14 +310,6 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 	}
 
 	@Override
-	public NettyOutbound sendFile(Path file, long position, long count) {
-		if (compressionPredicate != null && compressionPredicate.test(this, this)) {
-			compression(true);
-		}
-		return super.sendFile(file, position, count);
-	}
-
-	@Override
 	public Mono<Void> sendNotFound() {
 		return this.status(HttpResponseStatus.NOT_FOUND)
 		           .send();


### PR DESCRIPTION
When NettyOutbound#sendFile, defer the decision for
DefaultFileRegion vs ChunkedInput