### PR TITLE
fix #940 Switch auto-read to true when LastHttpContent received on the server

### DIFF
--- a/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -467,6 +467,8 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 			if (msg instanceof FullHttpRequest) {
 				super.onInboundNext(ctx, msg);
 				if (isHttp2()) {
+					//force auto read to enable more accurate close selection now inbound is done
+					channel().config().setAutoRead(true);
 					onInboundComplete();
 				}
 			}
@@ -477,6 +479,8 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 				super.onInboundNext(ctx, msg);
 			}
 			if (msg instanceof LastHttpContent) {
+				//force auto read to enable more accurate close selection now inbound is done
+				channel().config().setAutoRead(true);
 				onInboundComplete();
 			}
 		}


### PR DESCRIPTION
Switching `auto-read` to `true` allows to detect disconnected client,
otherwise the disconnected client event will be detected on the next
attempt to read/write.