### PR TITLE
Ensure re-acquire in case of channel was active when acquiring but cl…

### DIFF
--- a/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
+++ b/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
@@ -54,12 +54,16 @@ final class ChannelOperationsHandler extends ChannelInboundHandlerAdapter {
 
 	@Override
 	public void channelActive(ChannelHandlerContext ctx) {
-		Connection c = Connection.from(ctx.channel());
-		listener.onStateChange(c, ConnectionObserver.State.CONNECTED);
-		ChannelOperations<?, ?> ops = opsFactory.create(c, listener, null);
-		if (ops != null) {
-			ops.bind();
-			listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED);
+		// When AbstractNioChannel.AbstractNioUnsafe.finishConnect/fulfillConnectPromise,
+		// fireChannelActive will be triggered regardless that the channel might be closed in the meantime
+		if (ctx.channel().isActive()) {
+			Connection c = Connection.from(ctx.channel());
+			listener.onStateChange(c, ConnectionObserver.State.CONNECTED);
+			ChannelOperations<?, ?> ops = opsFactory.create(c, listener, null);
+			if (ops != null) {
+				ops.bind();
+				listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED);
+			}
 		}
 	}
 


### PR DESCRIPTION
…osed when PooledConnectionProvider.DisposableAcquire#onNext

Ensure the "owner" will be set in the channel only if the channel is active

Related to #782, #981