### PR TITLE
Use the default port when cannot extract the port from forwarded headers.

### DIFF
--- a/src/main/java/reactor/netty/http/server/ConnectionInfo.java
+++ b/src/main/java/reactor/netty/http/server/ConnectionInfo.java
@@ -44,6 +44,7 @@ final class ConnectionInfo {
 	static final Pattern FORWARDED_HOST_PATTERN  = Pattern.compile("host=\"?([^;,\"]+)\"?");
 	static final Pattern FORWARDED_PROTO_PATTERN = Pattern.compile("proto=\"?([^;,\"]+)\"?");
 	static final Pattern FORWARDED_FOR_PATTERN   = Pattern.compile("for=\"?([^;,\"]+)\"?");
+	static final Pattern PORT_PATTERN = Pattern.compile("\\d");
 	static final String XFORWARDED_IP_HEADER = "X-Forwarded-For";
 
 	static final String XFORWARDED_HOST_HEADER = "X-Forwarded-Host";
@@ -125,8 +126,11 @@ final class ConnectionInfo {
 		int ipV6HostSeparatorIdx = address.lastIndexOf("]");
 		if(separatorIdx > ipV6HostSeparatorIdx) {
 			if(separatorIdx == address.indexOf(":") || ipV6HostSeparatorIdx > -1) {
-				return InetSocketAddressUtil.createUnresolved(address.substring(0, separatorIdx),
-					Integer.parseInt(address.substring(separatorIdx + 1)));
+				String port = address.substring(separatorIdx + 1);
+				if (PORT_PATTERN.matcher(port).matches()) {
+					return InetSocketAddressUtil.createUnresolved(address.substring(0, separatorIdx),
+							Integer.parseInt(port));
+				}
 			}
 		}
 		return InetSocketAddressUtil.createUnresolved(address, defaultPort);

--- a/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -305,10 +305,18 @@ public class ConnectionInfoTests {
 	}
 
 	@Test
-	public void parseAddressForIpV6WithPortAndBrackets() {
+	public void parseAddressForIpV6WithPortAndBrackets_1() {
 		testParseAddress("[1abc:2abc:3abc::5ABC:6abc]:443", 8080, inetSocketAddress -> {
 			Assertions.assertThat(inetSocketAddress.getHostName()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
 			Assertions.assertThat(inetSocketAddress.getPort()).isEqualTo(443);
+		});
+	}
+
+	@Test
+	public void parseAddressForIpV6WithPortAndBrackets_2() {
+		testParseAddress("[2001:db8:a0b:12f0::1]:dba2", 8080, inetSocketAddress -> {
+			Assertions.assertThat(inetSocketAddress.getHostName()).isEqualTo("[2001:db8:a0b:12f0::1]:dba2");
+			Assertions.assertThat(inetSocketAddress.getPort()).isEqualTo(8080);
 		});
 	}
 


### PR DESCRIPTION
Related to #625#issuecomment-498604554