### PR TITLE
fix shading config (exclude compile dependencies from `shaded`)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,8 +213,6 @@ configure(rootProject) { project ->
 
   configurations {
 	shaded
-
-	[testCompile]*.extendsFrom shaded
   }
 
 	// dependencies that are common across all java projects
@@ -255,6 +253,7 @@ configure(rootProject) { project ->
 
 	for (dependency in project.configurations.shaded.dependencies) {
 	  compileOnly(dependency)
+	  testRuntime(dependency)
 	}
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -214,7 +214,7 @@ configure(rootProject) { project ->
   configurations {
 	shaded
 
-	[compileOnly, testCompile]*.extendsFrom shaded
+	[testCompile]*.extendsFrom shaded
   }
 
 	// dependencies that are common across all java projects
@@ -222,9 +222,9 @@ configure(rootProject) { project ->
 	// JSR-305 annotations
 	compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
-	compile "io.netty:netty-handler-proxy:${nettyVersion}"
-	compile "io.netty:netty-codec-http2:${nettyVersion}"
-	optional "io.netty:netty-codec-haproxy:${nettyVersion}"
+	shaded "io.netty:netty-handler-proxy:${nettyVersion}"
+	shaded "io.netty:netty-codec-http2:${nettyVersion}"
+	shaded "io.netty:netty-codec-haproxy:${nettyVersion}"
 
 	// Logging
 	optional "org.slf4j:slf4j-api:$slf4jVersion"
@@ -252,6 +252,10 @@ configure(rootProject) { project ->
 
 	jarFileTestCompile 'org.assertj:assertj-core:3.12.2'
 	jarFileTestCompile 'junit:junit:4.12'
+
+	for (dependency in project.configurations.shaded.dependencies) {
+	  compileOnly(dependency)
+	}
   }
 
 
@@ -309,6 +313,7 @@ configure(rootProject) { project ->
 		for (id in project.configurations.compile.resolvedConfiguration.resolvedArtifacts*.moduleVersion*.id) {
 		  def module = "${id.group}:${id.name}".toString()
 		  if (!shadedDependencies.contains(module)) {
+			project.configurations.shaded.exclude(group: id.group, module: id.name)
 			exclude(dependency(module))
 		  }
 		}
@@ -318,9 +323,14 @@ configure(rootProject) { project ->
 	exclude 'META-INF/*'
 	exclude 'META-INF/maven*/**'
 	exclude 'META-INF/native-image/**'
-
-//	relocate 'io.netty.', 'reactor.netty.internal.shaded.io.netty.'
   }
+
+  task relocateShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation) {
+	target = tasks.shadowJar
+	prefix = "reactor.netty.internal.shaded"
+  }
+
+  tasks.shadowJar.dependsOn tasks.relocateShadowJar
 
   artifacts.archives shadowJar
 

--- a/build.gradle
+++ b/build.gradle
@@ -253,7 +253,6 @@ configure(rootProject) { project ->
 
 	for (dependency in project.configurations.shaded.dependencies) {
 	  compileOnly(dependency)
-	  testRuntime(dependency)
 	}
   }
 
@@ -342,6 +341,24 @@ configure(rootProject) { project ->
 	dependsOn(shadowJar)
   }
   project.tasks.check.dependsOn(jarFileTest)
+
+  project.tasks.test.classpath += configurations.shaded
+
+  task shadedJarTest(type: Test) {
+	testClassesDirs = sourceSets.test.output.classesDirs
+
+	Set<? super File> mainOutputs = [
+			project.sourceSets.main.output.resourcesDir,
+			project.sourceSets.main.java.outputDir,
+	]
+
+	classpath = shadowJar.outputs.files
+	// Exclude main outputs since we have the shaded JAR on the classpath already
+	classpath += sourceSets.test.runtimeClasspath.filter { !(it in mainOutputs) }
+
+	dependsOn(shadowJar)
+  }
+  project.tasks.check.dependsOn(shadedJarTest)
 }
 
 configurations.all {


### PR DESCRIPTION
The structure now:
<img width="1372" alt="Screen Shot 2019-05-07 at 08 51 59" src="https://user-images.githubusercontent.com/1050762/57277957-8d0f0f80-70a5-11e9-9dc4-0367fdb40e73.png">
