### PR TITLE
Add keeping of scheme on relative redirection of http requests

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -609,12 +609,12 @@ final class HttpClientConnect extends HttpClient {
 				SocketAddress address = from.getRemoteAddress();
 				if (address instanceof InetSocketAddress) {
 					InetSocketAddress inetSocketAddress = (InetSocketAddress) address;
-					toURI = uriEndpointFactory.createUriEndpoint(to, from.isWs(),
+					toURI = uriEndpointFactory.createUriEndpoint(from, to,
 							() -> URI_ADDRESS_MAPPER.apply(inetSocketAddress.getHostString(), inetSocketAddress.getPort()));
 				}
 				else {
-					toURI = uriEndpointFactory.createUriEndpoint(to, from.isWs(),
-							() -> URI_ADDRESS_MAPPER.apply(from.host, from.port));
+					toURI = uriEndpointFactory.createUriEndpoint(from, to,
+								() -> URI_ADDRESS_MAPPER.apply(from.host, from.port));
 				}
 			}
 			else {

--- a/src/main/java/reactor/netty/http/client/UriEndpointFactory.java
+++ b/src/main/java/reactor/netty/http/client/UriEndpointFactory.java
@@ -70,6 +70,14 @@ final class UriEndpointFactory {
 		}
 	}
 
+	UriEndpoint createUriEndpoint(UriEndpoint from, String to, Supplier<SocketAddress> connectAddress) {
+		if (to.startsWith("/")) {
+			return new UriEndpoint(from.scheme, from.host, from.port, connectAddress, to);
+		} else {
+			throw new IllegalArgumentException("Must provide a relative address in parameter `to`");
+		}
+	}
+
 	String cleanPathAndQuery(@Nullable String pathAndQuery) {
 		if (pathAndQuery == null) {
 			pathAndQuery = "/";


### PR DESCRIPTION
Hello,

We're using reactor-netty in our application through Spring WebClient to download various content from the internet. There are some sites that do not have HTTPS support, so we need to download their content on plain HTTP. Unfortunately the current implementation of redirect causes all relative redirects to be routed to the HTTPS version of the site, which makes it impossible to download from  the site if it has no support of HTTPS, but on the other hand makes relative redirects.