### PR TITLE
Clean resources of long living connections to reduce gc pressure

### DIFF
--- a/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ChannelOperationsHandler.java
@@ -572,6 +572,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 					else {
 						// Returned value is deliberately ignored
 						promise.setFailure(new AbortedException("Connection has been closed"));
+						clean();
 						return;
 					}
 				}
@@ -604,6 +605,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 				produced(p);
 				// Returned value is deliberately ignored
 				promise.setSuccess();
+				clean();
 				parent.drain();
 			}
 		}
@@ -630,6 +632,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 				else {
 					// Returned value is deliberately ignored
 					promise.setFailure(new AbortedException("Connection has been closed"));
+					clean();
 					return;
 				}
 			}
@@ -658,10 +661,12 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 					if (!future.isSuccess()) {
 						// Returned value is deliberately ignored
 						promise.setFailure(Exceptions.addSuppressed(future.cause(), t));
+						clean();
 						return;
 					}
 					// Returned value is deliberately ignored
 					promise.setFailure(t);
+					clean();
 				});
 			}
 			else {
@@ -669,6 +674,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 				produced(p);
 				// Returned value is deliberately ignored
 				promise.setFailure(t);
+				clean();
 				parent.drain();
 			}
 		}
@@ -760,6 +766,7 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 				// Returned value is deliberately ignored
 				promise.setFailure(future.cause());
 			}
+			clean();
 		}
 
 		@Override
@@ -923,6 +930,12 @@ final class ChannelOperationsHandler extends ChannelDuplexHandler
 			Operators.addCap(MISSED_PRODUCED, this, n);
 
 			drain();
+		}
+
+		private void clean() {
+			promise = null;
+			actual = null;
+			lastWrite = null;
 		}
 
 		@SuppressWarnings("rawtypes")

--- a/src/main/java/reactor/ipc/netty/channel/ClientContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ClientContextHandler.java
@@ -86,7 +86,7 @@ final class ClientContextHandler<CHANNEL extends Channel>
 
 	@Override
 	protected void doPipeline(Channel ch) {
-		addSslAndLogHandlers(clientOptions, this, loggingHandler, secure, getSNI(), ch.pipeline());
+		addSslAndLogHandlers(clientOptions, loggingHandler, secure, getSNI(), ch.pipeline());
 		addProxyHandler(clientOptions, ch.pipeline(), providedAddress);
 	}
 

--- a/src/main/java/reactor/ipc/netty/channel/ContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ContextHandler.java
@@ -393,7 +393,6 @@ public abstract class ContextHandler<CHANNEL extends Channel>
 	static final Logger         log      = Loggers.getLogger(ContextHandler.class);
 
 	static void addSslAndLogHandlers(NettyOptions<?, ?> options,
-			ContextHandler<?> sink,
 			LoggingHandler loggingHandler,
 			boolean secure,
 			Tuple2<String, Integer> sniInfo,
@@ -432,12 +431,12 @@ public abstract class ContextHandler<CHANNEL extends Channel>
 						loggingHandler);
 				pipeline.addAfter(NettyPipeline.LoggingHandler,
 						NettyPipeline.SslReader,
-						new SslReadHandler(sink));
+						new SslReadHandler());
 			}
 			else {
 				pipeline.addAfter(NettyPipeline.SslHandler,
 						NettyPipeline.SslReader,
-						new SslReadHandler(sink));
+						new SslReadHandler());
 			}
 		}
 		else if (log.isDebugEnabled()) {

--- a/src/main/java/reactor/ipc/netty/channel/ServerContextHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/ServerContextHandler.java
@@ -20,13 +20,9 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
 import io.netty.channel.Channel;
-import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.ServerSocketChannel;
-import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.logging.LoggingHandler;
-import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
-import reactor.ipc.netty.FutureMono;
 import reactor.ipc.netty.NettyContext;
 import reactor.ipc.netty.options.ServerOptions;
 
@@ -105,6 +101,6 @@ final class ServerContextHandler extends CloseableContextHandler<Channel>
 
 	@Override
 	protected void doPipeline(Channel ch) {
-		addSslAndLogHandlers(options, this, loggingHandler, true, getSNI(), ch.pipeline());
+		addSslAndLogHandlers(options, loggingHandler, true, getSNI(), ch.pipeline());
 	}
 }

--- a/src/main/java/reactor/ipc/netty/channel/SslReadHandler.java
+++ b/src/main/java/reactor/ipc/netty/channel/SslReadHandler.java
@@ -25,12 +25,9 @@ import io.netty.handler.ssl.SslHandshakeCompletionEvent;
  */
 final class SslReadHandler extends ChannelInboundHandlerAdapter {
 
-	final ContextHandler<?> sink;
-
 	boolean handshakeDone;
 
-	SslReadHandler(ContextHandler<?> sink) {
-		this.sink = sink;
+	SslReadHandler() {
 	}
 
 	@Override
@@ -60,7 +57,10 @@ final class SslReadHandler extends ChannelInboundHandlerAdapter {
 				ctx.fireChannelActive();
 			}
 			else {
-				sink.fireContextError(handshake.cause());
+				ChannelOperationsHandler h = ctx.channel().pipeline()
+						.get(ChannelOperationsHandler.class);
+
+				h.lastContext.fireContextError(handshake.cause());
 			}
 		}
 		super.userEventTriggered(ctx, evt);

--- a/src/main/java/reactor/ipc/netty/tcp/TcpClient.java
+++ b/src/main/java/reactor/ipc/netty/tcp/TcpClient.java
@@ -184,7 +184,7 @@ public class TcpClient implements NettyConnector<NettyInbound, NettyOutbound> {
 			PoolResources poolResources = options.getPoolResources();
 			if (poolResources != null) {
 				pool = poolResources.selectOrCreate(remote, options,
-						doHandler(null, sink, secure, remote, null, null),
+						doHandler(null, null, secure, remote, null, null),
 						options.getLoopResources().onClient(options.preferNative()));
 			}
 


### PR DESCRIPTION
When Using `HttpClient` with connection pool enabled, We found that there is some resources not released after some http request is completed and before the keep-alive connection is closed. When there are many long living connections, the java gc will be very bad.

The following code can reproduce this issue:

```
public class HttpClientBugTest {

    private static class MyConsumer implements Consumer<HttpClientResponse>{
        @Override
        public void accept(HttpClientResponse httpClientResponse) {
            httpClientResponse.receiveContent().map(httpContent -> httpContent.content())
                    .subscribe(byteBuf -> System.out.println(byteBuf.toString(Charset.defaultCharset())));
        }
    }

    public static void main(String[] args) throws IOException {
        HttpClient httpClient = HttpClient.create(opts -> {
            opts.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000);
            PoolResources poolResources = PoolResources.fixed("a",
                    100, 1000);
            opts.poolResources(poolResources);
        });

        Mono<HttpClientResponse> resp = httpClient.get("https://www.google.com/");
        resp.subscribe(new MyConsumer());

        System.in.read();
    }

}
```

Execute the above code, and as soon as the console shows the http response string, use shell `jmap -dump:live,format=b,file=a.heap ${pid}` to generate the heap dump file(this shell must be executed before the keep-alive connection is closed!), then use `Eclipse Memory Analyzer` to open it, the following image shows the memory leak:

![image](https://user-images.githubusercontent.com/3961789/60428613-c7bba100-9c2b-11e9-8330-cb42485e0844.png)


This PR tries to fix this issue.