### PR TITLE
Pin Micrometer optional dep to 1.3.0 rather than latest.release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ ext {
   blockHoundVersion = "1.0.0.RC1"
 
   //Metrics
-  micrometerVersion = 'latest.release'
+  micrometerVersion = '1.3.0' //optional baseline: technically could work with 1.2.x, should work with any 1.3.x
 
   // Logging
   slf4jVersion = '1.7.12'


### PR DESCRIPTION
Micrometer is an optional dependency, meaning that the exported version is only informative.
reactor-netty could technically work with any 1.2.x version, but support has ended.

NB: reactor-core will soon pin to 1.3.x as well, which is the LTS version, so one more reason to align on 1.3.0.