### PR TITLE
fix #522 New HttpClient API to allow configuring redirects via a predicate

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -651,7 +652,7 @@ public abstract class HttpClient {
 	}
 
 	/**
-	 * Specifies whether http status 301/302 auto-redirect support is enabled
+	 * Specifies whether http status 301|302|307|308 auto-redirect support is enabled
 	 *
 	 * @param followRedirect if true http status 301/302 auto-redirect support
 	 *                       is enabled otherwise disabled (default: true)
@@ -664,6 +665,23 @@ public abstract class HttpClient {
 		else {
 			return tcpConfiguration(FOLLOW_REDIRECT_ATTR_DISABLE);
 		}
+	}
+
+	/**
+	 * Enables auto-redirect support if the passed
+	 * {@link java.util.function.Predicate} matches.
+	 * <p>
+	 *     note the passed {@link HttpClientRequest} and {@link HttpClientResponse}
+	 *     should be considered read-only and the implement SHOULD NOT consume or
+	 *     write the request/response in this predicate.
+	 *
+	 * @param predicate that returns true to enable auto-redirect support.
+	 * @return a new {@link HttpClient}
+	 */
+	public final HttpClient followRedirect(BiPredicate<HttpClientRequest, HttpClientResponse> predicate) {
+		Objects.requireNonNull(predicate, "predicate");
+		return tcpConfiguration(tcp -> tcp.bootstrap(
+				b -> HttpClientConfiguration.followRedirectPredicate(b, predicate)));
 	}
 
 	/**

--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -418,7 +419,6 @@ final class HttpClientConnect extends HttpClient {
 		final HttpHeaders        defaultHeaders;
 		final BiFunction<? super HttpClientRequest, ? super NettyOutbound, ? extends Publisher<Void>>
 		                         handler;
-		final boolean            followRedirect;
 		final boolean            compress;
 		final Boolean            chunkedTransfer;
 		final UriEndpointFactory uriEndpointFactory;
@@ -427,6 +427,8 @@ final class HttpClientConnect extends HttpClient {
 
 		final ClientCookieEncoder cookieEncoder;
 		final ClientCookieDecoder cookieDecoder;
+
+		final BiPredicate<HttpClientRequest, HttpClientResponse> followRedirectPredicate;
 
 		final ProxyProvider proxyProvider;
 
@@ -438,7 +440,7 @@ final class HttpClientConnect extends HttpClient {
 				@Nullable SslProvider sslProvider, @Nullable ProxyProvider proxyProvider) {
 			this.method = configuration.method;
 			this.compress = configuration.acceptGzip;
-			this.followRedirect = configuration.followRedirect;
+			this.followRedirectPredicate = configuration.followRedirectPredicate;
 			this.chunkedTransfer = configuration.chunkedTransfer;
 			this.cookieEncoder = configuration.cookieEncoder;
 			this.cookieDecoder = configuration.cookieDecoder;
@@ -527,7 +529,7 @@ final class HttpClientConnect extends HttpClient {
 					headers.set(HttpHeaderNames.ACCEPT, ALL);
 				}
 
-				ch.followRedirect(followRedirect);
+				ch.followRedirectPredicate(followRedirectPredicate);
 
 				if (Objects.equals(method, HttpMethod.GET) ||
 						Objects.equals(method, HttpMethod.HEAD) ||

--- a/src/test/java/reactor/netty/http/client/HttpClientOperationsTest.java
+++ b/src/test/java/reactor/netty/http/client/HttpClientOperationsTest.java
@@ -137,7 +137,7 @@ public class HttpClientOperationsTest {
 		HttpClientOperations ops1 = new HttpClientOperations(() -> channel,
 				ConnectionObserver.emptyListener(),
 				ClientCookieEncoder.STRICT, ClientCookieDecoder.STRICT);
-		ops1.followRedirect(true);
+		ops1.followRedirectPredicate((req, res) -> true);
 
 		HttpClientOperations ops2 = new HttpClientOperations(ops1);
 
@@ -147,7 +147,7 @@ public class HttpClientOperationsTest {
 		assertSame(ops1.isSecure, ops2.isSecure);
 		assertSame(ops1.nettyRequest, ops2.nettyRequest);
 		assertSame(ops1.responseState, ops2.responseState);
-		assertSame(ops1.redirectable, ops2.redirectable);
+		assertSame(ops1.followRedirectPredicate, ops2.followRedirectPredicate);
 		assertSame(ops1.requestHeaders, ops2.requestHeaders);
 	}
 }


### PR DESCRIPTION
`reactor.netty.http.client.HttpClient#followRedirect(boolean)` will redirect when
`301`|`302`|`307`|`308`

`reactor.netty.http.client.HttpClient#followRedirect(
BiPredicate<HttpClientRequest,HttpClientResponse>)` will redirect based on
the predicate