### PR TITLE
Documentation fix for error: "neither SslContextBuilder nor SslContext is specified"

### DIFF
--- a/src/docs/asciidoc/http-server.adoc
+++ b/src/docs/asciidoc/http-server.adoc
@@ -550,11 +550,11 @@ import java.io.File;
 public class Application {
 
     public static void main(String[] args) {
+        File cert = new File("certificate.crt");
+        File key = new File("private.key");
         DisposableServer server =
                 HttpServer.create()
-                          .secure(spec ->
-                                  SslContextBuilder.forServer(new File("certificate.crt"),
-                                                              new File("private.key")))
+                          .secure(spec -> spec.sslContext(SslContextBuilder.forServer(cert,key)))
                           .bindNow();
 
         server.onDispose()


### PR DESCRIPTION
According to https://github.com/reactor/reactor-netty/issues/387#issuecomment-404280715