### PR TITLE
fix #768 Do not remove the reactive bridge in case of a close frame.

### DIFF
--- a/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
@@ -202,7 +202,6 @@ final class WebsocketClientOperations extends HttpClientOperations
 			return FutureMono.deferFuture(() -> {
 				if (CLOSE_SENT.getAndSet(this, 1) == 0) {
 					discard();
-					channel().pipeline().remove(NettyPipeline.ReactiveBridge);
 					return channel().writeAndFlush(frame)
 					                .addListener(ChannelFutureListener.CLOSE);
 				}

--- a/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
+++ b/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
@@ -188,7 +188,6 @@ final class WebsocketServerOperations extends HttpServerOperations
 			return FutureMono.deferFuture(() -> {
 				if (CLOSE_SENT.getAndSet(this, 1) == 0) {
 					discard();
-					channel().pipeline().remove(NettyPipeline.ReactiveBridge);
 					return channel().writeAndFlush(frame)
 					                .addListener(ChannelFutureListener.CLOSE);
 				}


### PR DESCRIPTION
Removing reactive bridge was added as a fix for #444.
The removing functionality forces PublisherSender to invoke cancel
and ChannelOperationsHandler to drain the queued messages.
As PublisherSender functionality is not part of ChannelOperationsHandler
anymore there is no need to remove ChannelOperationsHandler from the pipeline.