### PR TITLE
Move RESPONSE_RECEIVED from HttpObserver to HttpIOHandlerObserver

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -398,10 +398,6 @@ final class HttpClientConnect extends HttpClient {
 
 		@Override
 		public void onStateChange(Connection connection, State newState) {
-			if (newState == HttpClientState.RESPONSE_RECEIVED) {
-				sink.success(connection);
-				return;
-			}
 			if (newState == State.CONFIGURED && HttpClientOperations.class == connection.getClass()) {
 				handler.channel((HttpClientOperations) connection);
 			}
@@ -425,6 +421,10 @@ final class HttpClientConnect extends HttpClient {
 
 		@Override
 		public void onStateChange(Connection connection, State newState) {
+			if (newState == HttpClientState.RESPONSE_RECEIVED) {
+				sink.success(connection);
+				return;
+			}
 			if (newState == ConnectionObserver.State.CONFIGURED
 					&& HttpClientOperations.class == connection.getClass()) {
 				if (log.isDebugEnabled()) {


### PR DESCRIPTION
Thus connection state observers of RESPONSE_RECEIVED will be invoked before
HttpObserver and HttpIOHandlerObserver

Keep CONFIGURED and exception handling in HttpObserver in order to be able to
handle redirecting and retrying functionality.