### PR TITLE
Added invoking parent.drain if future/promise exists

### DIFF
--- a/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
@@ -645,10 +645,12 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 					if (!future.isSuccess()) {
 						// Returned value is deliberately ignored
 						promise.setFailure(Exceptions.addSuppressed(future.cause(), t));
+						parent.drain();
 						return;
 					}
 					// Returned value is deliberately ignored
 					promise.setFailure(t);
+					parent.drain();
 				});
 			}
 			else {


### PR DESCRIPTION
Motivation:

I create a server, client and I have 2 processors to send via them some ByteBuf-s. And I send these processors on the client side. Ok, I understand that while the first processor is not finished the another won't be processed at all. But when I invoke `dispose` (or emit some error) on the first processor I expect that the second one will be started to process. But for now, it's not so, because in my case I have the `lastWrite` promise and the `parent.drain()` isn't invoked to handle the `PENDING_WRITES` flag and other processors in the `pendingWrites` queue. And only if after that I send something else, finally the second processor will be started to process.

See example:

```java
public static void main(String[] args) throws InterruptedException {
    InetSocketAddress address = new InetSocketAddress(7071);

    DirectProcessor<ByteBuf> clientStream1 = DirectProcessor.create();
    DirectProcessor<ByteBuf> clientStream2 = DirectProcessor.create();

    DisposableServer server =
        TcpServer.create()
            .runOn(LoopResources.create("server", 1, true))
            .addressSupplier(() -> address)
            .handle(
                (in, out) -> {
                  in.receive()
                      .asString()
                      .log("server receive ")
                      .subscribe(null, e -> System.err.println(e.getMessage()));

                  return Mono.never();
                })
            .bind()
            .block();

    Connection connection =
        TcpClient.create(ConnectionProvider.fixed("client-0", 1))
            .runOn(LoopResources.create("client", 1, true))
            .host(address.getHostString())
            .port(address.getPort())
            .handle(
                (in, out) -> {
                  in.receive()
                      .asString()
                      .log("client receive ")
                      .subscribe(null, e -> System.err.println(e.getMessage()));

                  out.options(SendOptions::flushOnEach)
                      .send(clientStream1)
                      .then()
                      .log("clientStream1 send ")
                      .subscribe(null, e -> System.err.println(e.getMessage()));

                  out.options(SendOptions::flushOnEach)
                      .send(clientStream2)
                      .then()
                      .log("clientStream2 send ")
                      .subscribe(null, e -> System.err.println(e.getMessage()));

                  return Mono.never();
                })
            .doOnConnected(c -> System.out.println("connected"))
            .connectNow();

    Flux.interval(Duration.ofSeconds(1))
        .map(i -> "HELLO from clientStream1 | " + i)
        .map(Scratch::toByteBuf)
        .subscribe(clientStream1::onNext, e -> System.err.println(e.getMessage()));
    Flux.interval(Duration.ofSeconds(1))
        .map(i -> "HELLO from clientStream2 | " + i)
        .map(Scratch::toByteBuf)
        .subscribe(clientStream2::onNext, e -> System.err.println(e.getMessage()));

    Mono.delay(Duration.ofSeconds(5))
        .doOnSuccess($ -> clientStream1.dispose())
        .subscribe(null, e -> System.err.println(e.getMessage()));

    Thread.currentThread().join();
  }

  private static ByteBuf toByteBuf(String str) {
    ByteBuf bb = ByteBufAllocator.DEFAULT.buffer();
    ByteBufOutputStream stream = new ByteBufOutputStream(bb);
    try {
      stream.writeUTF(str);
    } catch (Exception e) {
      bb.release();
      throw new EncoderException(e);
    }
    return bb;
  }
```