### PR TITLE
fix #663 Allow client to proxy ping frames instead of respond

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -903,16 +903,41 @@ public abstract class HttpClient {
 	/**
 	 * HTTP Websocket to connect the {@link HttpClient}.
 	 *
+	 * @param proxyPing whether to proxy websocket ping frames or respond to them
+	 *
+	 * @return a {@link WebsocketSender} ready to consume for response
+	 */
+	public final WebsocketSender websocket(boolean proxyPing) {
+		return websocket("", 65536, proxyPing);
+	}
+
+	/**
+	 * HTTP Websocket to connect the {@link HttpClient}.
+	 *
 	 * @param subprotocols a websocket subprotocol comma separated list
 	 * @param maxFramePayloadLength maximum allowable frame payload length
 	 *
 	 * @return a {@link WebsocketSender} ready to consume for response
 	 */
 	public final WebsocketSender websocket(String subprotocols, int maxFramePayloadLength) {
+		return websocket(subprotocols, maxFramePayloadLength, false);
+	}
+
+	/**
+	 * HTTP Websocket to connect the {@link HttpClient}.
+	 *
+	 * @param subprotocols a websocket subprotocol comma separated list
+	 * @param maxFramePayloadLength maximum allowable frame payload length
+	 * @param proxyPing whether to proxy websocket ping frames or respond to them
+	 *
+	 * @return a {@link WebsocketSender} ready to consume for response
+	 */
+	public final WebsocketSender websocket(String subprotocols, int maxFramePayloadLength, boolean proxyPing) {
 		Objects.requireNonNull(subprotocols, "subprotocols");
 		TcpClient tcpConfiguration = tcpConfiguration()
 				.bootstrap(b -> HttpClientConfiguration.websocketSubprotocols(b, subprotocols))
-				.bootstrap(b -> HttpClientConfiguration.websocketMaxFramePayloadLength(b, maxFramePayloadLength));
+				.bootstrap(b -> HttpClientConfiguration.websocketMaxFramePayloadLength(b, maxFramePayloadLength))
+				.bootstrap(b -> HttpClientConfiguration.websocketProxyPing(b, proxyPing));
 		return new WebsocketFinalizer(tcpConfiguration);
 	}
 

--- a/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
@@ -53,6 +53,7 @@ final class HttpClientConfiguration {
 	HttpMethod                    method                         = HttpMethod.GET;
 	String                        websocketSubprotocols          = null;
 	int                           websocketMaxFramePayloadLength = 65536;
+	boolean                       websocketProxyPing             = false;
 	int                           protocols                      = h11;
 	HttpResponseDecoderSpec       decoder                        = new HttpResponseDecoderSpec();
 
@@ -81,6 +82,7 @@ final class HttpClientConfiguration {
 		this.method = from.method;
 		this.websocketSubprotocols = from.websocketSubprotocols;
 		this.websocketMaxFramePayloadLength = from.websocketMaxFramePayloadLength;
+		this.websocketProxyPing = from.websocketProxyPing;
 		this.body = from.body;
 		this.protocols = from.protocols;
 		this.deferredConf = from.deferredConf;
@@ -258,6 +260,11 @@ final class HttpClientConfiguration {
 
 	static Bootstrap websocketMaxFramePayloadLength(Bootstrap b, int websocketMaxFramePayloadLength) {
 		getOrCreate(b).websocketMaxFramePayloadLength = websocketMaxFramePayloadLength;
+		return b;
+	}
+
+	static Bootstrap websocketProxyPing(Bootstrap b, boolean websocketProxyPing) {
+		getOrCreate(b).websocketProxyPing = websocketProxyPing;
 		return b;
 	}
 

--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -443,6 +443,7 @@ final class HttpClientConnect extends HttpClient {
 		final UriEndpointFactory      uriEndpointFactory;
 		final String                  websocketProtocols;
 		final int                     maxFramePayloadLength;
+		final boolean                 websocketProxyPing;
 		final ClientCookieEncoder     cookieEncoder;
 		final ClientCookieDecoder     cookieDecoder;
 		final BiPredicate<HttpClientRequest, HttpClientResponse>
@@ -506,6 +507,7 @@ final class HttpClientConnect extends HttpClient {
 
 			this.websocketProtocols = configuration.websocketSubprotocols;
 			this.maxFramePayloadLength = configuration.websocketMaxFramePayloadLength;
+			this.websocketProxyPing = configuration.websocketProxyPing;
 			this.handler = configuration.body;
 			this.toURI = uriEndpointFactory.createUriEndpoint(uri, configuration.websocketSubprotocols != null);
 		}
@@ -569,7 +571,7 @@ final class HttpClientConnect extends HttpClient {
 
 				if (handler != null) {
 					if (websocketProtocols != null) {
-						return Mono.fromRunnable(() -> ch.withWebsocketSupport(websocketProtocols, maxFramePayloadLength, compress))
+						return Mono.fromRunnable(() -> ch.withWebsocketSupport(websocketProtocols, maxFramePayloadLength, websocketProxyPing, compress))
 						           .thenEmpty(Mono.fromRunnable(() -> Flux.concat(handler.apply(ch, ch))));
 					}
 					else {
@@ -578,7 +580,7 @@ final class HttpClientConnect extends HttpClient {
 				}
 				else {
 					if (websocketProtocols != null) {
-						return Mono.fromRunnable(() -> ch.withWebsocketSupport(websocketProtocols, maxFramePayloadLength, compress));
+						return Mono.fromRunnable(() -> ch.withWebsocketSupport(websocketProtocols, maxFramePayloadLength, websocketProxyPing, compress));
 					}
 					else {
 						return ch.send();

--- a/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -636,7 +636,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 	}
 
 	@SuppressWarnings("FutureReturnValueIgnored")
-	final void withWebsocketSupport(String protocols, int maxFramePayloadLength, boolean compress) {
+	final void withWebsocketSupport(String protocols, int maxFramePayloadLength, boolean proxyPing, boolean compress) {
 		URI url = websocketUri();
 		//prevent further header to be sent for handshaking
 		if (markSentHeaders()) {
@@ -652,7 +652,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 				                WebSocketClientCompressionHandler.INSTANCE);
 			}
 
-			WebsocketClientOperations ops = new WebsocketClientOperations(url, protocols, maxFramePayloadLength, this);
+			WebsocketClientOperations ops = new WebsocketClientOperations(url, protocols, maxFramePayloadLength, proxyPing, this);
 
 			if(!rebind(ops)) {
 				log.error(format(channel(), "Error while rebinding websocket in channel attribute: " +

--- a/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
@@ -57,14 +57,17 @@ final class WebsocketClientOperations extends HttpClientOperations
 
 	final WebSocketClientHandshaker handshaker;
 	final MonoProcessor<WebSocketCloseStatus> onCloseState;
+	final boolean proxyPing;
 
 	volatile int closeSent;
 
 	WebsocketClientOperations(URI currentURI,
 			String protocols,
 			int maxFramePayloadLength,
+			boolean proxyPing,
 			HttpClientOperations replaced) {
 		super(replaced);
+		this.proxyPing = proxyPing;
 		Channel channel = channel();
 		onCloseState = MonoProcessor.create();
 
@@ -128,7 +131,7 @@ final class WebsocketClientOperations extends HttpClientOperations
 			}
 			return;
 		}
-		if (msg instanceof PingWebSocketFrame) {
+		if (!this.proxyPing && msg instanceof PingWebSocketFrame) {
 			//"FutureReturnValueIgnored" this is deliberate
 			ctx.writeAndFlush(new PongWebSocketFrame(((PingWebSocketFrame) msg).content()));
 			ctx.read();

--- a/src/test/java/reactor/netty/http/client/WebsocketTest.java
+++ b/src/test/java/reactor/netty/http/client/WebsocketTest.java
@@ -1254,7 +1254,8 @@ public class WebsocketTest {
                 .port(0)
                 .handle((req, resp) ->
                         resp.sendWebsocket((i, o) -> {
-                            return o.sendObject(Flux.just(new PingWebSocketFrame(), new CloseWebSocketFrame()))
+                            return o.sendObject(Flux.just(new PingWebSocketFrame(), new CloseWebSocketFrame())
+                                    .delayElements(Duration.ofMillis(100)))
                                     .then(i.receiveFrames()
                                             .subscribeWith(incomingData)
                                             .then());
@@ -1284,7 +1285,8 @@ public class WebsocketTest {
                 .port(0)
                 .handle((req, resp) ->
                         resp.sendWebsocket((i, o) -> {
-                            return o.sendObject(Flux.just(new PingWebSocketFrame(), new CloseWebSocketFrame()))
+                            return o.sendObject(Flux.just(new PingWebSocketFrame(), new CloseWebSocketFrame())
+                                    .delayElements(Duration.ofMillis(100)))
                                     .then(i.receiveFrames()
                                             .subscribeWith(incomingData)
                                             .then());

--- a/src/test/java/reactor/netty/http/client/WebsocketTest.java
+++ b/src/test/java/reactor/netty/http/client/WebsocketTest.java
@@ -1246,63 +1246,63 @@ public class WebsocketTest {
 		            .verify(Duration.ofSeconds(30));
 	}
 
-	@Test
-	public void testIssue927() {
-		DirectProcessor<WebSocketFrame> incomingData = DirectProcessor.create();
+    @Test
+    public void testIssue927() {
+        DirectProcessor<WebSocketFrame> incomingData = DirectProcessor.create();
 
-		httpServer = HttpServer.create()
-				.port(0)
-				.handle((req, resp) ->
-						resp.sendWebsocket((i, o) -> {
-							return o.sendObject(Flux.just(new PingWebSocketFrame(), new CloseWebSocketFrame()))
-									.then(i.receiveFrames()
-											.subscribeWith(incomingData)
-											.then());
-				}))
-				.wiretap(true)
-				.bindNow();
+        httpServer = HttpServer.create()
+                .port(0)
+                .handle((req, resp) ->
+                        resp.sendWebsocket((i, o) -> {
+                            return o.sendObject(Flux.just(new PingWebSocketFrame(), new CloseWebSocketFrame()))
+                                    .then(i.receiveFrames()
+                                            .subscribeWith(incomingData)
+                                            .then());
+                }))
+                .wiretap(true)
+                .bindNow();
 
-		HttpClient.create()
-				.port(httpServer.address().getPort())
-				.wiretap(true)
-				.websocket()
-				.uri("/")
-				.handle((in, out) -> in.receiveFrames())
-				.subscribe();
+        HttpClient.create()
+                .port(httpServer.address().getPort())
+                .wiretap(true)
+                .websocket()
+                .uri("/")
+                .handle((in, out) -> in.receiveFrames())
+                .subscribe();
 
-		StepVerifier.create(incomingData)
-				.expectNext(new PongWebSocketFrame())
-				.expectComplete()
-				.verify(Duration.ofSeconds(30));
-	}
+        StepVerifier.create(incomingData)
+                .expectNext(new PongWebSocketFrame())
+                .expectComplete()
+                .verify(Duration.ofSeconds(30));
+    }
 
-	@Test
-	public void testIssue927_2() {
-		DirectProcessor<WebSocketFrame> incomingData = DirectProcessor.create();
+    @Test
+    public void testIssue927_2() {
+        DirectProcessor<WebSocketFrame> incomingData = DirectProcessor.create();
 
-		httpServer = HttpServer.create()
-				.port(0)
-				.handle((req, resp) ->
-						resp.sendWebsocket((i, o) -> {
-							return o.sendObject(Flux.just(new PingWebSocketFrame(), new CloseWebSocketFrame()))
-									.then(i.receiveFrames()
-											.subscribeWith(incomingData)
-											.then());
-						}))
-				.wiretap(true)
-				.bindNow();
+        httpServer = HttpServer.create()
+                .port(0)
+                .handle((req, resp) ->
+                        resp.sendWebsocket((i, o) -> {
+                            return o.sendObject(Flux.just(new PingWebSocketFrame(), new CloseWebSocketFrame()))
+                                    .then(i.receiveFrames()
+                                            .subscribeWith(incomingData)
+                                            .then());
+                        }))
+                .wiretap(true)
+                .bindNow();
 
-		HttpClient.create()
-				.port(httpServer.address().getPort())
-				.wiretap(true)
-				.websocket(true)
-				.uri("/")
-				.handle((in, out) -> in.receiveFrames())
-				.subscribe();
+        HttpClient.create()
+                .port(httpServer.address().getPort())
+                .wiretap(true)
+                .websocket(true)
+                .uri("/")
+                .handle((in, out) -> in.receiveFrames())
+                .subscribe();
 
-		StepVerifier.create(incomingData)
-				.expectComplete()
-				.verify(Duration.ofSeconds(30));
-	}
+        StepVerifier.create(incomingData)
+                .expectComplete()
+                .verify(Duration.ofSeconds(30));
+    }
 
 }

--- a/src/test/java/reactor/netty/http/client/WebsocketTest.java
+++ b/src/test/java/reactor/netty/http/client/WebsocketTest.java
@@ -31,6 +31,8 @@ import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
@@ -1243,4 +1245,64 @@ public class WebsocketTest {
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(30));
 	}
+
+	@Test
+	public void testIssue927() {
+		DirectProcessor<WebSocketFrame> incomingData = DirectProcessor.create();
+
+		httpServer = HttpServer.create()
+				.port(0)
+				.handle((req, resp) ->
+						resp.sendWebsocket((i, o) -> {
+							return o.sendObject(Flux.just(new PingWebSocketFrame(), new CloseWebSocketFrame()))
+									.then(i.receiveFrames()
+											.subscribeWith(incomingData)
+											.then());
+				}))
+				.wiretap(true)
+				.bindNow();
+
+		HttpClient.create()
+				.port(httpServer.address().getPort())
+				.wiretap(true)
+				.websocket()
+				.uri("/")
+				.handle((in, out) -> in.receiveFrames())
+				.subscribe();
+
+		StepVerifier.create(incomingData)
+				.expectNext(new PongWebSocketFrame())
+				.expectComplete()
+				.verify(Duration.ofSeconds(30));
+	}
+
+	@Test
+	public void testIssue927_2() {
+		DirectProcessor<WebSocketFrame> incomingData = DirectProcessor.create();
+
+		httpServer = HttpServer.create()
+				.port(0)
+				.handle((req, resp) ->
+						resp.sendWebsocket((i, o) -> {
+							return o.sendObject(Flux.just(new PingWebSocketFrame(), new CloseWebSocketFrame()))
+									.then(i.receiveFrames()
+											.subscribeWith(incomingData)
+											.then());
+						}))
+				.wiretap(true)
+				.bindNow();
+
+		HttpClient.create()
+				.port(httpServer.address().getPort())
+				.wiretap(true)
+				.websocket(true)
+				.uri("/")
+				.handle((in, out) -> in.receiveFrames())
+				.subscribe();
+
+		StepVerifier.create(incomingData)
+				.expectComplete()
+				.verify(Duration.ofSeconds(30));
+	}
+
 }


### PR DESCRIPTION
Fix for the situation in https://github.com/spring-cloud/spring-cloud-gateway/issues/729 where Spring Cloud Gateway responds to ping frames from a websocket server instead of proxying them to the client. I used the project from that issue to verify the functionality.

Please see the following commits in spring-framework and spring-cloud-gateway that will make this configurable by a new `spring.cloud.gateway.httpclient.websocket.proxy-ping` property:

https://github.com/spring-projects/spring-framework/compare/master...JacobASeverson:proxy-ping

https://github.com/spring-cloud/spring-cloud-gateway/compare/master...JacobASeverson:issue-729