### PR TITLE
Pass HttpHeaders to HttpProxyHandler for newInitialMessage

### DIFF
--- a/src/main/java/reactor/netty/tcp/ProxyProvider.java
+++ b/src/main/java/reactor/netty/tcp/ProxyProvider.java
@@ -74,6 +74,8 @@ public final class ProxyProvider {
 		return proxy.proxyProvider;
 	}
 
+	private static final Supplier<? extends HttpHeaders> NO_HTTP_HEADERS = () -> null;
+
 	final String username;
 	final Function<? super String, ? extends String> password;
 	final Supplier<? extends InetSocketAddress> address;
@@ -97,7 +99,7 @@ public final class ProxyProvider {
 			this.nonProxyHosts = null;
 		}
 		if (Objects.isNull(builder.httpHeaders)) {
-			this.httpHeaders = () -> null;
+			this.httpHeaders = NO_HTTP_HEADERS;
 		}
 		else {
 			this.httpHeaders = builder.httpHeaders;

--- a/src/main/java/reactor/netty/tcp/ProxyProvider.java
+++ b/src/main/java/reactor/netty/tcp/ProxyProvider.java
@@ -20,6 +20,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Objects;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -28,6 +29,8 @@ import javax.annotation.Nullable;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.proxy.HttpProxyHandler;
 import io.netty.handler.proxy.ProxyHandler;
@@ -75,6 +78,7 @@ public final class ProxyProvider {
 	final Function<? super String, ? extends String> password;
 	final Supplier<? extends InetSocketAddress> address;
 	final Pattern nonProxyHosts;
+	final Supplier<? extends HttpHeaders> httpHeaders;
 	final Proxy type;
 
 	ProxyProvider(ProxyProvider.Build builder) {
@@ -91,6 +95,12 @@ public final class ProxyProvider {
 		}
 		else {
 			this.nonProxyHosts = null;
+		}
+		if (Objects.isNull(builder.httpHeaders)) {
+			this.httpHeaders = () -> null;
+		}
+		else {
+			this.httpHeaders = builder.httpHeaders;
 		}
 		this.type = builder.type;
 	}
@@ -139,8 +149,8 @@ public final class ProxyProvider {
 		switch (this.type) {
 			case HTTP:
 				return Objects.nonNull(username) && Objects.nonNull(password) ?
-						new HttpProxyHandler(proxyAddr, username, password) :
-						new HttpProxyHandler(proxyAddr);
+						new HttpProxyHandler(proxyAddr, username, password, this.httpHeaders.get()) :
+						new HttpProxyHandler(proxyAddr, this.httpHeaders.get());
 			case SOCKS4:
 				return Objects.nonNull(username) ? new Socks4ProxyHandler(proxyAddr, username) :
 						new Socks4ProxyHandler(proxyAddr);
@@ -216,12 +226,14 @@ public final class ProxyProvider {
 				Objects.equals(getPasswordValue(), that.getPasswordValue()) &&
 				Objects.equals(getAddress().get(), that.getAddress().get()) &&
 				Objects.equals(getNonProxyHosts(), that.getNonProxyHosts()) &&
+				Objects.equals(httpHeaders.get(), that.httpHeaders.get()) &&
 				getType() == that.getType();
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(username, getPasswordValue(), getAddress().get(), getNonProxyHosts(), getType());
+		return Objects.hash(
+				username, getPasswordValue(), getAddress().get(), getNonProxyHosts(), httpHeaders.get(), getType());
 	}
 
 	@Nullable
@@ -239,6 +251,7 @@ public final class ProxyProvider {
 		int port;
 		Supplier<? extends InetSocketAddress> address;
 		String nonProxyHosts;
+		Supplier<? extends HttpHeaders> httpHeaders;
 		Proxy type;
 
 		Build() {
@@ -284,6 +297,16 @@ public final class ProxyProvider {
 		@Override
 		public final Builder nonProxyHosts(String nonProxyHostsPattern) {
 			this.nonProxyHosts = nonProxyHostsPattern;
+			return this;
+		}
+
+		@Override
+		public Builder httpHeaders(Consumer<HttpHeaders> headers) {
+			this.httpHeaders = () -> new DefaultHttpHeaders() {
+				{
+					headers.accept(this);
+				}
+			};
 			return this;
 		}
 
@@ -372,6 +395,14 @@ public final class ProxyProvider {
 		 * @return {@code this}
 		 */
 		Builder nonProxyHosts(String nonProxyHostsPattern);
+
+		/**
+		 * A consumer to add request headers for the http proxy.
+		 *
+		 * @param headers A consumer to add request headers for the http proxy.
+		 * @return {@code this}
+		 */
+		Builder httpHeaders(Consumer<HttpHeaders> headers);
 
 		/**
 		 * Builds new ProxyProvider


### PR DESCRIPTION
I would like to use the http proxy which has header-based authentication with reactor-netty. This patch makes it possible. It is able to pass HttpHeaders(has auth-header) to HttpProxyHandler.

Related netty's codes are below.
https://github.com/netty/netty/blob/netty-4.1.34.Final/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java#L64
https://github.com/netty/netty/blob/netty-4.1.34.Final/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java#L156-L169

Please check this pull request.

Thanks.