### PR TITLE
HAProxyMessage should be released to avoid memory leak.

### DIFF
--- a/src/main/java/reactor/netty/http/server/ConnectionInfo.java
+++ b/src/main/java/reactor/netty/http/server/ConnectionInfo.java
@@ -168,7 +168,7 @@ final class ConnectionInfo {
 	private static InetSocketAddress getRemoteAddress(SocketChannel channel) {
 		if (HAProxyMessageReader.hasProxyProtocol()) {
 			InetSocketAddress remoteAddressFromProxyProtocol =
-					channel.attr(REMOTE_ADDRESS_FROM_PROXY_PROTOCOL).getAndSet(null);
+					channel.attr(REMOTE_ADDRESS_FROM_PROXY_PROTOCOL).get();
 
 			if (remoteAddressFromProxyProtocol != null) {
 				return remoteAddressFromProxyProtocol;

--- a/src/main/java/reactor/netty/http/server/HAProxyMessageReader.java
+++ b/src/main/java/reactor/netty/http/server/HAProxyMessageReader.java
@@ -60,6 +60,8 @@ final class HAProxyMessageReader extends ChannelInboundHandlerAdapter {
 				   .set(remoteAddress);
 			}
 
+			proxyMessage.release();
+
 			ctx.channel()
 			   .pipeline()
 			   .remove(this);

--- a/src/main/java/reactor/netty/http/server/Http2StreamBridgeHandler.java
+++ b/src/main/java/reactor/netty/http/server/Http2StreamBridgeHandler.java
@@ -15,10 +15,14 @@
  */
 package reactor.netty.http.server;
 
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
@@ -39,6 +43,7 @@ final class Http2StreamBridgeHandler extends ChannelDuplexHandler {
 
 	final boolean            readForwardHeaders;
 	Boolean                  secured;
+	InetSocketAddress        remoteAddress;
 	final ConnectionObserver listener;
 	final ServerCookieEncoder cookieEncoder;
 	final ServerCookieDecoder cookieDecoder;
@@ -66,6 +71,11 @@ final class Http2StreamBridgeHandler extends ChannelDuplexHandler {
 		if (secured == null) {
 			secured = ctx.channel().pipeline().get(SslHandler.class) != null;
 		}
+		if (remoteAddress == null) {
+			remoteAddress =
+					Optional.ofNullable(HAProxyMessageReader.resolveRemoteAddressFromProxyProtocol(ctx.channel()))
+							.orElse(((SocketChannel) ctx.channel()).remoteAddress());
+		}
 		if (msg instanceof Http2HeadersFrame) {
 			Http2HeadersFrame headersFrame = (Http2HeadersFrame)msg;
 			HttpRequest request;
@@ -88,7 +98,8 @@ final class Http2StreamBridgeHandler extends ChannelDuplexHandler {
 					                       .parent(),
 							readForwardHeaders,
 							request,
-							secured),
+							secured,
+							remoteAddress),
 					cookieEncoder, cookieDecoder);
 			ops.bind();
 			listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED);

--- a/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -193,6 +193,22 @@ public class ConnectionInfoTests {
 		          });
 
 		assertThat(resultQueue.poll(5, TimeUnit.SECONDS)).isEqualTo(remoteAddress);
+
+		//send a http request again to confirm that removeAddress is not changed.
+		ByteBuf httpMsg = clientConn.channel()
+				.alloc()
+				.buffer();
+		httpMsg.writeCharSequence("GET /test HTTP/1.1\r\nHost: a.example.com\r\n\r\n",
+				Charset.defaultCharset());
+		clientConn.channel()
+				.writeAndFlush(httpMsg)
+				.addListener(f -> {
+					if (!f.isSuccess()) {
+						fail("Writing proxyProtocolMsg was not successful");
+					}
+				});
+
+		assertThat(resultQueue.poll(5, TimeUnit.SECONDS)).isEqualTo(remoteAddress);
 	}
 
 	@Test


### PR DESCRIPTION
HAProxyMessage is sub class of `ReferenceCounted`, so it should be released to avoid memory leak.

And `REMOTE_ADDRESS_FROM_PROXY_PROTOCOL` attribute should not be removed from  channel, or else the second http request and the subsequent requests in the same connection will lose the removeAddress info.