### PR TITLE
Use example.com urls instead of foo/google

### DIFF
--- a/src/test/java/reactor/netty/channel/FluxReceiveTest.java
+++ b/src/test/java/reactor/netty/channel/FluxReceiveTest.java
@@ -126,44 +126,4 @@ public class FluxReceiveTest {
 		server1.disposeNow();
 		server2.disposeNow();
 	}
-
-	/*static final Logger logger = Loggers.getLogger(FluxReceiveTest.class);
-
-	@Test
-	public void issue362() throws InterruptedException {
-		HttpClient client = HttpClient.newConnection()
-		                              .tcpConfiguration(tcp -> tcp.runOn(LoopResources.create("my-loop", 2, false))
-		                                                          .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2000));
-
-		client.doOnRequest((req, c) -> c.addHandlerFirst(new IdleStateHandler(1, 0, 0))
-		                                .addHandlerLast(new ChannelDuplexHandler() {
-			                                @Override
-			                                public void userEventTriggered(
-					                                ChannelHandlerContext ctx,
-					                                Object evt) throws Exception {
-				                                if (evt instanceof IdleStateEvent) {
-					                                ctx.close();
-				                                }
-				                                else {
-					                                super.userEventTriggered(ctx, evt);
-				                                }
-			                                }
-		                                }))
-		      .get()
-		      .uri("http://releases.ubuntu.com/16.04.4/ubuntu-16.04.4-desktop-amd64.iso")
-		      .responseContent()
-		      .log(logger.getName())
-		      .retry(IOException.class::isInstance)
-		      .subscribe(byteBuf -> {
-			      logger.info("Msg: {}", byteBuf);
-			      Flux.just(1, 2, 3)
-			          .onErrorReturn(8)
-			          .subscribe(i -> {
-				          throw new RuntimeException(i + " error");
-			          });
-		      });
-
-		Thread.sleep(Duration.ofMinutes(5)
-		                     .toMillis());
-	}*/
 }

--- a/src/test/java/reactor/netty/http/HttpResponseStatusCodesHandlingTests.java
+++ b/src/test/java/reactor/netty/http/HttpResponseStatusCodesHandlingTests.java
@@ -47,7 +47,7 @@ public class HttpResponseStatusCodesHandlingTests {
 
 		Mono<Integer> content = client.headers(h -> h.add("Content-Type", "text/plain"))
 				                      .request(HttpMethod.GET)
-				                      .uri("/unsupportedURI")
+				                      .uri("/status/404")
 				                      .send(ByteBufFlux.fromString(Flux.just("Hello")
 				                                                       .log("client-send")))
 				                      .responseSingle((res, buf) -> Mono.just(res.status().code()))

--- a/src/test/java/reactor/netty/http/client/UriEndpointFactoryTest.java
+++ b/src/test/java/reactor/netty/http/client/UriEndpointFactoryTest.java
@@ -109,14 +109,14 @@ public class UriEndpointFactoryTest {
 	@Test
 	public void createUriEndpointRelativeNoLeadingSlash() {
 		String test1 = this.builder.build()
-				.createUriEndpoint("foo:8080/bar", false)
+				.createUriEndpoint("example.com:8080/bar", false)
 				.toExternalForm();
 		String test2 = this.builder.build()
-				.createUriEndpoint("foo:8080/bar", true)
+				.createUriEndpoint("example.com:8080/bar", true)
 				.toExternalForm();
 
-		assertThat(test1).isEqualTo("http://foo:8080/bar");
-		assertThat(test2).isEqualTo("ws://foo:8080/bar");
+		assertThat(test1).isEqualTo("http://example.com:8080/bar");
+		assertThat(test2).isEqualTo("ws://example.com:8080/bar");
 	}
 
 	@Test
@@ -155,33 +155,33 @@ public class UriEndpointFactoryTest {
 
 	@Test
 	public void createUriEndpointRelativeAddressSsl() {
-		String test1 = this.builder.host("example")
+		String test1 = this.builder.host("example.com")
 				.port(8080)
 				.sslSupport()
 				.build()
 				.createUriEndpoint("/foo", false)
 				.toExternalForm();
-		String test2 = this.builder.host("example")
+		String test2 = this.builder.host("example.com")
 				.port(8080)
 				.sslSupport()
 				.build()
 				.createUriEndpoint("/foo", true)
 				.toExternalForm();
 
-		assertThat(test1).isEqualTo("https://example:8080/foo");
-		assertThat(test2).isEqualTo("wss://example:8080/foo");
+		assertThat(test1).isEqualTo("https://example.com:8080/foo");
+		assertThat(test2).isEqualTo("wss://example.com:8080/foo");
 	}
 
 	@Test
 	public void createUriEndpointRelativeWithPort() {
 		String test = this.builder
-				.host("google.com")
+				.host("example.com")
 				.port(80)
 				.build()
 				.createUriEndpoint("/foo", false)
 				.toExternalForm();
 
-		assertThat(test).isEqualTo("http://google.com/foo");
+		assertThat(test).isEqualTo("http://example.com/foo");
 	}
 
 	@Test

--- a/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -385,7 +385,7 @@ public class HttpServerTests {
 	public void gettingOptionsDuplicates() {
 		HttpServer server = HttpServer.create()
 		                              .port(123)
-		                              .host(("foo"))
+		                              .host(("example.com"))
 		                              .compress(true);
 		assertThat(server.tcpConfiguration().configure())
 		          .isNotSameAs(HttpServer.DEFAULT_TCP_SERVER)

--- a/src/test/java/reactor/netty/tcp/InetSocketAddressUtilTest.java
+++ b/src/test/java/reactor/netty/tcp/InetSocketAddressUtilTest.java
@@ -48,10 +48,10 @@ public class InetSocketAddressUtilTest {
 	@Test
 	public void shouldCreateUnresolvedAddressByHostName() {
 		InetSocketAddress socketAddress = InetSocketAddressUtil
-				.createUnresolved("google.com", 80);
+				.createUnresolved("example.com", 80);
 		assertThat(socketAddress.isUnresolved()).isTrue();
 		assertThat(socketAddress.getPort()).isEqualTo(80);
-		assertThat(socketAddress.getHostString()).isEqualTo("google.com");
+		assertThat(socketAddress.getHostString()).isEqualTo("example.com");
 	}
 
 	@Test
@@ -80,7 +80,7 @@ public class InetSocketAddressUtilTest {
 
 	@Test
 	public void shouldNotReplaceIfNonNumeric() {
-		InetSocketAddress socketAddress = InetSocketAddress.createUnresolved("google.com",
+		InetSocketAddress socketAddress = InetSocketAddress.createUnresolved("example.com",
 				80);
 		InetSocketAddress processedAddress = InetSocketAddressUtil
 				.replaceUnresolvedNumericIp(socketAddress);
@@ -97,7 +97,7 @@ public class InetSocketAddressUtilTest {
 
 	@Test
 	public void shouldResolveUnresolvedAddress() {
-		InetSocketAddress socketAddress = InetSocketAddress.createUnresolved("google.com",
+		InetSocketAddress socketAddress = InetSocketAddress.createUnresolved("example.com",
 				80);
 		InetSocketAddress processedAddress = InetSocketAddressUtil
 				.replaceWithResolved(socketAddress);
@@ -107,7 +107,7 @@ public class InetSocketAddressUtilTest {
 
 	@Test
 	public void shouldNotReplaceIfAlreadyResolved() {
-		InetSocketAddress socketAddress = new InetSocketAddress("google.com", 80);
+		InetSocketAddress socketAddress = new InetSocketAddress("example.com", 80);
 		InetSocketAddress processedAddress = InetSocketAddressUtil
 				.replaceWithResolved(socketAddress);
 		assertThat(processedAddress).isSameAs(socketAddress);

--- a/src/test/java/reactor/netty/tcp/TcpClientTests.java
+++ b/src/test/java/reactor/netty/tcp/TcpClientTests.java
@@ -563,7 +563,7 @@ public class TcpClientTests {
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		System.out.println(client.get()
-		                         .uri("http://www.google.com/?q=test%20d%20dq")
+		                         .uri("http://example.com/?q=test%20d%20dq")
 		                         .responseContent()
 		                         .asString()
 		                         .collectList()
@@ -575,7 +575,7 @@ public class TcpClientTests {
 
 	@Test
 	public void gettingOptionsDuplicates() {
-		TcpClient client = TcpClient.create().host("foo").port(123);
+		TcpClient client = TcpClient.create().host("example.com").port(123);
 		Assertions.assertThat(client.configure())
 		          .isNotSameAs(TcpClient.DEFAULT_BOOTSTRAP)
 		          .isNotSameAs(client.configure());

--- a/src/test/java/reactor/netty/tcp/TcpServerTests.java
+++ b/src/test/java/reactor/netty/tcp/TcpServerTests.java
@@ -403,7 +403,7 @@ public class TcpServerTests {
 
 	@Test
 	public void gettingOptionsDuplicates() {
-		TcpServer server = TcpServer.create().host("foo").port(123);
+		TcpServer server = TcpServer.create().host("example.com").port(123);
 		Assertions.assertThat(server.configure())
 		          .isNotSameAs(TcpServerBind.INSTANCE.serverBootstrap)
 		          .isNotSameAs(server.configure());


### PR DESCRIPTION
This is motivated by the fact that example.com is a reserved domain
for such tests, which should be enough for GET 200 and 404 tests.

The only exception is postUpload, which uses POST and form encoding.
It has been changed to use http://httpbin.org, which is also a
domain set up for testing (although privately owned).