### PR TITLE
Invoke cleanup only when cancel/error event

### DIFF
--- a/src/main/java/reactor/netty/ReactorNetty.java
+++ b/src/main/java/reactor/netty/ReactorNetty.java
@@ -388,7 +388,8 @@ public final class ReactorNetty {
 				}
 				else {
 					this.thenMono = Mono.from(thenPublisher)
-					                    .doFinally(s -> onCleanup.run());
+					                    .doOnCancel(onCleanup)
+					                    .doOnError(t -> onCleanup.run());
 				}
 			}
 			else {
@@ -397,7 +398,8 @@ public final class ReactorNetty {
 				}
 				else {
 					this.thenMono = parentMono.thenEmpty(thenPublisher)
-					                          .doFinally(s -> onCleanup.run());
+					                          .doOnCancel(onCleanup)
+					                          .doOnError(t -> onCleanup.run());
 				}
 			}
 		}


### PR DESCRIPTION
When the message is sent successfully the buffer will
be released by Netty.

In addition to #699