### PR TITLE
fix #625 Update ConnectionInfo#parseAddress behavior to handle ipv6 addresses without bracket

### DIFF
--- a/src/main/java/reactor/netty/http/server/ConnectionInfo.java
+++ b/src/main/java/reactor/netty/http/server/ConnectionInfo.java
@@ -115,14 +115,15 @@ final class ConnectionInfo {
 	}
 
 	static InetSocketAddress parseAddress(String address, int defaultPort) {
-		int portSeparatorIdx = address.lastIndexOf(":");
-		if (portSeparatorIdx > address.lastIndexOf("]")) {
-			return InetSocketAddressUtil.createUnresolved(address.substring(0, portSeparatorIdx),
-					Integer.parseInt(address.substring(portSeparatorIdx + 1)));
+		int separatorIdx = address.lastIndexOf(":");
+		int ipV6HostSeparatorIdx = address.lastIndexOf("]");
+		if(separatorIdx > ipV6HostSeparatorIdx) {
+			if(separatorIdx == address.indexOf(":") || ipV6HostSeparatorIdx > -1) {
+				return InetSocketAddressUtil.createUnresolved(address.substring(0, separatorIdx),
+					Integer.parseInt(address.substring(separatorIdx + 1)));
+			}
 		}
-		else {
-			return InetSocketAddressUtil.createUnresolved(address, defaultPort);
-		}
+		return InetSocketAddressUtil.createUnresolved(address, defaultPort);
 	}
 
 	static ConnectionInfo parseXForwardedInfo(HttpRequest request, SocketChannel channel) {


### PR DESCRIPTION
parseAddress changed to check number of ':' separators to infer ipv4 vs. ipv6. For ipv6 addresses, only parse last segment if following correct bracket notation required for ipv6 with ports.
This allows for valid, no-port ipv6 addresses that do not use bracket notation to be provided in forward headers without throwing NumberFormatException.
Added specific tests for these cases and updated tearDown to account for added tests not creating connection object.