### PR TITLE
fix #850 Specify fire-and-forget dispose() behaviour for LoopResources, ConnectionProvider

### DIFF
--- a/src/main/java/reactor/netty/http/HttpResources.java
+++ b/src/main/java/reactor/netty/http/HttpResources.java
@@ -72,6 +72,10 @@ public final class HttpResources extends TcpResources {
 	/**
 	 * Shutdown the global {@link HttpResources} without resetting them,
 	 * effectively cleaning up associated resources without creating new ones.
+	 * This method is NOT blocking. It is implemented as fire-and-forget.
+	 * Use {@link #disposeLoopsAndConnectionsLater()} when you need to observe
+	 * the final status of the operation, combined with {@link Mono#block()}
+	 * if you need to synchronously wait for the underlying resources to be disposed.
 	 */
 	public static void disposeLoopsAndConnections() {
 		HttpResources resources = httpResources.getAndSet(null);

--- a/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -212,6 +212,13 @@ public interface ConnectionProvider extends Disposable {
 	default void disposeWhen(@NonNull SocketAddress address) {
 	}
 
+	/**
+	 * Dispose this ConnectionProvider.
+	 * This method is NOT blocking. It is implemented as fire-and-forget.
+	 * Use {@link #disposeLater()} when you need to observe the final
+	 * status of the operation, combined with {@link Mono#block()}
+	 * if you need to synchronously wait for the underlying resources to be disposed.
+	 */
 	@Override
 	default void dispose() {
 		//noop default
@@ -219,12 +226,13 @@ public interface ConnectionProvider extends Disposable {
 	}
 
 	/**
-	 * Returns a Mono that triggers the disposal of underlying resources when subscribed to.
+	 * Returns a Mono that triggers the disposal of the ConnectionProvider when subscribed to.
 	 *
-	 * @return a Mono representing the completion of resources disposal.
+	 * @return a Mono representing the completion of the ConnectionProvider disposal.
 	 **/
 	default Mono<Void> disposeLater() {
-		return Mono.empty(); //noop default
+		//noop default
+		return Mono.empty();
 	}
 
 	/**

--- a/src/main/java/reactor/netty/resources/LoopResources.java
+++ b/src/main/java/reactor/netty/resources/LoopResources.java
@@ -225,6 +225,13 @@ public interface LoopResources extends Disposable {
 		return false;
 	}
 
+	/**
+	 * Dispose the underlying LoopResources.
+	 * This method is NOT blocking. It is implemented as fire-and-forget.
+	 * Use {@link #disposeLater()} when you need to observe the final
+	 * status of the operation, combined with {@link Mono#block()}
+	 * if you need to synchronously wait for the underlying resources to be disposed.
+	 */
 	@Override
 	default void dispose() {
 		//noop default
@@ -232,11 +239,12 @@ public interface LoopResources extends Disposable {
 	}
 
 	/**
-	 * Returns a Mono that triggers the disposal of underlying resources when subscribed to.
+	 * Returns a Mono that triggers the disposal of the underlying LoopResources when subscribed to.
 	 *
-	 * @return a Mono representing the completion of resources disposal.
+	 * @return a Mono representing the completion of the LoopResources disposal.
 	 **/
 	default Mono<Void> disposeLater() {
-		return Mono.empty(); //noop default
+		//noop default
+		return Mono.empty();
 	}
 }

--- a/src/main/java/reactor/netty/tcp/TcpResources.java
+++ b/src/main/java/reactor/netty/tcp/TcpResources.java
@@ -82,6 +82,10 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 	/**
 	 * Shutdown the global {@link TcpResources} without resetting them,
 	 * effectively cleaning up associated resources without creating new ones.
+	 * This method is NOT blocking. It is implemented as fire-and-forget.
+	 * Use {@link #disposeLoopsAndConnectionsLater()} when you need to observe
+	 * the final status of the operation, combined with {@link Mono#block()}
+	 * if you need to synchronously wait for the underlying resources to be disposed.
 	 */
 	public static void disposeLoopsAndConnections() {
 		TcpResources resources = tcpResources.getAndSet(null);
@@ -116,14 +120,21 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 		this.defaultProvider = defaultProvider;
 	}
 
+	/**
+	 * Use {@link #disposeLoopsAndConnections()}
+	 */
 	@Override
 	public void dispose() {
 		//noop on global by default
 	}
 
+	/**
+	 * Use {@link #disposeLoopsAndConnectionsLater()}
+	 */
 	@Override
 	public Mono<Void> disposeLater() {
-		return Mono.empty(); //noop on global by default
+		//noop on global by default
+		return Mono.empty();
 	}
 
 	/**

--- a/src/main/java/reactor/netty/udp/UdpResources.java
+++ b/src/main/java/reactor/netty/udp/UdpResources.java
@@ -70,6 +70,10 @@ public class UdpResources implements LoopResources {
 	/**
 	 * Shutdown the global {@link UdpResources} without resetting them,
 	 * effectively cleaning up associated resources without creating new ones.
+	 * This method is NOT blocking. It is implemented as fire-and-forget.
+	 * Use {@link #shutdownLater()} when you need to observe the final
+	 * status of the operation, combined with {@link Mono#block()}
+	 * if you need to synchronously wait for the underlying resources to be disposed.
 	 */
 	public static void shutdown() {
 		UdpResources resources = udpResources.getAndSet(null);
@@ -99,16 +103,6 @@ public class UdpResources implements LoopResources {
 
 	protected UdpResources(LoopResources defaultLoops) {
 		this.defaultLoops = defaultLoops;
-	}
-
-	@Override
-	public void dispose() {
-		//noop on global by default
-	}
-
-	@Override
-	public Mono<Void> disposeLater() {
-		return Mono.empty(); //noop on global by default
 	}
 
 	/**


### PR DESCRIPTION
Specify fire-and-forget disposeLoopsAndConnections() behaviour for
TcpResources, HttpResources
Specify fire-and-forget shutdown() behaviour for UdpResources