### PR TITLE
Avoid NPE when a connect address isn't specified and newHandler is in use

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientOptions.java
@@ -134,6 +134,9 @@ public final class HttpClientOptions extends ClientOptions {
 					return scheme + "localhost" + url;
 				}
 			}
+			else if (url.equals("")) {
+				return scheme + "localhost";
+			}
 			else {
 				//consider absolute URL
 				return scheme + url;

--- a/src/main/java/reactor/ipc/netty/tcp/TcpClient.java
+++ b/src/main/java/reactor/ipc/netty/tcp/TcpClient.java
@@ -162,7 +162,7 @@ public class TcpClient implements NettyConnector<NettyInbound, NettyOutbound> {
 	 *
 	 * @return a new Mono to connect on subscribe
 	 */
-	protected Mono<NettyContext> newHandler(BiFunction<? super NettyInbound, ? super NettyOutbound, ? extends Publisher<Void>> handler,
+	protected Mono<? extends NettyContext> newHandler(BiFunction<? super NettyInbound, ? super NettyOutbound, ? extends Publisher<Void>> handler,
 			InetSocketAddress address,
 			boolean secure,
 			Consumer<? super Channel> onSetup) {

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
@@ -17,6 +17,7 @@
 package reactor.ipc.netty.http.client;
 
 import java.io.InputStream;
+import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -977,5 +978,31 @@ public class HttpClientTest {
 
 		server.dispose();
 		fixedPool.dispose();
+	}
+
+	@Test
+	public void testConnectAddressNotSpecifiedNewHandler() {
+		StepVerifier.create(
+				HttpClient.create()
+				          .newHandler((res, req) -> Mono.empty()))
+				    .expectError(ConnectException.class)
+				    .verify(Duration.ofSeconds(30));
+	}
+
+	@Test
+	public void testConnectAddressNotSpecifiedGetRequest1() {
+		StepVerifier.create(
+				HttpClient.create()
+				          .get(""))
+				    .expectError(ConnectException.class)
+				    .verify(Duration.ofSeconds(30));
+	}
+	@Test
+	public void testConnectAddressNotSpecifiedGetRequest2() {
+		StepVerifier.create(
+				HttpClient.create()
+				          .get("/"))
+				    .expectError(ConnectException.class)
+				    .verify(Duration.ofSeconds(30));
 	}
 }


### PR DESCRIPTION
In case of `HttpClient` used with a specified request type and no connect address,
it will be calculated based on the `url` (`HttpClientOptions#formatSchemeAndHost`).
In case no request type is specified, but `newHandler` is used, the `HttpClient` will try
to connect to `https://localhost`.

```
java.lang.NullPointerException
	at reactor.ipc.netty.resources.DefaultPoolResources$SocketAddressHolder.hashCode(DefaultPoolResources.java:294)
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
	at reactor.ipc.netty.resources.DefaultPoolResources.selectOrCreate(DefaultPoolResources.java:73)
	at reactor.ipc.netty.tcp.TcpResources.selectOrCreate(TcpResources.java:157)
	at reactor.ipc.netty.tcp.TcpClient.lambda$newHandler$1(TcpClient.java:181)
	at reactor.core.publisher.MonoCreate.subscribe(MonoCreate.java:53)
	at reactor.core.publisher.Mono.block(Mono.java:1498)
```