### PR TITLE
upgrade netty to 4.1.47.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
   logbackVersion = '1.2.3'
 
   // Netty
-  nettyDefaultVersion = '4.1.46.Final'
+  nettyDefaultVersion = '4.1.47.Final'
   if (!project.hasProperty("forceNettyVersion")) {
 	nettyVersion = nettyDefaultVersion
   }


### PR DESCRIPTION
refer: [Netty 4.1.47.Final released](https://netty.io/news/2020/03/09/4-1-47-Final.html)