### PR TITLE
Deprecate server/client #doOnLifecycle method in favour of #doOn* methods

### DIFF
--- a/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -273,9 +273,11 @@ public abstract class TcpClient {
 	 * @param doOnConnect a consumer observing client start event
 	 * @param doOnConnected a consumer observing client started event
 	 * @param doOnDisconnected a consumer observing client stop event
-	 *
 	 * @return a new {@link TcpClient}
+	 * @deprecated as of 0.9.7. Use {@link #doOnConnect(Consumer)}, {@link #doOnConnected(Consumer)}
+	 * or {@link #doOnDisconnected(Consumer)}
 	 */
+	@Deprecated
 	public final TcpClient doOnLifecycle(Consumer<? super Bootstrap> doOnConnect,
 			Consumer<? super Connection> doOnConnected,
 			Consumer<? super Connection> doOnDisconnected) {

--- a/src/main/java/reactor/netty/tcp/TcpServer.java
+++ b/src/main/java/reactor/netty/tcp/TcpServer.java
@@ -297,9 +297,11 @@ public abstract class TcpServer {
 	 * @param onBind a consumer observing server start event
 	 * @param onBound a consumer observing server started event
 	 * @param onUnbound a consumer observing server stop event
-	 *
 	 * @return a new {@link TcpServer}
+	 * @deprecated as of 0.9.7. Use {@link #doOnBind(Consumer)}, {@link #doOnBound(Consumer)}
+	 * or {@link #doOnUnbound(Consumer)}
 	 */
+	@Deprecated
 	public final TcpServer doOnLifecycle(Consumer<? super ServerBootstrap> onBind,
 			Consumer<? super DisposableServer> onBound,
 			Consumer<? super DisposableServer> onUnbound) {

--- a/src/main/java/reactor/netty/udp/UdpClient.java
+++ b/src/main/java/reactor/netty/udp/UdpClient.java
@@ -217,9 +217,11 @@ public abstract class UdpClient {
 	 * @param doOnConnect a consumer observing client start event
 	 * @param doOnConnected a consumer observing client started event
 	 * @param doOnDisconnected a consumer observing client stop event
-	 *
 	 * @return a new {@link UdpClient}
+	 * @deprecated as of 0.9.7. Use {@link #doOnConnect(Consumer)}, {@link #doOnConnected(Consumer)}
+	 * or {@link #doOnDisconnected(Consumer)}
 	 */
+	@Deprecated
 	public final UdpClient doOnLifecycle(Consumer<? super Bootstrap> doOnConnect,
 			Consumer<? super Connection> doOnConnected,
 			Consumer<? super Connection> doOnDisconnected) {

--- a/src/main/java/reactor/netty/udp/UdpServer.java
+++ b/src/main/java/reactor/netty/udp/UdpServer.java
@@ -218,9 +218,11 @@ public abstract class UdpServer {
 	 * @param onBind a consumer observing server start event
 	 * @param onBound a consumer observing server started event
 	 * @param onUnbound a consumer observing server stop event
-	 *
 	 * @return a new {@link UdpServer}
+	 * @deprecated as of 0.9.7. Use {@link #doOnBind(Consumer)}, {@link #doOnBound(Consumer)}
+	 * or {@link #doOnUnbound(Consumer)}
 	 */
+	@Deprecated
 	public final UdpServer doOnLifecycle(Consumer<? super Bootstrap> onBind,
 			Consumer<? super Connection> onBound,
 			Consumer<? super Connection> onUnbound) {


### PR DESCRIPTION
Motivation: `#doOnLifecycle` cannot be extended when a new `doOn*` method is introduced.