### PR TITLE
Add NettyOutbound.send/sendObject API with a predicate for enforcing flush operation

### DIFF
--- a/src/main/java/reactor/netty/ReactorNetty.java
+++ b/src/main/java/reactor/netty/ReactorNetty.java
@@ -24,10 +24,12 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -534,13 +536,13 @@ public final class ReactorNetty {
 		}
 
 		@Override
-		public NettyOutbound send(Publisher<? extends ByteBuf> dataStream) {
-			return then(source.send(dataStream));
+		public NettyOutbound send(Publisher<? extends ByteBuf> dataStream, Predicate<ByteBuf> predicate) {
+			return then(source.send(dataStream, predicate));
 		}
 
 		@Override
-		public NettyOutbound sendObject(Publisher<?> dataStream) {
-			return then(source.sendObject(dataStream));
+		public NettyOutbound sendObject(Publisher<?> dataStream, Predicate<Object> predicate) {
+			return then(source.sendObject(dataStream, predicate));
 		}
 
 		@Override
@@ -720,12 +722,12 @@ public final class ReactorNetty {
 			}
 
 			@Override
-			public NettyOutbound send(Publisher<? extends ByteBuf> dataStream) {
+			public NettyOutbound send(Publisher<? extends ByteBuf> dataStream, Predicate<ByteBuf> predicate) {
 				return this;
 			}
 
 			@Override
-			public NettyOutbound sendObject(Publisher<?> dataStream) {
+			public NettyOutbound sendObject(Publisher<?> dataStream, Predicate<Object> predicate) {
 				return this;
 			}
 
@@ -785,8 +787,12 @@ public final class ReactorNetty {
 	};
 
 
+	static final Predicate<ByteBuf>        PREDICATE_BB_FLUSH    = b -> false;
 
+	static final Predicate<Object>         PREDICATE_FLUSH       = o -> false;
 
+	static final ByteBuf                   BOUNDARY              = Unpooled.EMPTY_BUFFER;
 
+	public static final Predicate<ByteBuf> PREDICATE_GROUP_FLUSH = b -> b == BOUNDARY;
 
 }

--- a/src/main/java/reactor/netty/channel/ChannelOperations.java
+++ b/src/main/java/reactor/netty/channel/ChannelOperations.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 import io.netty.buffer.ByteBuf;
@@ -227,22 +228,22 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public NettyOutbound send(Publisher<? extends ByteBuf> dataStream) {
+	public NettyOutbound send(Publisher<? extends ByteBuf> dataStream, Predicate<ByteBuf> predicate) {
 		if (dataStream instanceof Mono) {
 			return then(((Mono<?>)dataStream).flatMap(m -> FutureMono.from(channel().writeAndFlush(m)))
 			                                 .doOnDiscard(ByteBuf.class, ByteBuf::release));
 		}
-		return then(MonoSendMany.byteBufSource(dataStream, channel()));
+		return then(MonoSendMany.byteBufSource(dataStream, channel(), predicate));
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public NettyOutbound sendObject(Publisher<?> dataStream) {
+	public NettyOutbound sendObject(Publisher<?> dataStream, Predicate<Object> predicate) {
 		if (dataStream instanceof Mono) {
 			return then(((Mono<?>)dataStream).flatMap(m -> FutureMono.from(channel().writeAndFlush(m)))
 			                                 .doOnDiscard(ReferenceCounted.class, ReferenceCounted::release));
 		}
-		return then(MonoSendMany.objectSource(dataStream, channel()));
+		return then(MonoSendMany.objectSource(dataStream, channel(), predicate));
 	}
 
 	@Override

--- a/src/main/java/reactor/netty/channel/MonoSend.java
+++ b/src/main/java/reactor/netty/channel/MonoSend.java
@@ -27,6 +27,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.FileRegion;
 import io.netty.util.ReferenceCountUtil;
 import reactor.core.publisher.Mono;
+import reactor.netty.ReactorNetty;
 
 /**
  * @author Stephane Maldini
@@ -59,9 +60,15 @@ abstract class MonoSend<I, O> extends Mono<Void> {
 
 	static final int                    REFILL_SIZE = MAX_SIZE / 2;
 
-	static final Function<ByteBuf, ByteBuf> FUNCTION_BB_IDENTITY = Function.identity();
+	static final Function<ByteBuf, ByteBuf> TRANSFORMATION_FUNCTION_BB =
+		msg -> {
+			if (ReactorNetty.PREDICATE_GROUP_FLUSH.test(msg)) {
+				return null;
+			}
+			return msg;
+		};
 
-	static final Function<Object, Object>   FUNCTION_IDENTITY    = Function.identity();
+	static final Function<Object, Object>   TRANSFORMATION_FUNCTION    = Function.identity();
 
 	static final Consumer<ByteBuf> CONSUMER_BB_NOCHECK_CLEANUP = ByteBuf::release;
 

--- a/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/src/main/java/reactor/netty/http/HttpOperations.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -335,13 +336,13 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 		}
 
 		@Override
-		public NettyOutbound send(Publisher<? extends ByteBuf> dataStream) {
-			return parent.send(dataStream);
+		public NettyOutbound send(Publisher<? extends ByteBuf> dataStream, Predicate<ByteBuf> predicate) {
+			return parent.send(dataStream, predicate);
 		}
 
 		@Override
-		public NettyOutbound sendObject(Publisher<?> dataStream) {
-			return parent.sendObject(dataStream);
+		public NettyOutbound sendObject(Publisher<?> dataStream, Predicate<Object> predicate) {
+			return parent.sendObject(dataStream, predicate);
 		}
 
 		@Override

--- a/src/test/java/reactor/netty/NettyOutboundTest.java
+++ b/src/test/java/reactor/netty/NettyOutboundTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import javax.net.ssl.SSLException;
 
 import io.netty.buffer.ByteBuf;
@@ -87,7 +88,7 @@ public class NettyOutboundTest {
 		Connection mockContext = () -> channel;
 		NettyOutbound outbound = new NettyOutbound() {
 			@Override
-			public NettyOutbound sendObject(Publisher<?> dataStream) {
+			public NettyOutbound sendObject(Publisher<?> dataStream, Predicate<Object> predicate) {
 				return this;
 			}
 
@@ -97,7 +98,7 @@ public class NettyOutboundTest {
 			}
 
 			@Override
-			public NettyOutbound send(Publisher<? extends ByteBuf> dataStream) {
+			public NettyOutbound send(Publisher<? extends ByteBuf> dataStream, Predicate<ByteBuf> predicate) {
 				return this;
 			}
 
@@ -179,7 +180,7 @@ public class NettyOutboundTest {
 		Connection mockContext = () -> channel;
 		NettyOutbound outbound = new NettyOutbound() {
 			@Override
-			public NettyOutbound sendObject(Publisher<?> dataStream) {
+			public NettyOutbound sendObject(Publisher<?> dataStream, Predicate<Object> predicate) {
 				return this;
 			}
 
@@ -189,7 +190,7 @@ public class NettyOutboundTest {
 			}
 
 			@Override
-			public NettyOutbound send(Publisher<? extends ByteBuf> dataStream) {
+			public NettyOutbound send(Publisher<? extends ByteBuf> dataStream, Predicate<ByteBuf> predicate) {
 				return this;
 			}
 
@@ -268,7 +269,7 @@ public class NettyOutboundTest {
 		Connection mockContext = () -> channel;
 		NettyOutbound outbound = new NettyOutbound() {
 			@Override
-			public NettyOutbound sendObject(Publisher<?> dataStream) {
+			public NettyOutbound sendObject(Publisher<?> dataStream, Predicate<Object> predicate) {
 				return this;
 			}
 
@@ -278,7 +279,7 @@ public class NettyOutboundTest {
 			}
 
 			@Override
-			public NettyOutbound send(Publisher<? extends ByteBuf> dataStream) {
+			public NettyOutbound send(Publisher<? extends ByteBuf> dataStream, Predicate<ByteBuf> predicate) {
 				return this;
 			}
 

--- a/src/test/java/reactor/netty/channel/MonoSendManyTest.java
+++ b/src/test/java/reactor/netty/channel/MonoSendManyTest.java
@@ -35,12 +35,12 @@ public class MonoSendManyTest {
 		//use an extra handler
 		EmbeddedChannel channel = new EmbeddedChannel(new WriteTimeoutHandler(1), new ChannelHandlerAdapter() {});
 
-		Mono<Void> m = MonoSendMany.objectSource(Flux.just("test"), channel);
+		Mono<Void> m = MonoSendMany.objectSource(Flux.just("test"), channel, b -> false);
 
 		StepVerifier.create(m)
 		            .then(() -> {
-		            	channel.runPendingTasks(); //run flush
-			            assertThat(channel.<String>readOutbound()).isEqualToIgnoringCase("test");
+		                channel.runPendingTasks(); //run flush
+		                assertThat(channel.<String>readOutbound()).isEqualToIgnoringCase("test");
 		            })
 		            .verifyComplete();
 	}


### PR DESCRIPTION
Implement NettyOutbound.sendGroup with one send operation