### PR TITLE
Enable BlockHound during the tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,10 @@ configure(rootProject) { project ->
 	  maxGranularity 3
 	}
 
+	useJUnitPlatform {
+	  includeEngines 'junit-vintage'
+	}
+
 	onOutput { descriptor, event ->
 	  if (event.message.contains("ResourceLeakDetector")) {
 		logger.error("ERROR: Test: " + descriptor + " produced resource leak: " + event.message )
@@ -236,6 +240,11 @@ configure(rootProject) { project ->
 
 	// Needed for HTTP/2 testing
 	testRuntime "io.netty:netty-tcnative-boringssl-static:2.0.25.Final" + os_suffix
+
+	testCompile 'org.junit.jupiter:junit-jupiter-api:5.4.1'
+	testRuntime "io.projectreactor.tools:blockhound-junit-platform:$blockHoundVersion"
+	testRuntime 'org.junit.vintage:junit-vintage-engine:5.4.1'
+	testRuntime 'org.junit.platform:junit-platform-launcher:1.0.0'
   }
 
 

--- a/src/test/java/reactor/netty/NettyTestBlockHoundIntegration.java
+++ b/src/test/java/reactor/netty/NettyTestBlockHoundIntegration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.netty;
+
+import reactor.blockhound.BlockHound;
+import reactor.blockhound.integration.BlockHoundIntegration;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+public class NettyTestBlockHoundIntegration implements BlockHoundIntegration {
+    @Override
+    public void applyTo(BlockHound.Builder builder) {
+        // Calls blocking SecureRandom.next
+        builder.allowBlockingCallsInside("java.nio.file.Files", "createTempFile");
+
+        // System.out.println
+        builder.allowBlockingCallsInside("java.io.PrintStream", "println");
+
+        // TODO remove once BlockHound adds Thread#run by default
+        builder.disallowBlockingCallsInside("java.lang.Thread", "run");
+        builder.allowBlockingCallsInside(ScheduledThreadPoolExecutor.class.getName() + "$DelayedWorkQueue", "take");
+    }
+}

--- a/src/test/java/reactor/netty/NettyTestBlockHoundIntegration.java
+++ b/src/test/java/reactor/netty/NettyTestBlockHoundIntegration.java
@@ -30,6 +30,8 @@ public class NettyTestBlockHoundIntegration implements BlockHoundIntegration {
         // System.out.println
         builder.allowBlockingCallsInside("java.io.PrintStream", "println");
 
+        builder.allowBlockingCallsInside("java.util.concurrent.ConcurrentHashMap", "initTable");
+
         // TODO remove once BlockHound adds Thread#run by default
         builder.disallowBlockingCallsInside("java.lang.Thread", "run");
         builder.allowBlockingCallsInside(ScheduledThreadPoolExecutor.class.getName() + "$DelayedWorkQueue", "take");

--- a/src/test/java/reactor/netty/resources/NettyBlockHoundIntegrationTest.java
+++ b/src/test/java/reactor/netty/resources/NettyBlockHoundIntegrationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.netty.resources;
+
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.*;
+
+/**
+ * Smoke test that ensures that BlockHound is enabled
+ */
+public class NettyBlockHoundIntegrationTest {
+
+    @Test
+    public void shouldDisallowBlockingCalls() throws Exception {
+        DefaultLoopResources resources = new DefaultLoopResources(
+                "foo",
+                1,
+                true
+        );
+        try {
+            CompletableFuture<?> future = new CompletableFuture<>();
+            resources.cacheNioSelectLoops().submit(() -> {
+                try {
+                    Thread.sleep(10);
+                    future.complete(null);
+                } catch (Throwable e) {
+                    future.completeExceptionally(e);
+                }
+                return "";
+            });
+
+            try {
+                future.get(10, TimeUnit.SECONDS);
+                fail("should fail");
+            }
+            catch (ExecutionException e) {
+                assertThat(
+                        e.getCause().getMessage(),
+                        containsString("Blocking call!")
+                );
+            }
+        }
+        finally {
+            resources.disposeLater().block();
+        }
+    }
+
+}

--- a/src/test/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
+++ b/src/test/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
@@ -1,0 +1,1 @@
+reactor.netty.NettyTestBlockHoundIntegration


### PR DESCRIPTION
This PR enables BlockHound during the tests.

There are a few issues to fix:
- [ ] **HIGH PRIO**: `Object#wait` in `io.netty.channel.pool.FixedChannelPool.close`
- [ ] **HIGH PRIO**: `java.io.FileInputStream#readBytes` in `io.netty.handler.codec.http.multipart.AbstractMemoryHttpData.setContent`
- [ ] **MEDIUM PRIO**: `java.io.FileInputStream#readBytes` in `io.netty.internal.tcnative.SSL.readFromSSL`