### PR TITLE
fix #529 Fix HttpClientFinalizer cleanup for interrupted responses

### DIFF
--- a/src/main/java/reactor/netty/channel/ChannelOperations.java
+++ b/src/main/java/reactor/netty/channel/ChannelOperations.java
@@ -283,6 +283,13 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 	}
 
 	/**
+	 * Drop pending content and complete inbound
+	 */
+	public final void discard(){
+		inbound.cancel();
+	}
+
+	/**
 	 * Return true if inbound traffic is not expected anymore
 	 *
 	 * @return true if inbound traffic is not expected anymore
@@ -378,13 +385,6 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 				setSuccess(null);
 			}
 		}
-	}
-
-	/**
-	 * Drop pending content and complete inbound
-	 */
-	protected final void discard(){
-		inbound.discard();
 	}
 
 	/**

--- a/src/main/java/reactor/netty/channel/FluxReceive.java
+++ b/src/main/java/reactor/netty/channel/FluxReceive.java
@@ -89,12 +89,6 @@ final class FluxReceive extends Flux<Object> implements Subscription, Disposable
 		return receiverCancel == CANCELLED;
 	}
 
-	final void discard() {
-		inboundDone = true;
-		receiverCancel = CANCELLED;
-		drainReceiver();
-	}
-
 	@Override
 	public void dispose() {
 		cancel();
@@ -385,6 +379,13 @@ final class FluxReceive extends Flux<Object> implements Subscription, Disposable
 		if(isCancelled()) {
 			parent.onInboundCancel();
 		}
+	}
+
+	@Override
+	public String toString() {
+		return "FluxReceive{receiverQueueSize" +
+				"=" + (receiverQueue != null ? receiverQueue.size() : 0) + ", inboundDone=" + inboundDone
+				+ ",inboundError=" + inboundError + '}';
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
+++ b/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
@@ -71,7 +71,8 @@ final class WebsocketFinalizer extends HttpClient implements HttpClient.Websocke
 
 	@Override
 	public <V> Flux<V> handle(BiFunction<? super WebsocketInbound, ? super WebsocketOutbound, ? extends Publisher<V>> receiver) {
-		return connect().flatMapMany(c -> Flux.from(receiver.apply(c, c)));
+		return connect().flatMapMany(c -> Flux.from(receiver.apply(c, c))
+		                                      .doFinally(s -> HttpClientFinalizer.discard(c)));
 	}
 }
 


### PR DESCRIPTION
- HttpClientFinalizer and WebclientFinalizer now trigger discard()
- Do not check for isDisposed but rather inbound only
- Merge FluxReceive#discard into cancel()