### PR TITLE
fix #595 Ensure message is released when I/O handler throws RuntimeException

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -489,7 +489,14 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 			}
 
 			if (notRedirected(response)) {
-				listener().onStateChange(this, HttpClientState.RESPONSE_RECEIVED);
+				try {
+					listener().onStateChange(this, HttpClientState.RESPONSE_RECEIVED);
+				}
+				catch (Exception e) {
+					onInboundError(e);
+					ReferenceCountUtil.release(msg);
+					return;
+				}
 			}
 			if (msg instanceof FullHttpResponse) {
 				super.onInboundNext(ctx, msg);

--- a/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
@@ -32,7 +32,6 @@ import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
-import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import reactor.core.publisher.Mono;
 import reactor.netty.FutureMono;
@@ -110,8 +109,8 @@ final class WebsocketClientOperations extends HttpClientOperations
 					handshaker.finishHandshake(channel(), response);
 					listener().onStateChange(this, HttpClientState.RESPONSE_RECEIVED);
 				}
-				catch (WebSocketHandshakeException wshe) {
-					onInboundError(wshe);
+				catch (Exception e) {
+					onInboundError(e);
 				}
 				finally {
 					//Release unused content (101 status)


### PR DESCRIPTION
Message may have content only when it is FullHttpResponse/FullHttpRequest