### PR TITLE
Add proxy protocol auto detect feature.

### DIFF
--- a/src/main/java/reactor/netty/http/server/HAProxyMessageDetector.java
+++ b/src/main/java/reactor/netty/http/server/HAProxyMessageDetector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package reactor.netty.http.server;
 
 import java.util.List;

--- a/src/main/java/reactor/netty/http/server/HAProxyMessageDetector.java
+++ b/src/main/java/reactor/netty/http/server/HAProxyMessageDetector.java
@@ -1,0 +1,38 @@
+package reactor.netty.http.server;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.ProtocolDetectionResult;
+import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
+import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
+import reactor.netty.NettyPipeline;
+
+/**
+ * Auto detect whether the first packet of a channel is proxy protocol,
+ * if so, replace current handler with a `HAProxyMessageDecoder`,
+ * so each channel in the same `HttpServer` instance can choose to support
+ * proxy protocol or not at runtime.
+ *
+ * @author aftersss
+ */
+final class HAProxyMessageDetector extends ByteToMessageDecoder {
+
+	@Override
+	protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+		ProtocolDetectionResult<HAProxyProtocolVersion> detectionResult = HAProxyMessageDecoder.detectProtocol(in);
+		if (detectionResult.equals(ProtocolDetectionResult.needsMoreData())) {
+			return;
+		} else if(detectionResult.equals(ProtocolDetectionResult.invalid())) {
+			ctx.pipeline().remove(this);
+		} else {
+			ctx.pipeline()
+					.addAfter(NettyPipeline.ProxyProtocolDecoder,
+							NettyPipeline.ProxyProtocolReader, new HAProxyMessageReader());
+			ctx.pipeline().replace(this, NettyPipeline.ProxyProtocolDecoder, new HAProxyMessageDecoder());
+		}
+	}
+
+}

--- a/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -263,10 +263,17 @@ public abstract class HttpServer {
 	 *
 	 * @param proxyProtocolSupportType
 	 * 		<ul>
-	 *         <li>choose {@link ProxyProtocolSupportType#ON} to enable support for the {@code "HAProxy proxy protocol"}
-	 *             for deriving information about the address of the remote peer.</li>
+	 *         <li>
+     *             choose {@link ProxyProtocolSupportType#ON}
+     *             to enable support for the {@code "HAProxy proxy protocol"}
+	 *             for deriving information about the address of the remote peer.
+     *         </li>
 	 *         <li>choose {@link ProxyProtocolSupportType#OFF} to disable the proxy protocol support.</li>
-	 *         <li>choose {@link ProxyProtocolSupportType#AUTO} then each connection of the same `HttpServer` will auto detect whether there is proxy protocol, so HttpServer can accept requests with or without proxy protocol.</li>
+	 *         <li>
+     *             choose {@link ProxyProtocolSupportType#AUTO}
+     *             then each connection of the same `HttpServer` will auto detect whether there is proxy protocol,
+     *             so HttpServer can accept requests with or without proxy protocol at the same time.
+     *         </li>
 	 *      </ul>
 	 *
 	 * @return a new {@link HttpServer}

--- a/src/main/java/reactor/netty/http/server/ProxyProtocolSupportType.java
+++ b/src/main/java/reactor/netty/http/server/ProxyProtocolSupportType.java
@@ -1,0 +1,26 @@
+package reactor.netty.http.server;
+
+/**
+ * Proxy protocol support type, this enum class defines how the HttpServer handles proxy protocol.
+ *
+ * @author aftersss
+ */
+public enum ProxyProtocolSupportType {
+    /**
+     * Each connection of the same `HttpServer` will auto detect whether there is proxy protocol.
+     * The HttpServer can support multiple clients(or reverse proxy server like HaProxy)
+     * with and without proxy protocol enabled at the same time.
+     */
+    AUTO,
+
+    /**
+     * Enable support for the {@code "HAProxy proxy protocol"}
+     * for deriving information about the address of the remote peer.
+     */
+    ON,
+
+    /**
+     * Disable the proxy protocol support
+     */
+    OFF
+}

--- a/src/main/java/reactor/netty/http/server/ProxyProtocolSupportType.java
+++ b/src/main/java/reactor/netty/http/server/ProxyProtocolSupportType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package reactor.netty.http.server;
 
 /**

--- a/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -145,7 +145,7 @@ public class ConnectionInfoTests {
 	}
 
 	@Test
-	public void proxyProtocol() throws InterruptedException {
+	public void proxyProtocolOn() throws InterruptedException {
 		String remoteAddress = "202.112.144.236";
 		ArrayBlockingQueue<String> resultQueue = new ArrayBlockingQueue<>(1);
 
@@ -209,6 +209,81 @@ public class ConnectionInfoTests {
 		          });
 
 		assertThat(resultQueue.poll(5, TimeUnit.SECONDS)).isEqualTo(remoteAddress);
+	}
+
+	@Test
+	public void proxyProtocolAuto() throws InterruptedException {
+		String remoteAddress = "202.112.144.236";
+		ArrayBlockingQueue<String> resultQueue = new ArrayBlockingQueue<>(1);
+
+		Consumer<HttpServerRequest> requestConsumer = serverRequest -> {
+			String remoteAddrFromRequest = serverRequest.remoteAddress().getHostString();
+			resultQueue.add(remoteAddrFromRequest);
+		};
+
+		this.connection =
+				HttpServer.create()
+						.port(0)
+						.proxyProtocol(ProxyProtocolSupportType.AUTO)
+						.handle((req, res) -> {
+							try {
+								requestConsumer.accept(req);
+								return res.status(200)
+										.sendString(Mono.just("OK"));
+							}
+							catch (Throwable e) {
+								return res.status(500)
+										.sendString(Mono.just(e.getMessage()));
+							}
+						})
+						.wiretap(true)
+						.bindNow();
+
+		Connection clientConn =
+				TcpClient.create()
+						.port(this.connection.port())
+						.connectNow();
+
+		ByteBuf proxyProtocolMsg = clientConn.channel()
+				.alloc()
+				.buffer();
+		proxyProtocolMsg.writeCharSequence("PROXY TCP4 " + remoteAddress + " 10.210.12.10 5678 80\r\n",
+				Charset.defaultCharset());
+		proxyProtocolMsg.writeCharSequence("GET /test HTTP/1.1\r\nHost: a.example.com\r\n\r\n",
+				Charset.defaultCharset());
+		clientConn.channel()
+				.writeAndFlush(proxyProtocolMsg)
+				.addListener(f -> {
+					if (!f.isSuccess()) {
+						fail("Writing proxyProtocolMsg was not successful");
+					}
+				});
+
+		assertThat(resultQueue.poll(5, TimeUnit.SECONDS)).isEqualTo(remoteAddress);
+
+		clientConn.disposeNow();
+
+		clientConn =
+				TcpClient.create()
+						.port(this.connection.port())
+						.connectNow();
+
+		//Send a http request without proxy protocol in a new connection, server should support this when proxyProtocol is set to ProxyProtocolSupportType.AUTO
+		ByteBuf httpMsg = clientConn.channel()
+				.alloc()
+				.buffer();
+		httpMsg.writeCharSequence("GET /test HTTP/1.1\r\nHost: a.example.com\r\n\r\n",
+				Charset.defaultCharset());
+		clientConn.channel()
+				.writeAndFlush(httpMsg)
+				.addListener(f -> {
+					if (!f.isSuccess()) {
+						fail("Writing proxyProtocolMsg was not successful");
+					}
+				});
+
+		assertThat(resultQueue.poll(5, TimeUnit.SECONDS))
+				.containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
 	}
 
 	@Test


### PR DESCRIPTION
We are using the following architecture: 
```
User's Http Request -> HaProxy(with proxy protocol enabled) -> spring-cloud-gateway -> realServer.
```

We configured the spring-cloud-gateway to enable proxy protocol support, but this bring us a new problem: it is hard to check if `spring-cloud-gateway` is alive,  most http health check tools does not support proxy protocol, so if `spring-cloud-gateway` can support proxy-protocol-enabled/proxy-protocol-disabled requests at the same time, it should be better.

So I create this PR to support proxy-protocol `AUTO` mode, this mode can auto detect whether the client(or reverse proxy server) has enabled proxy protocol, so the `HttpServer` can support proxy-protocol-enabled and proxy-protocol-disabled clients at the same time.

The proxy-protocol auto detect feature should also be convenient for this case: maybe in production environment `spring-cloud-gateway` runs behind HaProxy Server, but in development environment `spring-cloud-gateway` need to be accessed directly, users can set proxy-protocol to `AUTO` mode, and won't worry about the environment any more.