### PR TITLE
When creating HttpServerOperations directly set a header "Transfer-Encoding: chunked"

### DIFF
--- a/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -120,6 +120,7 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		this.nettyRequest = nettyRequest;
 		this.nettyResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
 		this.responseHeaders = nettyResponse.headers();
+		this.responseHeaders.set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
 		this.compressionPredicate = compressionPredicate;
 		this.cookieHolder = Cookies.newServerRequestHolder(requestHeaders(), decoder);
 		this.connectionInfo = connectionInfo;
@@ -460,10 +461,6 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 
 	@Override
 	protected void preSendHeadersAndStatus(){
-		if (!HttpUtil.isTransferEncodingChunked(nettyResponse) && !HttpUtil.isContentLengthSet(
-				nettyResponse)) {
-			markPersistent(false);
-		}
 		if (HttpResponseStatus.NOT_MODIFIED.equals(status())) {
 			responseHeaders.remove(HttpHeaderNames.TRANSFER_ENCODING)
 			               .remove(HttpHeaderNames.CONTENT_LENGTH);

--- a/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -154,8 +154,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 						listener,
 						compress,
 						request, ConnectionInfo.from(ctx.channel(), readForwardHeaders, request),
-						cookieEncoder, cookieDecoder)
-						.chunkedTransfer(true);
+						cookieEncoder, cookieDecoder);
 				ops.bind();
 				listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED);
 


### PR DESCRIPTION
Instead of checking whether the headers are sent (which does the invocation of
`HttpServerOperations#chunkedTransfer(true)`).
In `HttpServerOperations#preSendHeadersAndStatus()` there is no need to check
`Transfer-Encoding` and `Content-Length`, this is done in `HttpTrafficHandler#write`.