### PR TITLE
Fix ProxyProvider hash function leading to memory leakage

### DIFF
--- a/src/main/java/reactor/netty/tcp/ProxyProvider.java
+++ b/src/main/java/reactor/netty/tcp/ProxyProvider.java
@@ -227,7 +227,7 @@ public final class ProxyProvider {
 		return Objects.equals(username, that.username) &&
 				Objects.equals(getPasswordValue(), that.getPasswordValue()) &&
 				Objects.equals(getAddress().get(), that.getAddress().get()) &&
-				Objects.equals(getNonProxyHosts(), that.getNonProxyHosts()) &&
+				Objects.equals(getNonProxyHostsValue(), that.getNonProxyHostsValue()) &&
 				Objects.equals(httpHeaders.get(), that.httpHeaders.get()) &&
 				getType() == that.getType();
 	}
@@ -235,7 +235,11 @@ public final class ProxyProvider {
 	@Override
 	public int hashCode() {
 		return Objects.hash(
-				username, getPasswordValue(), getAddress().get(), getNonProxyHosts(), httpHeaders.get(), getType());
+				username, getPasswordValue(), getAddress().get(), getNonProxyHostsValue(), httpHeaders.get(), getType());
+	}
+
+	private String getNonProxyHostsValue() {
+		return (getNonProxyHosts() == null) ? null : getNonProxyHosts().toString();
 	}
 
 	@Nullable

--- a/src/test/java/reactor/netty/tcp/ProxyProviderTest.java
+++ b/src/test/java/reactor/netty/tcp/ProxyProviderTest.java
@@ -30,6 +30,8 @@ public class ProxyProviderTest {
     private static final Function<String, String> PASSWORD_1 = username -> "123";
     private static final Function<String, String> PASSWORD_2 = username -> "456";
 
+    private static final String NON_PROXY_HOSTS = "localhost";
+
     private static final InetSocketAddress ADDRESS_1 = InetSocketAddress.createUnresolved("localhost", 80);
     private static final InetSocketAddress ADDRESS_2 = InetSocketAddress.createUnresolved("example.com", 80);
 
@@ -79,6 +81,7 @@ public class ProxyProviderTest {
                 .address(address)
                 .username("netty")
                 .password(passwordFunc)
+                .nonProxyHosts(NON_PROXY_HOSTS)
                 .build();
     }
 
@@ -87,6 +90,7 @@ public class ProxyProviderTest {
                 .builder()
                 .type(ProxyProvider.Proxy.SOCKS5)
                 .address(address)
+                .nonProxyHosts("localhost")
                 .build();
     }
 


### PR DESCRIPTION
it seems i triggered a memory leak by registering a proxy with `reactor.netty.http.client.HttpClient.create().tcpConfiguration(this::configureProxy)` as the lambda is called for every connection due to the ChannelHandler being a "different" one in every call of `reactor/netty/resources/PooledConnectionProvider.java:137`

i guess the problem is that the used hash function `reactor.netty.tcp.ProxyProvider#hashCode` includes the nonProxyHosts as a regex pattern which gets his hash function from `java.lang.Object#hashCode` and therefore fails to recognize equal regexes. The tests in `src/test/java/reactor/netty/tcp/ProxyProviderTest.java` did not break because they get null as test fixture for nonProxyHosts.

This ultimately causes the `reactor.netty.resources.PooledConnectionProvider#channelPools` to grow indefinitely once a proxy with defined `nonProxyHosts` is used, no matter if the connection is actually proxied or not.