### PR TITLE
Override reactor.netty.http.HttpDecoderSpec methods to keep compatibility in 0.8.x

### DIFF
--- a/src/main/java/reactor/netty/http/server/HttpRequestDecoderSpec.java
+++ b/src/main/java/reactor/netty/http/server/HttpRequestDecoderSpec.java
@@ -32,6 +32,31 @@ import reactor.netty.tcp.TcpServer;
 public final class HttpRequestDecoderSpec extends HttpDecoderSpec<HttpRequestDecoderSpec> {
 
 	@Override
+	public HttpRequestDecoderSpec maxInitialLineLength(int value) {
+		return super.maxInitialLineLength(value);
+	}
+
+	@Override
+	public HttpRequestDecoderSpec maxHeaderSize(int value) {
+		return super.maxHeaderSize(value);
+	}
+
+	@Override
+	public HttpRequestDecoderSpec maxChunkSize(int value) {
+		return super.maxChunkSize(value);
+	}
+
+	@Override
+	public HttpRequestDecoderSpec validateHeaders(boolean validate) {
+		return super.validateHeaders(validate);
+	}
+
+	@Override
+	public HttpRequestDecoderSpec initialBufferSize(int value) {
+		return super.initialBufferSize(value);
+	}
+
+	@Override
 	public HttpRequestDecoderSpec get() {
 		return this;
 	}


### PR DESCRIPTION
This change is only for 0.8.x it will not be ported to 0.9.x