### PR TITLE
Fix compilation errors when using Java 13+

### DIFF
--- a/src/test/java/reactor/netty/http/server/HttpSendFileTests.java
+++ b/src/test/java/reactor/netty/http/server/HttpSendFileTests.java
@@ -88,7 +88,7 @@ public class HttpSendFileTests {
 		Files.copy(this.getClass().getResourceAsStream("/zipFile.zip"), path, StandardCopyOption.REPLACE_EXISTING);
 		path.toFile().deleteOnExit();
 
-		try (FileSystem zipFs = FileSystems.newFileSystem(path, null)) {
+		try (FileSystem zipFs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
 			Path fromZipFile = zipFs.getPath("/largeFile.txt");
 			long fileSize = Files.size(fromZipFile);
 			assertSendFile(out -> out.sendFileChunked(fromZipFile, 0, fileSize));
@@ -101,7 +101,7 @@ public class HttpSendFileTests {
 		Files.copy(this.getClass().getResourceAsStream("/zipFile.zip"), path, StandardCopyOption.REPLACE_EXISTING);
 		path.toFile().deleteOnExit();
 
-		try (FileSystem zipFs = FileSystems.newFileSystem(path, null)) {
+		try (FileSystem zipFs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
 			Path fromZipFile = zipFs.getPath("/largeFile.txt");
 			long fileSize = Files.size(fromZipFile);
 
@@ -115,7 +115,7 @@ public class HttpSendFileTests {
 		Files.copy(this.getClass().getResourceAsStream("/zipFile.zip"), path, StandardCopyOption.REPLACE_EXISTING);
 		path.toFile().deleteOnExit();
 
-		try (FileSystem zipFs = FileSystems.newFileSystem(path, null)) {
+		try (FileSystem zipFs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
 			Path fromZipFile = zipFs.getPath("/largeFile.txt");
 			long fileSize = Files.size(fromZipFile);
 
@@ -129,7 +129,7 @@ public class HttpSendFileTests {
 		Files.copy(this.getClass().getResourceAsStream("/zipFile.zip"), path, StandardCopyOption.REPLACE_EXISTING);
 		path.toFile().deleteOnExit();
 
-		try (FileSystem zipFs = FileSystems.newFileSystem(path, null)) {
+		try (FileSystem zipFs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
 			Path fromZipFile = zipFs.getPath("/largeFile.txt");
 			long fileSize = Files.size(fromZipFile);
 
@@ -144,7 +144,7 @@ public class HttpSendFileTests {
 		Files.copy(this.getClass().getResourceAsStream("/zipFile.zip"), path, StandardCopyOption.REPLACE_EXISTING);
 		path.toFile().deleteOnExit();
 
-		try (FileSystem zipFs = FileSystems.newFileSystem(path, null)) {
+		try (FileSystem zipFs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
 			Path fromZipFile = zipFs.getPath("/largeFile.txt");
 			long fileSize = Files.size(fromZipFile);
 
@@ -159,7 +159,7 @@ public class HttpSendFileTests {
 		Files.copy(this.getClass().getResourceAsStream("/zipFile.zip"), path, StandardCopyOption.REPLACE_EXISTING);
 		path.toFile().deleteOnExit();
 
-		try (FileSystem zipFs = FileSystems.newFileSystem(path, null)) {
+		try (FileSystem zipFs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
 			Path fromZipFile = zipFs.getPath("/largeFile.txt");
 			long fileSize = Files.size(fromZipFile);
 
@@ -174,7 +174,7 @@ public class HttpSendFileTests {
 		Files.copy(this.getClass().getResourceAsStream("/zipFile.zip"), path, StandardCopyOption.REPLACE_EXISTING);
 		path.toFile().deleteOnExit();
 
-		try (FileSystem zipFs = FileSystems.newFileSystem(path, null)) {
+		try (FileSystem zipFs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
 			Path fromZipFile = zipFs.getPath("/largeFile.txt");
 			long fileSize = Files.size(fromZipFile);
 
@@ -189,7 +189,7 @@ public class HttpSendFileTests {
 		Files.copy(this.getClass().getResourceAsStream("/zipFile.zip"), path, StandardCopyOption.REPLACE_EXISTING);
 		path.toFile().deleteOnExit();
 
-		try (FileSystem zipFs = FileSystems.newFileSystem(path, null)) {
+		try (FileSystem zipFs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
 			Path fromZipFile = zipFs.getPath("/largeFile.txt");
 			long fileSize = Files.size(fromZipFile);
 
@@ -203,7 +203,7 @@ public class HttpSendFileTests {
 		Files.copy(this.getClass().getResourceAsStream("/zipFile.zip"), path, StandardCopyOption.REPLACE_EXISTING);
 		path.toFile().deleteOnExit();
 
-		try (FileSystem zipFs = FileSystems.newFileSystem(path, null)) {
+		try (FileSystem zipFs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
 			Path fromZipFile = zipFs.getPath("/largeFile.txt");
 			long fileSize = Files.size(fromZipFile);
 
@@ -218,7 +218,7 @@ public class HttpSendFileTests {
 		Files.copy(this.getClass().getResourceAsStream("/zipFile.zip"), path, StandardCopyOption.REPLACE_EXISTING);
 		path.toFile().deleteOnExit();
 
-		try (FileSystem zipFs = FileSystems.newFileSystem(path, null)) {
+		try (FileSystem zipFs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
 			Path fromZipFile = zipFs.getPath("/largeFile.txt");
 			long fileSize = Files.size(fromZipFile);
 

--- a/src/test/java/reactor/netty/tcp/TcpServerTests.java
+++ b/src/test/java/reactor/netty/tcp/TcpServerTests.java
@@ -435,7 +435,7 @@ public class TcpServerTests {
 		Files.copy(this.getClass().getResourceAsStream("/zipFile.zip"), path, StandardCopyOption.REPLACE_EXISTING);
 		path.toFile().deleteOnExit();
 
-		try (FileSystem zipFs = FileSystems.newFileSystem(path, null)) {
+		try (FileSystem zipFs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
 			Path fromZipFile = zipFs.getPath("/largeFile.txt");
 			long fileSize = Files.size(fromZipFile);
 			assertSendFile(out -> out.sendFileChunked(fromZipFile, 0, fileSize));
@@ -447,7 +447,7 @@ public class TcpServerTests {
 		Path path = Files.createTempFile(null, ".zip");
 		Files.copy(this.getClass().getResourceAsStream("/zipFile.zip"), path, StandardCopyOption.REPLACE_EXISTING);
 
-		try (FileSystem zipFs = FileSystems.newFileSystem(path, null)) {
+		try (FileSystem zipFs = FileSystems.newFileSystem(path, (ClassLoader) null)) {
 			Path fromZipFile = zipFs.getPath("/largeFile.txt");
 			long fileSize = Files.size(fromZipFile);
 			assertSendFile(out -> out.sendFile(fromZipFile, 0, fileSize));


### PR DESCRIPTION
Java 13 introduced a new overload for `FileSystems.newFileSystem`. See the [documentation](https://docs.oracle.com/en/java/javase/13/docs/api/java.base/java/nio/file/FileSystems.html#newFileSystem(java.nio.file.Path,java.util.Map)) for more details.

Several unit tests were longer compiling as `FileSystems.newFileSystem(path, null)` has now become ambiguous.

This pull request fixes the problem by adding an explicit cast.