### PR TITLE
URL Cleanup

### DIFF
--- a/src/api/stylesheet.css
+++ b/src/api/stylesheet.css
@@ -108,7 +108,7 @@ Document title and Copyright styles
     position: absolute;
     right: 2px;
     top: 10px;
-    background: url(http://projectreactor.io/assets/img/logo-2x.png) no-repeat 0 -30px;
+    background: url(https://projectreactor.io/assets/img/logo-2x.png) no-repeat 0 -30px;
     background-size: 189px 60px;
     height: 40px;
     width: 44px;

--- a/src/docs/asciidoc/highlight/CHANGES.md
+++ b/src/docs/asciidoc/highlight/CHANGES.md
@@ -336,7 +336,7 @@ Improvements to existing languages and styles:
 - Recognize b-prefixed chars and strings in Rust
 - Better numbers handling in Verilog
 
-[Brendan Rocks]: http://brendanrocks.com
+[Brendan Rocks]: https://brendanrocks.com
 [Raphaël Assénat]: https://github.com/raphnet
 [Matt Evans]: https://github.com/matthewevans
 [Martin Braun]: https://github.com/mbr0wn
@@ -391,7 +391,7 @@ Other notable changes:
 [webworkers]: https://github.com/isagalaev/highlight.js#web-workers
 [Jeremy Hull]: https://github.com/sourrust
 [#348]: https://github.com/isagalaev/highlight.js/issues/348
-[sg]: http://highlightjs.readthedocs.org/en/latest/style-guide.html
+[sg]: https://highlightjs.readthedocs.org/en/latest/style-guide.html
 [issues]: https://github.com/isagalaev/highlight.js/issues
 [Nebuleon Fumika]: https://github.com/Nebuleon
 [prince]: https://github.com/prince-0203
@@ -669,7 +669,7 @@ New languages in this release:
 - *ERB* (Ruby in HTML) by [Lucas Mazza][]
 - *Roboconf* by [Vincent Zurczak][]
 
-[b]: http://highlightjs.readthedocs.org/en/latest/building-testing.html
+[b]: https://highlightjs.readthedocs.org/en/latest/building-testing.html
 [Jeremy Hull]: https://github.com/sourrust
 [ik]: https://twitter.com/IvanKleshnin/status/514041599484231680
 [Max Mikhailov]: https://github.com/seven-phases-max
@@ -800,7 +800,7 @@ Other improvements:
 - Various improvements to Objective-C definition by [Matt Diephouse][].
 - Fixed highlighting of generics in Java.
 
-[ll]: http://highlightjs.readthedocs.org/en/latest/api.html#listlanguages
+[ll]: https://highlightjs.readthedocs.org/en/latest/api.html#listlanguages
 [Sindre Sorhus]: https://github.com/sindresorhus
 [Heiko August]: https://github.com/auge8472
 [Nikolay Lisienko]: https://github.com/neor-ru
@@ -893,10 +893,10 @@ Miscellaneous improvements:
 - Big overhaul of relevance counting for a number of languages. Please do report
   bugs about mis-detection of non-trivial code snippets!
 
-[API reference]: http://highlightjs.readthedocs.org/en/latest/api.html
+[API reference]: https://highlightjs.readthedocs.org/en/latest/api.html
 
-[cr]: http://highlightjs.readthedocs.org/en/latest/css-classes-reference.html
-[api docs]: http://highlightjs.readthedocs.org/en/latest/api.html
+[cr]: https://highlightjs.readthedocs.org/en/latest/css-classes-reference.html
+[api docs]: https://highlightjs.readthedocs.org/en/latest/api.html
 [variants]: https://groups.google.com/d/topic/highlightjs/VoGC9-1p5vk/discussion
 [beginKeywords]: https://github.com/isagalaev/highlight.js/commit/6c7fdea002eb3949577a85b3f7930137c7c3038d
 [php-html]: https://twitter.com/highlightjs/status/408890903017689088
@@ -941,12 +941,12 @@ Improvements:
 [mehdid]: https://github.com/mehdid
 [nbraud]: https://github.com/nbraud
 [revig]: https://github.com/revig
-[lcs]: http://livecode.com/developers/guides/server/
+[lcs]: https://livecode.com/developers/guides/server/
 [sylvestre]: https://github.com/sylvestre
 [isagalaev]: https://github.com/isagalaev
 [treep]: https://github.com/treep
 [sourrust]: https://github.com/sourrust
-[d]: http://highlightjs.org/download/
+[d]: https://highlightjs.org/download/
 
 
 ## New core developers
@@ -974,7 +974,7 @@ This long overdue version is a snapshot of the current source tree with all the
 changes that happened during the past year. Sorry for taking so long!
 
 Along with the changes in code highlight.js has finally got its new home at
-<http://highlightjs.org/>, moving from its cradle on Software Maniacs which it
+<https://highlightjs.org/>, moving from its cradle on Software Maniacs which it
 outgrew a long time ago. Be sure to report any bugs about the site to
 <mailto:info@highlightjs.org>.
 
@@ -1009,7 +1009,7 @@ New style themes:
 - Mono Blue by [Ivan Sagalaev][] (uses a single color hue for everything)
 - Foundation by [Dan Allen][]
 
-[noformnocontent]: http://nn.mit-license.org/
+[noformnocontent]: https://nn.mit-license.org/
 [Damien White]: https://github.com/visoft
 [Alexander Marenin]: https://github.com/ioncreature
 [Simon Madine]: https://github.com/thingsinjars
@@ -1050,7 +1050,7 @@ Other notable changes:
 - Also Oleg Efimov did a great job of moving all the docs for language and style
   developers and contributors from the old wiki under the source code in the
   "docs" directory. Now these docs are nicely presented at
-  <http://highlightjs.readthedocs.org/>.
+  <https://highlightjs.readthedocs.org/>.
 
 [ng]: https://github.com/nathan11g
 [dd]: https://github.com/drdrang
@@ -1081,10 +1081,10 @@ A Summer crop:
   fixes, including a pretty significant refactoring of Ruby.
 
 [mf]: https://github.com/mfornos
-[tm]: http://jmblog.github.com/color-themes-for-highlightjs/
+[tm]: https://jmblog.github.com/color-themes-for-highlightjs/
 [tm0]: https://github.com/ChrisKempson/Tomorrow-Theme
 [cd]: https://github.com/caseman
-[amd]: http://requirejs.org/docs/whyamd.html
+[amd]: https://requirejs.org/docs/whyamd.html
 
 
 ## Version 7.0
@@ -1125,8 +1125,8 @@ language detection.
 
 Overall highlight.js currently supports 51 languages and 20 style themes.
 
-[node.js]: http://nodejs.org/
-[api]: http://softwaremaniacs.org/wiki/doku.php/highlight.js:api
+[node.js]: https://nodejs.org/
+[api]: https://highlightjs.readthedocs.org/
 [p]: http://softwaremaniacs.org/blog/2012/05/10/http-and-json-in-highlight-js/en/
 [pojoaque]: http://web-cms-designs.com/ftopict-10-pojoaque-style-for-highlight-js-code-highlighter.html
 [ao]: https://github.com/angelolloqui
@@ -1161,7 +1161,7 @@ from all this activity:
 [oe]: https://github.com/Sannis
 [db]: https://github.com/btd
 [jc]: https://github.com/seejohnrun
-[lm]: http://grigio.org/
+[lm]: https://grigio.org/
 [ak]: https://github.com/geekpanth3r
 [es]: https://github.com/bolknote
 [log]: https://github.com/isagalaev/highlight.js/commits/
@@ -1178,7 +1178,7 @@ This version also adds a new original style Arta. Its author pumbur maintains a
 [heavily modified fork of highlight.js][pb] on GitHub.
 
 [jh]: https://github.com/sourrust
-[solarized]: http://ethanschoonover.com/solarized
+[solarized]: https://ethanschoonover.com/solarized
 [pb]: https://github.com/pumbur/highlight.js
 
 
@@ -1252,9 +1252,9 @@ Bug fixes:
   just replaces the contents.
 - Small fixes in browser compatibility and heuristics.
 
-[c++ 0x]: http://ru.wikipedia.org/wiki/C%2B%2B0x
-[html 5]: http://en.wikipedia.org/wiki/HTML5
-[ik]: http://kalnitsky.org.ua/
+[c++ 0x]: https://ru.wikipedia.org/wiki/C%252B%252B0x
+[html 5]: https://en.wikipedia.org/wiki/HTML5
+[ik]: https://kalnitsky.org.ua/
 
 ### For developers
 
@@ -1282,8 +1282,8 @@ expected one. Test summary is displayed right above all language snippets.
 Fine people at [Yandex][] agreed to host highlight.js on their big fast servers.
 [Link up][l]!
 
-[yandex]: http://yandex.com/
-[l]: http://softwaremaniacs.org/soft/highlight/en/download/
+[yandex]: https://yandex.com/
+[l]: https://highlightjs.org/download/
 
 
 ## Version 5.10 — "Paris".
@@ -1307,8 +1307,8 @@ New languages:
   Nginx config
 - [Vladimir Moskva][vm] made a definition for TeX
 
-[pl]: http://kung-fu-tzu.ru/
-[vm]: http://fulc.ru/
+[pl]: https://kung-fu-tzu.ru/
+[vm]: https://fulc.ru/
 
 Fixes for existing languages:
 
@@ -1317,8 +1317,8 @@ Fixes for existing languages:
 - the definition of SQL has become more solid and now it shouldn't be overly
   greedy when it comes to language detection
 
-[ls]: http://gnuu.org/
-[yard]: http://yardoc.org/
+[ls]: https://gnuu.org/
+[yard]: https://yardoc.org/
 
 The highlighter has become more usable as a library allowing to do highlighting
 from initialization code of JS frameworks and in ajax methods (see.
@@ -1327,8 +1327,8 @@ readme.eng.txt).
 Also this version drops support for the [WordPress][wp] plugin. Everyone is
 welcome to [pick up its maintenance][p] if needed.
 
-[wp]: http://wordpress.org/
-[p]: http://bazaar.launchpad.net/~isagalaev/+junk/highlight/annotate/342/src/wp_highlight.js.php
+[wp]: https://wordpress.org/
+[p]: https://bazaar.launchpad.net/~isagalaev/+junk/highlight/annotate/342/src/wp_highlight.js.php
 
 
 ## Version 5.8
@@ -1372,10 +1372,10 @@ Also in this version:
 - Yura Zaripov has sent two styles: Brown Paper and School Book.
 - Oleg Volchkov has sent a definition for [Parser 3][p3].
 
-[1]: http://softwaremaniacs.org/forum/highlightjs/6612/
-[p3]: http://www.parser.ru/
-[vp]: http://vasily.polovnyov.ru/
-[vd]: http://dolzhenko.blogspot.com/
+[1]: https://pytalk.ru/forum/highlightjs/6612/
+[p3]: https://www.parser.ru/
+[vp]: https://vasily.polovnyov.ru/
+[vd]: https://dolzhenko.blogspot.com/
 
 
 ## Version 5.2
@@ -1400,9 +1400,9 @@ contributions!
   the matter.
 
 [vooon]: http://vehq.ru/about/
-[rukeba]: http://rukeba.com/
-[drake]: http://drakeguan.org/
-[ke]: http://k-evdokimenko.moikrug.ru/
+[rukeba]: https://rukeba.com/
+[drake]: https://drakeguan.org/
+[ke]: https://k-evdokimenko.moikrug.ru/
 
 
 ## Version 5.0
@@ -1429,7 +1429,7 @@ This version comes with two contributions from [Jason Diamond][jd]:
 
 Plus there are a couple of minor bug fixes for parsing HTML and XML attributes.
 
-[jd]: http://jason.diamond.name/weblog/
+[jd]: https://jason.diamond.name/weblog/
 
 
 ## Version 4.2
@@ -1451,10 +1451,10 @@ Other changes:
 - better auto-detection of C++ and PHP
 - HTML allows embedded VBScript (`<% .. %>`)
 
-[f]: http://softwaremaniacs.org/forum/highlightjs/
-[voldmar]: http://voldmar.ya.ru/
-[mel]: http://en.wikipedia.org/wiki/Maya_Embedded_Language
-[drake]: http://drakeguan.org/
+[f]: https://pytalk.ru/forum/highlightjs/
+[voldmar]: https://voldmar.ya.ru/
+[mel]: https://en.wikipedia.org/wiki/Maya_Embedded_Language
+[drake]: https://drakeguan.org/
 
 
 ## Version 4.1
@@ -1479,10 +1479,10 @@ Python and C++ which improved auto-detection for the latter (it was shame that
 thanks go to Sam for getting rid of my stylistic comments in code that were
 getting in the way of [JSMin][].
 
-[zenburn]: http://en.wikipedia.org/wiki/Zenburn
-[alenacpp]: http://alenacpp.blogspot.com/
-[bug]: http://softwaremaniacs.org/forum/viewtopic.php?id=1823
-[jsmin]: http://code.google.com/p/jsmin-php/
+[zenburn]: https://en.wikipedia.org/wiki/Zenburn
+[alenacpp]: https://alenacpp.blogspot.com/
+[bug]: https://pytalk.ru/forum/viewtopic.php?id=1823
+[jsmin]: https://code.google.com/p/jsmin-php/
 
 
 ## Version 4.0
@@ -1516,7 +1516,7 @@ and didn't highlight custom tags. In this version I tried to make custom XML to
 be detected and highlighted by its own rules. Which by the way include such
 things as CDATA sections and processing instructions (`<? ... ?>`).
 
-[f]: http://softwaremaniacs.org/forum/viewforum.php?id=6
+[f]: https://pytalk.ru/forum/viewforum.php?id=6
 
 
 ## Version 3.3
@@ -1527,7 +1527,7 @@ paste an HTML code generated by the highlighter for any code snippet. This can
 be useful in situations when one can't use the script itself on a site.
 
 
-[xonix]: http://xonixx.blogspot.com/
+[xonix]: https://xonixx.blogspot.com/
 
 
 ## Version 3.2 consists completely of contributions:
@@ -1549,7 +1549,7 @@ SQL definition but I'd never started it be it from the ground up :-)
 The engine itself has got a long awaited feature of grouping keywords
 ("keyword", "built-in function", "literal"). No more hacks!
 
-[1]: http://roudakov.ru/
+[1]: https://roudakov.ru/
 
 
 ## Version 3.0
@@ -1632,7 +1632,7 @@ already downloaded that one!
 - this same way allows now correct highlighting of keywords in some tricky
   places (like keyword "End" at the end of Delphi classes)
 
-[ak]: http://anton.kovalyov.net/
+[ak]: https://anton.kovalyov.net/
 
 
 ## Version 1.0
@@ -1643,4 +1643,4 @@ It's the first version available with English description. Feel free to post
 your comments and question to [highlight.js forum][forum]. And don't be afraid
 if you find there some fancy Cyrillic letters -- it's for Russian users too :-)
 
-[forum]: http://softwaremaniacs.org/forum/viewforum.php?id=6
+[forum]: https://pytalk.ru/forum/viewforum.php?id=6

--- a/src/docs/asciidoc/highlight/README.md
+++ b/src/docs/asciidoc/highlight/README.md
@@ -136,15 +136,15 @@ for details.
 The official site for the library is at <https://highlightjs.org/>.
 
 Further in-depth documentation for the API and other topics is at
-<http://highlightjs.readthedocs.io/>.
+<https://highlightjs.readthedocs.io/>.
 
 Authors and contributors are listed in the [AUTHORS.en.txt][8] file.
 
-[1]: http://highlightjs.readthedocs.io/en/latest/api.html#inithighlightingonload
-[2]: http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html
-[3]: http://highlightjs.readthedocs.io/en/latest/api.html#highlightblock-block
-[4]: http://highlightjs.readthedocs.io/en/latest/api.html#configure-options
+[1]: https://highlightjs.readthedocs.io/en/latest/api.html#inithighlightingonload
+[2]: https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html
+[3]: https://highlightjs.readthedocs.io/en/latest/api.html#highlightblock-block
+[4]: https://highlightjs.readthedocs.io/en/latest/api.html#configure-options
 [5]: https://highlightjs.org/download/
-[6]: http://highlightjs.readthedocs.io/en/latest/building-testing.html
+[6]: https://highlightjs.readthedocs.io/en/latest/building-testing.html
 [7]: https://github.com/isagalaev/highlight.js/blob/master/LICENSE
 [8]: https://github.com/isagalaev/highlight.js/blob/master/AUTHORS.en.txt

--- a/src/docs/asciidoc/highlight/README.ru.md
+++ b/src/docs/asciidoc/highlight/README.ru.md
@@ -128,15 +128,15 @@ Highlight.js распространяется под лицензией BSD. П�
 Официальный сайт билиотеки расположен по адресу <https://highlightjs.org/>.
 
 Более подробная документация по API и другим темам расположена на
-<http://highlightjs.readthedocs.io/>.
+<https://highlightjs.readthedocs.io/>.
 
 Авторы и контрибьюторы перечислены в файле [AUTHORS.ru.txt][8] file.
 
-[1]: http://highlightjs.readthedocs.io/en/latest/api.html#inithighlightingonload
-[2]: http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html
-[3]: http://highlightjs.readthedocs.io/en/latest/api.html#highlightblock-block
-[4]: http://highlightjs.readthedocs.io/en/latest/api.html#configure-options
+[1]: https://highlightjs.readthedocs.io/en/latest/api.html#inithighlightingonload
+[2]: https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html
+[3]: https://highlightjs.readthedocs.io/en/latest/api.html#highlightblock-block
+[4]: https://highlightjs.readthedocs.io/en/latest/api.html#configure-options
 [5]: https://highlightjs.org/download/
-[6]: http://highlightjs.readthedocs.io/en/latest/building-testing.html
+[6]: https://highlightjs.readthedocs.io/en/latest/building-testing.html
 [7]: https://github.com/isagalaev/highlight.js/blob/master/LICENSE
 [8]: https://github.com/isagalaev/highlight.js/blob/master/AUTHORS.ru.txt

--- a/src/docs/asciidoc/http-client.adoc
+++ b/src/docs/asciidoc/http-client.adoc
@@ -27,7 +27,7 @@ public class Application {
         HttpClientResponse response =
                 HttpClient.create()                   <1>
                           .get()                      <2>
-                          .uri("http://example.com/") <3>
+                          .uri("https://example.com/") <3>
                           .response()                 <4>
                           .block();
     }
@@ -122,7 +122,7 @@ public class Application {
         HttpClientResponse response =
                 HttpClient.create()
                           .post()
-                          .uri("http://example.com/")
+                          .uri("https://example.com/")
                           .send(ByteBufFlux.fromString(Mono.just("hello"))) <1>
                           .response()
                           .block();
@@ -153,7 +153,7 @@ public class Application {
                 HttpClient.create()
                           .headers(h -> h.set(HttpHeaderNames.CONTENT_LENGTH, 5)) <1>
                           .post()
-                          .uri("http://example.com/")
+                          .uri("https://example.com/")
                           .send(ByteBufFlux.fromString(Mono.just("hello")))
                           .response()
                           .block();
@@ -182,7 +182,7 @@ public class Application {
                 HttpClient.create()
                           .compress(true)
                           .get()
-                          .uri("http://example.com/")
+                          .uri("https://example.com/")
                           .response()
                           .block();
     }
@@ -215,7 +215,7 @@ public class Application {
                 HttpClient.create()
                           .followRedirect(true)
                           .get()
-                          .uri("http://example.com/")
+                          .uri("https://example.com/")
                           .response()
                           .block();
     }
@@ -251,7 +251,7 @@ public class Application {
         HttpClientResponse response =
                 HttpClient.create()
                           .post()
-                          .uri("http://example.com/")
+                          .uri("https://example.com/")
                           .send((request, outbound) ->
                                   outbound.options(o -> o.flushOnEach(false)) <1>
                                           .sendString(Flux.just("Hello", "World", "!")))
@@ -284,7 +284,7 @@ public class Application {
         String response =
                 HttpClient.create()
                           .get()
-                          .uri("http://example.com/")
+                          .uri("https://example.com/")
                           .responseContent() <1>
                           .aggregate()       <2>
                           .asString()        <3>
@@ -314,7 +314,7 @@ public class Application {
         String response =
                 HttpClient.create()
                           .get()
-                          .uri("http://example.com/")
+                          .uri("https://example.com/")
                           .responseSingle((resp, bytes) -> {
                               System.out.println(resp.status()); <1>
                               return bytes.asString();
@@ -346,7 +346,7 @@ public class Application {
                           .tcpConfiguration(tcpClient ->
                                   tcpClient.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000))
                           .get()
-                          .uri("http://example.com/")
+                          .uri("https://example.com/")
                           .response()
                           .block();
     }
@@ -376,7 +376,7 @@ public class Application {
                 HttpClient.create()
                           .wiretap(true) <1>
                           .get()
-                          .uri("http://example.com/")
+                          .uri("https://example.com/")
                           .response()
                           .block();
     }

--- a/src/docs/asciidoc/stylesheets/reactor.css
+++ b/src/docs/asciidoc/stylesheets/reactor.css
@@ -1,5 +1,5 @@
 @import url(https://fonts.googleapis.com/css?family=Montserrat:400,700);
-@import url(http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css);
 
 
 #header .details br+span.author:before {
@@ -18,7 +18,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -70,7 +70,7 @@ import reactor.netty.tcp.TcpClient;
  * <pre>
  * {@code
  * HttpClient.create()
- *           .baseUrl("http://example.com")
+ *           .baseUrl("https://example.com")
  *           .get()
  *           .response()
  *           .block();
@@ -78,14 +78,14 @@ import reactor.netty.tcp.TcpClient;
  * {@code
  * HttpClient.create()
  *           .post()
- *           .uri("http://example.com")
+ *           .uri("https://example.com")
  *           .send(Flux.just(bb1, bb2, bb3))
  *           .responseSingle((res, content) -> Mono.just(res.status().code()))
  *           .block();
  * }
  * {@code
  * HttpClient.create()
- *           .baseUri("http://example.com")
+ *           .baseUri("https://example.com")
  *           .post()
  *           .send(ByteBufFlux.fromString(flux))
  *           .responseSingle((res, content) -> Mono.just(res.status().code()))

--- a/src/main/java/reactor/netty/http/websocket/WebsocketOutbound.java
+++ b/src/main/java/reactor/netty/http/websocket/WebsocketOutbound.java
@@ -75,7 +75,7 @@ public interface WebsocketOutbound extends NettyOutbound {
 	 * Prepare to send a close frame on subscribe then close the underlying channel
 	 *
 	 * @param statusCode
-	 *            Integer status code as per <a href="http://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
+	 *            Integer status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
 	 *            example, <tt>1000</tt> indicates normal closure.
 	 * @param reasonText
 	 *            Reason text. Set to null if no text.
@@ -91,7 +91,7 @@ public interface WebsocketOutbound extends NettyOutbound {
 	 * @param rsv
 	 *            reserved bits used for protocol extensions
 	 * @param statusCode
-	 *            Integer status code as per <a href="http://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
+	 *            Integer status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
 	 *            example, <tt>1000</tt> indicates normal closure.
 	 * @param reasonText
 	 *            Reason text. Set to null if no text.

--- a/src/test/java/reactor/netty/SocketUtils.java
+++ b/src/test/java/reactor/netty/SocketUtils.java
@@ -35,7 +35,7 @@ import javax.net.ServerSocketFactory;
  * @author Ben Hale
  * @author Arjen Poutsma
  * @author Gunnar Hillert
- * @see <a href="http://spring.io">Borrowed from the Spring Framework</a>
+ * @see <a href="https://spring.io">Borrowed from the Spring Framework</a>
  * */
 public final class SocketUtils {
 

--- a/src/test/java/reactor/netty/channel/FluxReceiveTest.java
+++ b/src/test/java/reactor/netty/channel/FluxReceiveTest.java
@@ -150,7 +150,7 @@ public class FluxReceiveTest {
 			                                }
 		                                }))
 		      .get()
-		      .uri("http://releases.ubuntu.com/16.04.4/ubuntu-16.04.4-desktop-amd64.iso")
+		      .uri("http://old-releases.ubuntu.com/releases/16.04.4/ubuntu-16.04.4-desktop-amd64.iso")
 		      .responseContent()
 		      .log(logger.getName())
 		      .retry(IOException.class::isInstance)

--- a/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -431,7 +431,7 @@ public class HttpClientTest {
 				          .doOnResponse((res, c) -> ch1.set(c.channel()))
 				          .wiretap(true)
 				          .get()
-				          .uri("http://google.com/unsupportedURI")
+				          .uri("https://google.com/unsupportedURI")
 				          .responseSingle((res, buf) -> buf.thenReturn(res.status()))
 				          .block(Duration.ofSeconds(30));
 
@@ -439,7 +439,7 @@ public class HttpClientTest {
 		          .doOnResponse((res, c) -> ch2.set(c.channel()))
 		          .wiretap(true)
 		          .get()
-		          .uri("http://google.com/unsupportedURI")
+		          .uri("https://google.com/unsupportedURI")
 		          .responseSingle((res, buf) -> buf.thenReturn(res.status()))
 		          .block(Duration.ofSeconds(30));
 
@@ -496,13 +496,13 @@ public class HttpClientTest {
 
 		HttpResponseStatus r =
 				client.request(HttpMethod.GET)
-				      .uri("http://google.com")
+				      .uri("https://google.com")
 				      .send(ByteBufFlux.fromString(Mono.just(" ")))
 				      .responseSingle((res, buf) -> Mono.just(res.status()))
 				      .block(Duration.ofSeconds(30));
 
 		client.request(HttpMethod.GET)
-		      .uri("http://google.com")
+		      .uri("https://google.com")
 		      .send(ByteBufFlux.fromString(Mono.just(" ")))
 		      .responseSingle((res, buf) -> Mono.just(res.status()))
 		      .block(Duration.ofSeconds(30));

--- a/src/test/java/reactor/netty/http/client/UriEndpointFactoryTest.java
+++ b/src/test/java/reactor/netty/http/client/UriEndpointFactoryTest.java
@@ -115,7 +115,7 @@ public class UriEndpointFactoryTest {
 				.createUriEndpoint("foo:8080/bar", true)
 				.toExternalForm();
 
-		assertThat(test1).isEqualTo("http://foo:8080/bar");
+		assertThat(test1).isEqualTo("https://foo:8080/bar");
 		assertThat(test2).isEqualTo("ws://foo:8080/bar");
 	}
 
@@ -181,7 +181,7 @@ public class UriEndpointFactoryTest {
 				.createUriEndpoint("/foo", false)
 				.toExternalForm();
 
-		assertThat(test).isEqualTo("http://google.com/foo");
+		assertThat(test).isEqualTo("https://google.com/foo");
 	}
 
 	@Test

--- a/src/test/java/reactor/netty/tcp/TcpClientTests.java
+++ b/src/test/java/reactor/netty/tcp/TcpClientTests.java
@@ -561,7 +561,7 @@ public class TcpClientTests {
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		System.out.println(client.get()
-		                         .uri("http://www.google.com/?q=test%20d%20dq")
+		                         .uri("https://www.google.com/?q=test%20d%20dq")
 		                         .responseContent()
 		                         .asString()
 		                         .collectList()


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://christopher.kaster.ws (200) with 1 occurrences could not be migrated:  
   ([https](https://christopher.kaster.ws) result ConnectTimeoutException).
* [ ] http://desh.su/ (200) with 1 occurrences could not be migrated:  
   ([https](https://desh.su/) result SSLHandshakeException).
* [ ] http://ribkit.sourceforge.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://ribkit.sourceforge.net/) result AnnotatedConnectException).
* [ ] http://softwaremaniacs.org/blog/2011/04/25/highlight-js-60-beta/en/ (200) with 1 occurrences could not be migrated:  
   ([https](https://softwaremaniacs.org/blog/2011/04/25/highlight-js-60-beta/en/) result SSLHandshakeException).
* [ ] http://softwaremaniacs.org/blog/2012/05/10/http-and-json-in-highlight-js/en/ (200) with 1 occurrences could not be migrated:  
   ([https](https://softwaremaniacs.org/blog/2012/05/10/http-and-json-in-highlight-js/en/) result SSLHandshakeException).
* [ ] http://web-cms-designs.com/ftopict-10-pojoaque-style-for-highlight-js-code-highlighter.html (200) with 1 occurrences could not be migrated:  
   ([https](https://web-cms-designs.com/ftopict-10-pojoaque-style-for-highlight-js-code-highlighter.html) result SSLHandshakeException).
* [ ] http://releases.ubuntu.com/16.04.4/ubuntu-16.04.4-desktop-amd64.iso (301) with 1 occurrences could not be migrated:  
   ([https](https://releases.ubuntu.com/16.04.4/ubuntu-16.04.4-desktop-amd64.iso) result AnnotatedConnectException).
* [ ] http://vehq.ru/about/ (404) with 1 occurrences could not be migrated:  
   ([https](https://vehq.ru/about/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://softwaremaniacs.org/forum/highlightjs/ (301) with 1 occurrences migrated to:  
  https://pytalk.ru/forum/highlightjs/ ([https](https://softwaremaniacs.org/forum/highlightjs/) result ConnectTimeoutException).
* [ ] http://softwaremaniacs.org/forum/highlightjs/6612/ (301) with 1 occurrences migrated to:  
  https://pytalk.ru/forum/highlightjs/6612/ ([https](https://softwaremaniacs.org/forum/highlightjs/6612/) result ConnectTimeoutException).
* [ ] http://softwaremaniacs.org/forum/viewforum.php?id=6 (301) with 2 occurrences migrated to:  
  https://pytalk.ru/forum/viewforum.php?id=6 ([https](https://softwaremaniacs.org/forum/viewforum.php?id=6) result ConnectTimeoutException).
* [ ] http://softwaremaniacs.org/forum/viewtopic.php?id=1823 (301) with 1 occurrences migrated to:  
  https://pytalk.ru/forum/viewtopic.php?id=1823 ([https](https://softwaremaniacs.org/forum/viewtopic.php?id=1823) result ConnectTimeoutException).
* [ ] http://jason.diamond.name/weblog/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://jason.diamond.name/weblog/ ([https](https://jason.diamond.name/weblog/) result ConnectTimeoutException).
* [ ] http://kalnitsky.org.ua/ (UnknownHostException) with 1 occurrences migrated to:  
  https://kalnitsky.org.ua/ ([https](https://kalnitsky.org.ua/) result UnknownHostException).
* [ ] http://ru.wikipedia.org/wiki/C%2B%2B0x (301) with 1 occurrences migrated to:  
  https://ru.wikipedia.org/wiki/C%252B%252B0x ([https](https://ru.wikipedia.org/wiki/C%2B%2B0x) result 400).
* [ ] http://en.wikipedia.org/wiki/Zenburn (301) with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Zenburn ([https](https://en.wikipedia.org/wiki/Zenburn) result 404).
* [ ] http://voldmar.ya.ru/ (404) with 1 occurrences migrated to:  
  https://voldmar.ya.ru/ ([https](https://voldmar.ya.ru/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://alenacpp.blogspot.com/ with 1 occurrences migrated to:  
  https://alenacpp.blogspot.com/ ([https](https://alenacpp.blogspot.com/) result 200).
* [ ] http://anton.kovalyov.net/ with 1 occurrences migrated to:  
  https://anton.kovalyov.net/ ([https](https://anton.kovalyov.net/) result 200).
* [ ] http://bazaar.launchpad.net/~isagalaev/+junk/highlight/annotate/342/src/wp_highlight.js.php with 1 occurrences migrated to:  
  https://bazaar.launchpad.net/~isagalaev/+junk/highlight/annotate/342/src/wp_highlight.js.php ([https](https://bazaar.launchpad.net/~isagalaev/+junk/highlight/annotate/342/src/wp_highlight.js.php) result 200).
* [ ] http://brendanrocks.com with 1 occurrences migrated to:  
  https://brendanrocks.com ([https](https://brendanrocks.com) result 200).
* [ ] http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css with 1 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css ([https](https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css) result 200).
* [ ] http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css with 1 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css ([https](https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css) result 200).
* [ ] http://dolzhenko.blogspot.com/ with 1 occurrences migrated to:  
  https://dolzhenko.blogspot.com/ ([https](https://dolzhenko.blogspot.com/) result 200).
* [ ] http://drakeguan.org/ with 2 occurrences migrated to:  
  https://drakeguan.org/ ([https](https://drakeguan.org/) result 200).
* [ ] http://en.wikipedia.org/wiki/HTML5 with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/HTML5 ([https](https://en.wikipedia.org/wiki/HTML5) result 200).
* [ ] http://en.wikipedia.org/wiki/Maya_Embedded_Language with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Maya_Embedded_Language ([https](https://en.wikipedia.org/wiki/Maya_Embedded_Language) result 200).
* [ ] http://example.com with 3 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://example.com/ with 10 occurrences migrated to:  
  https://example.com/ ([https](https://example.com/) result 200).
* [ ] http://fulc.ru/ with 1 occurrences migrated to:  
  https://fulc.ru/ ([https](https://fulc.ru/) result 200).
* [ ] http://gnuu.org/ with 1 occurrences migrated to:  
  https://gnuu.org/ ([https](https://gnuu.org/) result 200).
* [ ] http://grigio.org/ with 1 occurrences migrated to:  
  https://grigio.org/ ([https](https://grigio.org/) result 200).
* [ ] http://highlightjs.org/ with 1 occurrences migrated to:  
  https://highlightjs.org/ ([https](https://highlightjs.org/) result 200).
* [ ] http://highlightjs.org/download/ with 1 occurrences migrated to:  
  https://highlightjs.org/download/ ([https](https://highlightjs.org/download/) result 200).
* [ ] http://softwaremaniacs.org/soft/highlight/en/download/ (301) with 1 occurrences migrated to:  
  https://highlightjs.org/download/ ([https](https://softwaremaniacs.org/soft/highlight/en/download/) result 200).
* [ ] http://highlightjs.readthedocs.io/en/latest/api.html with 6 occurrences migrated to:  
  https://highlightjs.readthedocs.io/en/latest/api.html ([https](https://highlightjs.readthedocs.io/en/latest/api.html) result 200).
* [ ] http://highlightjs.readthedocs.io/en/latest/building-testing.html with 2 occurrences migrated to:  
  https://highlightjs.readthedocs.io/en/latest/building-testing.html ([https](https://highlightjs.readthedocs.io/en/latest/building-testing.html) result 200).
* [ ] http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html with 2 occurrences migrated to:  
  https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html ([https](https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html) result 200).
* [ ] http://kung-fu-tzu.ru/ with 1 occurrences migrated to:  
  https://kung-fu-tzu.ru/ ([https](https://kung-fu-tzu.ru/) result 200).
* [ ] http://nn.mit-license.org/ with 1 occurrences migrated to:  
  https://nn.mit-license.org/ ([https](https://nn.mit-license.org/) result 200).
* [ ] http://projectreactor.io/assets/img/logo-2x.png with 1 occurrences migrated to:  
  https://projectreactor.io/assets/img/logo-2x.png ([https](https://projectreactor.io/assets/img/logo-2x.png) result 200).
* [ ] http://requirejs.org/docs/whyamd.html with 1 occurrences migrated to:  
  https://requirejs.org/docs/whyamd.html ([https](https://requirejs.org/docs/whyamd.html) result 200).
* [ ] http://roudakov.ru/ with 1 occurrences migrated to:  
  https://roudakov.ru/ ([https](https://roudakov.ru/) result 200).
* [ ] http://rukeba.com/ with 1 occurrences migrated to:  
  https://rukeba.com/ ([https](https://rukeba.com/) result 200).
* [ ] http://tools.ietf.org/html/rfc6455 with 2 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6455 ([https](https://tools.ietf.org/html/rfc6455) result 200).
* [ ] http://vasily.polovnyov.ru/ with 1 occurrences migrated to:  
  https://vasily.polovnyov.ru/ ([https](https://vasily.polovnyov.ru/) result 200).
* [ ] http://wordpress.org/ with 1 occurrences migrated to:  
  https://wordpress.org/ ([https](https://wordpress.org/) result 200).
* [ ] http://www.parser.ru/ with 1 occurrences migrated to:  
  https://www.parser.ru/ ([https](https://www.parser.ru/) result 200).
* [ ] http://yandex.com/ with 1 occurrences migrated to:  
  https://yandex.com/ ([https](https://yandex.com/) result 200).
* [ ] http://yardoc.org/ with 1 occurrences migrated to:  
  https://yardoc.org/ ([https](https://yardoc.org/) result 200).
* [ ] http://code.google.com/p/jsmin-php/ with 1 occurrences migrated to:  
  https://code.google.com/p/jsmin-php/ ([https](https://code.google.com/p/jsmin-php/) result 301).
* [ ] http://ethanschoonover.com/solarized with 1 occurrences migrated to:  
  https://ethanschoonover.com/solarized ([https](https://ethanschoonover.com/solarized) result 301).
* [ ] http://softwaremaniacs.org/wiki/doku.php/highlight.js:api (301) with 1 occurrences migrated to:  
  https://highlightjs.readthedocs.org/ ([https](https://softwaremaniacs.org/wiki/doku.php/highlight.js:api) result 301).
* [ ] http://highlightjs.readthedocs.org/ with 1 occurrences migrated to:  
  https://highlightjs.readthedocs.org/ ([https](https://highlightjs.readthedocs.org/) result 301).
* [ ] http://highlightjs.readthedocs.org/en/latest/api.html with 3 occurrences migrated to:  
  https://highlightjs.readthedocs.org/en/latest/api.html ([https](https://highlightjs.readthedocs.org/en/latest/api.html) result 301).
* [ ] http://highlightjs.readthedocs.org/en/latest/building-testing.html with 1 occurrences migrated to:  
  https://highlightjs.readthedocs.org/en/latest/building-testing.html ([https](https://highlightjs.readthedocs.org/en/latest/building-testing.html) result 301).
* [ ] http://highlightjs.readthedocs.org/en/latest/css-classes-reference.html with 1 occurrences migrated to:  
  https://highlightjs.readthedocs.org/en/latest/css-classes-reference.html ([https](https://highlightjs.readthedocs.org/en/latest/css-classes-reference.html) result 301).
* [ ] http://highlightjs.readthedocs.org/en/latest/style-guide.html with 1 occurrences migrated to:  
  https://highlightjs.readthedocs.org/en/latest/style-guide.html ([https](https://highlightjs.readthedocs.org/en/latest/style-guide.html) result 301).
* [ ] http://jmblog.github.com/color-themes-for-highlightjs/ with 1 occurrences migrated to:  
  https://jmblog.github.com/color-themes-for-highlightjs/ ([https](https://jmblog.github.com/color-themes-for-highlightjs/) result 301).
* [ ] http://k-evdokimenko.moikrug.ru/ with 1 occurrences migrated to:  
  https://k-evdokimenko.moikrug.ru/ ([https](https://k-evdokimenko.moikrug.ru/) result 301).
* [ ] http://highlightjs.readthedocs.io/ with 2 occurrences migrated to:  
  https://highlightjs.readthedocs.io/ ([https](https://highlightjs.readthedocs.io/) result 302).
* [ ] http://livecode.com/developers/guides/server/ with 1 occurrences migrated to:  
  https://livecode.com/developers/guides/server/ ([https](https://livecode.com/developers/guides/server/) result 302).
* [ ] http://nodejs.org/ with 1 occurrences migrated to:  
  https://nodejs.org/ ([https](https://nodejs.org/) result 302).
* [ ] http://xonixx.blogspot.com/ with 1 occurrences migrated to:  
  https://xonixx.blogspot.com/ ([https](https://xonixx.blogspot.com/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:7000/ with 1 occurrences
* http://127.0.0.1:8080/foo with 1 occurrences
* http://localhost with 15 occurrences
* http://localhost/ with 1 occurrences
* http://localhost/:1234 with 1 occurrences
* http://localhost/?key=val with 10 occurrences
* http://localhost/foo with 5 occurrences
* http://localhost/foo?key=val with 5 occurrences
* http://localhost/path with 1 occurrences
* http://localhost/path?key=val with 1 occurrences
* http://localhost:7000/ with 1 occurrences
* http://localhost:80 with 1 occurrences
* http://localhost:80/?key=val with 1 occurrences
* http://localhost:80/foo?key=val with 1 occurrences
* http://localhost:80/path with 1 occurrences
* http://localhost:80/path?key=val with 1 occurrences
* http://localhost:8080 with 1 occurrences
* http://localhost:80?key=val with 2 occurrences
* http://localhost:9999 with 1 occurrences
* http://localhost?key=val with 2 occurrences
* http://www.w3.org/1999/xhtml with 2 occurrences