### PR TITLE
Add WebsocketOutbound#sendClose() API

### DIFF
--- a/src/main/java/reactor/ipc/netty/NettyOutbound.java
+++ b/src/main/java/reactor/ipc/netty/NettyOutbound.java
@@ -146,6 +146,7 @@ public interface NettyOutbound extends Publisher<Void> {
 	 * (complete|error). <p>A new {@link NettyOutbound} type (or the same) for typed send
 	 * sequences. An implementor can therefore specialize the Outbound after a first after
 	 * a prepending data publisher.
+	 * Note: Nesting any send* method is not supported.
 	 *
 	 * @param dataStream the dataStream publishing OUT items to write on this channel
 	 *
@@ -160,6 +161,7 @@ public interface NettyOutbound extends Publisher<Void> {
 	 * Send bytes to the peer, listen for any error on write and close on terminal
 	 * signal (complete|error). If more than one publisher is attached (multiple calls to
 	 * send()) completion occurs after all publishers complete.
+	 * Note: Nesting any send* method is not supported.
 	 *
 	 * @param dataStream the dataStream publishing Buffer items to write on this channel
 	 *
@@ -184,6 +186,7 @@ public interface NettyOutbound extends Publisher<Void> {
 	 * <p>
 	 * Note: this will emit {@link io.netty.channel.FileRegion} in the outbound
 	 * {@link io.netty.channel.ChannelPipeline}
+	 * Note: Nesting any send* method is not supported.
 	 *
 	 * @param file the file Path
 	 *
@@ -213,6 +216,7 @@ public interface NettyOutbound extends Publisher<Void> {
 	 * <p>
 	 * Note: this will emit {@link io.netty.channel.FileRegion} in the outbound
 	 * {@link io.netty.channel.ChannelPipeline}
+	 * Note: Nesting any send* method is not supported.
 	 *
 	 * @param file the file Path
 	 * @param position where to start
@@ -262,6 +266,16 @@ public interface NettyOutbound extends Publisher<Void> {
 				}));
 	}
 
+	/**
+	 * Note: Nesting any send* method is not supported.
+	 *
+	 * @param file the file Path
+	 * @param position where to start
+	 * @param count how much to transfer
+	 *
+	 * @return A Publisher to signal successful sequence write (e.g. after "flush") or any
+	 * error during write
+	 */
 	default NettyOutbound sendFileChunked(Path file, long position, long count) {
 		Objects.requireNonNull(file);
 		final FileChunkedStrategy<?> strategy = getFileChunkedStrategy();
@@ -293,6 +307,7 @@ public interface NettyOutbound extends Publisher<Void> {
 	 * Send data to the peer, listen for any error on write and close on terminal signal
 	 * (complete|error).Each individual {@link Publisher} completion will flush
 	 * the underlying IO runtime.
+	 * Note: Nesting any send* method is not supported.
 	 *
 	 * @param dataStreams the dataStream publishing OUT items to write on this channel
 	 *
@@ -309,6 +324,7 @@ public interface NettyOutbound extends Publisher<Void> {
 	 * Send Object to the peer, listen for any error on write and close on terminal signal
 	 * (complete|error). If more than one publisher is attached (multiple calls to send())
 	 * completion occurs after all publishers complete.
+	 * Note: Nesting any send* method is not supported.
 	 *
 	 * @param dataStream the dataStream publishing Buffer items to write on this channel
 	 *
@@ -322,6 +338,7 @@ public interface NettyOutbound extends Publisher<Void> {
 	/**
 	 * Send data to the peer, listen for any error on write and close on terminal signal
 	 * (complete|error).
+	 * Note: Nesting any send* method is not supported.
 	 *
 	 * @param msg the object to publish
 	 *
@@ -337,6 +354,7 @@ public interface NettyOutbound extends Publisher<Void> {
 	 * Send String to the peer, listen for any error on write and close on terminal signal
 	 * (complete|error). If more than one publisher is attached (multiple calls to send())
 	 * completion occurs after all publishers complete.
+	 * Note: Nesting any send* method is not supported.
 	 *
 	 * @param dataStream the dataStream publishing Buffer items to write on this channel
 	 *
@@ -351,6 +369,7 @@ public interface NettyOutbound extends Publisher<Void> {
 	 * Send String to the peer, listen for any error on write and close on terminal signal
 	 * (complete|error). If more than one publisher is attached (multiple calls to send())
 	 * completion occurs after all publishers complete.
+	 * Note: Nesting any send* method is not supported.
 	 *
 	 * @param dataStream the dataStream publishing Buffer items to write on this channel
 	 * @param charset the encoding charset

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOperations.java
@@ -54,6 +54,7 @@ import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory;
 import io.netty.handler.codec.http.multipart.HttpDataFactory;
 import io.netty.handler.codec.http.multipart.HttpPostRequestEncoder;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
@@ -421,6 +422,36 @@ class HttpClientOperations extends HttpOperations<HttpClientResponse, HttpClient
 			@Override
 			public String selectedSubprotocol() {
 				return null;
+			}
+
+			@Override
+			public Mono<Void> sendClose() {
+				return sendClose(new CloseWebSocketFrame());
+			}
+
+			@Override
+			public Mono<Void> sendClose(int rsv) {
+				return sendClose(new CloseWebSocketFrame(true, rsv));
+			}
+
+			@Override
+			public Mono<Void> sendClose(int statusCode, String reasonText) {
+				return sendClose(new CloseWebSocketFrame(statusCode, reasonText));
+			}
+
+			@Override
+			public Mono<Void> sendClose(int rsv, int statusCode, String reasonText) {
+				return sendClose(new CloseWebSocketFrame(true, rsv, statusCode, reasonText));
+			}
+
+			Mono<Void> sendClose(CloseWebSocketFrame frame) {
+				if (isWebsocket()) {
+					HttpClientWSOperations ops = (HttpClientWSOperations) get(channel());
+					return ops.sendClose(frame);
+				}
+				else {
+					return Mono.empty();
+				}
 			}
 
 			@Override

--- a/src/main/java/reactor/ipc/netty/http/websocket/WebsocketOutbound.java
+++ b/src/main/java/reactor/ipc/netty/http/websocket/WebsocketOutbound.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.ipc.netty.NettyOutbound;
 
 /**
@@ -43,6 +44,55 @@ public interface WebsocketOutbound extends NettyOutbound {
 	 * @return the subprotocol, or null
 	 */
 	String selectedSubprotocol();
+
+	/**
+	 * Prepare to send a close frame on subscribe then close the underlying channel
+	 *
+	 * @return a {@link Mono} fulfilled when the send succeeded or failed, immediately
+	 * completed if already closed
+	 */
+	Mono<Void> sendClose();
+
+	/**
+	 * Prepare to send a close frame on subscribe then close the underlying channel
+	 *
+	 * @param rsv
+	 *            reserved bits used for protocol extensions
+	 *
+	 * @return a {@link Mono} fulfilled when the send succeeded or failed, immediately
+	 * completed if already closed
+	 */
+	Mono<Void> sendClose(int rsv);
+
+	/**
+	 * Prepare to send a close frame on subscribe then close the underlying channel
+	 *
+	 * @param statusCode
+	 *            Integer status code as per <a href="http://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
+	 *            example, <tt>1000</tt> indicates normal closure.
+	 * @param reasonText
+	 *            Reason text. Set to null if no text.
+	 *
+	 * @return a {@link Mono} fulfilled when the send succeeded or failed, immediately
+	 * completed if already closed
+	 */
+	Mono<Void> sendClose(int statusCode, String reasonText);
+
+	/**
+	 * Prepare to send a close frame on subscribe then close the underlying channel
+	 *
+	 * @param rsv
+	 *            reserved bits used for protocol extensions
+	 * @param statusCode
+	 *            Integer status code as per <a href="http://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
+	 *            example, <tt>1000</tt> indicates normal closure.
+	 * @param reasonText
+	 *            Reason text. Set to null if no text.
+	 *
+	 * @return a {@link Mono} fulfilled when the send succeeded or failed, immediately
+	 * completed if already closed
+	 */
+	Mono<Void> sendClose(int rsv, int statusCode, String reasonText);
 
 	@Override
 	default NettyOutbound send(Publisher<? extends ByteBuf> dataStream) {


### PR DESCRIPTION
Prepare to send a close frame on subscribe then close the
underlying channel. Any previous publisher will be canceled.

Clarify that nesting NettyOutbound#send* methods is not supported.

Related to #444