### PR TITLE
resolve the errorprone warning.

### DIFF
--- a/src/main/java/reactor/netty/ReactorNetty.java
+++ b/src/main/java/reactor/netty/ReactorNetty.java
@@ -794,6 +794,6 @@ public final class ReactorNetty {
 
 	static final ByteBuf                   BOUNDARY              = Unpooled.EMPTY_BUFFER;
 
-	public static final Predicate<ByteBuf> PREDICATE_GROUP_FLUSH = BOUNDARY::equals;
+	public static final Predicate<ByteBuf> PREDICATE_GROUP_FLUSH = b -> b == BOUNDARY;
 
 }

--- a/src/main/java/reactor/netty/ReactorNetty.java
+++ b/src/main/java/reactor/netty/ReactorNetty.java
@@ -794,6 +794,8 @@ public final class ReactorNetty {
 
 	static final ByteBuf                   BOUNDARY              = Unpooled.EMPTY_BUFFER;
 
+	@SuppressWarnings("ReferenceEquality")
+	//Desigin to use reference comparison here
 	public static final Predicate<ByteBuf> PREDICATE_GROUP_FLUSH = b -> b == BOUNDARY;
 
 }

--- a/src/main/java/reactor/netty/ReactorNetty.java
+++ b/src/main/java/reactor/netty/ReactorNetty.java
@@ -794,6 +794,6 @@ public final class ReactorNetty {
 
 	static final ByteBuf                   BOUNDARY              = Unpooled.EMPTY_BUFFER;
 
-	public static final Predicate<ByteBuf> PREDICATE_GROUP_FLUSH = b -> b == BOUNDARY;
+	public static final Predicate<ByteBuf> PREDICATE_GROUP_FLUSH = BOUNDARY::equals;
 
 }

--- a/src/main/java/reactor/netty/channel/BootstrapHandlers.java
+++ b/src/main/java/reactor/netty/channel/BootstrapHandlers.java
@@ -614,6 +614,7 @@ public abstract class BootstrapHandlers {
 					"BootstrapHandlers.finalizeHandler() call");
 		}
 
+		@SuppressWarnings("deprecation")
 		@Override
 		public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
 			throw Exceptions.propagate(cause);

--- a/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
@@ -100,7 +100,7 @@ final class ChannelOperationsHandler extends ChannelInboundHandlerAdapter {
 						}
 					}
 					String loggingMsg;
-					if (msg instanceof ByteBufHolder && ((ByteBufHolder)msg).content() != Unpooled.EMPTY_BUFFER) {
+					if (msg instanceof ByteBufHolder && !Unpooled.EMPTY_BUFFER.equals(((ByteBufHolder) msg).content())) {
 						ByteBuf buffer = ((ByteBufHolder) msg).content();
 						loggingMsg = "\n"+ByteBufUtil.prettyHexDump(buffer);
 					}

--- a/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
@@ -32,6 +32,8 @@ import reactor.netty.NettyOutbound;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
+import java.util.Objects;
+
 import static reactor.netty.ReactorNetty.format;
 
 /**
@@ -100,7 +102,7 @@ final class ChannelOperationsHandler extends ChannelInboundHandlerAdapter {
 						}
 					}
 					String loggingMsg;
-					if (msg instanceof ByteBufHolder && !Unpooled.EMPTY_BUFFER.equals(((ByteBufHolder) msg).content())) {
+					if (msg instanceof ByteBufHolder && !Objects.equals(Unpooled.EMPTY_BUFFER,((ByteBufHolder) msg).content())) {
 						ByteBuf buffer = ((ByteBufHolder) msg).content();
 						loggingMsg = "\n"+ByteBufUtil.prettyHexDump(buffer);
 					}

--- a/src/main/java/reactor/netty/channel/MonoSendMany.java
+++ b/src/main/java/reactor/netty/channel/MonoSendMany.java
@@ -609,7 +609,6 @@ final class MonoSendMany<I, O> extends MonoSend<I, O> implements Scannable {
 		}
 
 		@Override
-		@SuppressWarnings("rawtypes")
 		public Void get(long timeout, TimeUnit unit) {
 			throw new UnsupportedOperationException();
 		}

--- a/src/main/java/reactor/netty/channel/MonoSendMany.java
+++ b/src/main/java/reactor/netty/channel/MonoSendMany.java
@@ -83,6 +83,7 @@ final class MonoSendMany<I, O> extends MonoSend<I, O> implements Scannable {
 
 	@Override
 	@Nullable
+	@SuppressWarnings("rawtypes")
 	public Object scanUnsafe(Attr key) {
 		if (key == Attr.PREFETCH) return MAX_SIZE;
 		if (key == Attr.PARENT) return source;
@@ -388,6 +389,7 @@ final class MonoSendMany<I, O> extends MonoSend<I, O> implements Scannable {
 		}
 
 		@Override
+		@SuppressWarnings("rawtypes")
 		public Object scanUnsafe(Attr key) {
 			if (key == Attr.PARENT) return s;
 			if (key == Attr.ACTUAL) return actual;
@@ -437,6 +439,7 @@ final class MonoSendMany<I, O> extends MonoSend<I, O> implements Scannable {
 			throw new UnsupportedOperationException();
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
 		public ChannelPromise addListeners(GenericFutureListener<? extends Future<? super Void>>... listeners) {
 			throw new UnsupportedOperationException();
@@ -447,6 +450,7 @@ final class MonoSendMany<I, O> extends MonoSend<I, O> implements Scannable {
 			return this;
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
 		public ChannelPromise removeListeners(GenericFutureListener<? extends Future<? super Void>>... listeners) {
 			return this;
@@ -605,12 +609,15 @@ final class MonoSendMany<I, O> extends MonoSend<I, O> implements Scannable {
 		}
 
 		@Override
+		@SuppressWarnings("rawtypes")
 		public Void get(long timeout, TimeUnit unit) {
 			throw new UnsupportedOperationException();
 		}
 
+		@SuppressWarnings("rawtypes")
 		static final AtomicIntegerFieldUpdater<SendManyInner>                 WIP          =
 				AtomicIntegerFieldUpdater.newUpdater(SendManyInner.class, "wip");
+		@SuppressWarnings("rawtypes")
 		static final AtomicReferenceFieldUpdater<SendManyInner, Subscription> SUBSCRIPTION =
 				AtomicReferenceFieldUpdater.newUpdater(SendManyInner.class, Subscription.class, "s");
 

--- a/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/src/main/java/reactor/netty/http/HttpOperations.java
@@ -267,6 +267,7 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 	 */
 	protected abstract HttpMessage outboundHttpMessage();
 
+	@SuppressWarnings("rawtypes")
 	final static AtomicIntegerFieldUpdater<HttpOperations> HTTP_STATE =
 			AtomicIntegerFieldUpdater.newUpdater(HttpOperations.class,
 					"statusAndHeadersSent");

--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -624,7 +624,7 @@ final class HttpClientConnect extends HttpClient {
 			this.redirectedFrom = addToRedirectedFromArray(redirectedFrom, from);
 		}
 
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({"unchecked","rawtypes"})
 		static Supplier<String>[] addToRedirectedFromArray(@Nullable Supplier<String>[] redirectedFrom,
 				UriEndpoint from) {
 			Supplier<String> fromUrlSupplier = from::toExternalForm;
@@ -955,6 +955,7 @@ final class HttpClientConnect extends HttpClient {
 
 	}
 
+	@SuppressWarnings("rawtypes")
 	static void openStream(Channel ch, ConnectionObserver listener,
 			HttpClientInitializer initializer) {
 		Http2StreamChannelBootstrap http2StreamChannelBootstrap =

--- a/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -769,7 +769,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 	}
 
 	static final int                    MAX_REDIRECTS      = 50;
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked","rawtypes"})
 	static final Supplier<String>[]     EMPTY_REDIRECTIONS = (Supplier<String>[])new Supplier[0];
 	static final Logger                 log                = Loggers.getLogger(HttpClientOperations.class);
 }

--- a/src/main/java/reactor/netty/http/server/ConnectionInfo.java
+++ b/src/main/java/reactor/netty/http/server/ConnectionInfo.java
@@ -102,7 +102,7 @@ final class ConnectionInfo {
 		InetSocketAddress hostAddress = channel.localAddress();
 		String scheme = secured ? "https" : "http";
 
-		String forwarded = request.headers().get(FORWARDED_HEADER).split(",")[0];
+		String forwarded = request.headers().get(FORWARDED_HEADER).split(",",2)[0];
 		Matcher hostMatcher = FORWARDED_HOST_PATTERN.matcher(forwarded);
 		if (hostMatcher.find()) {
 			hostAddress = parseAddress(hostMatcher.group(1), hostAddress.getPort());
@@ -141,18 +141,18 @@ final class ConnectionInfo {
 		InetSocketAddress hostAddress = channel.localAddress();
 		String scheme =  secured ? "https" : "http";
 		if (request.headers().contains(XFORWARDED_IP_HEADER)) {
-			String remoteIpValue = request.headers().get(XFORWARDED_IP_HEADER).split(",")[0];
+			String remoteIpValue = request.headers().get(XFORWARDED_IP_HEADER).split(",",2)[0];
 			remoteAddress = parseAddress(remoteIpValue, remoteAddress.getPort());
 		}
 		if(request.headers().contains(XFORWARDED_HOST_HEADER)) {
 			if(request.headers().contains(XFORWARDED_PORT_HEADER)) {
 				hostAddress = InetSocketAddressUtil.createUnresolved(
-						request.headers().get(XFORWARDED_HOST_HEADER).split(",")[0].trim(),
-						Integer.parseInt(request.headers().get(XFORWARDED_PORT_HEADER).split(",")[0].trim()));
+						request.headers().get(XFORWARDED_HOST_HEADER).split(",",2)[0].trim(),
+						Integer.parseInt(request.headers().get(XFORWARDED_PORT_HEADER).split(",",2)[0].trim()));
 			}
 			else {
 				hostAddress = InetSocketAddressUtil.createUnresolved(
-						request.headers().get(XFORWARDED_HOST_HEADER).split(",")[0].trim(),
+						request.headers().get(XFORWARDED_HOST_HEADER).split(",",2)[0].trim(),
 						channel.localAddress().getPort());
 			}
 		}

--- a/src/main/java/reactor/netty/http/server/HttpServerMetricsHandler.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerMetricsHandler.java
@@ -73,7 +73,7 @@ final class HttpServerMetricsHandler extends ChannelDuplexHandler {
 
 		if (msg instanceof LastHttpContent) {
 			promise.addListener(future -> {
-				ChannelOperations channelOps = ChannelOperations.get(ctx.channel());
+				ChannelOperations<?,?> channelOps = ChannelOperations.get(ctx.channel());
 				if (channelOps instanceof HttpServerOperations) {
 					HttpServerOperations ops = (HttpServerOperations) channelOps;
 					recorder.recordDataSentTime(

--- a/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -290,6 +290,7 @@ final class PooledConnectionProvider implements ConnectionProvider {
 			public void handlerRemoved(ChannelHandlerContext ctx) {
 			}
 
+			@SuppressWarnings("deprecation")
 			@Override
 			public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
 				ctx.pipeline().remove(this);

--- a/src/main/java/reactor/netty/tcp/TcpServerBind.java
+++ b/src/main/java/reactor/netty/tcp/TcpServerBind.java
@@ -200,6 +200,7 @@ final class TcpServerBind extends TcpServer {
 			this.childObs = childObs;
 		}
 
+		@SuppressWarnings("rawtypes")
 		@Override
 		public void onUncaughtException(Connection connection, Throwable error) {
 			ChannelOperations ops = ChannelOperations.get(connection.channel());

--- a/src/main/java/reactor/netty/tcp/TcpServerBind.java
+++ b/src/main/java/reactor/netty/tcp/TcpServerBind.java
@@ -200,10 +200,9 @@ final class TcpServerBind extends TcpServer {
 			this.childObs = childObs;
 		}
 
-		@SuppressWarnings("rawtypes")
 		@Override
 		public void onUncaughtException(Connection connection, Throwable error) {
-			ChannelOperations ops = ChannelOperations.get(connection.channel());
+			ChannelOperations<?, ?> ops = ChannelOperations.get(connection.channel());
 			if (ops == null && (error instanceof IOException || AbortedException.isConnectionReset(error))) {
 				if (log.isDebugEnabled()) {
 					log.debug(format(connection.channel(), "onUncaughtException(" + connection + ")"), error);


### PR DESCRIPTION
Resolve some of the errorprone warning, including `ReferenceEquality`, `StringSplitter`, and suppress the `unchecked `, `rawtype `and `deprecation `warning.
There are still two type of warning unresolved, including `FunctionalInerfaceMethodChanged` and `FutureReturnValueIgnored`.Should I suppress them or resolve them?