### PR TITLE
Fix unintended stack trace suppression despite DEBUG level being enab…

### DIFF
--- a/src/main/java/reactor/netty/channel/FluxReceive.java
+++ b/src/main/java/reactor/netty/channel/FluxReceive.java
@@ -341,7 +341,7 @@ final class FluxReceive extends Flux<Object> implements Subscription, Disposable
 	final void onInboundError(Throwable err) {
 		if (isCancelled() || inboundDone) {
 			if (log.isDebugEnabled()) {
-				log.error(format(channel, "An exception has been observed post termination"), err);
+				log.warn(format(channel, "An exception has been observed post termination"), err);
 			} else if (log.isWarnEnabled()) {
 				log.warn(format(channel, "An exception has been observed post termination, use DEBUG level to see the full stack: {}"), err.toString());
 			}

--- a/src/main/java/reactor/netty/channel/FluxReceive.java
+++ b/src/main/java/reactor/netty/channel/FluxReceive.java
@@ -340,11 +340,10 @@ final class FluxReceive extends Flux<Object> implements Subscription, Disposable
 
 	final void onInboundError(Throwable err) {
 		if (isCancelled() || inboundDone) {
-			if (log.isWarnEnabled()) {
-				log.warn(format(channel, "An exception has been observed post termination, use DEBUG level to see the full stack: {}"), err.getClass().getSimpleName());
-			}
-			else if (log.isDebugEnabled()) {
+			if (log.isDebugEnabled()) {
 				log.error(format(channel, "An exception has been observed post termination"), err);
+			} else if (log.isWarnEnabled()) {
+				log.warn(format(channel, "An exception has been observed post termination, use DEBUG level to see the full stack: {}"), err.toString());
 			}
 			return;
 		}


### PR DESCRIPTION
…led, expose exception message

The order of checks `log.isWarnEnabled()` and `log.isDebugEnabled()` is wrong. If debug-logging is enabled, `log.isWarnEnabled()` is also true causing the debug branch to be never executed. This change fixes that by swapping the branches.

In addition, I changed the warning-level logging to not just output the exception class name, but also the message (using `Exception#toString()`) as the exception class name alone often is not sufficient to infer what went wrong.