### PR TITLE
Adds test showing implicit redirects are invisible to metrics/tracing

### DIFF
--- a/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
+++ b/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
@@ -152,6 +152,7 @@ public class HttpRedirectTest {
 
 		assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
 		assertThat(onRequestCount.get()).isEqualTo(2);
+		// This fails, with only 1. This means we can get success count, but not error count or duration
 		assertThat(onResponseCount.get()).isEqualTo(2);
 
 		server.disposeNow();


### PR DESCRIPTION
To complete https://github.com/spring-cloud/spring-cloud-sleuth/pull/1554, we need to allow visibility into implicit handling such as redirects or auto-retry on failure. This could be most easily accomplished on our side, if it uses the onXXX hooks. Alternatives could be evaluated as well.