### PR TITLE
When redirecting ensure the HttpResponse is released

### DIFF
--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientException.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientException.java
@@ -16,6 +16,7 @@
 
 package reactor.ipc.netty.http.client;
 
+import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -58,6 +59,9 @@ public class HttpClientException extends AbortedException {
 
 	/**
 	 * Return the netty HTTP response message
+	 * Note: When the message is of type
+	 * {@link FullHttpResponse} then {@link FullHttpResponse#release()}
+	 * has to be invoked after consuming the response.
 	 *
 	 * @return the HTTP response message
 	 */

--- a/src/main/java/reactor/ipc/netty/http/client/MonoHttpClientResponse.java
+++ b/src/main/java/reactor/ipc/netty/http/client/MonoHttpClientResponse.java
@@ -25,8 +25,10 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import io.netty.channel.Channel;
+import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AsciiString;
 import org.reactivestreams.Publisher;
@@ -184,6 +186,10 @@ final class MonoHttpClientResponse extends Mono<HttpClientResponse> {
 			if (throwable instanceof RedirectClientException) {
 				RedirectClientException re = (RedirectClientException) throwable;
 				redirect(re.location);
+				HttpResponse response = re.message();
+				if (response instanceof FullHttpResponse) {
+					((FullHttpResponse) response).release();
+				}
 				return true;
 			}
 			if (AbortedException.isConnectionReset(throwable) && !retried) {

--- a/src/test/java/reactor/ipc/netty/http/HttpTests.java
+++ b/src/test/java/reactor/ipc/netty/http/HttpTests.java
@@ -24,6 +24,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import reactor.core.publisher.EmitterProcessor;
@@ -163,7 +165,17 @@ public class HttpTests {
 				      .log("received-status-1");
 
 		StepVerifier.create(code)
-				    .expectError(HttpClientException.class)
+				    .expectErrorMatches(t -> {
+				        if (t instanceof HttpClientException) {
+				            HttpClientException throwable = (HttpClientException) t;
+				            HttpResponse response = throwable.message();
+				            if (response instanceof FullHttpResponse) {
+				                ((FullHttpResponse) response).release();
+				            }
+				            return true;
+				        }
+				        return false;
+				    })
 				    .verify(Duration.ofSeconds(30));
 
 		Mono<ByteBuf> content =
@@ -225,7 +237,17 @@ public class HttpTests {
 				     .next();
 
 		StepVerifier.create(code)
-				    .expectError(HttpClientException.class)
+				    .expectErrorMatches(t -> {
+				        if (t instanceof HttpClientException) {
+				            HttpClientException throwable = (HttpClientException) t;
+				            HttpResponse response = throwable.message();
+				            if (response instanceof FullHttpResponse) {
+				                ((FullHttpResponse) response).release();
+				            }
+				            return true;
+				        }
+				        return false;
+				    })
 				    .verify(Duration.ofSeconds(30));
 
 		server.dispose();

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
@@ -36,8 +36,10 @@ import javax.net.ssl.SSLException;
 
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
@@ -339,8 +341,14 @@ public class HttpClientTest {
 				            })
 				            .log()
 				            .onErrorResume(HttpClientException.class,
-				                    e -> Mono.just(e.status()
-				                                    .code()))
+				                    e -> {
+				                        HttpResponse msg = e.message();
+				                        if (msg instanceof FullHttpResponse) {
+				                            ((FullHttpResponse) msg).release();
+				                        }
+				                        return Mono.just(e.status()
+				                                          .code());
+				                    })
 				            .block(Duration.ofSeconds(30));
 
 		assertThat(res).isNotNull();


### PR DESCRIPTION
HttpClientException holds HttpResponse, when it is FullHttpResponse
it should be released. RedirectClientException extends HttpClientException,
so when do a redirection ensure the response is released.