### PR TITLE
Do not release the channel twice

### DIFF
--- a/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -591,7 +591,9 @@ final class PooledConnectionProvider implements ConnectionProvider {
 			}
 			c.closeFuture()
 			 .addListener(ff -> {
-			     pool.release(c);
+			     if (AttributeKey.exists("channelPool")) {
+			         pool.release(c);
+			     }
 			     pool.inactiveConnections.decrementAndGet();
 			     if (log.isDebugEnabled()) {
 			         log.debug(format(c, "Channel closed, now {} active connections and {} inactive connections"),


### PR DESCRIPTION
When a channel is first released to the pool and then closed the
exception below will be created, that's because `release` will be
called twice. In order to prevent the exception creation
check for channel attribute `channelPool` when `closed channel` event
is received and only if it is present then release the channel.

```
java.lang.IllegalArgumentException.<init>(String) IllegalArgumentException.java:52
io.netty.channel.pool.SimpleChannelPool.doReleaseChannel(Channel, Promise) SimpleChannelPool.java:300
io.netty.channel.pool.SimpleChannelPool.release(Channel, Promise) SimpleChannelPool.java:281
io.netty.channel.pool.SimpleChannelPool.release(Channel) SimpleChannelPool.java:271
reactor.netty.resources.PooledConnectionProvider$Pool.release(Channel) PooledConnectionProvider.java:254
reactor.netty.resources.PooledConnectionProvider$DisposableAcquire.lambda$registerClose$0(Channel, Future) PooledConnectionProvider.java:583
```