### PR TITLE
fix #508 If the channel is not active do not continue with writing

### DIFF
--- a/src/main/java/reactor/ipc/netty/FutureMono.java
+++ b/src/main/java/reactor/ipc/netty/FutureMono.java
@@ -36,6 +36,7 @@ import reactor.core.publisher.FluxOperator;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoOperator;
 import reactor.core.publisher.Operators;
+import reactor.ipc.netty.channel.AbortedException;
 import reactor.util.context.Context;
 
 /**
@@ -316,6 +317,12 @@ public abstract class FutureMono extends Mono<Void> {
 
 		@Override
 		public void subscribe(CoreSubscriber<? super Void> s) {
+			if (!channel.isActive()) {
+				Operators.error(s, new AbortedException("Cannot publish the content" +
+						dataStream + ", the connection has been closed"));
+				return;
+			}
+
 			ChannelFutureSubscription cfs = new ChannelFutureSubscription(channel, s);
 
 			s.onSubscribe(cfs);


### PR DESCRIPTION
When there is `Connection: close` and `Content-Length: 0`
`Reactor Netty` prepares for as outgoing message
`DefaultFullHttpRequest`/`DefaultFullHttpResponse` and closes the connection.
`FutureMono` should not continue with writing the data.