### PR TITLE
fix #651 Ensure context is available when HttpClient#doAfterResponse

### DIFF
--- a/src/main/java/reactor/netty/channel/ChannelOperations.java
+++ b/src/main/java/reactor/netty/channel/ChannelOperations.java
@@ -154,10 +154,9 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 
 	@Override
 	public void dispose() {
-		if (inbound.isDisposed()) {
-			return;
+		if (!inbound.isDisposed()) {
+			inbound.cancel();
 		}
-		inbound.cancel();
 		connection.dispose();
 	}
 
@@ -377,7 +376,6 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 			}
 
 			Operators.terminate(OUTBOUND_CLOSE, this);
-			listener.onStateChange(this, ConnectionObserver.State.DISCONNECTING);
 			// Do not call directly inbound.onInboundComplete()
 			// HttpClientOperations need to notify with error
 			// when there is no response state
@@ -433,12 +431,22 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 	public ChannelPromise setSuccess(Void result) {
 		// Returned value is deliberately ignored
 		super.setSuccess(result);
+		listener.onStateChange(this, ConnectionObserver.State.DISCONNECTING);
 		return this;
 	}
 
 	@Override
 	public boolean trySuccess() {
-		return trySuccess(null);
+		boolean result = super.trySuccess(null);
+		listener.onStateChange(this, ConnectionObserver.State.DISCONNECTING);
+		return result;
+	}
+
+	@Override
+	public boolean tryFailure(Throwable cause) {
+		boolean result = super.tryFailure(cause);
+		listener.onStateChange(this, ConnectionObserver.State.DISCONNECTING);
+		return result;
 	}
 
 	@Override
@@ -456,6 +464,7 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 	public ChannelPromise setFailure(Throwable cause) {
 		// Returned value is deliberately ignored
 		super.setFailure(cause);
+		listener.onStateChange(this, ConnectionObserver.State.DISCONNECTING);
 		return this;
 	}
 

--- a/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
@@ -418,7 +418,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 				else if (future instanceof ChannelPromise) {
 					ChannelPromise promise = (ChannelPromise) future;
 					if (v == ChannelOperations.TERMINATED_OPS) {
-						promise.trySuccess();
+						promise.setSuccess(null);
 					}
 					else if (v instanceof Publisher) {
 						Publisher<?> p = (Publisher<?>) v;

--- a/src/main/java/reactor/netty/http/client/HttpClientDoOn.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientDoOn.java
@@ -62,12 +62,11 @@ final class HttpClientDoOn extends HttpClientOperator implements ConnectionObser
 			onRequest.accept(connection.as(HttpClientOperations.class), connection);
 			return;
 		}
-		if (afterResponse != null) {
-			if (newState == State.RELEASED){
-				afterResponse.accept(connection.as(HttpClientOperations.class), connection);
-			}
-			else if (newState == State.DISCONNECTING) {
-				connection.onDispose(() -> afterResponse.accept(connection.as(HttpClientOperations.class), connection));
+		if (afterResponse != null && newState == HttpClientState.RESPONSE_RECEIVED) {
+			HttpClientOperations ops = connection.as(HttpClientOperations.class);
+			if (ops != null) {
+				ops.onTerminate().subscribe(null, null,
+						() -> afterResponse.accept(connection.as(HttpClientOperations.class), connection));
 			}
 			return;
 		}


### PR DESCRIPTION
Send `Disconnecting` when ChannelOperations#setSuccess/tryFailure/setFailure