### PR TITLE
Fixed memory leak in ByteBufFlux#aggregate

### DIFF
--- a/src/main/java/reactor/netty/ByteBufFlux.java
+++ b/src/main/java/reactor/netty/ByteBufFlux.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.IllegalReferenceCountException;
 import org.reactivestreams.Publisher;
@@ -259,23 +260,36 @@ public class ByteBufFlux extends FluxOperator<ByteBuf, ByteBuf> {
 	 * @return {@link ByteBufMono} of aggregated {@link ByteBuf}
 	 */
 	public final ByteBufMono aggregate() {
-		return Mono.using(alloc::compositeBuffer,
-				b -> this.reduce(b,
-				                 (prev, next) -> {
-				                     if (prev.refCnt() > 0) {
-				                         return prev.addComponent(true, next.retain());
-				                     }
-				                     else {
-				                         return prev;
-				                     }
-				                 })
-				         .filter(ByteBuf::isReadable),
-				b -> {
-				    if (b.refCnt() > 0) {
-				        b.release();
-				    }
-				})
-				.as(ByteBufMono::maybeFuse);
+		return Mono.defer(() -> {
+		               CompositeByteBuf output = alloc.compositeBuffer();
+		               return doOnNext(ByteBuf::retain)
+		                       .collectList()
+		                       .doOnDiscard(ByteBuf.class, ByteBuf::release)
+		                       .handle((list, sink) -> {
+		                           if (!list.isEmpty()) {
+		                               for (ByteBuf component : list) {
+		                                   if (component.isReadable()) {
+		                                       output.addComponent(true, component);
+		                                   }
+		                                   else {
+		                                       component.release();
+		                                   }
+		                               }
+		                           }
+		                           if (output.isReadable()) {
+		                               sink.next(output);
+		                           }
+		                           else {
+		                               sink.complete();
+		                           }
+		                       })
+		                       .doFinally(signalType -> {
+		                           if (output.refCnt() > 0) {
+		                               output.release();
+		                           }
+		                       });
+		               })
+		           .as(ByteBufMono::maybeFuse);
 	}
 
 	/**

--- a/src/main/java/reactor/netty/channel/FluxReceive.java
+++ b/src/main/java/reactor/netty/channel/FluxReceive.java
@@ -86,7 +86,12 @@ final class FluxReceive extends Flux<Object> implements Subscription, Disposable
 	@Override
 	public void cancel() {
 		cancelReceiver();
-		drainReceiver();
+		if (eventLoop.inEventLoop()) {
+			drainReceiver();
+		}
+		else {
+			eventLoop.execute(this::drainReceiver);
+		}
 	}
 
 	final long getPending() {

--- a/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -1523,8 +1523,7 @@ public class HttpClientTest {
 	}
 
 	@Test
-	@Ignore
-	public void testIssue700() {
+	public void testIssue700AndIssue876() {
 		DisposableServer server =
 				HttpServer.create()
 				          .port(0)
@@ -1536,7 +1535,7 @@ public class HttpClientTest {
 				          .bindNow();
 
 		HttpClient client = createHttpClientForContextWithAddress(server);
-		for(int i = 0; i < 500; ++i) {
+		for(int i = 0; i < 1000; ++i) {
 			try {
 				client.get()
 				      .uri("/")


### PR DESCRIPTION
Fixed memory leak when `timeout` occurs.


Related to #876 