### PR TITLE
Fix extra character trimming if baseUrl ends with a slash

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -455,7 +455,7 @@ final class HttpClientConnect extends HttpClient {
 
 			if (baseUrl != null && uri.startsWith("/")) {
 				if (baseUrl.endsWith("/")) {
-					baseUrl = baseUrl.substring(0, baseUrl.length() - 2);
+					baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
 				}
 				uri = baseUrl + uri;
 			}


### PR DESCRIPTION
If a baseUrl ends with a slash, one extra character removed from the end of it.