### PR TITLE
Extend `EventLoop` from Netty's `FastThreadLocalThread`

### DIFF
--- a/src/main/java/reactor/netty/resources/DefaultLoopResources.java
+++ b/src/main/java/reactor/netty/resources/DefaultLoopResources.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.concurrent.Future;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.NonBlocking;
@@ -276,7 +277,7 @@ final class DefaultLoopResources extends AtomicLong implements LoopResources {
 		}
 	}
 
-	final static class EventLoop extends Thread implements NonBlocking {
+	final static class EventLoop extends FastThreadLocalThread implements NonBlocking {
 
 		EventLoop(Runnable target) {
 			super(target);


### PR DESCRIPTION
As was suggested by @normanmaurer, we should extend from `FastThreadLocalThread`.

`FastThreadLocal` is a special optimization in Netty that is faster than JVM's ThreadLocals in Netty's use cases