### PR TITLE
fix #558 Add CONFIGURING step to the lifecycle listener

### DIFF
--- a/src/main/java/reactor/netty/ConnectionObserver.java
+++ b/src/main/java/reactor/netty/ConnectionObserver.java
@@ -102,6 +102,12 @@ public interface ConnectionObserver {
 		State CONFIGURED = ReactorNetty.CONFIGURED;
 
 		/**
+		 * Propagated when a connection is bound to a channelOperation but still
+		 * allowing for observers' configuration.
+		 */
+		State CONFIGURED_ALMOST = ReactorNetty.CONFIGURED_ALMOST;
+
+		/**
 		 * Propagated when a connection has been reused / acquired
 		 * (keep-alive or pooling)
 		 */

--- a/src/main/java/reactor/netty/ReactorNetty.java
+++ b/src/main/java/reactor/netty/ReactorNetty.java
@@ -467,6 +467,13 @@ public final class ReactorNetty {
 		}
 	};
 
+	final static ConnectionObserver.State CONFIGURED_ALMOST = new ConnectionObserver.State() {
+		@Override
+		public String toString() {
+			return "[almost_configured]";
+		}
+	};
+
 	final static ConnectionObserver.State CONFIGURED = new ConnectionObserver.State() {
 		@Override
 		public String toString() {

--- a/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
@@ -109,6 +109,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 		ChannelOperations<?, ?> ops = opsFactory.create(c, listener, null);
 		if (ops != null) {
 			ops.bind();
+			listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED_ALMOST);
 			listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED);
 		}
 	}

--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -316,6 +316,7 @@ final class HttpClientConnect extends HttpClient {
 				}
 
 				BootstrapHandlers.connectionObserver(finalBootstrap,
+
 						new HttpObserver(sink, handler).then(BootstrapHandlers.connectionObserver(finalBootstrap)));
 
 				tcpClient.connect(finalBootstrap)
@@ -794,6 +795,7 @@ final class HttpClientConnect extends HttpClient {
 		public void channelActive(ChannelHandlerContext ctx) {
 			ChannelOperations<?, ?> ops = Connection.from(ctx.channel()).as(ChannelOperations.class);
 			if (ops != null) {
+				ops.listener().onStateChange(ops, ConnectionObserver.State.CONFIGURED_ALMOST);
 				ops.listener().onStateChange(ops, ConnectionObserver.State.CONFIGURED);
 			}
 			ctx.fireChannelActive();

--- a/src/main/java/reactor/netty/http/client/HttpClientDoOn.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientDoOn.java
@@ -29,8 +29,8 @@ import reactor.netty.tcp.TcpClient;
 /**
  * @author Stephane Maldini
  */
-final class HttpClientDoOn extends HttpClientOperator implements ConnectionObserver,
-                                                           Function<Bootstrap, Bootstrap> {
+final class HttpClientDoOn extends HttpClientOperator implements
+		ConnectionObserver, Function<Bootstrap, Bootstrap> {
 
 	final BiConsumer<? super HttpClientRequest, ? super Connection>  onRequest;
 	final BiConsumer<? super HttpClientRequest, ? super Connection>  afterRequest;
@@ -56,17 +56,16 @@ final class HttpClientDoOn extends HttpClientOperator implements ConnectionObser
 		return bootstrap;
 	}
 
-	@Override
-	public void onStateChange(Connection connection, State newState) {
-		if (onRequest != null && newState == State.CONFIGURED) {
+	public void onStateChange(Connection connection, ConnectionObserver.State newState) {
+		if (onRequest != null && newState == State.CONFIGURED_ALMOST) {
 			onRequest.accept(connection.as(HttpClientOperations.class), connection);
-			return;
 		}
+
 		if (afterResponse != null) {
-			if (newState == State.RELEASED){
+			if (newState == ConnectionObserver.State.RELEASED){
 				afterResponse.accept(connection.as(HttpClientOperations.class), connection);
 			}
-			else if (newState == State.DISCONNECTING) {
+			else if (newState == ConnectionObserver.State.DISCONNECTING) {
 				connection.onDispose(() -> afterResponse.accept(connection.as(HttpClientOperations.class), connection));
 			}
 			return;

--- a/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -32,7 +32,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
-import com.sun.tools.internal.ws.wsdl.document.http.HTTPOperation;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufHolder;

--- a/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
+import com.sun.tools.internal.ws.wsdl.document.http.HTTPOperation;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufHolder;
@@ -127,6 +128,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 		                                .get();
 		this.redirectedFrom = redirects == null ? EMPTY_REDIRECTIONS : redirects;
 		this.nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+//		listener().onStateChange(this, HttpClientState.REQUEST_BEFORE);
 		this.requestHeaders = nettyRequest.headers();
 		this.cookieDecoder = decoder;
 		this.cookieEncoder = encoder;

--- a/src/main/java/reactor/netty/http/client/HttpClientState.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientState.java
@@ -25,6 +25,15 @@ import reactor.netty.ConnectionObserver;
  */
 public enum HttpClientState implements ConnectionObserver.State {
 	/**
+	 * The request has not yet been sent
+	 */
+	REQUEST_BEFORE() {
+		@Override
+		public String toString() {
+			return "[request_before]";
+		}
+	},
+	/**
 	 * The request has been sent
 	 */
 	REQUEST_SENT() {

--- a/src/main/java/reactor/netty/http/server/Http2StreamBridgeHandler.java
+++ b/src/main/java/reactor/netty/http/server/Http2StreamBridgeHandler.java
@@ -85,6 +85,7 @@ final class Http2StreamBridgeHandler extends ChannelDuplexHandler {
 							request),
 					cookieEncoder, cookieDecoder);
 			ops.bind();
+			listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED_ALMOST);
 			listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED);
 		}
 		ctx.fireChannelRead(msg);

--- a/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -155,6 +155,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 						cookieEncoder, cookieDecoder)
 						.chunkedTransfer(true);
 				ops.bind();
+				listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED_ALMOST);
 				listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED);
 
 				ctx.fireChannelRead(msg);
@@ -288,6 +289,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 						cookieEncoder, cookieDecoder)
 						.chunkedTransfer(true);
 				ops.bind();
+				listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED_ALMOST);
 				listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED);
 			}
 			ctx.fireChannelRead(pipelined.poll());

--- a/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -549,6 +549,7 @@ final class PooledConnectionProvider implements ConnectionProvider {
 					ChannelOperations<?, ?> ops = pool.opsFactory.create(con, con, null);
 					if (ops != null) {
 						ops.bind();
+						obs.onStateChange(ops, State.CONFIGURED_ALMOST);
 						obs.onStateChange(ops, State.CONFIGURED);
 						sink.success(ops);
 					}


### PR DESCRIPTION
This additional step lets listeners react before a request body is sent,
since once the CONFIGURED state is reached, it triggers sending the
request over the wire.