### PR TITLE
fix #807 Safely call removeListener on MonoSendMany terminal signal

### DIFF
--- a/src/test/java/reactor/netty/channel/MonoSendManyTest.java
+++ b/src/test/java/reactor/netty/channel/MonoSendManyTest.java
@@ -15,10 +15,14 @@
  */
 package reactor.netty.channel;
 
+import java.lang.ref.WeakReference;
+
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.timeout.WriteTimeoutHandler;
 import org.junit.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -43,5 +47,140 @@ public class MonoSendManyTest {
 			            assertThat(channel.<String>readOutbound()).isEqualToIgnoringCase("test");
 		            })
 		            .verifyComplete();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void cleanupFuseableSyncCloseFuture() {
+		//use an extra handler
+		EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandlerAdapter() {});
+
+		Mono<Void> m = MonoSendMany.objectSource(Flux.fromArray(new String[]{"test", "test2"}), channel, false);
+
+		WeakReference[] _w = new WeakReference[1];
+		StepVerifier.create(m)
+		            .consumeSubscriptionWith(s -> {
+			            _w[0] = new WeakReference(s);
+		            })
+		            .then(() -> {
+			            channel.runPendingTasks();
+			            assertThat(channel.<String>readOutbound()).isEqualToIgnoringCase("test");
+			            assertThat(channel.<String>readOutbound()).isEqualToIgnoringCase("test2");
+		            })
+		            .verifyComplete();
+
+		System.gc();
+		wait(_w[0]);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void cleanupFuseableAsyncCloseFuture() {
+		//use an extra handler
+		EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandlerAdapter() {});
+
+		Mono<Void> m = MonoSendMany.objectSource(Flux.fromArray(new String[]{"test", "test2"}).limitRate(10), channel, false);
+
+		WeakReference[] _w = new WeakReference[1];
+		StepVerifier.create(m)
+		            .consumeSubscriptionWith(s -> {
+			            _w[0] = new WeakReference(s);
+		            })
+		            .then(() -> {
+			            channel.runPendingTasks();
+			            assertThat(channel.<String>readOutbound()).isEqualToIgnoringCase("test");
+			            assertThat(channel.<String>readOutbound()).isEqualToIgnoringCase("test2");
+		            })
+		            .verifyComplete();
+
+		System.gc();
+		wait(_w[0]);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void cleanupFuseableErrorCloseFuture() {
+		//use an extra handler
+		EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandlerAdapter() {});
+
+		Mono<Void> m = MonoSendMany.objectSource(Flux.fromArray(new String[]{"test", "test2"}).concatWith(Mono.error(new Exception("boo"))).limitRate(10), channel, false);
+
+		WeakReference[] _w = new WeakReference[1];
+		StepVerifier.create(m)
+		            .consumeSubscriptionWith(s -> {
+			            _w[0] = new WeakReference(s);
+		            })
+		            .then(() -> {
+			            channel.runPendingTasks();
+			            assertThat(channel.<String>readOutbound()).isEqualToIgnoringCase("test");
+			            assertThat(channel.<String>readOutbound()).isEqualToIgnoringCase("test2");
+		            })
+		            .verifyErrorMessage("boo");
+
+		System.gc();
+		wait(_w[0]);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void cleanupCancelCloseFuture() {
+		//use an extra handler
+		EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandlerAdapter() {});
+
+		Mono<Void> m = MonoSendMany.objectSource(Flux.fromArray(new String[]{"test", "test2"}).concatWith(Mono.never()), channel, false);
+
+		WeakReference[] _w = new WeakReference[1];
+		StepVerifier.create(m)
+		            .consumeSubscriptionWith(s -> {
+			            _w[0] = new WeakReference(s);
+		            })
+		            .then(() -> {
+			            channel.runPendingTasks();
+		            })
+		            .thenCancel()
+		            .verify();
+
+		System.gc();
+		wait(_w[0]);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void cleanupErrorCloseFuture() {
+		//use an extra handler
+		EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandlerAdapter() {});
+
+		Mono<Void> m = MonoSendMany.objectSource(Mono.error(new Exception("boo")), channel, false);
+
+		WeakReference[] _w = new WeakReference[1];
+		StepVerifier.create(m)
+		            .consumeSubscriptionWith(s -> {
+			            _w[0] = new WeakReference(s);
+		            })
+		            .then(() -> {
+			            channel.runPendingTasks();
+		            })
+		            .verifyErrorMessage("boo");
+
+		System.gc();
+		wait(_w[0]);
+	}
+
+	static void wait(WeakReference<?> ref){
+		int duration = 5_000;
+		int spins = duration / 100;
+		int i = 0;
+		while(ref.get() != null && i < spins) {
+			try {
+				Thread.sleep(100);
+				i++;
+			}
+			catch (Throwable e) {
+				throw Exceptions.propagate(e);
+			}
+		}
+		if (ref.get() != null) {
+			throw new IllegalStateException("Has not cleaned");
+		}
 	}
 }


### PR DESCRIPTION
This commit also makes sure producer errors are serialized after queue drain