### PR TITLE
Shade Netty's HAProxy, Proxy and HTTP/2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ buildscript {
   dependencies {
 	classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7',
 			'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE',
-			'com.github.jengelman.gradle.plugins:shadow:1.2.0',
 			'com.google.gradle:osdetector-gradle-plugin:1.4.0'
   }
 }
@@ -30,6 +29,7 @@ buildscript {
 plugins {
   id "com.github.hierynomus.license" version "0.14.0"
   id 'org.asciidoctor.convert' version '1.5.11'
+  id 'com.github.johnrengelman.shadow' version '5.0.0'
 }
 
 description = 'Reactive Streams Netty driver'
@@ -98,6 +98,9 @@ configure(rootProject) { project ->
 
   ext.bundleImportPackages = [ '!javax.annotation',
 							   'io.netty.channel.kqueue;resolution:=optional;version="[4.1,5)"',
+							   '!io.netty.handler.codec.haproxy',
+							   '!io.netty.handler.codec.http2',
+							   '!io.netty.handler.proxy',
 							   '*']
 
   [compileJava, compileTestJava]*.options*.compilerArgs = ["-Xlint:varargs",
@@ -181,6 +184,12 @@ configure(rootProject) { project ->
 	}
   }
 
+  sourceSets {
+	jarFileTest
+  }
+
+  idea.module.testSourceDirs += sourceSets.jarFileTest.allSource.srcDirs
+
   repositories {
 	mavenCentral()
 	if (version.endsWith('BUILD-SNAPSHOT') || project.hasProperty('platformVersion')) {
@@ -202,10 +211,20 @@ configure(rootProject) { project ->
 		os_suffix = ":" + osdetector.classifier
 	}
 
+  configurations {
+	shaded
+
+	[compileOnly, testCompile]*.extendsFrom shaded
+  }
+
 	// dependencies that are common across all java projects
   dependencies {
 	// JSR-305 annotations
 	compileOnly "com.google.code.findbugs:jsr305:3.0.2"
+
+	shaded "io.netty:netty-handler-proxy:${nettyVersion}"
+	shaded "io.netty:netty-codec-http2:${nettyVersion}"
+	shaded "io.netty:netty-codec-haproxy:${nettyVersion}"
 
 	// Logging
 	optional "org.slf4j:slf4j-api:$slf4jVersion"
@@ -213,10 +232,7 @@ configure(rootProject) { project ->
 	compile "io.projectreactor:reactor-core:$reactorCoreVersion"
 
 	compile "io.netty:netty-handler:${nettyVersion}"
-	compile "io.netty:netty-handler-proxy:${nettyVersion}"
 	compile "io.netty:netty-codec-http:${nettyVersion}"
-	compile "io.netty:netty-codec-http2:${nettyVersion}"
-	optional "io.netty:netty-codec-haproxy:${nettyVersion}"
 	compile "io.netty:netty-transport-native-epoll:${nettyVersion}:linux-x86_64"
 	optional "io.netty:netty-transport-native-kqueue:${nettyVersion}"
 
@@ -233,6 +249,9 @@ configure(rootProject) { project ->
 
 	// Needed for HTTP/2 testing
 	testRuntime "io.netty:netty-tcnative-boringssl-static:2.0.25.Final" + os_suffix
+
+	jarFileTestCompile 'org.assertj:assertj-core:3.12.2'
+	jarFileTestCompile 'junit:junit:4.12'
   }
 
 
@@ -254,6 +273,8 @@ configure(rootProject) { project ->
 
 
   jar {
+	  classifier = 'original'
+
 	manifest {
 	  instruction 'Import-Package', bundleImportPackages.join(',')
 	  attributes("Created-By": "${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})",
@@ -263,8 +284,55 @@ configure(rootProject) { project ->
   }
 
   check.dependsOn jacocoTestReport
-}
 
+  shadowJar {
+	classifier = null
+
+	dependsOn(project.tasks.jar)
+
+	manifest {
+	  inheritFrom project.tasks.jar.manifest
+	}
+
+	configurations = [project.configurations.shaded]
+
+	project.afterEvaluate {
+	  dependencies {
+		def shadedDependencies = project.configurations
+										.shaded
+										.dependencies
+										.collect { "${it.group}:${it.name}".toString() }
+										.toSet()
+
+		// Exclude every compile-scoped dependency (including the transitive ones)
+		for (id in project.configurations.compile.resolvedConfiguration.resolvedArtifacts*.moduleVersion*.id) {
+		  def module = "${id.group}:${id.name}".toString()
+		  if (!shadedDependencies.contains(module)) {
+			exclude(dependency(module))
+		  }
+		}
+	  }
+	}
+
+	exclude 'META-INF/*'
+	exclude 'META-INF/maven*/**'
+	exclude 'META-INF/native-image/**'
+
+	relocate 'io.netty.', 'reactor.netty.internal.shaded.io.netty.'
+  }
+
+  artifacts.archives shadowJar
+
+  task jarFileTest(type: Test) {
+	testClassesDirs = sourceSets.jarFileTest.output.classesDirs
+	classpath = sourceSets.jarFileTest.runtimeClasspath
+
+	systemProperty("jarFile", shadowJar.outputs.files.singleFile)
+
+	dependsOn(shadowJar)
+  }
+  project.tasks.check.dependsOn(jarFileTest)
+}
 
 configurations.all {
   // check for updates every build

--- a/src/jarFileTest/java/reactor/netty/AbstractJarFileTest.java
+++ b/src/jarFileTest/java/reactor/netty/AbstractJarFileTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.netty;
+
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * A helper class to access the content of a shaded JAR
+ */
+class AbstractJarFileTest {
+
+	static Path root;
+
+	static {
+		try {
+			Path jarFilePath = Paths.get(System.getProperty("jarFile"));
+			URI jarFileUri = new URI("jar", jarFilePath.toUri().toString(), null);
+			FileSystem fileSystem = FileSystems.newFileSystem(jarFileUri, emptyMap());
+			root = fileSystem.getPath("/");
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/src/jarFileTest/java/reactor/netty/JarFileShadingTest.java
+++ b/src/jarFileTest/java/reactor/netty/JarFileShadingTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.netty;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.assertj.core.api.ListAssert;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This test must be executed with Gradle because it requires a shadow JAR
+ */
+public class JarFileShadingTest extends AbstractJarFileTest {
+
+	@Test
+	public void testPackages() throws Exception {
+		assertThatFileList(root).containsOnly(
+				"reactor",
+				"META-INF"
+		);
+
+		assertThatFileList(root.resolve("reactor")).containsOnly(
+				"netty"
+		);
+	}
+
+	@Test
+	public void testMetaInf() throws Exception {
+		assertThatFileList(root.resolve("META-INF")).containsOnly(
+				"MANIFEST.MF"
+		);
+	}
+
+	private ListAssert<String> assertThatFileList(Path path) throws IOException {
+		return (ListAssert) assertThat(Files.list(path))
+				.extracting(Path::getFileName)
+				.extracting(Path::toString)
+				.extracting(it -> it.endsWith("/") ? it.substring(0, it.length() - 1) : it);
+	}
+
+}


### PR DESCRIPTION
- for now, we strip the native image metadata
- OSGI excludes could be generated automatically, but it requires an additional effort and can be done separately