### PR TITLE
use WireMock to locally simulate HTTP server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ ext {
   // Testing
   mockitoVersion = '1.10.19'
   hoverflyJavaVersion = '0.11.1'
+  wireMockVersion = '2.23.2'
 
   javadocLinks = ["https://docs.oracle.com/javase/7/docs/api/",
 				  "https://docs.oracle.com/javaee/6/api/",
@@ -225,6 +226,7 @@ configure(rootProject) { project ->
 	testCompile "org.hamcrest:hamcrest-library:1.3"
 	testCompile "org.assertj:assertj-core:$assertJVersion"
 	testCompile "io.specto:hoverfly-java:${hoverflyJavaVersion}"
+	testCompile "com.github.tomakehurst:wiremock-jre8-standalone:${wireMockVersion}"
 
 	testRuntime "org.slf4j:jcl-over-slf4j:$slf4jVersion"
 

--- a/src/test/java/reactor/netty/HttpEchoTestingServer.java
+++ b/src/test/java/reactor/netty/HttpEchoTestingServer.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import org.junit.rules.ExternalResource;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+/**
+ * An utility class that sets up a "echo-testing" server, a bit like https://httpbin.org.
+ * The HTTP server replies to all requests on the `/anything` endpoint with a representation
+ * of the request it received, and on the `/status/{xxx}` endpoint with a response of the
+ * xxx status. It is started/stopped as a JUnit {@link org.junit.ClassRule}.
+ *
+ * @author Simon Baslé
+ */
+public class HttpEchoTestingServer extends ExternalResource {
+
+	static final Pattern STATUS_ENDPOINT_PATTERN = Pattern.compile("/status/([0-9][0-9][0-9])");
+
+	private int port;
+	private WireMockServer server;
+
+	@Override
+	protected void before() throws Throwable {
+		start();
+	}
+
+	@Override
+	protected void after() {
+		stop();
+	}
+
+	public void start() {
+		this.port = SocketUtils.findAvailableTcpPort();
+		server = createWireMockServer(port);
+		server.start();
+	}
+
+	public void stop() {
+		server.stop();
+	}
+
+	/**
+	 * @return the port on which the http echo-testing server runs. Host is always localhost.
+	 */
+	public int getPort() {
+		return this.port;
+	}
+
+	/**
+	 * @return the base HTTP url on which the http echo-testing server has its endpoints.
+	 */
+	public String getBaseUrl() {
+		return "http://localhost:" + port + "/";
+	}
+
+	private static class HttpEchoTransformer extends ResponseDefinitionTransformer {
+
+		private final ObjectWriter writer;
+
+		public HttpEchoTransformer(ObjectMapper mapper) {
+			this.writer = mapper.writerWithDefaultPrettyPrinter();
+		}
+
+		@Override
+		public ResponseDefinition transform(Request request, ResponseDefinition responseDefinition, FileSource files, Parameters parameters) {
+			int status = 200;
+			boolean parseStatus = parameters.getBoolean("parseStatus", Boolean.FALSE);
+			boolean headersOnly = parameters.getBoolean("headersOnly", Boolean.FALSE);
+
+			Map<String, Object> requestMap = new LinkedHashMap<>();
+			Map<String, Object> headers = new LinkedHashMap<>();
+			for (HttpHeader h : request.getHeaders()
+			                           .all()) {
+				headers.put(h.key(), h.isSingleValued() ? h.firstValue() : h.values());
+			}
+
+			if (headersOnly) {
+				requestMap.put("headers", headers);
+			}
+			else {
+				requestMap.put("method", request.getMethod().getName());
+				requestMap.put("uri", request.getAbsoluteUrl());
+
+				String path = request.getUrl();
+				int queryParamsStart = request.getUrl().indexOf('?');
+				if (queryParamsStart >=0) {
+					path = request.getUrl().substring(0, queryParamsStart);
+					String queryParams = request.getUrl().substring(queryParamsStart + 1);
+					String[] paramsArray = queryParams.split("&");
+
+					Map<String, List<String>> params = new LinkedHashMap<>();
+					for (String entry : paramsArray) {
+						String[] param = entry.split("=");
+						params.put(param[0], Collections.singletonList(param[1]));
+					}
+					requestMap.put("path", path);
+					requestMap.put("queryParams", params);
+				}
+				else {
+					requestMap.put("path", request.getUrl());
+				}
+
+				if (parseStatus) {
+					Matcher matcher = STATUS_ENDPOINT_PATTERN.matcher(path);
+					if (matcher.matches()) {
+						String statusString = matcher.group(1);
+						status = Integer.parseInt(statusString);
+					}
+				}
+
+				requestMap.put("headers", headers);
+				requestMap.put("body", request.getBodyAsString());
+			}
+
+			String requestAsString;
+			try {
+				requestAsString = writer.writeValueAsString(requestMap);
+			}
+			catch (JsonProcessingException e) {
+				e.printStackTrace();
+				requestAsString = request.toString();
+			}
+			return new ResponseDefinitionBuilder()
+					.withStatus(status)
+					.withBody(requestAsString)
+					.build();
+		}
+
+		@Override
+		public String getName() {
+			return "httpEcho";
+		}
+
+		@Override
+		public boolean applyGlobally() {
+			return false;
+		}
+	}
+
+	private static WireMockServer createWireMockServer(int port) {
+		WireMockServer wireMockServer = new WireMockServer(options()
+				.extensions(new HttpEchoTransformer(new ObjectMapper()))
+				.disableRequestJournal()
+				.port(port));
+
+		wireMockServer.stubFor(any(urlPathMatching(STATUS_ENDPOINT_PATTERN.pattern()))
+				.willReturn(aResponse()
+				.withTransformer("httpEcho", "parseStatus", true)));
+
+		wireMockServer.stubFor(any(urlPathEqualTo("/anything"))
+				.willReturn(aResponse()
+				.withTransformers("httpEcho")));
+
+		wireMockServer.stubFor(any(urlPathEqualTo("/headers"))
+				.willReturn(aResponse()
+				.withTransformer("httpEcho", "headersOnly", true)));
+
+		return wireMockServer;
+	}
+
+}

--- a/src/test/java/reactor/netty/HttpEchoTestingServerTest.java
+++ b/src/test/java/reactor/netty/HttpEchoTestingServerTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Simon Baslé
+ */
+public class HttpEchoTestingServerTest {
+
+	@ClassRule
+	public static HttpEchoTestingServer server = new HttpEchoTestingServer();
+
+	@Test
+	public void echoGetStatus() {
+		Tuple2<Integer, String> response =
+				HttpClient.create()
+				          .baseUrl(server.getBaseUrl())
+				          .get()
+				          .uri("/status/400?q=p+space&p=q+space")
+				          .responseSingle((r, body) -> body.asString().map(b -> Tuples.of(r.status().code(), b)))
+				          .block();
+
+		assertThat(response.getT1()).as("status code").isEqualTo(400);
+		assertThat(response.getT2())
+				.startsWith("{\n" +
+						"  \"method\" : \"GET\",\n" +
+						"  \"uri\" : \"" + server.getBaseUrl() + "status/400?q=p+space&p=q+space\",\n" +
+						"  \"path\" : \"/status/400\",\n" +
+						"  \"queryParams\" : {\n" +
+						"    \"q\" : [ \"p+space\" ],\n" +
+						"    \"p\" : [ \"q+space\" ]\n" +
+						"  },\n" +
+						"  \"headers\" : {\n" +
+						"    \"User-Agent\" : \"ReactorNetty/dev\",\n")
+				.endsWith(
+						"    \"Accept\" : \"*/*\",\n" +
+								"    \"Content-Length\" : \"0\"\n" +
+								"  },\n" +
+								"  \"body\" : \"\"\n" +
+								"}"
+				);
+	}
+
+	@Test
+	public void echoPutAnything() {
+		Tuple2<Integer, String> response =
+				HttpClient.create()
+				          .baseUrl(server.getBaseUrl())
+				          .put()
+				          .uri("/anything?q=p+space&p=q+space")
+				          .send(Mono.just(ByteBufUtil.writeUtf8(ByteBufAllocator.DEFAULT, "Example Body é™")))
+				          .responseSingle((r, body) -> body.asString().map(b -> Tuples.of(r.status().code(), b)))
+				          .block();
+
+		assertThat(response.getT1()).as("status code").isEqualTo(200);
+		assertThat(response.getT2())
+				.startsWith("{\n" +
+						"  \"method\" : \"PUT\",\n" +
+						"  \"uri\" : \"" + server.getBaseUrl() + "anything?q=p+space&p=q+space\",\n" +
+						"  \"path\" : \"/anything\",\n" +
+						"  \"queryParams\" : {\n" +
+						"    \"q\" : [ \"p+space\" ],\n" +
+						"    \"p\" : [ \"q+space\" ]\n" +
+						"  },\n" +
+						"  \"headers\" : {\n" +
+						"    \"User-Agent\" : \"ReactorNetty/dev\",\n")
+				.endsWith(
+						"    \"Accept\" : \"*/*\",\n" +
+								"    \"Content-Length\" : \"18\"\n" +
+								"  },\n" +
+								"  \"body\" : \"Example Body é™\"\n" +
+								"}"
+				);
+	}
+
+	@Test
+	public void echoHeaders() {
+		Tuple2<Integer, String> response =
+				HttpClient.create()
+				          .baseUrl(server.getBaseUrl())
+				          .headers(h -> h.add("x-custom", "foo")
+				                         .add(HttpHeaderNames.CACHE_CONTROL, HttpHeaderValues.NO_CACHE)
+				                         .remove(HttpHeaderNames.HOST))
+				          .get()
+				          .uri("/headers")
+				          .responseSingle((r, body) -> body.asString().map(b -> Tuples.of(r.status().code(), b)))
+				          .block();
+
+		assertThat(response.getT1()).as("status code").isEqualTo(200);
+		assertThat(response.getT2())
+				.isEqualTo("{\n" +
+						"  \"headers\" : {\n" +
+						"    \"User-Agent\" : \"ReactorNetty/dev\",\n" +
+						"    \"Host\" : \"localhost:" + server.getPort() + "\",\n" +
+						"    \"Cache-Control\" : \"no-cache\",\n" +
+						"    \"Accept\" : \"*/*\",\n" +
+						"    \"Content-Length\" : \"0\",\n" +
+						"    \"x-custom\" : \"foo\"\n" +
+						"  }\n" +
+						"}"
+				);
+	}
+
+}


### PR DESCRIPTION
The server is exposed as HttpEchoTestingServer utility class, which
is a JUnit ClassRule and can also be used standalone (has start and
stop methods). It exposes the port it runs on, as well as the base
HTTP url.

Other approaches were explored and discarded:
 - httpin.org in a Docker container (via TestContainers): a bit
 overkill on resources, and not all dev / ci machine will have Docker
 - MockServer: uses Netty AND doesn't shade the dependency, resulting
 in potential Netty version conflics.

WireMock doesn't use Netty dependency like MockServer, so no clash.
Furthermore, there is a shaded standalone version of WireMock.

This commit also polishes some tests to run on local HTTP server:
  - polish tests that don't BAD_REQUEST anymore due to GET having a body
  (not enforced on MockServer, contrary to example.com and google.com)
 - polish one TcpClientTests to also avoid HTTP remote, using the
 HttpEchoTestingServer standalone.