### PR TITLE
Add responseUrl to HttpClientResponse

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -523,6 +523,8 @@ final class HttpClientConnect extends HttpClient {
 
 		Publisher<Void> requestWithBody(HttpClientOperations ch) {
 			try {
+				ch.resourceUrl = toURI.toExternalForm();
+
 				UriEndpoint uri = toURI;
 				HttpHeaders headers = ch.getNettyRequest()
 				                        .setUri(uri.getPathAndQuery())

--- a/src/main/java/reactor/netty/http/client/HttpClientDoOnError.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientDoOnError.java
@@ -117,6 +117,11 @@ final class HttpClientDoOnError extends HttpClientOperator {
 			return EMPTY;
 		}
 
+		@Override
+		public String resourceUrl() {
+			return null;
+		}
+
 		final static String[] EMPTY = new String[0];
 
 		@Override

--- a/src/main/java/reactor/netty/http/client/HttpClientInfos.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientInfos.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.netty.http.client;
+
+import reactor.netty.http.HttpInfos;
+import reactor.util.context.Context;
+
+public interface HttpClientInfos extends HttpInfos {
+
+    /**
+     * Return the current {@link Context} associated with the Mono/Flux exposed
+     * via {@link HttpClient.ResponseReceiver#response()} or related terminating API.
+     *
+     * @return the current user {@link Context}
+     */
+    Context currentContext();
+
+    /**
+     * Return the previous redirections or empty array
+     *
+     * @return the previous redirections or empty array
+     */
+    String[] redirectedFrom();
+
+    /**
+     * Return the fully qualified URL of the requested resource. In case of redirects, return the URL the last
+     * redirect led to.
+     *
+     * @return The URL of the retrieved resource. This method can return null in case there was an error before the
+     * client could create the URL
+     */
+    String resourceUrl();
+}

--- a/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -96,7 +96,8 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 	final ClientCookieEncoder   cookieEncoder;
 	final ClientCookieDecoder   cookieDecoder;
 
-	Supplier<String>[]    redirectedFrom = EMPTY_REDIRECTIONS;
+	Supplier<String>[]    		redirectedFrom = EMPTY_REDIRECTIONS;
+	String    		    		resourceUrl;
 
 	volatile ResponseState responseState;
 
@@ -422,6 +423,11 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 	@Override
 	public final String uri() {
 		return this.nettyRequest.uri();
+	}
+
+	@Override
+	public String resourceUrl() {
+		return resourceUrl;
 	}
 
 	@Override

--- a/src/main/java/reactor/netty/http/client/HttpClientRequest.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientRequest.java
@@ -18,8 +18,6 @@ package reactor.netty.http.client;
 
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.cookie.Cookie;
-import reactor.netty.http.HttpInfos;
-import reactor.util.context.Context;
 
 /**
  * An Http Reactive client metadata contract for outgoing requests. It inherits several
@@ -28,7 +26,7 @@ import reactor.util.context.Context;
  * @author Stephane Maldini
  * @author Simon Baslé
  */
-public interface HttpClientRequest extends HttpInfos {
+public interface HttpClientRequest extends HttpClientInfos {
 
 	/**
 	 * Add an outbound cookie
@@ -68,26 +66,11 @@ public interface HttpClientRequest extends HttpInfos {
 	HttpClientRequest headers(HttpHeaders headers);
 
 	/**
-	 * Return the current {@link Context} associated with the Mono/Flux exposed
-	 * via {@link HttpClient.ResponseReceiver#response()} or related terminating API.
-	 *
-	 * @return the current user {@link Context}
-	 */
-	Context currentContext();
-
-	/**
 	 * Return true  if redirected will be followed
 	 *
 	 * @return true if redirected will be followed
 	 */
 	boolean isFollowRedirect();
-
-	/**
-	 * Return the previous redirections or empty array
-	 *
-	 * @return the previous redirections or empty array
-	 */
-	String[] redirectedFrom();
 
 	/**
 	 * Return outbound headers to be sent

--- a/src/main/java/reactor/netty/http/client/HttpClientResponse.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientResponse.java
@@ -18,8 +18,6 @@ package reactor.netty.http.client;
 
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import reactor.netty.http.HttpInfos;
-import reactor.util.context.Context;
 
 /**
  * An HttpClient Reactive metadata contract for incoming response. It inherits several
@@ -31,22 +29,7 @@ import reactor.util.context.Context;
  * @author Stephane Maldini
  * @since 0.5
  */
-public interface HttpClientResponse extends HttpInfos {
-
-	/**
-	 * Return the current {@link Context} associated with the Mono/Flux exposed
-	 * via {@link HttpClient.ResponseReceiver#response()} or related terminating API.
-	 *
-	 * @return the current user {@link Context}
-	 */
-	Context currentContext();
-
-	/**
-	 * Return the previous redirections or empty array
-	 *
-	 * @return the previous redirections or empty array
-	 */
-	String[] redirectedFrom();
+public interface HttpClientResponse extends HttpClientInfos {
 
 	/**
 	 * Return response HTTP headers.

--- a/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -1889,4 +1889,26 @@ public class HttpClientTest {
 		provider.dispose();
 		return new ChannelId[] {id1, id2};
 	}
+
+	@Test
+	public void testResourceUrlSetInResponse() {
+		DisposableServer server =
+				HttpServer.create()
+						.port(0)
+						.handle((req, res) -> res.send())
+						.wiretap(true)
+						.bindNow();
+
+		final String requestUri = "http://localhost:" + server.port() + "/foo";
+		StepVerifier.create(
+				createHttpClientForContextWithAddress(server)
+						.get()
+						.uri(requestUri)
+						.responseConnection((res, conn) -> Mono.just(res.resourceUrl())))
+				.expectNext(requestUri)
+				.expectComplete()
+				.verify(Duration.ofSeconds(30));
+
+		server.disposeNow();
+	}
 }


### PR DESCRIPTION
Hello,

I would like to ask your help to implement this feature we need in our project. In our application we would need to know the last URL of a redirect chain, because we're downloading content from various sites across the internet and we would need to know where we've been before. I'm not sure this is the correct implementation, but this is something I have in mind. The other option that came to my mind (similar to Apache HttpClient's implementation) is adding the last url to redirectedFrom array, but this implementation seems cleaner to me.