### PR TITLE
Add release of HttpContent when redirecting

### DIFF
--- a/src/test/java/reactor/netty/http/client/HttpClientOperationsTest.java
+++ b/src/test/java/reactor/netty/http/client/HttpClientOperationsTest.java
@@ -142,11 +142,14 @@ public class HttpClientOperationsTest {
 				ConnectionObserver.emptyListener(),
 				ClientCookieEncoder.STRICT, ClientCookieDecoder.STRICT);
 		ops1.followRedirectPredicate((req, res) -> true);
+		ops1.started = true;
+		ops1.redirected = true;
 
 		HttpClientOperations ops2 = new HttpClientOperations(ops1);
 
 		assertSame(ops1.channel(), ops2.channel());
 		assertSame(ops1.started, ops2.started);
+		assertSame(ops1.redirected, ops2.redirected);
 		assertSame(ops1.redirectedFrom, ops2.redirectedFrom);
 		assertSame(ops1.isSecure, ops2.isSecure);
 		assertSame(ops1.nettyRequest, ops2.nettyRequest);

--- a/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
+++ b/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
@@ -16,9 +16,14 @@
 
 package reactor.netty.http.client;
 
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.security.cert.CertificateException;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -27,6 +32,8 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.ReferenceCountUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Ignore;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
@@ -582,5 +589,58 @@ public class HttpRedirectTest {
 
 		initialServer.disposeNow();
 		redirectServer.disposeNow();
+	}
+
+	@Test
+	public void testBuffersForRedirectWithContentShouldBeReleased() {
+		doTestBuffersForRedirectWithContentShouldBeReleased("Redirect response content!");
+	}
+
+	@Test
+	public void testBuffersForRedirectWithLargeContentShouldBeReleased() {
+		doTestBuffersForRedirectWithContentShouldBeReleased(StringUtils.repeat("a", 10000));
+	}
+
+	private void doTestBuffersForRedirectWithContentShouldBeReleased(String redirectResponseContent) {
+		final String initialPath = "/initial";
+		final String redirectPath = "/redirect";
+
+		DisposableServer server =
+				HttpServer.create()
+						.port(0)
+						.route(r -> r
+								.get(initialPath, (req, res) -> res
+										.status(HttpResponseStatus.MOVED_PERMANENTLY)
+										.header(HttpHeaderNames.LOCATION, redirectPath)
+										.sendString(Mono.just(redirectResponseContent)))
+								.get(redirectPath, (req, res) -> res.send()))
+						.wiretap(true)
+						.bindNow();
+
+		final List<Integer> redirectBufferRefCounts = new ArrayList<>();
+		HttpClient.create()
+				.doOnRequest((r, c) -> c.addHandler("test-buffer-released", new ChannelInboundHandlerAdapter() {
+					@Override public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+						super.channelRead(ctx, msg);
+
+						if(initialPath.equals(r.fullPath()) && msg instanceof HttpContent) {
+							redirectBufferRefCounts.add(ReferenceCountUtil.refCnt(msg));
+						}
+					}
+				}))
+				.wiretap(true)
+				.followRedirect(true)
+				.get()
+				.uri("http://localhost:" + server.port() + initialPath)
+				.response()
+				.block();
+
+		System.gc();
+
+		assertThat(redirectBufferRefCounts)
+				.as("The HttpContents belonging to the redirection response should all be released")
+				.containsOnly(0);
+
+		server.disposeNow();
 	}
 }


### PR DESCRIPTION
Currently, there is a leak error on redirection, in case the redirection response has a body and not just headers. This is because `HttpClientOperations#onInboundNext` won't pass forward the HttpContent as there is no receiver yet, but it won't release it either, because it usually expects downstream to release it.