### PR TITLE
Deprecate #addressSupplier(Supplier) in favour of server#localAddress…

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -431,10 +431,24 @@ public abstract class HttpClient {
 	 * @param connectAddressSupplier A supplier of the address to connect to.
 	 *
 	 * @return a new {@link HttpClient}
+	 * @deprecated as of 0.9.7. Use {@link #remoteAddress(Supplier)}
 	 */
+	@Deprecated
 	public final HttpClient addressSupplier(Supplier<? extends SocketAddress> connectAddressSupplier) {
-		Objects.requireNonNull(connectAddressSupplier, "connectAddressSupplier");
-		return tcpConfiguration(tcpClient -> tcpClient.addressSupplier(connectAddressSupplier));
+		return remoteAddress(connectAddressSupplier);
+	}
+
+	/**
+	 * The address to which this client should connect for each subscribe.
+	 *
+	 * @param remoteAddressSupplier A supplier of the address to connect to.
+	 *
+	 * @return a new {@link HttpClient}
+	 * @since 0.9.7
+	 */
+	public final HttpClient remoteAddress(Supplier<? extends SocketAddress> remoteAddressSupplier) {
+		Objects.requireNonNull(remoteAddressSupplier, "remoteAddressSupplier");
+		return tcpConfiguration(tcpClient -> tcpClient.remoteAddress(remoteAddressSupplier));
 	}
 
 	/**

--- a/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -16,6 +16,7 @@
 
 package reactor.netty.http.server;
 
+import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -304,6 +305,19 @@ public abstract class HttpServer {
 			//Will never be here
 			throw new IllegalArgumentException("Invalid proxyProtocolSupportType");
 		}
+	}
+
+	/**
+	 * The address to which this server should bind on subscribe.
+	 *
+	 * @param bindAddressSupplier A supplier of the address to bind to.
+	 *
+	 * @return a new {@link HttpServer}
+	 * @since 0.9.7
+	 */
+	public final HttpServer bindAddress(Supplier<? extends SocketAddress> bindAddressSupplier) {
+		Objects.requireNonNull(bindAddressSupplier, "bindAddressSupplier");
+		return tcpConfiguration(tcpServer -> tcpServer.bindAddress(bindAddressSupplier));
 	}
 
 	/**

--- a/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -116,9 +116,23 @@ public abstract class TcpClient {
 	 * @param connectAddressSupplier A supplier of the address to connect to.
 	 *
 	 * @return a new {@link TcpClient}
+	 * @deprecated as of 0.9.7. Use {@link #remoteAddress(Supplier)}
 	 */
+	@Deprecated
 	public final TcpClient addressSupplier(Supplier<? extends SocketAddress> connectAddressSupplier) {
-		SocketAddress lazy = TcpUtils.lazyAddress(connectAddressSupplier);
+		return remoteAddress(connectAddressSupplier);
+	}
+
+	/**
+	 * The address to which this client should connect for each subscribe.
+	 *
+	 * @param remoteAddressSupplier A supplier of the address to connect to.
+	 *
+	 * @return a new {@link TcpClient}
+	 * @since 0.9.7
+	 */
+	public final TcpClient remoteAddress(Supplier<? extends SocketAddress> remoteAddressSupplier) {
+		SocketAddress lazy = TcpUtils.lazyAddress(remoteAddressSupplier);
 		return bootstrap(b -> b.remoteAddress(lazy));
 	}
 

--- a/src/main/java/reactor/netty/tcp/TcpServer.java
+++ b/src/main/java/reactor/netty/tcp/TcpServer.java
@@ -93,10 +93,24 @@ public abstract class TcpServer {
 	 * @param bindingAddressSupplier A supplier of the address to bind to.
 	 *
 	 * @return a new {@link TcpServer}
+	 * @deprecated as of 0.9.7. Use {@link #bindAddress(Supplier)}
 	 */
+	@Deprecated
 	public final TcpServer addressSupplier(Supplier<? extends SocketAddress> bindingAddressSupplier) {
-		Objects.requireNonNull(bindingAddressSupplier, "bindingAddressSupplier");
-		return bootstrap(b -> b.localAddress(bindingAddressSupplier.get()));
+		return bindAddress(bindingAddressSupplier);
+	}
+
+	/**
+	 * The address to which this server should bind on subscribe.
+	 *
+	 * @param bindAddressSupplier A supplier of the address to bind to.
+	 *
+	 * @return a new {@link TcpServer}
+	 * @since 0.9.7
+	 */
+	public final TcpServer bindAddress(Supplier<? extends SocketAddress> bindAddressSupplier) {
+		Objects.requireNonNull(bindAddressSupplier, "bindAddressSupplier");
+		return bootstrap(b -> b.localAddress(bindAddressSupplier.get()));
 	}
 
 	/**

--- a/src/main/java/reactor/netty/udp/UdpClient.java
+++ b/src/main/java/reactor/netty/udp/UdpClient.java
@@ -89,10 +89,24 @@ public abstract class UdpClient {
 	 * @param connectingAddressSupplier A supplier of the address to connect to.
 	 *
 	 * @return a new {@link UdpClient}
+	 * @deprecated as of 0.9.7. Use {@link #remoteAddress(Supplier)}
 	 */
+	@Deprecated
 	public final UdpClient addressSupplier(Supplier<? extends SocketAddress> connectingAddressSupplier) {
-		Objects.requireNonNull(connectingAddressSupplier, "connectingAddressSupplier");
-		return bootstrap(b -> b.remoteAddress(connectingAddressSupplier.get()));
+		return remoteAddress(connectingAddressSupplier);
+	}
+
+	/**
+	 * The address to which this client should connect on subscribe.
+	 *
+	 * @param remoteAddressSupplier A supplier of the address to connect to.
+	 *
+	 * @return a new {@link UdpClient}
+	 * @since 0.9.7
+	 */
+	public final UdpClient remoteAddress(Supplier<? extends SocketAddress> remoteAddressSupplier) {
+		Objects.requireNonNull(remoteAddressSupplier, "remoteAddressSupplier");
+		return bootstrap(b -> b.remoteAddress(remoteAddressSupplier.get()));
 	}
 
 	/**

--- a/src/main/java/reactor/netty/udp/UdpServer.java
+++ b/src/main/java/reactor/netty/udp/UdpServer.java
@@ -89,10 +89,24 @@ public abstract class UdpServer {
 	 * @param bindingAddressSupplier A supplier of the address to bind to.
 	 *
 	 * @return a new {@link UdpServer}
+	 * @deprecated as of 0.9.7. Use {@link #bindAddress(Supplier)}
 	 */
+	@Deprecated
 	public final UdpServer addressSupplier(Supplier<? extends SocketAddress> bindingAddressSupplier) {
-		Objects.requireNonNull(bindingAddressSupplier, "bindingAddressSupplier");
-		return bootstrap(b -> b.localAddress(bindingAddressSupplier.get()));
+		return bindAddress(bindingAddressSupplier);
+	}
+
+	/**
+	 * The address to which this server should bind on subscribe.
+	 *
+	 * @param bindAddressSupplier A supplier of the address to bind to.
+	 *
+	 * @return a new {@link UdpServer}
+	 * @since 0.9.7
+	 */
+	public final UdpServer bindAddress(Supplier<? extends SocketAddress> bindAddressSupplier) {
+		Objects.requireNonNull(bindAddressSupplier, "bindAddressSupplier");
+		return bootstrap(b -> b.localAddress(bindAddressSupplier.get()));
 	}
 
 	/**

--- a/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
+++ b/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
@@ -16,7 +16,6 @@
 package reactor.netty.http;
 
 import java.io.ByteArrayInputStream;
-import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
@@ -55,7 +54,7 @@ public class HttpCompressionClientServerTests {
 				      .bindNow(Duration.ofSeconds(10));
 
 		HttpClient.create()
-		          .addressSupplier(() -> address(runningServer))
+		          .remoteAddress(runningServer::address)
 		          .wiretap(true)
 		          .compress(true)
 		          .headers(h -> Assert.assertTrue(h.contains("Accept-Encoding", "gzip", true)))
@@ -80,7 +79,7 @@ public class HttpCompressionClientServerTests {
 				      .bindNow(Duration.ofSeconds(10));
 
 		HttpClient client = HttpClient.create()
-				                      .addressSupplier(() -> address(runningServer))
+				                      .remoteAddress(runningServer::address)
 				                      .wiretap(true);
 		Tuple2<String, HttpHeaders> resp =
 				client.headers(h -> h.add("Accept-Encoding", "gzip"))
@@ -113,7 +112,7 @@ public class HttpCompressionClientServerTests {
 
 		//don't activate compression on the client options to avoid auto-handling (which removes the header)
 		HttpClient client = HttpClient.create()
-				                      .addressSupplier(() -> address(runningServer))
+				                      .remoteAddress(runningServer::address)
 				                      .wiretap(true);
 		Tuple2<String, HttpHeaders> resp =
 				//edit the header manually to attempt to trigger compression on server side
@@ -147,7 +146,7 @@ public class HttpCompressionClientServerTests {
 
 		//don't activate compression on the client options to avoid auto-handling (which removes the header)
 		HttpClient client = HttpClient.create()
-				                      .addressSupplier(() -> address(runningServer))
+				                      .remoteAddress(runningServer::address)
 		                              .compress(false)
 				                      .wiretap(true);
 		Tuple2<byte[], HttpHeaders> resp =
@@ -195,7 +194,7 @@ public class HttpCompressionClientServerTests {
 
 		//don't activate compression on the client options to avoid auto-handling (which removes the header)
 		HttpClient client = HttpClient.create()
-		                              .addressSupplier(() -> address(connection));
+		                              .remoteAddress(connection::address);
 		Tuple2<String, HttpHeaders> resp =
 				//edit the header manually to attempt to trigger compression on server side
 				client.headers(h -> h.add("Accept-Encoding", "gzip"))
@@ -232,7 +231,7 @@ public class HttpCompressionClientServerTests {
 
 		//don't activate compression on the client options to avoid auto-handling (which removes the header)
 		HttpClient client = HttpClient.create()
-		                              .addressSupplier(() -> address(connection));
+		                              .remoteAddress(connection::address);
 		Tuple2<HttpHeaders, byte[]> resp =
 				//edit the header manually to attempt to trigger compression on server side
 				client.headers(h -> h.add("Accept-Encoding", "gzip"))
@@ -281,7 +280,7 @@ public class HttpCompressionClientServerTests {
 
 		//don't activate compression on the client options to avoid auto-handling (which removes the header)
 		HttpClient client = HttpClient.create()
-				                      .addressSupplier(() -> address(runningServer))
+				                      .remoteAddress(runningServer::address)
 				                      .wiretap(true);
 		Tuple2<String, HttpHeaders> resp =
 				//edit the header manually to attempt to trigger compression on server side
@@ -319,7 +318,7 @@ public class HttpCompressionClientServerTests {
 
 		//don't activate compression on the client options to avoid auto-handling (which removes the header)
 		HttpClient client = HttpClient.create()
-				                      .addressSupplier(() -> address(runningServer))
+				                      .remoteAddress(runningServer::address)
 				                      .wiretap(true);
 		Tuple2<byte[], HttpHeaders> resp =
 				//edit the header manually to attempt to trigger compression on server side
@@ -364,7 +363,7 @@ public class HttpCompressionClientServerTests {
 				      .bindNow(Duration.ofSeconds(10));
 
 		HttpClient client = HttpClient.create()
-				                      .addressSupplier(() -> address(runningServer))
+				                      .remoteAddress(runningServer::address)
 				                      .wiretap(true)
 				                      .compress(false);
 
@@ -396,7 +395,7 @@ public class HttpCompressionClientServerTests {
 				      .bindNow(Duration.ofSeconds(10));
 
 		HttpClient client = HttpClient.create()
-				                      .addressSupplier(() -> address(runningServer))
+				                      .remoteAddress(runningServer::address)
 				                      .wiretap(true);
 
 		Tuple2<String, HttpHeaders> resp =
@@ -427,7 +426,7 @@ public class HttpCompressionClientServerTests {
 				      .wiretap(true)
 				      .bindNow(Duration.ofSeconds(10));
 		HttpClient.create()
-		          .addressSupplier(() -> address(runningServer))
+		          .remoteAddress(runningServer::address)
 		          .wiretap(true)
 		          .compress(true)
 		          .headers(h -> zip.set(h.get("accept-encoding")))
@@ -440,10 +439,6 @@ public class HttpCompressionClientServerTests {
 		runningServer.dispose();
 		runningServer.onDispose()
 				.block();
-	}
-
-	private InetSocketAddress address(DisposableServer runningServer) {
-		return runningServer.address();
 	}
 
 	@Test

--- a/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -74,7 +74,7 @@ public class HttpMetricsHandlerTests {
 		provider = ConnectionProvider.create("HttpMetricsHandlerTests", 1);
 		httpClient =
 				customizeClientOptions(HttpClient.create(provider)
-				                                 .addressSupplier(() -> disposableServer.address())
+				                                 .remoteAddress(() -> disposableServer.address())
 				                                 .metrics(true));
 
 		registry = new SimpleMeterRegistry();

--- a/src/test/java/reactor/netty/http/client/HttpClientProxyTest.java
+++ b/src/test/java/reactor/netty/http/client/HttpClientProxyTest.java
@@ -180,7 +180,7 @@ public class HttpClientProxyTest {
 				          });
 
 		if (connectAddressSupplier != null) {
-			client = client.addressSupplier(server::address);
+			client = client.remoteAddress(server::address);
 		}
 
 		return client.wiretap(wiretap)

--- a/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -880,7 +880,7 @@ public class HttpClientTest {
 		else {
 			client = HttpClient.create(pool);
 		}
-		return client.addressSupplier(disposableServer::address)
+		return client.remoteAddress(disposableServer::address)
 		             .wiretap(true);
 	}
 

--- a/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
+++ b/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
@@ -87,7 +87,7 @@ public class HttpRedirectTest {
 
 		HttpClient client =
 				HttpClient.create(pool)
-				          .addressSupplier(server::address);
+				          .remoteAddress(server::address);
 
 		try {
 			Flux.range(0, 1000)
@@ -119,7 +119,7 @@ public class HttpRedirectTest {
 
 		HttpClientResponse response =
 				HttpClient.create()
-				          .addressSupplier(server::address)
+				          .remoteAddress(server::address)
 				          .wiretap(true)
 				          .get()
 				          .uri("/1")
@@ -152,7 +152,7 @@ public class HttpRedirectTest {
 		AtomicInteger doOnResponseError = new AtomicInteger();
 		Tuple2<String, HttpResponseStatus> response =
 				HttpClient.create()
-				          .addressSupplier(server::address)
+				          .remoteAddress(server::address)
 				          .wiretap(true)
 				          .followRedirect(true)
 				          .doOnRequest((r, c) -> onRequestCount.incrementAndGet())
@@ -196,7 +196,7 @@ public class HttpRedirectTest {
 		BlockingQueue<Long> doOnResponseNanos = new LinkedBlockingQueue<>();
 		Long responseNanos =
 				HttpClient.create()
-				          .addressSupplier(server::address)
+				          .remoteAddress(server::address)
 				          .wiretap(true)
 				          .followRedirect(true)
 				          .doOnResponse((r, c) -> doOnResponseNanos.add(System.nanoTime()))
@@ -233,7 +233,7 @@ public class HttpRedirectTest {
 
 		HttpClient client =
 				HttpClient.create()
-				          .addressSupplier(server::address)
+				          .remoteAddress(server::address)
 				          .wiretap(true);
 
 		String value =
@@ -373,7 +373,7 @@ public class HttpRedirectTest {
 
 		HttpClient client =
 				HttpClient.create()
-				          .addressSupplier(server::address)
+				          .remoteAddress(server::address)
 				          .wiretap(true);
 
 		StepVerifier.create(client.followRedirect(true)
@@ -453,7 +453,7 @@ public class HttpRedirectTest {
 
 		AtomicInteger followRedirects = new AtomicInteger(0);
 		HttpClient.create()
-		          .addressSupplier(server::address)
+		          .remoteAddress(server::address)
 		          .wiretap(true)
 		          .followRedirect((req, res) -> {
 		              boolean result = req.redirectedFrom().length < 4;
@@ -486,7 +486,7 @@ public class HttpRedirectTest {
 
 		StepVerifier.create(
 		        HttpClient.create()
-		                  .addressSupplier(server::address)
+		                  .remoteAddress(server::address)
 		                  .wiretap(true)
 		                  .followRedirect((req, res) -> {
 		                      throw new RuntimeException("testFollowRedirectPredicateThrowsException");
@@ -525,7 +525,7 @@ public class HttpRedirectTest {
 
 		AtomicInteger peerPort = new AtomicInteger(0);
 		HttpClient.create()
-		          .addressSupplier(server1::address)
+		          .remoteAddress(server1::address)
 		          .wiretap(true)
 		          .followRedirect(true)
 		          .secure(spec -> spec.sslContext(SslContextBuilder.forClient()

--- a/src/test/java/reactor/netty/http/client/WebsocketTest.java
+++ b/src/test/java/reactor/netty/http/client/WebsocketTest.java
@@ -942,7 +942,7 @@ public class WebsocketTest {
 				          .bindNow();
 
 		TcpClient client = TcpClient.create()
-		                            .addressSupplier(() -> new InetSocketAddress("not a valid host name", 42));
+		                            .remoteAddress(() -> new InetSocketAddress("not a valid host name", 42));
 		HttpClient httpClient = HttpClient.from(client);
 		StepVerifier.create(httpClient.websocket()
 		                              .connect())
@@ -983,7 +983,7 @@ public class WebsocketTest {
 
 		StepVerifier.create(
 				HttpClient.create()
-				          .addressSupplier(() -> httpServer.address())
+				          .remoteAddress(httpServer::address)
 				          .wiretap(true)
 				          .websocket()
 				          .uri("/")
@@ -1012,7 +1012,7 @@ public class WebsocketTest {
 		AtomicBoolean clientHandler = new AtomicBoolean();
 		HttpClient client =
 				HttpClient.create()
-				          .addressSupplier(httpServer::address)
+				          .remoteAddress(httpServer::address)
 				          .wiretap(true);
 
 		String perMessageDeflateEncoder = "io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateEncoder";
@@ -1433,7 +1433,7 @@ public class WebsocketTest {
 		AtomicBoolean clientHandler = new AtomicBoolean();
 		HttpClient client =
 				HttpClient.create()
-				          .addressSupplier(httpServer::address)
+				          .remoteAddress(httpServer::address)
 				          .wiretap(true);
 
 		String perMessageDeflateEncoder = "io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateEncoder";

--- a/src/test/java/reactor/netty/http/server/HttpSendFileTests.java
+++ b/src/test/java/reactor/netty/http/server/HttpSendFileTests.java
@@ -259,12 +259,12 @@ public class HttpSendFileTests {
 		HttpClient client;
 		if (compression) {
 			client = HttpClient.create()
-			                   .addressSupplier(context::address)
+			                   .remoteAddress(context::address)
 			                   .compress(true);
 		}
 		else {
 			client = HttpClient.create()
-			                   .addressSupplier(context::address);
+			                   .remoteAddress(context::address);
 		}
 		Mono<String> response =
 				customizeClientOptions(client)
@@ -346,7 +346,7 @@ public class HttpSendFileTests {
 		try {
 			byte[] response =
 					customizeClientOptions(HttpClient.create()
-					                                 .addressSupplier(context::address))
+					                                 .remoteAddress(context::address))
 //							.tcpConfiguration(tcp -> tcp.option(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(1024, 1024)))
 //.wiretap(true)
 					    .request(HttpMethod.POST)

--- a/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -167,7 +167,7 @@ public class HttpServerTests {
 		HttpServer server2 =
 				HttpServer.create()
 				          // Any local address
-				          .tcpConfiguration(tcpServer -> tcpServer.addressSupplier(() -> new InetSocketAddress(8080)));
+				          .bindAddress(() -> new InetSocketAddress(8080));
 		HttpClient client1 = HttpClient.create()
 		                               .port(8080)
 		                               .tcpConfiguration(tcpClient -> tcpClient.host("localhost"));
@@ -508,7 +508,7 @@ public class HttpServerTests {
 	private void checkResponse(String url, InetSocketAddress address) {
 		Mono<Tuple3<Integer, HttpHeaders, String>> response =
 				HttpClient.create()
-				          .addressSupplier(() -> address)
+				          .remoteAddress(() -> address)
 				          .wiretap(true)
 				          .get()
 				          .uri(url)
@@ -595,7 +595,7 @@ public class HttpServerTests {
 			HttpMethod method, boolean chunk, boolean close) {
 		Mono<Tuple2<HttpHeaders, String>> response =
 				HttpClient.create()
-				          .addressSupplier(() -> address)
+				          .remoteAddress(() -> address)
 				          .wiretap(true)
 				          .request(method)
 				          .uri(url)
@@ -648,7 +648,7 @@ public class HttpServerTests {
 
 		HttpClient client =
 				HttpClient.create(ConnectionProvider.create("testIssue186", 1))
-				          .addressSupplier(disposableServer::address)
+				          .remoteAddress(disposableServer::address)
 				          .wiretap(true);
 
 		doTestIssue186(client);
@@ -713,7 +713,7 @@ public class HttpServerTests {
 
 		HttpClient client =
 				HttpClient.create(ConnectionProvider.create("contextShouldBeTransferredFromDownStreamToUpStream", 1))
-				          .addressSupplier(disposableServer::address);
+				          .remoteAddress(disposableServer::address);
 
 		Mono<String> content = client.post()
 		                             .uri("/")
@@ -810,7 +810,7 @@ public class HttpServerTests {
 		disposableServer = server.bindNow();
 
 		HttpClient.create()
-		          .addressSupplier(disposableServer::address)
+		          .remoteAddress(disposableServer::address)
 		          .post()
 		          .uri("/")
 		          .send(ByteBufFlux.fromString(Mono.just("bodysample")))
@@ -1014,7 +1014,7 @@ public class HttpServerTests {
 
 		StepVerifier.create(
 		        HttpClient.create()
-		                  .addressSupplier(disposableServer::address)
+		                  .remoteAddress(disposableServer::address)
 		                  .wiretap(true)
 		                  .get()
 		                  .uri("/")
@@ -1040,7 +1040,7 @@ public class HttpServerTests {
 		Flux.range(0, 70)
 		    .flatMap(i ->
 		        HttpClient.create()
-		                  .addressSupplier(disposableServer::address)
+		                  .remoteAddress(disposableServer::address)
 		                  .post()
 		                  .uri("/")
 		                  .send(ByteBufFlux.fromString(Mono.just("test")))
@@ -1079,7 +1079,7 @@ public class HttpServerTests {
 		                                        .build();
 		StepVerifier.create(
 				HttpClient.create()
-				          .addressSupplier(disposableServer::address)
+				          .remoteAddress(disposableServer::address)
 				          .secure(spec -> spec.sslContext(clientCtx))
 				          .get()
 				          .uri("/")
@@ -1551,7 +1551,7 @@ public class HttpServerTests {
 		int port = disposableServer.port();
 		Connection connection =
 				TcpClient.create()
-				         .addressSupplier(disposableServer::address)
+				         .remoteAddress(disposableServer::address)
 				         .wiretap(true)
 				         .connectNow();
 
@@ -1579,7 +1579,7 @@ public class HttpServerTests {
 
 		StepVerifier.create(
 		        HttpClient.create()
-		                  .addressSupplier(disposableServer::address)
+		                  .remoteAddress(disposableServer::address)
 		                  .wiretap(true)
 		                  .get()
 		                  .uri("/<")
@@ -1613,7 +1613,7 @@ public class HttpServerTests {
 				          .bindNow(Duration.ofSeconds(30));
 
 		HttpClient client = HttpClient.create()
-		                              .addressSupplier(disposableServer::address)
+		                              .remoteAddress(disposableServer::address)
 		                              .wiretap(true);
 
 		MonoProcessor<String> result = MonoProcessor.create();

--- a/src/test/java/reactor/netty/resources/PooledConnectionProviderTest.java
+++ b/src/test/java/reactor/netty/resources/PooledConnectionProviderTest.java
@@ -513,7 +513,7 @@ public class PooledConnectionProviderTest {
 				(PooledConnectionProvider) ConnectionProvider.create("connectionReleasedOnRedirect", 1);
 		String response =
 				HttpClient.create(provider)
-				          .addressSupplier(server::address)
+				          .remoteAddress(server::address)
 				          .wiretap(true)
 				          .followRedirect(true)
 				          .observe((conn, state) -> {

--- a/src/test/java/reactor/netty/tcp/TcpClientTests.java
+++ b/src/test/java/reactor/netty/tcp/TcpClientTests.java
@@ -795,13 +795,13 @@ public class TcpClientTests {
 		if (withLoop) {
 			client =
 					TcpClient.create(pool)
-					         .addressSupplier(server::address)
+					         .remoteAddress(server::address)
 					         .runOn(loop);
 		}
 		else {
 			client =
 					TcpClient.create(pool)
-					         .addressSupplier(server::address);
+					         .remoteAddress(server::address);
 		}
 
 		Set<String> threadNames = new ConcurrentSkipListSet<>();
@@ -846,7 +846,7 @@ public class TcpClientTests {
 
 		Connection  conn =
 				TcpClient.create()
-				         .addressSupplier(addressSupplier)
+				         .remoteAddress(addressSupplier)
 				         .doOnConnected(connection -> latch.countDown())
 				         .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 100)
 				         .handle((in, out) -> Mono.never())
@@ -923,7 +923,7 @@ public class TcpClientTests {
 
 		Connection conn =
 				TcpClient.create()
-				         .addressSupplier(server::address)
+				         .remoteAddress(server::address)
 				         .wiretap(true)
 				         .connectNow();
 
@@ -981,7 +981,7 @@ public class TcpClientTests {
 
 		Connection conn =
 				TcpClient.create()
-				         .addressSupplier(server::address)
+				         .remoteAddress(server::address)
 				         .wiretap(true)
 				         .connectNow();
 

--- a/src/test/java/reactor/netty/tcp/TcpMetricsTests.java
+++ b/src/test/java/reactor/netty/tcp/TcpMetricsTests.java
@@ -67,7 +67,7 @@ public class TcpMetricsTests {
 		provider = ConnectionProvider.create("TcpMetricsTests", 1);
 		tcpClient =
 				customizeClientOptions(TcpClient.create(provider)
-				                                .addressSupplier(() -> disposableServer.address())
+				                                .remoteAddress(() -> disposableServer.address())
 				                                .metrics(true));
 
 		registry = new SimpleMeterRegistry();

--- a/src/test/java/reactor/netty/tcp/TcpServerTests.java
+++ b/src/test/java/reactor/netty/tcp/TcpServerTests.java
@@ -741,7 +741,7 @@ public class TcpServerTests {
 		assertNotNull(server);
 
 		Connection client = TcpClient.create()
-		                             .addressSupplier(server::address)
+		                             .remoteAddress(server::address)
 		                             .handle((in, out) -> {
 		                                 in.receive()
 		                                   .asString()
@@ -833,7 +833,7 @@ public class TcpServerTests {
 				         .bindNow();
 
 		TcpClient.create()
-		         .addressSupplier(boundServer::address)
+		         .remoteAddress(boundServer::address)
 		         .wiretap(true)
 		         .connect()
 		         .subscribe();
@@ -875,7 +875,7 @@ public class TcpServerTests {
 				         .bindNow();
 
 		TcpClient.create()
-		         .addressSupplier(server::address)
+		         .remoteAddress(server::address)
 		         .wiretap(true)
 		         .connect()
 		         .subscribe();
@@ -914,7 +914,7 @@ public class TcpServerTests {
 				         .bindNow(Duration.ofSeconds(30));
 
 		TcpClient client = TcpClient.create()
-		                            .addressSupplier(disposableServer::address)
+		                            .remoteAddress(disposableServer::address)
 		                            .wiretap(true);
 
 		MonoProcessor<String> result = MonoProcessor.create();

--- a/src/test/java/reactor/netty/udp/UdpMetricsTests.java
+++ b/src/test/java/reactor/netty/udp/UdpMetricsTests.java
@@ -70,7 +70,7 @@ public class UdpMetricsTests {
 
 		udpClient =
 				UdpClient.create()
-				         .addressSupplier(() -> serverConnection.address())
+				         .remoteAddress(() -> serverConnection.address())
 				         .metrics(true);
 
 		registry = new SimpleMeterRegistry();

--- a/src/test/java/reactor/netty/udp/UdpServerTests.java
+++ b/src/test/java/reactor/netty/udp/UdpServerTests.java
@@ -143,7 +143,7 @@ public class UdpServerTests {
 			Connection server =
 					UdpServer.create()
 					         .option(ChannelOption.SO_REUSEADDR, true)
-					         .addressSupplier(() -> new InetSocketAddress(port))
+					         .bindAddress(() -> new InetSocketAddress(port))
 					         .runOn(resources, InternetProtocolFamily.IPv4)
 					         .handle((in, out) -> {
 						         Flux.<NetworkInterface>generate(s -> {
@@ -258,7 +258,7 @@ public class UdpServerTests {
 
 		try {
 			UdpServer.create()
-			         .addressSupplier(conn::address)
+			         .bindAddress(conn::address)
 			         .bindNow(Duration.ofSeconds(30));
 			fail("illegal-success");
 		}


### PR DESCRIPTION
…(Supplier)/client#remoteAddress(Supplier)

Motivation:
It is clear on API level whether it is local or remote address configuration.
The API can provide on client both local and remote address configuration.