### PR TITLE
When Content-Length:0 release the Object scheduled for writing

### DIFF
--- a/src/main/java/reactor/ipc/netty/FutureMono.java
+++ b/src/main/java/reactor/ipc/netty/FutureMono.java
@@ -36,7 +36,6 @@ import reactor.core.publisher.FluxOperator;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoOperator;
 import reactor.core.publisher.Operators;
-import reactor.ipc.netty.channel.AbortedException;
 import reactor.util.context.Context;
 
 /**
@@ -317,12 +316,6 @@ public abstract class FutureMono extends Mono<Void> {
 
 		@Override
 		public void subscribe(CoreSubscriber<? super Void> s) {
-			if (!channel.isActive()) {
-				Operators.error(s, new AbortedException("Cannot publish the content " +
-						dataStream + ", the connection has been closed"));
-				return;
-			}
-
 			ChannelFutureSubscription cfs = new ChannelFutureSubscription(channel, s);
 
 			s.onSubscribe(cfs);

--- a/src/main/java/reactor/ipc/netty/NettyOutbound.java
+++ b/src/main/java/reactor/ipc/netty/NettyOutbound.java
@@ -346,6 +346,7 @@ public interface NettyOutbound extends Publisher<Void> {
 	 * any error during write
 	 */
 	default NettyOutbound sendObject(Object msg) {
+		context().onClose(() -> ReactorNetty.safeRelease(msg));
 		return then(FutureMono.deferFuture(() -> context().channel()
 		                                                  .writeAndFlush(msg)));
 	}

--- a/src/main/java/reactor/ipc/netty/ReactorNetty.java
+++ b/src/main/java/reactor/ipc/netty/ReactorNetty.java
@@ -31,6 +31,7 @@ import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.AttributeKey;
+import io.netty.util.ReferenceCounted;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -386,6 +387,20 @@ public final class ReactorNetty {
 		}
 		else {
 			return msg;
+		}
+	}
+
+	/**
+	 * Try to call {@link ReferenceCounted#release()} if the specified message implements {@link ReferenceCounted}.
+	 * If the specified message doesn't implement {@link ReferenceCounted} or it is already released,
+	 * this method does nothing.
+	 */
+	public static void safeRelease(Object msg) {
+		if (msg instanceof ReferenceCounted) {
+			ReferenceCounted referenceCounted = (ReferenceCounted) msg;
+			if (referenceCounted.refCnt() > 0) {
+				referenceCounted.release();
+			}
 		}
 	}
 

--- a/src/main/java/reactor/ipc/netty/http/client/HttpClientWSOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/client/HttpClientWSOperations.java
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.BiConsumer;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
@@ -38,6 +37,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import reactor.core.publisher.Mono;
 import reactor.ipc.netty.FutureMono;
 import reactor.ipc.netty.NettyPipeline;
+import reactor.ipc.netty.ReactorNetty;
 import reactor.ipc.netty.http.websocket.WebsocketInbound;
 import reactor.ipc.netty.http.websocket.WebsocketOutbound;
 
@@ -240,6 +240,7 @@ final class HttpClientWSOperations extends HttpClientOperations
 
 	Mono<Void> sendClose(CloseWebSocketFrame frame) {
 		if (CLOSE_SENT.get(this) == 0) {
+			context().onClose(() -> ReactorNetty.safeRelease(frame));
 			return FutureMono.deferFuture(() -> {
 				if (CLOSE_SENT.getAndSet(this, 1) == 0) {
 					discard();

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerHandler.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerHandler.java
@@ -207,8 +207,9 @@ final class HttpServerHandler extends ChannelDuplexHandler
 									"connection, preparing to close"),
 							pendingResponses);
 				}
-				promise.addListener(ChannelFutureListener.CLOSE);
-				ctx.write(msg, promise);
+				ctx.write(msg, promise)
+				   .addListener(new TerminateHttpHandler(ctx.channel()))
+				   .addListener(ChannelFutureListener.CLOSE);
 				return;
 			}
 

--- a/src/main/java/reactor/ipc/netty/http/server/HttpServerWSOperations.java
+++ b/src/main/java/reactor/ipc/netty/http/server/HttpServerWSOperations.java
@@ -34,6 +34,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory;
 import reactor.core.publisher.Mono;
 import reactor.ipc.netty.FutureMono;
 import reactor.ipc.netty.NettyPipeline;
+import reactor.ipc.netty.ReactorNetty;
 import reactor.ipc.netty.http.HttpOperations;
 import reactor.ipc.netty.http.websocket.WebsocketInbound;
 import reactor.ipc.netty.http.websocket.WebsocketOutbound;
@@ -144,6 +145,7 @@ final class HttpServerWSOperations extends HttpServerOperations
 
 	Mono<Void> sendClose(CloseWebSocketFrame frame) {
 		if (CLOSE_SENT.get(this) == 0) {
+			context().onClose(() -> ReactorNetty.safeRelease(frame));
 			return FutureMono.deferFuture(() -> {
 				if (CLOSE_SENT.getAndSet(this, 1) == 0) {
 					discard();


### PR DESCRIPTION
When Connection:close invoke first cleanup so that the cancelation
is propagated to the publishers and then close the connection