### PR TITLE
fix #1041 Ensure one and the same MicrometerChannelMetricsRecorder instance is used when enabling metrics

### DIFF
--- a/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -2131,7 +2131,8 @@ public class HttpClientTest {
 		ConnectionProvider provider = ConnectionProvider.create("testIssue988", 1);
 		HttpClient client =
 				createHttpClientForContextWithAddress(provider)
-				        .tcpConfiguration(tcpClient -> tcpClient.wiretap("testIssue988", LogLevel.INFO));
+				        .tcpConfiguration(tcpClient -> tcpClient.wiretap("testIssue988", LogLevel.INFO)
+				                                                .metrics(true));
 
 		AtomicReference<Channel> ch1 = new AtomicReference<>();
 		StepVerifier.create(client.tcpConfiguration(tcpClient -> tcpClient.doOnConnected(c -> ch1.set(c.channel())))


### PR DESCRIPTION
Fixes #1041 