### PR TITLE
fix #719 Filter the empty buffers emitted by the Publisher

### DIFF
--- a/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
@@ -694,6 +694,12 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 
 			produced++;
 
+			if ((t instanceof ByteBuf && ((ByteBuf) t).readableBytes() == 0) ||
+					(t instanceof FileRegion && ((FileRegion) t).count() == 0)) {
+				promise.setSuccess();
+				return;
+			}
+
 			// Returned value is deliberately ignored
 			parent.doWrite(t, promise, this);
 


### PR DESCRIPTION
Mark the promise as successful and do not proceed with writing.