### PR TITLE
Fixed inconsistent error resolution in FutureMono

### DIFF
--- a/src/main/java/reactor/netty/FutureMono.java
+++ b/src/main/java/reactor/netty/FutureMono.java
@@ -182,6 +182,7 @@ public abstract class FutureMono extends Mono<Void> {
 
 		private static Throwable wrapError(Throwable error) {
 			if(error instanceof ClosedChannelException) {
+				//Update with a common aborted exception?
 				return ReactorNetty.wrapException(error);
 			} else {
 				return error;

--- a/src/main/java/reactor/netty/FutureMono.java
+++ b/src/main/java/reactor/netty/FutureMono.java
@@ -47,7 +47,7 @@ public abstract class FutureMono extends Mono<Void> {
 	public static <F extends Future<Void>> Mono<Void> from(F future) {
 		if(future.isDone()){
 			if(!future.isSuccess()){
-				return Mono.error(future.cause());
+				return Mono.error(FutureSubscription.wrapError(future.cause()));
 			}
 			return Mono.empty();
 		}
@@ -84,7 +84,7 @@ public abstract class FutureMono extends Mono<Void> {
 					Operators.complete(s);
 				}
 				else{
-					Operators.error(s, future.cause());
+					Operators.error(s, FutureSubscription.wrapError(future.cause()));
 				}
 				return;
 			}
@@ -129,7 +129,7 @@ public abstract class FutureMono extends Mono<Void> {
 					Operators.complete(s);
 				}
 				else {
-					Operators.error(s, f.cause());
+					Operators.error(s, FutureSubscription.wrapError(f.cause()));
 				}
 				return;
 			}
@@ -173,18 +173,19 @@ public abstract class FutureMono extends Mono<Void> {
 		@SuppressWarnings("unchecked")
 		public void operationComplete(F future) {
 			if (!future.isSuccess()) {//Avoid singleton
-				if (future.cause() instanceof ClosedChannelException) {
-					//Update with a common aborted exception?
-					s.onError(ReactorNetty.wrapException(future.cause()));
-				}
-				else {
-					s.onError(future.cause());
-				}
+				s.onError(wrapError(future.cause()));
 			}
 			else {
 				s.onComplete();
 			}
 		}
 
+		private static Throwable wrapError(Throwable error) {
+			if(error instanceof ClosedChannelException) {
+				return ReactorNetty.wrapException(error);
+			} else {
+				return error;
+			}
+		}
 	}
 }

--- a/src/test/java/reactor/netty/FutureMonoTest.java
+++ b/src/test/java/reactor/netty/FutureMonoTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty;
+
+import io.netty.util.concurrent.*;
+import org.junit.Test;
+import reactor.test.StepVerifier;
+
+import java.nio.channels.ClosedChannelException;
+import java.util.function.Supplier;
+
+public class FutureMonoTest {
+
+    @Test
+    public void testImmediateFutureMonoImmediate() {
+        ImmediateEventExecutor eventExecutor = ImmediateEventExecutor.INSTANCE;
+        Future<Void> promise = eventExecutor.newFailedFuture(new ClosedChannelException());
+
+        StepVerifier.create(FutureMono.from(promise))
+                .expectError(ReactorNetty.InternalNettyException.class)
+                .verify();
+    }
+
+    // return value of setFailure not needed
+    @SuppressWarnings("FutureReturnValueIgnored")
+    @Test
+    public void testImmediateFutureMonoLater() {
+        ImmediateEventExecutor eventExecutor = ImmediateEventExecutor.INSTANCE;
+        Promise<Void> promise = eventExecutor.newPromise();
+
+        StepVerifier.create(FutureMono.from(promise))
+                .expectSubscription()
+                .then(() -> promise.setFailure(new ClosedChannelException()))
+                .expectError(ReactorNetty.InternalNettyException.class)
+                .verify();
+    }
+
+    @Test
+    public void testDeferredFutureMonoImmediate() {
+        ImmediateEventExecutor eventExecutor = ImmediateEventExecutor.INSTANCE;
+        Supplier<Future<Void>> promiseSupplier = () -> eventExecutor.newFailedFuture(new ClosedChannelException());
+
+        StepVerifier.create(FutureMono.deferFuture(promiseSupplier))
+                .expectError(ReactorNetty.InternalNettyException.class)
+                .verify();
+    }
+
+    // return value of setFailure not needed
+    @SuppressWarnings("FutureReturnValueIgnored")
+    @Test
+    public void testDeferredFutureMonoLater() {
+        ImmediateEventExecutor eventExecutor = ImmediateEventExecutor.INSTANCE;
+        Promise<Void> promise = eventExecutor.newPromise();
+        Supplier<Promise<Void>> promiseSupplier = () -> promise;
+
+        StepVerifier.create(FutureMono.deferFuture(promiseSupplier))
+                .expectSubscription()
+                .then(() -> promise.setFailure(new ClosedChannelException()))
+                .expectError(ReactorNetty.InternalNettyException.class)
+                .verify();
+    }
+}


### PR DESCRIPTION
There was inconsistent behavior regarding ClosedChannelException in FutureMono class depending on if the future was already finished or if it finished later on via a listener.