### PR TITLE
Use the correct address when cannot extract the port from forwarded headers

### DIFF
--- a/src/main/java/reactor/netty/http/server/ConnectionInfo.java
+++ b/src/main/java/reactor/netty/http/server/ConnectionInfo.java
@@ -131,6 +131,9 @@ final class ConnectionInfo {
 					return InetSocketAddressUtil.createUnresolved(address.substring(0, separatorIdx),
 							Integer.parseInt(port));
 				}
+				else {
+					return InetSocketAddressUtil.createUnresolved(address.substring(0, separatorIdx), defaultPort);
+				}
 			}
 		}
 		return InetSocketAddressUtil.createUnresolved(address, defaultPort);

--- a/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -315,7 +315,7 @@ public class ConnectionInfoTests {
 	@Test
 	public void parseAddressForIpV6WithPortAndBrackets_2() {
 		testParseAddress("[2001:db8:a0b:12f0::1]:dba2", 8080, inetSocketAddress -> {
-			Assertions.assertThat(inetSocketAddress.getHostName()).isEqualTo("[2001:db8:a0b:12f0::1]:dba2");
+			Assertions.assertThat(inetSocketAddress.getHostName()).isEqualTo("2001:db8:a0b:12f0:0:0:0:1");
 			Assertions.assertThat(inetSocketAddress.getPort()).isEqualTo(8080);
 		});
 	}


### PR DESCRIPTION
Related to #625#issuecomment-506403990