### PR TITLE
fix #553 Remove the deprecated HttpClient#chunkedTransfer

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -63,6 +63,9 @@ import reactor.netty.tcp.TcpClient;
  * is called to retrieve a ready to use {@link TcpClient}, then {@link
  * TcpClient#configure()} retrieve a usable {@link Bootstrap} for the final {@link
  * TcpClient#connect()} is called.
+ * {@code Transfer-Encoding: chunked} will be applied for those HTTP methods for which
+ * a request body is expected. {@code Content-Length} provided via request headers
+ * will disable {@code Transfer-Encoding: chunked}.
  * <p> Examples:
  * <pre>
  * {@code
@@ -409,25 +412,6 @@ public abstract class HttpClient {
 	 */
 	public final HttpClient mapConnect(BiFunction<? super Mono<? extends Connection>, ? super Bootstrap, ? extends Mono<? extends Connection>> connector) {
 		return new HttpClientOnConnectMap(this, connector);
-	}
-
-	/**
-	 * Specifies whether transfer-encoding is enabled
-	 *
-	 * @param chunkedEnabled if true transfer-encoding is enabled otherwise disabled.
-	 * (default: true)
-	 * @return a new {@link HttpClient}
-	 * @deprecated Using {@link #headers(Consumer)} for specifying the content length
-	 * will disable the transfer-encoding
-	 */
-	@Deprecated
-	public final HttpClient chunkedTransfer(boolean chunkedEnabled) {
-		if (chunkedEnabled) {
-			return tcpConfiguration(CHUNKED_ATTR_CONFIG);
-		}
-		else {
-			return tcpConfiguration(CHUNKED_ATTR_DISABLE);
-		}
 	}
 
 	/**
@@ -915,17 +899,11 @@ public abstract class HttpClient {
 	static final Function<TcpClient, TcpClient> COMPRESS_ATTR_DISABLE =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_NO_COMPRESS);
 
-	static final Function<TcpClient, TcpClient> CHUNKED_ATTR_CONFIG =
-			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_CHUNKED);
-
 	static final Function<TcpClient, TcpClient> KEEPALIVE_ATTR_CONFIG =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_KEEPALIVE);
 
 	static final Function<TcpClient, TcpClient> KEEPALIVE_ATTR_DISABLE =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_NO_KEEPALIVE);
-
-	static final Function<TcpClient, TcpClient> CHUNKED_ATTR_DISABLE =
-			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_NO_CHUNKED);
 
 	static final Function<TcpClient, TcpClient> FOLLOW_REDIRECT_ATTR_CONFIG =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_REDIRECT);

--- a/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
@@ -47,7 +47,6 @@ final class HttpClientConfiguration {
 			AttributeKey.newInstance("httpClientConf");
 
 	boolean                       acceptGzip                     = false;
-	Boolean                       chunkedTransfer                = null;
 	String                        uri                            = null;
 	String                        baseUrl                        = null;
 	HttpHeaders                   headers                        = null;
@@ -75,7 +74,6 @@ final class HttpClientConfiguration {
 		this.cookieEncoder = from.cookieEncoder;
 		this.cookieDecoder = from.cookieDecoder;
 		this.followRedirectPredicate = from.followRedirectPredicate;
-		this.chunkedTransfer = from.chunkedTransfer;
 		this.baseUrl = from.baseUrl;
 		this.headers = from.headers;
 		this.method = from.method;
@@ -96,7 +94,6 @@ final class HttpClientConfiguration {
 		return hcc;
 	}
 
-	@SuppressWarnings("unchecked")
 	static HttpClientConfiguration getOrCreate(Bootstrap b) {
 
 		HttpClientConfiguration hcc = (HttpClientConfiguration) b.config()
@@ -111,7 +108,6 @@ final class HttpClientConfiguration {
 		return hcc;
 	}
 
-	@SuppressWarnings("unchecked")
 	static HttpClientConfiguration get(Bootstrap b) {
 
 		HttpClientConfiguration hcc = (HttpClientConfiguration) b.config()
@@ -154,17 +150,6 @@ final class HttpClientConfiguration {
 
 	static final Function<Bootstrap, Bootstrap> MAP_NO_COMPRESS = b -> {
 		getOrCreate(b).acceptGzip = false;
-		return b;
-	};
-
-	static final Function<Bootstrap, Bootstrap> MAP_CHUNKED = b -> {
-		getOrCreate(b).chunkedTransfer = true;
-		return b;
-	};
-
-
-	static final Function<Bootstrap, Bootstrap> MAP_NO_CHUNKED = b -> {
-		getOrCreate(b).chunkedTransfer = false;
 		return b;
 	};
 

--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -435,7 +435,6 @@ final class HttpClientConnect extends HttpClient {
 		final BiFunction<? super HttpClientRequest, ? super NettyOutbound, ? extends Publisher<Void>>
 		                         handler;
 		final boolean            compress;
-		final Boolean            chunkedTransfer;
 		final UriEndpointFactory uriEndpointFactory;
 		final String             websocketProtocols;
 		final int                maxFramePayloadLength;
@@ -457,7 +456,6 @@ final class HttpClientConnect extends HttpClient {
 			this.method = configuration.method;
 			this.compress = configuration.acceptGzip;
 			this.followRedirectPredicate = configuration.followRedirectPredicate;
-			this.chunkedTransfer = configuration.chunkedTransfer;
 			this.cookieEncoder = configuration.cookieEncoder;
 			this.cookieDecoder = configuration.cookieDecoder;
 			this.proxyProvider = proxyProvider;
@@ -547,17 +545,14 @@ final class HttpClientConnect extends HttpClient {
 
 				ch.followRedirectPredicate(followRedirectPredicate);
 
-				if (chunkedTransfer == null) {
-					if (Objects.equals(method, HttpMethod.GET) ||
-							Objects.equals(method, HttpMethod.HEAD) ||
-							Objects.equals(method, HttpMethod.DELETE)) {
-						ch.chunkedTransfer(false);
-					} else if (!headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
-						ch.chunkedTransfer(true);
-					}
-				}
-				else {
-					ch.chunkedTransfer(chunkedTransfer);
+				if (Objects.equals(method, HttpMethod.GET) ||
+						Objects.equals(method, HttpMethod.HEAD) ||
+						Objects.equals(method, HttpMethod.DELETE)) {
+					ch.chunkedTransfer(false);
+				} else if (headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
+					ch.chunkedTransfer(false);
+				} else {
+					ch.chunkedTransfer(true);
 				}
 
 				if (handler != null) {


### PR DESCRIPTION
By default `Transfer-Encoding: chunked` will be applied for those HTTP methods
for which a request body is expected. If the user wants to disable that setting
then the user can provide `Content-Length` via request headers and
thus `Transfer-Encoding` will be removed.