### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Join the chat at https://gitter.im/reactor/reactor](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/reactor/reactor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![Reactor Netty](https://maven-badges.herokuapp.com/maven-central/io.projectreactor.ipc/reactor-netty/badge.svg?style=plastic)](http://mvnrepository.com/artifact/io.projectreactor.ipc/reactor-netty) [ ![Download](https://api.bintray.com/packages/spring/jars/io.projectreactor.ipc/images/download.svg) ](https://bintray.com/spring/jars/io.projectreactor.ipc/_latestVersion)
+[![Reactor Netty](https://maven-badges.herokuapp.com/maven-central/io.projectreactor.ipc/reactor-netty/badge.svg?style=plastic)](https://mvnrepository.com/artifact/io.projectreactor.ipc/reactor-netty) [ ![Download](https://api.bintray.com/packages/spring/jars/io.projectreactor.ipc/images/download.svg) ](https://bintray.com/spring/jars/io.projectreactor.ipc/_latestVersion)
 
 ## Javadoc
-http://projectreactor.io/docs/netty/release/api/
+https://projectreactor.io/docs/netty/release/api/
 
 _Licensed under [Apache Software License 2.0](www.apache.org/licenses/LICENSE-2.0)_
 
-_Sponsored by [Pivotal](http://pivotal.io)_
+_Sponsored by [Pivotal](https://pivotal.io)_

--- a/src/api/stylesheet.css
+++ b/src/api/stylesheet.css
@@ -100,7 +100,7 @@ Document title and Copyright styles
     position: absolute;
     right: 2px;
     top: 10px;
-    background: url(http://projectreactor.io/assets/img/logo-2x.png) no-repeat 0 -30px;
+    background: url(https://projectreactor.io/assets/img/logo-2x.png) no-repeat 0 -30px;
     background-size: 189px 60px;
     height: 40px;
     width: 44px;

--- a/src/docbook/xsl/common.xsl
+++ b/src/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 

--- a/src/docbook/xsl/epub.xsl
+++ b/src/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 

--- a/src/docbook/xsl/html.xsl
+++ b/src/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 

--- a/src/docbook/xsl/pdf.xsl
+++ b/src/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:d="http://docbook.org/ns/docbook"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl d"
                 version='1.0'>
 

--- a/src/docs/asciidoc/gettingstarted.adoc
+++ b/src/docs/asciidoc/gettingstarted.adoc
@@ -16,7 +16,7 @@ The project started in 2012, with a long internal incubation time. Reactor 1.x a
 
 Parallel to that work we also decided to re-align some of our Event-Driven and Task Coordination API to the increasingly popular and documented <<gettingstarted.adoc/#rx,Reactive Extensions>>.
 
-Reactor is sponsored by http://pivotal.io[Pivotal] and is https://www.apache.org/licenses/LICENSE-2.0
+Reactor is sponsored by https://pivotal.io[Pivotal] and is https://www.apache.org/licenses/LICENSE-2.0
 .html[Apache 2.0 licensed]. It is available on https://github.com/reactor/reactor-ipc[GitHub].
 
 === Requirements

--- a/src/docs/asciidoc/index-docinfo.html
+++ b/src/docs/asciidoc/index-docinfo.html
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
-<script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.js"></script>
 <script>
 $(function () {
     var y = '<header id="reactor-header">' +

--- a/src/docs/asciidoc/stylesheets/asciidoctor.css
+++ b/src/docs/asciidoc/stylesheets/asciidoctor.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/colony.css
+++ b/src/docs/asciidoc/stylesheets/colony.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/foundation-lime.css
+++ b/src/docs/asciidoc/stylesheets/foundation-lime.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/foundation-potion.css
+++ b/src/docs/asciidoc/stylesheets/foundation-potion.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/foundation.css
+++ b/src/docs/asciidoc/stylesheets/foundation.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/github.css
+++ b/src/docs/asciidoc/stylesheets/github.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/golo.css
+++ b/src/docs/asciidoc/stylesheets/golo.css
@@ -1,11 +1,11 @@
 @import url(https://fonts.googleapis.com/css?family=Montserrat:400,700);
-@import url(http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css);
 
 
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/iconic.css
+++ b/src/docs/asciidoc/stylesheets/iconic.css
@@ -1,9 +1,9 @@
-/* Inspired by the O'Reilly typography and the Atlas user manual | http://oreilly.com */
-@import url(http://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic);
+/* Inspired by the O'Reilly typography and the Atlas user manual | https://oreilly.com */
+@import url(https://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic);
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/maker.css
+++ b/src/docs/asciidoc/stylesheets/maker.css
@@ -1,8 +1,8 @@
-@import url(http://fonts.googleapis.com/css?family=Glegoo);
+@import url(https://fonts.googleapis.com/css?family=Glegoo);
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/readthedocs.css
+++ b/src/docs/asciidoc/stylesheets/readthedocs.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/rocket-panda.css
+++ b/src/docs/asciidoc/stylesheets/rocket-panda.css
@@ -1,8 +1,8 @@
-@import url(http://openshift.redhat.com/app/assets-20130701203230/overpass.css);
+@import url(https://openshift.redhat.com/app/assets-20130701203230/overpass.css);
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/rubygems.css
+++ b/src/docs/asciidoc/stylesheets/rubygems.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/main/java/reactor/ipc/netty/http/websocket/WebsocketOutbound.java
+++ b/src/main/java/reactor/ipc/netty/http/websocket/WebsocketOutbound.java
@@ -68,7 +68,7 @@ public interface WebsocketOutbound extends NettyOutbound {
 	 * Prepare to send a close frame on subscribe then close the underlying channel
 	 *
 	 * @param statusCode
-	 *            Integer status code as per <a href="http://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
+	 *            Integer status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
 	 *            example, <tt>1000</tt> indicates normal closure.
 	 * @param reasonText
 	 *            Reason text. Set to null if no text.
@@ -84,7 +84,7 @@ public interface WebsocketOutbound extends NettyOutbound {
 	 * @param rsv
 	 *            reserved bits used for protocol extensions
 	 * @param statusCode
-	 *            Integer status code as per <a href="http://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
+	 *            Integer status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
 	 *            example, <tt>1000</tt> indicates normal closure.
 	 * @param reasonText
 	 *            Reason text. Set to null if no text.

--- a/src/test/java/reactor/ipc/netty/SocketUtils.java
+++ b/src/test/java/reactor/ipc/netty/SocketUtils.java
@@ -35,7 +35,7 @@ import javax.net.ServerSocketFactory;
  * @author Ben Hale
  * @author Arjen Poutsma
  * @author Gunnar Hillert
- * @see <a href="http://spring.io">Borrowed from the Spring Framework</a>
+ * @see <a href="https://spring.io">Borrowed from the Spring Framework</a>
  * */
 public final class SocketUtils {
 

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientOptionsTest.java
@@ -45,12 +45,12 @@ public class HttpClientOptionsTest {
 		assertThat(this.builder.build().asSimpleString()).isEqualTo("connecting to no base address through SOCKS4 proxy");
 
 		//address
-		this.builder.host("http://google.com").port(123);
-		assertThat(this.builder.build().asSimpleString()).isEqualTo("connecting to http://google.com:123 through SOCKS4 proxy");
+		this.builder.host("https://google.com").port(123);
+		assertThat(this.builder.build().asSimpleString()).isEqualTo("connecting to https://google.com:123 through SOCKS4 proxy");
 
 		//gzip
 		this.builder.compression(true);
-		assertThat(this.builder.build().asSimpleString()).isEqualTo("connecting to http://google.com:123 through SOCKS4 proxy with gzip");
+		assertThat(this.builder.build().asSimpleString()).isEqualTo("connecting to https://google.com:123 through SOCKS4 proxy with gzip");
 	}
 
 	@Test
@@ -67,28 +67,28 @@ public class HttpClientOptionsTest {
 				.endsWith(", acceptGzip=false");
 
 		//address
-		this.builder.host("http://google.com").port(123);
+		this.builder.host("https://google.com").port(123);
 		assertThat(this.builder.build().asDetailedString())
-				.startsWith("connectAddress=http://google.com:123, proxy=SOCKS4(http://proxy")
+				.startsWith("connectAddress=https://google.com:123, proxy=SOCKS4(http://proxy")
 				.contains(":456)")
 				.endsWith(", acceptGzip=false");
 
 		//gzip
 		this.builder.compression(true);
 		assertThat(this.builder.build().asDetailedString())
-				.startsWith("connectAddress=http://google.com:123, proxy=SOCKS4(http://proxy")
+				.startsWith("connectAddress=https://google.com:123, proxy=SOCKS4(http://proxy")
 				.contains(":456)")
 				.endsWith(", acceptGzip=true");
 	}
 
 	@Test
 	public void toStringContainsAsDetailedString() {
-		this.builder.host("http://google.com")
+		this.builder.host("https://google.com")
 		            .port(123)
 		            .proxy(proxyOptions)
 		            .compression(true);
 		assertThat(this.builder.build().toString())
-				.startsWith("HttpClientOptions{connectAddress=http://google.com:123, proxy=SOCKS4(http://proxy")
+				.startsWith("HttpClientOptions{connectAddress=https://google.com:123, proxy=SOCKS4(http://proxy")
 				.contains(":456)")
 				.endsWith(", acceptGzip=true}");
 	}

--- a/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/ipc/netty/http/client/HttpClientTest.java
@@ -404,13 +404,13 @@ public class HttpClientTest {
 		PoolResources p = PoolResources.fixed("test", 1);
 
 		HttpClientResponse r = HttpClient.create(opts -> opts.poolResources(p))
-		                                 .get("http://google.com/unsupportedURI",
+		                                 .get("https://google.com/unsupportedURI",
 		                                         c -> c.failOnClientError(false)
 		                                               .sendHeaders())
 		                                 .block(Duration.ofSeconds(30));
 
 		HttpClientResponse r2 = HttpClient.create(opts -> opts.poolResources(p))
-		                                  .get("http://google.com/unsupportedURI",
+		                                  .get("https://google.com/unsupportedURI",
 		                                          c -> c.failOnClientError(false)
 		                                                .sendHeaders())
 		                                  .block(Duration.ofSeconds(30));
@@ -431,13 +431,13 @@ public class HttpClientTest {
 		PoolResources p = PoolResources.fixed("test", 1);
 
 		HttpClientResponse r = HttpClient.create(opts -> opts.poolResources(p))
-		                                 .get("http://google.com/unsupportedURI",
+		                                 .get("https://google.com/unsupportedURI",
 		                                         c -> c.chunkedTransfer(false)
 		                                               .failOnClientError(false))
 		                                 .block(Duration.ofSeconds(30));
 
 		HttpClientResponse r2 = HttpClient.create(opts -> opts.poolResources(p))
-		                                  .get("http://google.com/unsupportedURI",
+		                                  .get("https://google.com/unsupportedURI",
 		                                         c -> c.chunkedTransfer(false)
 		                                               .failOnClientError(false))
 		                                 .block(Duration.ofSeconds(30));
@@ -457,14 +457,14 @@ public class HttpClientTest {
 	public void contentHeader() {
 		PoolResources fixed = PoolResources.fixed("test", 1);
 		HttpClientResponse r = HttpClient.create(opts -> opts.poolResources(fixed))
-		                                 .get("http://google.com",
+		                                 .get("https://google.com",
 		                                         c -> c.header("content-length", "1")
 		                                               .failOnClientError(false)
 		                                               .sendString(Mono.just(" ")))
 		                                 .block(Duration.ofSeconds(30));
 
 		HttpClientResponse r1 = HttpClient.create(opts -> opts.poolResources(fixed))
-		                                  .get("http://google.com",
+		                                  .get("https://google.com",
 		                                          c -> c.header("content-length", "1")
 		                                                .failOnClientError(false)
 		                                                .sendString(Mono.just(" ")))

--- a/src/test/java/reactor/ipc/netty/options/ClientOptionsTest.java
+++ b/src/test/java/reactor/ipc/netty/options/ClientOptionsTest.java
@@ -45,8 +45,8 @@ public class ClientOptionsTest {
 		assertThat(this.builder.build().asSimpleString()).isEqualTo("connecting to no base address through SOCKS4 proxy");
 
 		//address
-		this.builder.host("http://google.com").port(123);
-		assertThat(this.builder.build().asSimpleString()).isEqualTo("connecting to http://google.com:123 through SOCKS4 proxy");
+		this.builder.host("https://google.com").port(123);
+		assertThat(this.builder.build().asSimpleString()).isEqualTo("connecting to https://google.com:123 through SOCKS4 proxy");
 	}
 
 	@Test
@@ -61,20 +61,20 @@ public class ClientOptionsTest {
 				.contains(":456)");
 
 		//address
-		this.builder.host("http://google.com").port(123);
+		this.builder.host("https://google.com").port(123);
 		assertThat(this.builder.build().asDetailedString())
-				.startsWith("connectAddress=http://google.com:123, proxy=SOCKS4(http://proxy")
+				.startsWith("connectAddress=https://google.com:123, proxy=SOCKS4(http://proxy")
 				.contains(":456)");
 	}
 
 	@Test
 	public void toStringContainsAsDetailedString() {
-		this.builder.host("http://google.com")
+		this.builder.host("https://google.com")
 		            .port(123)
 		            .proxy(proxyOptions)
 		            .build();
 		assertThat(this.builder.build().toString())
-				.startsWith("ClientOptions{connectAddress=http://google.com:123, proxy=SOCKS4(http://proxy")
+				.startsWith("ClientOptions{connectAddress=https://google.com:123, proxy=SOCKS4(http://proxy")
 				.contains(":456)")
 				.endsWith("}");
 	}

--- a/src/test/java/reactor/ipc/netty/options/ClientProxyOptionsTests.java
+++ b/src/test/java/reactor/ipc/netty/options/ClientProxyOptionsTests.java
@@ -36,9 +36,9 @@ public class ClientProxyOptionsTests {
 		assertThat(builder.build().asSimpleString()).startsWith("proxy=HTTP" +
 				"(http://proxy").endsWith(":456)");
 
-		builder = addrSpec.address(new InetSocketAddress("http://another.proxy", 123));
+		builder = addrSpec.address(new InetSocketAddress("https://another.proxy", 123));
 		assertThat(builder.build().asSimpleString()).startsWith("proxy=HTTP" +
-				"(http://another.proxy").endsWith(":123)");
+				"(https://another.proxy").endsWith(":123)");
 	}
 
 	@Test
@@ -51,14 +51,14 @@ public class ClientProxyOptionsTests {
 				.startsWith("address=http://proxy")
 				.endsWith(":456, nonProxyHosts=null, type=HTTP");
 
-		builder = addrSpec.address(() -> new InetSocketAddress("http://another.proxy", 123));
+		builder = addrSpec.address(() -> new InetSocketAddress("https://another.proxy", 123));
 		assertThat(builder.build().asDetailedString())
-				.startsWith("address=http://another.proxy")
+				.startsWith("address=https://another.proxy")
 				.endsWith(":123, nonProxyHosts=null, type=HTTP");
 
 		builder.nonProxyHosts("localhost");
 		assertThat(builder.build().asDetailedString())
-				.startsWith("address=http://another.proxy")
+				.startsWith("address=https://another.proxy")
 				.endsWith(":123, nonProxyHosts=localhost, type=HTTP");
 	}
 

--- a/src/test/java/reactor/ipc/netty/tcp/TcpClientTests.java
+++ b/src/test/java/reactor/ipc/netty/tcp/TcpClientTests.java
@@ -505,7 +505,7 @@ public class TcpClientTests {
 		HttpClient client = HttpClient.create();
 
 		final CountDownLatch latch = new CountDownLatch(1);
-		System.out.println(client.get("http://www.google.com/?q=test%20d%20dq")
+		System.out.println(client.get("https://www.google.com/?q=test%20d%20dq")
 		                         .flatMap(r -> r.receive()
 		                                     .asString()
 		                                     .collectList())


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://docbook.sourceforge.net/release/xsl/current/epub3/chunk.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/epub3/chunk.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/fo/highlight.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/fo/highlight.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/highlight.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/highlight.xsl) result AnnotatedConnectException).
* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://google.com:80/foo (404) with 1 occurrences could not be migrated:  
   ([https](https://google.com:80/foo) result NotSslRecordException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://google.com:123 (ConnectTimeoutException) with 8 occurrences migrated to:  
  https://google.com:123 ([https](https://google.com:123) result ConnectTimeoutException).
* [ ] http://another.proxy (UnknownHostException) with 5 occurrences migrated to:  
  https://another.proxy ([https](https://another.proxy) result UnknownHostException).
* [ ] http://google.com/unsupportedURI (404) with 4 occurrences migrated to:  
  https://google.com/unsupportedURI ([https](https://google.com/unsupportedURI) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css with 12 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css ([https](https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css) result 200).
* [ ] http://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js with 1 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js ([https](https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js) result 200).
* [ ] http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css with 1 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css ([https](https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css) result 200).
* [ ] http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.js with 1 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.js ([https](https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.js) result 200).
* [ ] http://fonts.googleapis.com/css?family=Glegoo with 1 occurrences migrated to:  
  https://fonts.googleapis.com/css?family=Glegoo ([https](https://fonts.googleapis.com/css?family=Glegoo) result 200).
* [ ] http://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic with 1 occurrences migrated to:  
  https://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic ([https](https://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic) result 200).
* [ ] http://mvnrepository.com/artifact/io.projectreactor.ipc/reactor-netty with 1 occurrences migrated to:  
  https://mvnrepository.com/artifact/io.projectreactor.ipc/reactor-netty ([https](https://mvnrepository.com/artifact/io.projectreactor.ipc/reactor-netty) result 200).
* [ ] http://pivotal.io with 2 occurrences migrated to:  
  https://pivotal.io ([https](https://pivotal.io) result 200).
* [ ] http://projectreactor.io/assets/img/logo-2x.png with 1 occurrences migrated to:  
  https://projectreactor.io/assets/img/logo-2x.png ([https](https://projectreactor.io/assets/img/logo-2x.png) result 200).
* [ ] http://projectreactor.io/docs/netty/release/api/ with 1 occurrences migrated to:  
  https://projectreactor.io/docs/netty/release/api/ ([https](https://projectreactor.io/docs/netty/release/api/) result 200).
* [ ] http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* [ ] http://tools.ietf.org/html/rfc6455 with 2 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6455 ([https](https://tools.ietf.org/html/rfc6455) result 200).
* [ ] http://www.google.com/?q=test%20d%20dq with 1 occurrences migrated to:  
  https://www.google.com/?q=test%20d%20dq ([https](https://www.google.com/?q=test%20d%20dq) result 200).
* [ ] http://google.com with 8 occurrences migrated to:  
  https://google.com ([https](https://google.com) result 301).
* [ ] http://openshift.redhat.com/app/assets-20130701203230/overpass.css with 1 occurrences migrated to:  
  https://openshift.redhat.com/app/assets-20130701203230/overpass.css ([https](https://openshift.redhat.com/app/assets-20130701203230/overpass.css) result 301).
* [ ] http://oreilly.com with 1 occurrences migrated to:  
  https://oreilly.com ([https](https://oreilly.com) result 301).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8080/foo with 1 occurrences
* http://docbook.org/ns/docbook with 1 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://foo:8080/bar with 1 occurrences
* http://localhost with 2 occurrences
* http://localhost/foo with 5 occurrences
* http://localhost:8888/3 with 1 occurrences
* http://localhost:8889/1 with 1 occurrences
* http://localhost:9991/3 with 2 occurrences
* http://localhost:9999 with 1 occurrences
* http://proxy with 22 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences