### PR TITLE
fix #825 Close the connection when the compression predicate throws RuntimeException

### DIFF
--- a/src/main/java/reactor/netty/FutureMono.java
+++ b/src/main/java/reactor/netty/FutureMono.java
@@ -161,7 +161,14 @@ public abstract class FutureMono extends Mono<Void> {
 		@Override
 		@SuppressWarnings("FutureReturnValueIgnored")
 		public void subscribe(CoreSubscriber<? super Void> s) {
-			F f = deferredFuture.get();
+			F f;
+			try {
+				f = deferredFuture.get();
+			}
+			catch(Throwable t) {
+				Operators.error(s, t);
+				return;
+			}
 
 			if (f == null) {
 				Operators.error(s,

--- a/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
@@ -118,6 +118,9 @@ final class ChannelOperationsHandler extends ChannelInboundHandlerAdapter {
 		}
 		catch (Throwable err) {
 			ReferenceCountUtil.safeRelease(msg);
+			log.error(format(ctx.channel(), "Error was received while reading the incoming data." +
+					" The connection will be closed."), err);
+			ctx.close();
 			exceptionCaught(ctx, err);
 		}
 	}

--- a/src/main/java/reactor/netty/channel/FluxReceive.java
+++ b/src/main/java/reactor/netty/channel/FluxReceive.java
@@ -206,7 +206,14 @@ final class FluxReceive extends Flux<Object> implements Subscription, Disposable
 					a.onNext(v);
 				}
 				finally {
-					ReferenceCountUtil.release(v);
+					try {
+						ReferenceCountUtil.release(v);
+					}
+					catch(Throwable t) {
+						inboundError = t;
+						cleanQueue(q);
+						terminateReceiver(q, a);
+					}
 				}
 
 				e++;


### PR DESCRIPTION
Close the connection when the follow redirect predicate throws RuntimeException
Close the connection when trying to release the ByteBuf in FluxReceive#drainReceiver.