### PR TITLE
fix #1012 Ensure invalidate() is invoked on the correct PooledRef

### DIFF
--- a/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -584,7 +584,8 @@ final class PooledConnectionProvider implements ConnectionProvider {
 			}
 			channel.closeFuture()
 			       .addListener(ff ->
-			           pooledRef.invalidate()
+			           ((DisposableAcquire) channel.attr(OWNER).get()).pooledRef
+			                    .invalidate()
 			                    .subscribe(null, null, () -> {
 			                        if (log.isDebugEnabled()) {
 			                            log.debug(format(channel, "Channel closed, now {} active connections and " +


### PR DESCRIPTION
With every acquire the PooledRef object is changed while the channel is the same,
used the OWNER attribute in order to obtain the current PooledRef.