### PR TITLE
Use ByteBuf#(write|read)CharSequence when transforming from/to String

### DIFF
--- a/src/main/java/reactor/netty/ByteBufMono.java
+++ b/src/main/java/reactor/netty/ByteBufMono.java
@@ -90,7 +90,7 @@ public final class ByteBufMono extends MonoOperator<ByteBuf, ByteBuf> {
 	public final Mono<String> asString(Charset charset) {
 		return handle((bb, sink) -> {
 			try {
-				sink.next(bb.toString(charset));
+				sink.next(bb.readCharSequence(bb.readableBytes(), charset).toString());
 			}
 			catch (IllegalReferenceCountException e) {
 				sink.complete();

--- a/src/main/java/reactor/netty/NettyOutbound.java
+++ b/src/main/java/reactor/netty/NettyOutbound.java
@@ -286,9 +286,12 @@ public interface NettyOutbound extends Publisher<Void> {
 	 */
 	default NettyOutbound sendString(Publisher<? extends String> dataStream,
 			Charset charset) {
-		return sendObject(ReactorNetty.publisherOrScalarMap(dataStream, s -> alloc()
-				.buffer()
-				.writeBytes(s.getBytes(charset))));
+		return sendObject(ReactorNetty.publisherOrScalarMap(
+				dataStream, s -> {
+				    ByteBuf buffer = alloc().buffer();
+				    buffer.writeCharSequence(s, charset);
+				    return buffer;
+				}));
 	}
 
 	/**

--- a/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
@@ -151,8 +151,8 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 						}
 					}
 					if (msg instanceof ByteBufHolder && ((ByteBufHolder)msg).content() != Unpooled.EMPTY_BUFFER) {
-						loggingMsg = ((ByteBufHolder) msg).content()
-						                                  .toString(Charset.defaultCharset());
+						ByteBuf buffer = ((ByteBufHolder) msg).content();
+						loggingMsg = buffer.readCharSequence(buffer.readableBytes(), Charset.defaultCharset()).toString();
 					}
 					log.debug(format(ctx.channel(), "No ChannelOperation attached. Dropping: {}"),
 							loggingMsg);

--- a/src/test/java/reactor/netty/NettyOutboundTest.java
+++ b/src/test/java/reactor/netty/NettyOutboundTest.java
@@ -154,7 +154,7 @@ public class NettyOutboundTest {
 					@Override
 					protected void encode(ChannelHandlerContext ctx, ByteBuf msg,
 							List<Object> out) {
-						clearMessages.add(msg.toString(CharsetUtil.UTF_8));
+						clearMessages.add(msg.readCharSequence(msg.readableBytes(), CharsetUtil.UTF_8));
 						out.add(msg.retain()); //the encoder will release the buffer, make sure it is retained for SslHandler
 					}
 				},
@@ -242,7 +242,7 @@ public class NettyOutboundTest {
 					@Override
 					protected void encode(ChannelHandlerContext ctx, ByteBuf msg,
 							List<Object> out) {
-						out.add(msg.toString(CharsetUtil.UTF_8));
+						out.add(msg.readCharSequence(msg.readableBytes(), CharsetUtil.UTF_8));
 					}
 				},
 				//transform the ChunkedFile into ByteBuf chunks:

--- a/src/test/java/reactor/netty/http/ClientServerHttpTests.java
+++ b/src/test/java/reactor/netty/http/ClientServerHttpTests.java
@@ -375,8 +375,9 @@ public class ClientServerHttpTests {
 					buf.append(n);
 				}
 			}
-			String data = buf.toString();
-			return alloc.buffer().writeBytes(data.getBytes(Charset.defaultCharset()));
+			ByteBuf buffer = alloc.buffer();
+			buffer.writeCharSequence(buf.toString(), Charset.defaultCharset());
+			return buffer;
 		}
 	}
 }

--- a/src/test/java/reactor/netty/http/HttpOperationsTest.java
+++ b/src/test/java/reactor/netty/http/HttpOperationsTest.java
@@ -70,14 +70,17 @@ public class HttpOperationsTest {
 
 		t = channel.readInbound();
 		assertThat(t, instanceOf(ByteBuf.class));
-		assertThat(((ByteBuf) t).toString(CharsetUtil.UTF_8), is("{\"some\": 1}"));
-		((ByteBuf) t).release();
+		ByteBuf b = (ByteBuf) t;
+		assertThat(b.readCharSequence(b.readableBytes(), CharsetUtil.UTF_8),
+				is("{\"some\": 1}"));
+		b.release();
 
 		t = channel.readInbound();
 		assertThat(t, instanceOf(ByteBuf.class));
-		assertThat(((ByteBuf) t).toString(CharsetUtil.UTF_8),
+		b = (ByteBuf) t;
+		assertThat(b.readCharSequence(b.readableBytes(), CharsetUtil.UTF_8),
 				is("{\"value\": true, \"test\": 1}"));
-		((ByteBuf) t).release();
+		b.release();
 
 		t = channel.readInbound();
 		assertThat(t, is(LastHttpContent.EMPTY_LAST_CONTENT));

--- a/src/test/java/reactor/netty/http/client/PostAndGetTests.java
+++ b/src/test/java/reactor/netty/http/client/PostAndGetTests.java
@@ -101,7 +101,8 @@ public class PostAndGetTests {
 			                          .flatMap(data -> {
 				                          final StringBuilder response =
 						                          new StringBuilder().append("hello ")
-						                                             .append(data.toString(
+						                                             .append(data.readCharSequence(
+						                                                     data.readableBytes(),
 								                                             Charset.defaultCharset()));
 				                          System.out.println(String.format(
 						                          "%s from thread %s",

--- a/src/test/java/reactor/netty/http/client/WebsocketTest.java
+++ b/src/test/java/reactor/netty/http/client/WebsocketTest.java
@@ -584,7 +584,8 @@ public class WebsocketTest {
 										.sendObject(in.aggregateFrames()
 												.receiveFrames()
 												.map(WebSocketFrame::content)
-												.map(byteBuf -> byteBuf.toString(Charset.defaultCharset()))
+												.map(byteBuf ->
+														byteBuf.readCharSequence(byteBuf.readableBytes(), Charset.defaultCharset()).toString())
 												.map(TextWebSocketFrame::new))))
 						.wiretap(true)
 						.bindNow();
@@ -598,7 +599,8 @@ public class WebsocketTest {
 						.then(in.aggregateFrames()
 								.receiveFrames()
 								.map(WebSocketFrame::content)
-								.map(byteBuf -> byteBuf.toString(Charset.defaultCharset()))
+								.map(byteBuf ->
+										byteBuf.readCharSequence(byteBuf.readableBytes(), Charset.defaultCharset()).toString())
 								.take(count)
 								.subscribeWith(output)
 								.then()))
@@ -712,7 +714,8 @@ public class WebsocketTest {
 		                         //.share()
 		                         .publish()
 		                         .autoConnect()
-		                         .map(byteBuf -> byteBuf.toString(Charset.defaultCharset()))
+		                         .map(byteBuf ->
+		                             byteBuf.readCharSequence(byteBuf.readableBytes(), Charset.defaultCharset()).toString())
 		                         .map(Integer::parseInt)
 		                         .map(i -> new TextWebSocketFrame(i + ""))
 		                         .retry()),
@@ -728,7 +731,8 @@ public class WebsocketTest {
 		                         .map(WebSocketFrame::content)
 		                         .concatMap(content ->
 		                             Mono.just(content)
-		                                 .map(byteBuf -> byteBuf.toString(Charset.defaultCharset()))
+		                                 .map(byteBuf ->
+		                                     byteBuf.readCharSequence(byteBuf.readableBytes(), Charset.defaultCharset()).toString())
 		                                 .map(Integer::parseInt)
 		                                 .map(i -> new TextWebSocketFrame(i + ""))
 		                                 .onErrorResume(t -> Mono.just(new TextWebSocketFrame("error"))))),
@@ -753,7 +757,8 @@ public class WebsocketTest {
 		                                                       .then(in.aggregateFrames()
 		                                                               .receiveFrames()
 		                                                               .map(WebSocketFrame::content)
-		                                                               .map(byteBuf -> byteBuf.toString(Charset.defaultCharset()))
+		                                                               .map(byteBuf ->
+		                                                                   byteBuf.readCharSequence(byteBuf.readableBytes(), Charset.defaultCharset()).toString())
 		                                                               .take(count)
 		                                                               .subscribeWith(output)
 		                                                               .then()))

--- a/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -905,10 +905,8 @@ public class HttpServerTests {
 
 	@Test
 	public void testDropPublisherConnectionClose() {
-		ByteBuf data =
-				ByteBufAllocator.DEFAULT
-				                .buffer()
-				                .writeBytes("test".getBytes(Charset.defaultCharset()));
+		ByteBuf data = ByteBufAllocator.DEFAULT.buffer();
+		data.writeCharSequence("test", Charset.defaultCharset());
 		doTestDropData(
 				(req, res) -> res.header("Content-Length", "0")
 				                 .send(Mono.fromRunnable(() -> Flux.just(data, data.retain(), data.retain())))
@@ -923,10 +921,8 @@ public class HttpServerTests {
 
 	@Test
 	public void testDropMessageConnectionClose() {
-		ByteBuf data =
-				ByteBufAllocator.DEFAULT
-				                .buffer()
-				                .writeBytes("test".getBytes(Charset.defaultCharset()));
+		ByteBuf data = ByteBufAllocator.DEFAULT.buffer();
+		data.writeCharSequence("test", Charset.defaultCharset());
 		doTestDropData(
 				(req, res) -> res.header("Content-Length", "0")
 				                 .sendObject(data),
@@ -939,10 +935,8 @@ public class HttpServerTests {
 
 	@Test
 	public void testDropPublisher() {
-		ByteBuf data =
-				ByteBufAllocator.DEFAULT
-				                .buffer()
-				                .writeBytes("test".getBytes(Charset.defaultCharset()));
+		ByteBuf data = ByteBufAllocator.DEFAULT.buffer();
+		data.writeCharSequence("test", Charset.defaultCharset());
 		doTestDropData(
 				(req, res) -> res.header("Content-Length", "0")
 				                 .send(Mono.fromRunnable(() -> Flux.just(data, data.retain(), data.retain())))
@@ -954,10 +948,8 @@ public class HttpServerTests {
 
 	@Test
 	public void testDropMessage() {
-		ByteBuf data =
-				ByteBufAllocator.DEFAULT
-				                .buffer()
-				                .writeBytes("test".getBytes(Charset.defaultCharset()));
+		ByteBuf data = ByteBufAllocator.DEFAULT.buffer();
+		data.writeCharSequence("test", Charset.defaultCharset());
 		doTestDropData(
 				(req, res) -> res.header("Content-Length", "0")
 				                 .sendObject(data),

--- a/src/test/java/reactor/netty/tcp/TcpServerTests.java
+++ b/src/test/java/reactor/netty/tcp/TcpServerTests.java
@@ -270,10 +270,7 @@ public class TcpServerTests {
 		assertNotNull(connected);
 
 		Connection clientContext =
-				client.handle((in, out) -> out.send(Flux.just("Hello World!\n", "Hello 11!\n")
-				                                        .map(b -> out.alloc()
-				                                                     .buffer()
-				                                                     .writeBytes(b.getBytes(Charset.defaultCharset())))))
+				client.handle((in, out) -> out.sendString(Flux.just("Hello World!\n", "Hello 11!\n")))
 				      .wiretap(true)
 				      .connectNow();
 

--- a/src/test/java/reactor/netty/udp/UdpClientTest.java
+++ b/src/test/java/reactor/netty/udp/UdpClientTest.java
@@ -46,9 +46,10 @@ public class UdpClientTest {
 				                                    .map(o -> {
 				                                            if (o instanceof DatagramPacket) {
 				                                                DatagramPacket received = (DatagramPacket) o;
-				                                                System.out.println("Server received " + received.content().toString(CharsetUtil.UTF_8));
+				                                                ByteBuf buffer = received.content();
+				                                                System.out.println("Server received " + buffer.readCharSequence(buffer.readableBytes(), CharsetUtil.UTF_8));
 				                                                ByteBuf buf1 = Unpooled.copiedBuffer("echo ", CharsetUtil.UTF_8);
-				                                                ByteBuf buf2 = Unpooled.copiedBuffer(buf1, received.content());
+				                                                ByteBuf buf2 = Unpooled.copiedBuffer(buf1, buffer);
 				                                                buf1.release();
 				                                                return new DatagramPacket(buf2, received.sender());
 				                                            }
@@ -69,7 +70,7 @@ public class UdpClientTest {
 				         .handle((in, out) -> {
 				                                  in.receive()
 				                                    .subscribe(b -> {
-				                                        System.out.println("Client1 received " + b.toString(CharsetUtil.UTF_8));
+				                                        System.out.println("Client1 received " + b.readCharSequence(b.readableBytes(), CharsetUtil.UTF_8));
 				                                        latch.countDown();
 				                                    });
 				                                  return out.sendString(Mono.just("ping1"))
@@ -88,7 +89,7 @@ public class UdpClientTest {
 				         .handle((in, out) -> {
 				                                  in.receive()
 				                                    .subscribe(b -> {
-				                                        System.out.println("Client2 received " + b.toString(CharsetUtil.UTF_8));
+				                                        System.out.println("Client2 received " + b.readCharSequence(b.readableBytes(), CharsetUtil.UTF_8));
 				                                        latch.countDown();
 				                                    });
 				                                  return out.sendString(Mono.just("ping3"))


### PR DESCRIPTION
ByteBuf#(write|read)CharSequence methods have optimisations for
CharsetUtil.US_ASCII
CharsetUtil.ISO_8859_1
CharsetUtil.UTF_8