### PR TITLE
fix connection header can contain other tokens

### DIFF
--- a/src/main/java/reactor/netty/http/server/HttpServerRoutes.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerRoutes.java
@@ -333,7 +333,7 @@ public interface HttpServerRoutes extends
 			int maxFramePayloadLength) {
 		return route(condition, (req, resp) -> {
 			if (req.requestHeaders()
-			       .contains(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE, true)) {
+			       .containsValue(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE, true)) {
 				HttpServerOperations ops = (HttpServerOperations) req;
 				return ops.withWebsocketSupport(req.uri(), protocols, maxFramePayloadLength, handler);
 			}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=691300

I'm just the messenger dealing with a broken Firefox 😄 when using a `ws` route.