### PR TITLE
fix #525 HttpServer CONFIGURED moved to HttpTrafficHandler/Http2StreamBridgeHandler

### DIFF
--- a/src/main/java/reactor/netty/http/server/Http2StreamBridgeHandler.java
+++ b/src/main/java/reactor/netty/http/server/Http2StreamBridgeHandler.java
@@ -75,7 +75,7 @@ final class Http2StreamBridgeHandler extends ChannelDuplexHandler {
 								headersFrame.headers(),
 								false);
 			}
-			new HttpToH2Operations(Connection.from(ctx.channel()),
+			HttpToH2Operations ops = new HttpToH2Operations(Connection.from(ctx.channel()),
 					listener,
 					request,
 					headersFrame.headers(),
@@ -83,7 +83,9 @@ final class Http2StreamBridgeHandler extends ChannelDuplexHandler {
 					                       .parent(),
 							readForwardHeaders,
 							request),
-					cookieEncoder, cookieDecoder).bind();
+					cookieEncoder, cookieDecoder);
+			ops.bind();
+			listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED);
 		}
 		ctx.fireChannelRead(msg);
 	}

--- a/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -431,7 +431,6 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 	@Override
 	protected void onInboundNext(ChannelHandlerContext ctx, Object msg) {
 		if (msg instanceof HttpRequest) {
-			listener().onStateChange(this, ConnectionObserver.State.CONFIGURED);
 			if (msg instanceof FullHttpRequest) {
 				super.onInboundNext(ctx, msg);
 			}

--- a/src/main/java/reactor/netty/http/server/HttpToH2Operations.java
+++ b/src/main/java/reactor/netty/http/server/HttpToH2Operations.java
@@ -56,7 +56,6 @@ public class HttpToH2Operations extends HttpServerOperations {
 			return;
 		}
 		else if(msg instanceof Http2HeadersFrame) {
-			listener().onStateChange(this, ConnectionObserver.State.CONFIGURED);
 			if (((Http2HeadersFrame) msg).isEndStream()) {
 				super.onInboundNext(ctx, msg);
 			}

--- a/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -148,13 +148,14 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 			else {
 				overflow = false;
 
-				new HttpServerOperations(Connection.from(ctx.channel()),
+				HttpServerOperations ops = new HttpServerOperations(Connection.from(ctx.channel()),
 						listener,
 						compress,
 						request, ConnectionInfo.from(ctx.channel(), readForwardHeaders, request),
 						cookieEncoder, cookieDecoder)
-						.chunkedTransfer(true)
-						.bind();
+						.chunkedTransfer(true);
+				ops.bind();
+				listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED);
 
 				ctx.fireChannelRead(msg);
 				return;
@@ -279,13 +280,14 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 					return;
 				}
 				nextRequest = (HttpRequest)next;
-				new HttpServerOperations(Connection.from(ctx.channel()),
+				HttpServerOperations ops = new HttpServerOperations(Connection.from(ctx.channel()),
 						listener,
 						compress,
 						nextRequest, ConnectionInfo.from(ctx.channel(), readForwardHeaders, nextRequest),
 						cookieEncoder, cookieDecoder)
-						.chunkedTransfer(true)
-						.bind();
+						.chunkedTransfer(true);
+				ops.bind();
+				listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED);
 			}
 			ctx.fireChannelRead(pipelined.poll());
 		}


### PR DESCRIPTION
`doOnConnection` is invoked when `HttpServer` reaches state `CONFIGURED`.
On that state the user can add new handlers to the channel pipeline, because
of that the state's change must happen before `ChannelOperationsHandler`,
otherwise the new handlers will miss the first `channelRead` event.