### PR TITLE
Enable ColocatedEventLoopGroup for the client

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -59,10 +59,7 @@ import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapterBuilder;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
-import io.netty.handler.ssl.JdkSslContext;
-import io.netty.handler.ssl.SslContext;
 import io.netty.util.AsciiString;
-import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import org.reactivestreams.Publisher;
@@ -133,17 +130,8 @@ final class HttpClientConnect extends HttpClient {
 
 				EventLoopGroup elg = loops.onClient(LoopResources.DEFAULT_NATIVE);
 
-				Integer maxConnections = (Integer) b.config().attrs().get(AttributeKey.valueOf("maxConnections"));
-
-				if (maxConnections != null && maxConnections != -1 && elg instanceof Supplier) {
-					EventLoopGroup delegate = (EventLoopGroup) ((Supplier) elg).get();
-					b.group(delegate)
-					 .channel(loops.onChannel(delegate));
-				}
-				else {
-					b.group(elg)
-					 .channel(loops.onChannel(elg));
-				}
+				b.group(elg)
+				 .channel(loops.onChannel(elg));
 			}
 
 			HttpClientConfiguration conf = HttpClientConfiguration.getAndClean(b);

--- a/src/main/java/reactor/netty/tcp/TcpClientConnect.java
+++ b/src/main/java/reactor/netty/tcp/TcpClientConnect.java
@@ -19,7 +19,6 @@ package reactor.netty.tcp;
 import java.util.Objects;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.util.AttributeKey;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.resources.ConnectionProvider;
@@ -32,23 +31,10 @@ final class TcpClientConnect extends TcpClient {
 
 	static final TcpClientConnect INSTANCE = new TcpClientConnect(ConnectionProvider.newConnection());
 
-	static final AttributeKey<Integer> MAX_CONNECTIONS = AttributeKey.newInstance("maxConnections");
-
 	final ConnectionProvider provider;
-	final int                maxConnections;
 
 	TcpClientConnect(ConnectionProvider provider) {
 		this.provider = Objects.requireNonNull(provider, "connectionProvider");
-		maxConnections = provider.maxConnections();
-	}
-
-	@Override
-	public Bootstrap configure() {
-		Bootstrap b = super.configure();
-		if (maxConnections != -1) {
-			b.attr(MAX_CONNECTIONS, maxConnections);
-		}
-		return b;
 	}
 
 	@Override
@@ -59,8 +45,7 @@ final class TcpClientConnect extends TcpClient {
 
 			TcpClientRunOn.configure(b,
 					LoopResources.DEFAULT_NATIVE,
-					TcpResources.get(),
-					maxConnections != -1);
+					TcpResources.get());
 		}
 
 		return provider.acquire(b);

--- a/src/main/java/reactor/netty/tcp/TcpClientRunOn.java
+++ b/src/main/java/reactor/netty/tcp/TcpClientRunOn.java
@@ -17,11 +17,9 @@
 package reactor.netty.tcp;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.EventLoopGroup;
-import io.netty.handler.ssl.JdkSslContext;
 import reactor.netty.resources.LoopResources;
 
 /**
@@ -41,27 +39,17 @@ final class TcpClientRunOn extends TcpClientOperator {
 	@Override
 	public Bootstrap configure() {
 		Bootstrap b = source.configure();
-		Integer maxConnections = (Integer) b.config().attrs().get(TcpClientConnect.MAX_CONNECTIONS);
 
-		configure(b, preferNative, loopResources, maxConnections != null && maxConnections != -1);
+		configure(b, preferNative, loopResources);
 
 		return b;
 	}
 
 	static void configure(Bootstrap b,
 			boolean preferNative,
-			LoopResources resources,
-			boolean useDelegate) {
+			LoopResources resources) {
 		EventLoopGroup elg = resources.onClient(preferNative);
 
-		if (useDelegate && elg instanceof Supplier) {
-			EventLoopGroup delegate = (EventLoopGroup) ((Supplier) elg).get();
-			b.group(delegate)
-			 .channel(resources.onChannel(delegate));
-		}
-		else {
-			b.group(elg)
-			 .channel(resources.onChannel(elg));
-		}
+		b.group(elg).channel(resources.onChannel(elg));
 	}
 }


### PR DESCRIPTION
Revert change 7393c610518fdfbbe15dca0e06a80656cd9b7d16.
It is not relevant anymore because of the switch to Reactor Pool.