### PR TITLE
Deprecate NettyOutbound.options and NettyPipeline.SendOptions

### DIFF
--- a/src/main/java/reactor/netty/NettyOutbound.java
+++ b/src/main/java/reactor/netty/NettyOutbound.java
@@ -72,7 +72,9 @@ public interface NettyOutbound extends Publisher<Void> {
 	 * @param configurator the callback invoked to retrieve send configuration
 	 *
 	 * @return this {@link NettyOutbound}
+	 * @deprecated No need of a replacement
 	 */
+	@Deprecated
 	NettyOutbound options(Consumer<? super NettyPipeline.SendOptions> configurator);
 
 	/**

--- a/src/main/java/reactor/netty/NettyPipeline.java
+++ b/src/main/java/reactor/netty/NettyPipeline.java
@@ -73,7 +73,9 @@ public interface NettyPipeline {
 	/**
 	 * A builder for sending strategy, similar prefixed methods being mutually exclusive
 	 * (flushXxx, prefetchXxx, requestXxx).
+	 * @deprecated No need of a replacement
 	 */
+	@Deprecated
 	interface SendOptions {
 
 		/**


### PR DESCRIPTION
There is not need of a flush strategy as a result of the changes
in the write/flush operations implementation.