### PR TITLE
fix #913 Apply BND convention to shadowJar as well

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import aQute.bnd.gradle.BundleTaskConvention
 
 buildscript {
   repositories {
@@ -303,7 +304,6 @@ configure(rootProject) { project ->
 	}
   }
 
-
   jar {
 	classifier = 'original'
 
@@ -319,6 +319,14 @@ configure(rootProject) { project ->
   check.dependsOn jacocoTestReport
 
   shadowJar {
+	  configure {
+		  it.convention.plugins.bundle = new BundleTaskConvention(it)
+		  doLast {
+			  buildBundle()
+		  }
+	  }
+	  bnd(bndOptions)
+
 	  classifier = null
 
 	  dependsOn(project.tasks.jar)

--- a/src/jarFileTest/java/reactor/netty/AbstractJarFileTest.java
+++ b/src/jarFileTest/java/reactor/netty/AbstractJarFileTest.java
@@ -28,11 +28,12 @@ import static java.util.Collections.emptyMap;
  */
 class AbstractJarFileTest {
 
+	static Path jarFilePath;
 	static Path root;
 
 	static {
 		try {
-			Path jarFilePath = Paths.get(System.getProperty("jarFile"));
+			jarFilePath = Paths.get(System.getProperty("jarFile"));
 			URI jarFileUri = new URI("jar", jarFilePath.toUri().toString(), null);
 			FileSystem fileSystem = FileSystems.newFileSystem(jarFileUri, emptyMap());
 			root = fileSystem.getPath("/");


### PR DESCRIPTION
The bnd plugin only applies to the default `jar` task. Since we're now
using the shadow plugin, `shadowJar` has no OSGI data in its MANIFEST.

This commit fixes the situation by applying the bnd plugin convention to
the shadowJar task. It also copies the bnd configuration since this is
not inherited.