### PR TITLE
fix #986 ConnectionProviderMetrics Set PoolName in a tag

### DIFF
--- a/src/main/java/reactor/netty/resources/PooledConnectionProviderMetrics.java
+++ b/src/main/java/reactor/netty/resources/PooledConnectionProviderMetrics.java
@@ -29,40 +29,41 @@ final class PooledConnectionProviderMetrics {
 
 	static void registerMetrics(String poolName, String id, String remoteAddress,
 			InstrumentedPool.PoolMetrics metrics) {
-		String name = String.format(NAME, poolName);
 
-		Gauge.builder(name + TOTAL_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::allocatedSize)
+		Gauge.builder(TOTAL_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::allocatedSize)
 		     .description("The number of all connections, active or idle.")
-		     .tags(ID, id, REMOTE_ADDRESS, remoteAddress)
+		     .tags(ID, id, REMOTE_ADDRESS, remoteAddress, POOL_NAME, poolName)
 		     .register(registry);
 
-		Gauge.builder(name + ACTIVE_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::acquiredSize)
+		Gauge.builder(ACTIVE_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::acquiredSize)
 		     .description("The number of the connections that have been successfully acquired and are in active use")
-		     .tags(ID, id, REMOTE_ADDRESS, remoteAddress)
+		     .tags(ID, id, REMOTE_ADDRESS, remoteAddress, POOL_NAME, poolName)
 		     .register(registry);
 
-		Gauge.builder(name + IDLE_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::idleSize)
+		Gauge.builder(IDLE_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::idleSize)
 		     .description("The number of the idle connections")
-		     .tags(ID, id, REMOTE_ADDRESS, remoteAddress)
+		     .tags(ID, id, REMOTE_ADDRESS, remoteAddress, POOL_NAME, poolName)
 		     .register(registry);
 
-		Gauge.builder(name + PENDING_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::pendingAcquireSize)
+		Gauge.builder(PENDING_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::pendingAcquireSize)
 		     .description("The number of the request, that are pending acquire a connection")
-		     .tags(ID, id, REMOTE_ADDRESS, remoteAddress)
+		     .tags(ID, id, REMOTE_ADDRESS, remoteAddress, POOL_NAME, poolName)
 		     .register(registry);
 	}
 
 	static final MeterRegistry registry = Metrics.globalRegistry;
 
-	static final String NAME = "reactor.netty.connection.provider.%s";
+	static final String NAME = "reactor.netty.connection.provider";
 
-	static final String TOTAL_CONNECTIONS = ".total.connections";
+	static final String TOTAL_CONNECTIONS = NAME + ".total.connections";
 
-	static final String ACTIVE_CONNECTIONS = ".active.connections";
+	static final String ACTIVE_CONNECTIONS = NAME + ".active.connections";
 
-	static final String IDLE_CONNECTIONS = ".idle.connections";
+	static final String IDLE_CONNECTIONS = NAME + ".idle.connections";
 
-	static final String PENDING_CONNECTIONS = ".pending.connections";
+	static final String PENDING_CONNECTIONS = NAME + ".pending.connections";
 
 	static final String ID = "id";
+
+	static final String POOL_NAME = "pool.name";
 }

--- a/src/test/java/reactor/netty/resources/PooledConnectionProviderMetricsTest.java
+++ b/src/test/java/reactor/netty/resources/PooledConnectionProviderMetricsTest.java
@@ -72,7 +72,8 @@ public class PooledConnectionProviderMetricsTest {
 
 		CountDownLatch latch = new CountDownLatch(1);
 
-		PooledConnectionProvider fixed = (PooledConnectionProvider) ConnectionProvider.create("test", 1);
+		String poolName = "test";
+		PooledConnectionProvider fixed = (PooledConnectionProvider) ConnectionProvider.create(poolName, 1);
 		AtomicReference<String[]> tags = new AtomicReference<>();
 
 		HttpClient.create(fixed)
@@ -84,13 +85,13 @@ public class PooledConnectionProviderMetricsTest {
 
 		              PooledConnectionProvider.PoolKey key = (PooledConnectionProvider.PoolKey) fixed.channelPools.keySet().toArray()[0];
 		              InetSocketAddress sa = (InetSocketAddress) conn.channel().remoteAddress();
-		              String[] tagsArr = new String[]{ID, key.hashCode() + "", REMOTE_ADDRESS, sa.getHostString() + ":" + sa.getPort()};
+		              String[] tagsArr = new String[]{ID, key.hashCode() + "", REMOTE_ADDRESS, sa.getHostString() + ":" + sa.getPort(), POOL_NAME, poolName};
 		              tags.set(tagsArr);
 
-		              double totalConnections = getGaugeValue(NAME + TOTAL_CONNECTIONS, tagsArr);
-		              double activeConnections = getGaugeValue(NAME + ACTIVE_CONNECTIONS, tagsArr);
-		              double idleConnections = getGaugeValue(NAME + IDLE_CONNECTIONS, tagsArr);
-		              double pendingConnections = getGaugeValue(NAME + PENDING_CONNECTIONS, tagsArr);
+		              double totalConnections = getGaugeValue(TOTAL_CONNECTIONS, tagsArr);
+		              double activeConnections = getGaugeValue(ACTIVE_CONNECTIONS, tagsArr);
+		              double idleConnections = getGaugeValue(IDLE_CONNECTIONS, tagsArr);
+		              double pendingConnections = getGaugeValue(PENDING_CONNECTIONS, tagsArr);
 
 		              if (totalConnections == 1 && activeConnections == 1 &&
 		                      idleConnections == 0 && pendingConnections == 0) {
@@ -109,10 +110,10 @@ public class PooledConnectionProviderMetricsTest {
 		assertTrue(metrics.get());
 		String[] tagsArr = tags.get();
 		assertNotNull(tagsArr);
-		assertEquals(0, getGaugeValue(NAME + TOTAL_CONNECTIONS, tagsArr), 0.0);
-		assertEquals(0, getGaugeValue(NAME + ACTIVE_CONNECTIONS, tagsArr), 0.0);
-		assertEquals(0, getGaugeValue(NAME + IDLE_CONNECTIONS, tagsArr), 0.0);
-		assertEquals(0, getGaugeValue(NAME + PENDING_CONNECTIONS, tagsArr), 0.0);
+		assertEquals(0, getGaugeValue(TOTAL_CONNECTIONS, tagsArr), 0.0);
+		assertEquals(0, getGaugeValue(ACTIVE_CONNECTIONS, tagsArr), 0.0);
+		assertEquals(0, getGaugeValue(IDLE_CONNECTIONS, tagsArr), 0.0);
+		assertEquals(0, getGaugeValue(PENDING_CONNECTIONS, tagsArr), 0.0);
 
 		fixed.disposeLater()
 		     .block(Duration.ofSeconds(30));
@@ -130,5 +131,4 @@ public class PooledConnectionProviderMetricsTest {
 		return result;
 	}
 
-	private static final String NAME = "reactor.netty.connection.provider.test";
 }


### PR DESCRIPTION
Use a fixed metric name for ConnectionProvider metrics.
Set the connection pool name as a tag "pool.name" (micrometer supports dimensional metrics)