### PR TITLE
Deprecate ChannelBindException#fail(AbstractBootstrap<?,?>, Throwable…

### DIFF
--- a/src/main/java/reactor/netty/ChannelBindException.java
+++ b/src/main/java/reactor/netty/ChannelBindException.java
@@ -18,6 +18,7 @@ package reactor.netty;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Objects;
 
 import io.netty.bootstrap.AbstractBootstrap;
@@ -37,7 +38,9 @@ public class ChannelBindException extends RuntimeException {
 	 * @param cause a root cause
 	 *
 	 * @return a new {@link ChannelBindException}
+	 * @deprecated as of 0.9.7. Use {@link #fail(SocketAddress, Throwable)}
 	 */
+	@Deprecated
 	public static ChannelBindException fail(AbstractBootstrap<?, ?> bootstrap, @Nullable Throwable cause) {
 		Objects.requireNonNull(bootstrap, "bootstrap");
 		if (cause instanceof java.net.BindException ||
@@ -51,6 +54,31 @@ public class ChannelBindException extends RuntimeException {
 			return new ChannelBindException(bootstrap.config().localAddress().toString(), -1, cause);
 		}
 		InetSocketAddress address = (InetSocketAddress)bootstrap.config().localAddress();
+
+		return new ChannelBindException(address.getHostString(), address.getPort(), cause);
+	}
+
+	/**
+	 * Build a {@link ChannelBindException}
+	 *
+	 * @param localAddress the local address
+	 * @param cause the root cause
+	 *
+	 * @return a new {@link ChannelBindException}
+	 */
+	public static ChannelBindException fail(SocketAddress localAddress, @Nullable Throwable cause) {
+		Objects.requireNonNull(localAddress, "localAddress");
+		if (cause instanceof java.net.BindException ||
+				    // With epoll/kqueue transport it is
+				    // io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Address already in use
+				    (cause instanceof IOException && cause.getMessage() != null &&
+						     cause.getMessage().contains("Address already in use"))) {
+			cause = null;
+		}
+		if (!(localAddress instanceof InetSocketAddress)) {
+			return new ChannelBindException(localAddress.toString(), -1, cause);
+		}
+		InetSocketAddress address = (InetSocketAddress) localAddress;
 
 		return new ChannelBindException(address.getHostString(), address.getPort(), cause);
 	}

--- a/src/main/java/reactor/netty/resources/NewConnectionProvider.java
+++ b/src/main/java/reactor/netty/resources/NewConnectionProvider.java
@@ -154,7 +154,7 @@ final class NewConnectionProvider implements ConnectionProvider {
 							// io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Address already in use
 							(cause instanceof IOException && cause.getMessage() != null &&
 									cause.getMessage().contains("Address already in use"))) {
-						sink.error(ChannelBindException.fail(bootstrap, null));
+						sink.error(ChannelBindException.fail(bootstrap.config().localAddress(), null));
 					}
 					else {
 						sink.error(cause);

--- a/src/main/java/reactor/netty/tcp/TcpServerBind.java
+++ b/src/main/java/reactor/netty/tcp/TcpServerBind.java
@@ -182,7 +182,7 @@ final class TcpServerBind extends TcpServer {
 					}
 					return;
 				}
-				sink.error(ChannelBindException.fail(bootstrap, f.cause()));
+				sink.error(ChannelBindException.fail(bootstrap.config().localAddress(), f.cause()));
 			}
 			else {
 				if (log.isDebugEnabled()) {


### PR DESCRIPTION
…) in favour of ChannelBindException#fail(SocketAddress, Throwable)