### PR TITLE
When creating client loop resources do not invoke shutdown on the ColocatedEventLoopGroup

### DIFF
--- a/src/main/java/reactor/ipc/netty/resources/DefaultLoopResources.java
+++ b/src/main/java/reactor/ipc/netty/resources/DefaultLoopResources.java
@@ -190,7 +190,7 @@ final class DefaultLoopResources extends AtomicLong implements LoopResources {
 		if (null == eventLoopGroup) {
 			EventLoopGroup newEventLoopGroup = LoopResources.colocate(cacheNioServerLoops());
 			if (!clientLoops.compareAndSet(null, newEventLoopGroup)) {
-				newEventLoopGroup.shutdownGracefully();
+				// Do not shutdown newEventLoopGroup as this will shutdown the server loops
 			}
 			eventLoopGroup = cacheNioClientLoops();
 		}
@@ -246,7 +246,7 @@ final class DefaultLoopResources extends AtomicLong implements LoopResources {
 		if (null == eventLoopGroup) {
 			EventLoopGroup newEventLoopGroup = LoopResources.colocate(cacheNativeServerLoops());
 			if (!cacheNativeClientLoops.compareAndSet(null, newEventLoopGroup)) {
-				newEventLoopGroup.shutdownGracefully();
+				// Do not shutdown newEventLoopGroup as this will shutdown the server loops
 			}
 			eventLoopGroup = cacheNativeClientLoops();
 		}


### PR DESCRIPTION
When creating client loop resources do not invoke shutdown on the
ColocatedEventLoopGroup because this will invoke shutdown on the
server loop resource.