### PR TITLE
fix #997 Ensure the actual request data is available when HttpClient#doOnRequest

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -509,7 +509,7 @@ public abstract class HttpClient {
 
 	/**
 	 * Setup a callback called when {@link HttpClientRequest} is about to be sent
-	 * and {@link HttpClientState#CONFIGURED} has been emitted.
+	 * and {@link HttpClientState#REQUEST_PREPARED} has been emitted.
 	 *
 	 * @param doOnRequest a callback called when {@link HttpClientRequest} is about to be sent
 	 *

--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -571,6 +571,7 @@ final class HttpClientConnect extends HttpClient {
 					ch.chunkedTransfer(true);
 				}
 
+				ch.listener().onStateChange(ch, HttpClientState.REQUEST_PREPARED);
 				if (handler != null) {
 					if (websocketProtocols != null) {
 						return Mono.fromRunnable(() -> ch.withWebsocketSupport(websocketProtocols, maxFramePayloadLength, websocketProxyPing, compress))

--- a/src/main/java/reactor/netty/http/client/HttpClientDoOn.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientDoOn.java
@@ -62,7 +62,7 @@ final class HttpClientDoOn extends HttpClientOperator implements ConnectionObser
 
 	@Override
 	public void onStateChange(Connection connection, State newState) {
-		if (onRequest != null && newState == State.CONFIGURED) {
+		if (onRequest != null && newState == HttpClientState.REQUEST_PREPARED) {
 			onRequest.accept(connection.as(HttpClientOperations.class), connection);
 			return;
 		}

--- a/src/main/java/reactor/netty/http/client/HttpClientState.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientState.java
@@ -25,6 +25,15 @@ import reactor.netty.ConnectionObserver;
  */
 public enum HttpClientState implements ConnectionObserver.State {
 	/**
+	 * The request has been prepared and ready for I/O handler to be invoked
+	 */
+	REQUEST_PREPARED() {
+		@Override
+		public String toString() {
+			return "[request_prepared]";
+		}
+	},
+	/**
 	 * The request has been sent
 	 */
 	REQUEST_SENT() {


### PR DESCRIPTION
The event will be trigger on `HttpClientState#REQUEST_PREPARED` and not on
`ConnectionObserver.State#CONFIGURED`