### PR TITLE
update parseAddress behavior to handle ipv6 addresses without bracket

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ With `Gradle` from [repo.spring.io](https://repo.spring.io) or `Maven Central` r
     }
 
     dependencies {
-      //compile "io.projectreactor.netty:reactor-netty:0.8.6.BUILD-SNAPSHOT"
+      //compile "io.projectreactor.netty:reactor-netty:0.9.0.BUILD-SNAPSHOT"
       compile "io.projectreactor.netty:reactor-netty:0.8.5.RELEASE"
     }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
   gradleVersion = '3.3'
   gradleScriptDir = "${rootProject.projectDir}/gradle"
 
-  reactorCoreVersion = "3.2.7.BUILD-SNAPSHOT"
+  reactorCoreVersion = "3.3.0.BUILD-SNAPSHOT"
 
   // Languages
   groovyVersion = '2.4.1'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.8.6.BUILD-SNAPSHOT
+version=0.9.0.BUILD-SNAPSHOT

--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -816,19 +816,6 @@ public abstract class HttpClient {
 	}
 
 	/**
-	 * Apply a wire logger configuration using {@link HttpClient} category
-	 * and {@code DEBUG} logger level
-	 *
-	 * @return a new {@link HttpClient}
-	 * @deprecated Use {@link HttpClient#wiretap(boolean)}
-	 */
-	@Deprecated
-	public final HttpClient wiretap() {
-		return tcpConfiguration(tcpClient -> tcpClient.bootstrap(
-		        b -> BootstrapHandlers.updateLogSupport(b, LOGGING_HANDLER)));
-	}
-
-	/**
 	 * Apply or remove a wire logger configuration using {@link HttpClient} category
 	 * and {@code DEBUG} logger level
 	 *

--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -63,6 +63,9 @@ import reactor.netty.tcp.TcpClient;
  * is called to retrieve a ready to use {@link TcpClient}, then {@link
  * TcpClient#configure()} retrieve a usable {@link Bootstrap} for the final {@link
  * TcpClient#connect()} is called.
+ * {@code Transfer-Encoding: chunked} will be applied for those HTTP methods for which
+ * a request body is expected. {@code Content-Length} provided via request headers
+ * will disable {@code Transfer-Encoding: chunked}.
  * <p> Examples:
  * <pre>
  * {@code
@@ -409,25 +412,6 @@ public abstract class HttpClient {
 	 */
 	public final HttpClient mapConnect(BiFunction<? super Mono<? extends Connection>, ? super Bootstrap, ? extends Mono<? extends Connection>> connector) {
 		return new HttpClientOnConnectMap(this, connector);
-	}
-
-	/**
-	 * Specifies whether transfer-encoding is enabled
-	 *
-	 * @param chunkedEnabled if true transfer-encoding is enabled otherwise disabled.
-	 * (default: true)
-	 * @return a new {@link HttpClient}
-	 * @deprecated Using {@link #headers(Consumer)} for specifying the content length
-	 * will disable the transfer-encoding
-	 */
-	@Deprecated
-	public final HttpClient chunkedTransfer(boolean chunkedEnabled) {
-		if (chunkedEnabled) {
-			return tcpConfiguration(CHUNKED_ATTR_CONFIG);
-		}
-		else {
-			return tcpConfiguration(CHUNKED_ATTR_DISABLE);
-		}
 	}
 
 	/**
@@ -915,17 +899,11 @@ public abstract class HttpClient {
 	static final Function<TcpClient, TcpClient> COMPRESS_ATTR_DISABLE =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_NO_COMPRESS);
 
-	static final Function<TcpClient, TcpClient> CHUNKED_ATTR_CONFIG =
-			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_CHUNKED);
-
 	static final Function<TcpClient, TcpClient> KEEPALIVE_ATTR_CONFIG =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_KEEPALIVE);
 
 	static final Function<TcpClient, TcpClient> KEEPALIVE_ATTR_DISABLE =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_NO_KEEPALIVE);
-
-	static final Function<TcpClient, TcpClient> CHUNKED_ATTR_DISABLE =
-			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_NO_CHUNKED);
 
 	static final Function<TcpClient, TcpClient> FOLLOW_REDIRECT_ATTR_CONFIG =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_REDIRECT);

--- a/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
@@ -47,7 +47,6 @@ final class HttpClientConfiguration {
 			AttributeKey.newInstance("httpClientConf");
 
 	boolean                       acceptGzip                     = false;
-	Boolean                       chunkedTransfer                = null;
 	String                        uri                            = null;
 	String                        baseUrl                        = null;
 	HttpHeaders                   headers                        = null;
@@ -75,7 +74,6 @@ final class HttpClientConfiguration {
 		this.cookieEncoder = from.cookieEncoder;
 		this.cookieDecoder = from.cookieDecoder;
 		this.followRedirectPredicate = from.followRedirectPredicate;
-		this.chunkedTransfer = from.chunkedTransfer;
 		this.baseUrl = from.baseUrl;
 		this.headers = from.headers;
 		this.method = from.method;
@@ -96,7 +94,6 @@ final class HttpClientConfiguration {
 		return hcc;
 	}
 
-	@SuppressWarnings("unchecked")
 	static HttpClientConfiguration getOrCreate(Bootstrap b) {
 
 		HttpClientConfiguration hcc = (HttpClientConfiguration) b.config()
@@ -111,7 +108,6 @@ final class HttpClientConfiguration {
 		return hcc;
 	}
 
-	@SuppressWarnings("unchecked")
 	static HttpClientConfiguration get(Bootstrap b) {
 
 		HttpClientConfiguration hcc = (HttpClientConfiguration) b.config()
@@ -154,17 +150,6 @@ final class HttpClientConfiguration {
 
 	static final Function<Bootstrap, Bootstrap> MAP_NO_COMPRESS = b -> {
 		getOrCreate(b).acceptGzip = false;
-		return b;
-	};
-
-	static final Function<Bootstrap, Bootstrap> MAP_CHUNKED = b -> {
-		getOrCreate(b).chunkedTransfer = true;
-		return b;
-	};
-
-
-	static final Function<Bootstrap, Bootstrap> MAP_NO_CHUNKED = b -> {
-		getOrCreate(b).chunkedTransfer = false;
 		return b;
 	};
 

--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -435,7 +435,6 @@ final class HttpClientConnect extends HttpClient {
 		final BiFunction<? super HttpClientRequest, ? super NettyOutbound, ? extends Publisher<Void>>
 		                         handler;
 		final boolean            compress;
-		final Boolean            chunkedTransfer;
 		final UriEndpointFactory uriEndpointFactory;
 		final String             websocketProtocols;
 		final int                maxFramePayloadLength;
@@ -457,7 +456,6 @@ final class HttpClientConnect extends HttpClient {
 			this.method = configuration.method;
 			this.compress = configuration.acceptGzip;
 			this.followRedirectPredicate = configuration.followRedirectPredicate;
-			this.chunkedTransfer = configuration.chunkedTransfer;
 			this.cookieEncoder = configuration.cookieEncoder;
 			this.cookieDecoder = configuration.cookieDecoder;
 			this.proxyProvider = proxyProvider;
@@ -547,17 +545,14 @@ final class HttpClientConnect extends HttpClient {
 
 				ch.followRedirectPredicate(followRedirectPredicate);
 
-				if (chunkedTransfer == null) {
-					if (Objects.equals(method, HttpMethod.GET) ||
-							Objects.equals(method, HttpMethod.HEAD) ||
-							Objects.equals(method, HttpMethod.DELETE)) {
-						ch.chunkedTransfer(false);
-					} else if (!headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
-						ch.chunkedTransfer(true);
-					}
-				}
-				else {
-					ch.chunkedTransfer(chunkedTransfer);
+				if (Objects.equals(method, HttpMethod.GET) ||
+						Objects.equals(method, HttpMethod.HEAD) ||
+						Objects.equals(method, HttpMethod.DELETE)) {
+					ch.chunkedTransfer(false);
+				} else if (headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
+					ch.chunkedTransfer(false);
+				} else {
+					ch.chunkedTransfer(true);
 				}
 
 				if (handler != null) {

--- a/src/main/java/reactor/netty/http/server/ConnectionInfo.java
+++ b/src/main/java/reactor/netty/http/server/ConnectionInfo.java
@@ -115,14 +115,15 @@ final class ConnectionInfo {
 	}
 
 	static InetSocketAddress parseAddress(String address, int defaultPort) {
-		int portSeparatorIdx = address.lastIndexOf(":");
-		if (portSeparatorIdx > address.lastIndexOf("]")) {
-			return InetSocketAddressUtil.createUnresolved(address.substring(0, portSeparatorIdx),
-					Integer.parseInt(address.substring(portSeparatorIdx + 1)));
+		int separatorIdx = address.lastIndexOf(":");
+		int ipV6HostSeparatorIdx = address.lastIndexOf("]");
+		if(separatorIdx > ipV6HostSeparatorIdx) {
+			if(separatorIdx == address.indexOf(":") || ipV6HostSeparatorIdx > -1) {
+				return InetSocketAddressUtil.createUnresolved(address.substring(0, separatorIdx),
+					Integer.parseInt(address.substring(separatorIdx + 1)));
+			}
 		}
-		else {
-			return InetSocketAddressUtil.createUnresolved(address, defaultPort);
-		}
+		return InetSocketAddressUtil.createUnresolved(address, defaultPort);
 	}
 
 	static ConnectionInfo parseXForwardedInfo(HttpRequest request, SocketChannel channel) {

--- a/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -386,19 +386,6 @@ public abstract class HttpServer {
 	}
 
 	/**
-	 * Apply a wire logger configuration using {@link HttpServer} category
-	 * and {@code DEBUG} logger level
-	 *
-	 * @return a new {@link HttpServer}
-	 * @deprecated Use {@link HttpServer#wiretap(boolean)}
-	 */
-	@Deprecated
-	public final HttpServer wiretap() {
-		return tcpConfiguration(tcpServer ->
-		        tcpServer.bootstrap(b -> BootstrapHandlers.updateLogSupport(b, LOGGING_HANDLER)));
-	}
-
-	/**
 	 * Apply or remove a wire logger configuration using {@link HttpServer} category
 	 * and {@code DEBUG} logger level
 	 *

--- a/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -495,21 +495,6 @@ public abstract class TcpClient {
 	}
 
 	/**
-	 * Apply an SSL configuration customization via the passed {@link SslContext}.
-	 * with a default value of {@code 10} seconds handshake timeout unless
-	 * the environment property {@code reactor.netty.tcp.sslHandshakeTimeout} is set.
-	 *
-	 * @param sslContext The context to set when configuring SSL
-	 *
-	 * @return a new {@link TcpClient}
-	 * @deprecated Use {@link TcpClient#secure(Consumer)}
-	 */
-	@Deprecated
-	public final TcpClient secure(SslContext sslContext) {
-		return secure(sslProviderBuilder -> sslProviderBuilder.sslContext(sslContext));
-	}
-
-	/**
 	 * Apply an SSL configuration via the passed {@link SslProvider}.
 	 *
 	 * @param sslProvider The provider to set when configuring SSL

--- a/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -533,18 +533,6 @@ public abstract class TcpClient {
 	}
 
 	/**
-	 * Apply a wire logger configuration using {@link TcpClient} category
-	 * and {@code DEBUG} logger level
-	 *
-	 * @return a new {@link TcpClient}
-	 * @deprecated Use {@link TcpClient#wiretap(boolean)}
-	 */
-	@Deprecated
-	public final TcpClient wiretap() {
-		return bootstrap(b -> BootstrapHandlers.updateLogSupport(b, LOGGING_HANDLER));
-	}
-
-	/**
 	 * Apply or remove a wire logger configuration using {@link TcpClient} category
 	 * and {@code DEBUG} logger level
 	 *

--- a/src/main/java/reactor/netty/tcp/TcpServer.java
+++ b/src/main/java/reactor/netty/tcp/TcpServer.java
@@ -428,31 +428,6 @@ public abstract class TcpServer {
 	}
 
 	/**
-	 * Apply an SSL configuration customization via the passed {@link SslContext}. with a
-	 * default value of {@code 10} seconds handshake timeout unless the environment
-	 * property {@code reactor.netty.tcp.sslHandshakeTimeout} is set.
-	 *
-	 * If {@link SelfSignedCertificate} needs to be used, the sample below can be
-	 * used. Note that {@link SelfSignedCertificate} should not be used in production.
-	 * <pre>
-	 * {@code
-	 *     SelfSignedCertificate cert = new SelfSignedCertificate();
-	 *     SslContextBuilder sslContextBuilder =
-	 *             SslContextBuilder.forServer(cert.certificate(), cert.privateKey());
-	 *     secure(sslContextBuilder.build());
-	 * }
-	 *
-	 * @param sslContext The context to set when configuring SSL
-	 *
-	 * @return a new {@link TcpServer}
-	 * @deprecated Use {@link TcpServer#secure(Consumer)}
-	 */
-	@Deprecated
-	public final TcpServer secure(SslContext sslContext) {
-		return secure(sslProviderBuilder -> sslProviderBuilder.sslContext(sslContext));
-	}
-
-	/**
 	 * Apply an SSL configuration customization via the passed builder. The builder
 	 * will produce the {@link SslContext} to be passed to with a default value of
 	 * {@code 10} seconds handshake timeout unless the environment property {@code

--- a/src/main/java/reactor/netty/tcp/TcpServer.java
+++ b/src/main/java/reactor/netty/tcp/TcpServer.java
@@ -543,18 +543,6 @@ public abstract class TcpServer {
 	}
 
 	/**
-	 * Apply a wire logger configuration using {@link TcpServer} category
-	 * and {@code DEBUG} logger level
-	 *
-	 * @return a new {@link TcpServer}
-	 * @deprecated Use {@link TcpServer#wiretap(boolean)}
-	 */
-	@Deprecated
-	public final TcpServer wiretap() {
-		return bootstrap(b -> BootstrapHandlers.updateLogSupport(b, LOGGING_HANDLER));
-	}
-
-	/**
 	 * Apply or remove a wire logger configuration using {@link TcpServer} category
 	 * and {@code DEBUG} logger level
 	 *

--- a/src/main/java/reactor/netty/udp/UdpClient.java
+++ b/src/main/java/reactor/netty/udp/UdpClient.java
@@ -355,18 +355,6 @@ public abstract class UdpClient {
 	}
 
 	/**
-	 * Apply a wire logger configuration using {@link UdpClient} category
-	 * and {@code DEBUG} logger level
-	 *
-	 * @return a new {@link UdpClient}
-	 * @deprecated Use {@link UdpClient#wiretap(boolean)}
-	 */
-	@Deprecated
-	public final UdpClient wiretap() {
-		return bootstrap(b -> BootstrapHandlers.updateLogSupport(b, LOGGING_HANDLER));
-	}
-
-	/**
 	 * Apply or remove a wire logger configuration using {@link UdpClient} category
 	 * and {@code DEBUG} logger level
 	 *

--- a/src/main/java/reactor/netty/udp/UdpServer.java
+++ b/src/main/java/reactor/netty/udp/UdpServer.java
@@ -356,18 +356,6 @@ public abstract class UdpServer {
 	}
 
 	/**
-	 * Apply a wire logger configuration using {@link UdpServer} category
-	 * and {@code DEBUG} logger level
-	 *
-	 * @return a new {@link UdpServer}
-	 * @deprecated Use {@link UdpServer#wiretap(boolean)}
-	 */
-	@Deprecated
-	public final UdpServer wiretap() {
-		return bootstrap(b -> BootstrapHandlers.updateLogSupport(b, LOGGING_HANDLER));
-	}
-
-	/**
 	 * Apply or remove a wire logger configuration using {@link UdpServer} category
 	 * and {@code DEBUG} logger level
 	 *

--- a/src/test/java/reactor/netty/http/HttpTests.java
+++ b/src/test/java/reactor/netty/http/HttpTests.java
@@ -275,12 +275,12 @@ public class HttpTests {
 				                                             .map(it -> it + ' ' + req.param("param") + '!')
 				                                             .log("server-reply")));
 				          }))
-				          .wiretap()
+				          .wiretap(true)
 				          .bindNow(Duration.ofSeconds(5));
 
 		HttpClient client = HttpClient.create()
 				                      .port(server.address().getPort())
-				                      .wiretap();
+				                      .wiretap(true);
 
 		Mono<List<String>> response =
 		    client.request(HttpMethod.GET)
@@ -596,14 +596,14 @@ public class HttpTests {
 //				HttpServer.create()
 //				          .protocol(HttpProtocol.H2C)
 //				          .handle((req, res) -> res.sendString(Mono.just("Hello")))
-//				          .wiretap()
+//				          .wiretap(true)
 //				          .bindNow();
 //
 //		StepVerifier.create(
 //				HttpClient.create()
 //				          .port(server.port())
 //				          .protocol(HttpProtocol.H2C)
-//				          .wiretap()
+//				          .wiretap(true)
 //				          .post()
 //				          .uri("/")
 ////				          .send((req, out) -> out.sendString(Mono.just("World")))


### PR DESCRIPTION
parseAddress changed to check number of ':' separators to infer ipv4 vs. ipv6. For ipv6 addresses, only parse last segment if following correct bracket notation required for ipv6 with ports.
This allows for valid, no-port ipv6 addresses that do not use bracket notation to be provided in forward headers without throwing NumberFormatException.
Added specific tests for these cases and updated tearDown to account for added tests not creating connection object.