### PR TITLE
Add HttpServer/HttpClient#metrics(boolean, Function<String, String>)

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1017,20 +1017,51 @@ public abstract class HttpClient {
 	/**
 	 * Whether to enable metrics to be collected and registered in Micrometer's
 	 * {@link io.micrometer.core.instrument.Metrics#globalRegistry globalRegistry}
-	 * under the name {@link reactor.netty.Metrics#HTTP_CLIENT_PREFIX}. Applications can
-	 * separately register their own
-	 * {@link io.micrometer.core.instrument.config.MeterFilter filters} associated with this name.
-	 * For example, to put an upper bound on the number of tags produced:
+	 * under the name {@link reactor.netty.Metrics#HTTP_CLIENT_PREFIX}.
+	 * <p><strong>Note:</strong>
+	 * It is strongly recommended applications to configure an upper limit for the number of the URI tags.
+	 * For example:
 	 * <pre class="code">
-	 * MeterFilter filter = ... ;
-	 * Metrics.globalRegistry.config().meterFilter(MeterFilter.maximumAllowableTags(HTTP_CLIENT_PREFIX, 100, filter));
+	 * Metrics.globalRegistry
+	 *        .config()
+	 *        .meterFilter(MeterFilter.maximumAllowableTags(HTTP_CLIENT_PREFIX, URI, 100, MeterFilter.deny()));
 	 * </pre>
-	 * <p>By default this is not enabled.
+	 * <p>By default metrics are not enabled.
 	 *
 	 * @param metricsEnabled true enables metrics collection; false disables it
 	 * @return a new {@link HttpClient}
+	 * @deprecated as of 0.9.7. Use {@link #metrics(boolean, Function)}
 	 */
+	@Deprecated
 	public final HttpClient metrics(boolean metricsEnabled) {
+		return metrics(metricsEnabled, (Function<String, String>) null);
+	}
+
+	/**
+	 * Whether to enable metrics to be collected and registered in Micrometer's
+	 * {@link io.micrometer.core.instrument.Metrics#globalRegistry globalRegistry}
+	 * under the name {@link reactor.netty.Metrics#HTTP_CLIENT_PREFIX}.
+	 * <p>{@code uriTagValue} function receives the actual uri and returns the uri tag value
+	 * that will be used for the metrics with {@link reactor.netty.Metrics#URI} tag.
+	 * For example instead of using the actual uri {@code "/users/1"} as uri tag value, templated uri
+	 * {@code "/users/{id}"} can be used.
+	 * <p><strong>Note:</strong>
+	 * It is strongly recommended applications to configure an upper limit for the number of the URI tags.
+	 * For example:
+	 * <pre class="code">
+	 * Metrics.globalRegistry
+	 *        .config()
+	 *        .meterFilter(MeterFilter.maximumAllowableTags(HTTP_CLIENT_PREFIX, URI, 100, MeterFilter.deny()));
+	 * </pre>
+	 * <p>By default metrics are not enabled.
+	 *
+	 * @param metricsEnabled true enables metrics collection; false disables it
+	 * @param uriTagValue a function that receives the actual uri and returns the uri tag value
+	 * that will be used for the metrics with {@link reactor.netty.Metrics#URI} tag
+	 * @return a new {@link HttpClient}
+	 * @since 0.9.7
+	 */
+	public final HttpClient metrics(boolean metricsEnabled, @Nullable Function<String, String> uriTagValue) {
 		if (metricsEnabled) {
 			if (!Metrics.isInstrumentationAvailable()) {
 				throw new UnsupportedOperationException(
@@ -1039,11 +1070,17 @@ public abstract class HttpClient {
 			}
 
 			return tcpConfiguration(tcpClient ->
-					tcpClient.bootstrap(b -> BootstrapHandlers.updateMetricsSupport(b,
-							MicrometerHttpClientMetricsRecorder.INSTANCE)));
+					tcpClient.bootstrap(b -> {
+						BootstrapHandlers.updateMetricsSupport(b, MicrometerHttpClientMetricsRecorder.INSTANCE);
+						return HttpClientConfiguration.uriTagValue(b, uriTagValue);
+					}));
 		}
 		else {
-			return tcpConfiguration(tcpClient -> tcpClient.bootstrap(BootstrapHandlers::removeMetricsSupport));
+			return tcpConfiguration(tcpClient ->
+					tcpClient.bootstrap(b -> {
+						BootstrapHandlers.removeMetricsSupport(b);
+						return HttpClientConfiguration.uriTagValue(b, null);
+					}));
 		}
 	}
 
@@ -1058,7 +1095,10 @@ public abstract class HttpClient {
 	 */
 	@Deprecated
 	public final HttpClient metrics(boolean metricsEnabled, HttpClientMetricsRecorder recorder) {
-		return tcpConfiguration(tcpClient -> tcpClient.metrics(metricsEnabled, recorder));
+		return tcpConfiguration(tcpClient -> {
+			tcpClient.metrics(metricsEnabled, recorder);
+			return tcpClient.bootstrap(b -> HttpClientConfiguration.uriTagValue(b, null));
+		});
 	}
 
 	/**
@@ -1072,7 +1112,10 @@ public abstract class HttpClient {
 	 * @since 0.9.7
 	 */
 	public final HttpClient metrics(boolean metricsEnabled, Supplier<? extends HttpClientMetricsRecorder> recorder) {
-		return tcpConfiguration(tcpClient -> tcpClient.metrics(metricsEnabled, recorder));
+		return tcpConfiguration(tcpClient -> {
+			tcpClient.metrics(metricsEnabled, recorder);
+			return tcpClient.bootstrap(b -> HttpClientConfiguration.uriTagValue(b, null));
+		});
 	}
 
 	/**

--- a/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
@@ -65,6 +65,8 @@ final class HttpClientConfiguration {
 	BiPredicate<HttpClientRequest, HttpClientResponse> followRedirectPredicate = null;
 	Consumer<HttpClientRequest> redirectRequestConsumer = null;
 
+	Function<String, String> uriTagValue = null;
+
 	Function<Mono<HttpClientConfiguration>, Mono<HttpClientConfiguration>> deferredConf                   = null;
 
 	BiFunction<? super HttpClientRequest, ? super NettyOutbound, ? extends Publisher<Void>>
@@ -91,6 +93,7 @@ final class HttpClientConfiguration {
 		this.body = from.body;
 		this.protocols = from.protocols;
 		this.deferredConf = from.deferredConf;
+		this.uriTagValue = from.uriTagValue;
 	}
 
 	static HttpClientConfiguration getAndClean(Bootstrap b) {
@@ -299,6 +302,11 @@ final class HttpClientConfiguration {
 
 	static Bootstrap decoder(Bootstrap b, HttpResponseDecoderSpec decoder) {
 		getOrCreate(b).decoder = decoder;
+		return b;
+	}
+
+	static Bootstrap uriTagValue(Bootstrap b, @Nullable Function<String, String> uriTagValue) {
+		getOrCreate(b).uriTagValue = uriTagValue;
 		return b;
 	}
 

--- a/src/main/java/reactor/netty/http/server/HttpServerBind.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerBind.java
@@ -151,7 +151,8 @@ final class HttpServerBind extends HttpServer
 								compressPredicate(conf.compressPredicate, conf.minCompressionSize),
 								conf.forwarded,
 								conf.cookieEncoder,
-								conf.cookieDecoder));
+								conf.cookieDecoder,
+								conf.uriTagValue));
 			}
 			if ((conf.protocols & HttpServerConfiguration.h11) == HttpServerConfiguration.h11) {
 				return BootstrapHandlers.updateConfiguration(b,
@@ -165,7 +166,8 @@ final class HttpServerBind extends HttpServer
 								compressPredicate(conf.compressPredicate, conf.minCompressionSize),
 								conf.forwarded,
 								conf.cookieEncoder,
-								conf.cookieDecoder));
+								conf.cookieDecoder,
+								conf.uriTagValue));
 			}
 			if ((conf.protocols & HttpServerConfiguration.h2) == HttpServerConfiguration.h2) {
 				return BootstrapHandlers.updateConfiguration(b,
@@ -198,7 +200,8 @@ final class HttpServerBind extends HttpServer
 								compressPredicate(conf.compressPredicate, conf.minCompressionSize),
 								conf.forwarded,
 								conf.cookieEncoder,
-								conf.cookieDecoder));
+								conf.cookieDecoder,
+								conf.uriTagValue));
 			}
 			if ((conf.protocols & HttpServerConfiguration.h11) == HttpServerConfiguration.h11) {
 				return BootstrapHandlers.updateConfiguration(b,
@@ -212,7 +215,8 @@ final class HttpServerBind extends HttpServer
 								compressPredicate(conf.compressPredicate, conf.minCompressionSize),
 								conf.forwarded,
 								conf.cookieEncoder,
-								conf.cookieDecoder));
+								conf.cookieDecoder,
+								conf.uriTagValue));
 			}
 			if ((conf.protocols & HttpServerConfiguration.h2c) == HttpServerConfiguration.h2c) {
 				return BootstrapHandlers.updateConfiguration(b,
@@ -323,6 +327,7 @@ final class HttpServerBind extends HttpServer
 		final boolean                                            forwarded;
 		final ServerCookieEncoder                                cookieEncoder;
 		final ServerCookieDecoder                                cookieDecoder;
+		final Function<String, String>                           uriTagValue;
 
 		Http1Initializer(int line,
 				int header,
@@ -333,7 +338,8 @@ final class HttpServerBind extends HttpServer
 				@Nullable BiPredicate<HttpServerRequest, HttpServerResponse> compressPredicate,
 				boolean forwarded,
 				ServerCookieEncoder encoder,
-				ServerCookieDecoder decoder) {
+				ServerCookieDecoder decoder,
+				@Nullable Function<String, String> uriTagValue) {
 			this.line = line;
 			this.header = header;
 			this.chunk = chunk;
@@ -344,6 +350,7 @@ final class HttpServerBind extends HttpServer
 			this.forwarded = forwarded;
 			this.cookieEncoder = encoder;
 			this.cookieDecoder = decoder;
+			this.uriTagValue = uriTagValue;
 		}
 
 		@Override
@@ -371,7 +378,7 @@ final class HttpServerBind extends HttpServer
 				ChannelMetricsRecorder channelMetricsRecorder = ((ChannelMetricsHandler) handler).recorder();
 				if (channelMetricsRecorder instanceof HttpServerMetricsRecorder) {
 					p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.HttpMetricsHandler,
-							new HttpServerMetricsHandler((HttpServerMetricsRecorder) channelMetricsRecorder));
+							new HttpServerMetricsHandler((HttpServerMetricsRecorder) channelMetricsRecorder, uriTagValue));
 				}
 			}
 
@@ -391,6 +398,7 @@ final class HttpServerBind extends HttpServer
 		final boolean                                            forwarded;
 		final ServerCookieEncoder                                cookieEncoder;
 		final ServerCookieDecoder                                cookieDecoder;
+		final Function<String, String>                           uriTagValue;
 
 		Http1OrH2CleartextInitializer(int line,
 				int header,
@@ -401,7 +409,8 @@ final class HttpServerBind extends HttpServer
 				@Nullable BiPredicate<HttpServerRequest, HttpServerResponse> compressPredicate,
 				boolean forwarded,
 				ServerCookieEncoder encoder,
-				ServerCookieDecoder decoder) {
+				ServerCookieDecoder decoder,
+				@Nullable Function<String, String> uriTagValue) {
 			this.line = line;
 			this.header = header;
 			this.chunk = chunk;
@@ -412,6 +421,7 @@ final class HttpServerBind extends HttpServer
 			this.forwarded = forwarded;
 			this.cookieEncoder = encoder;
 			this.cookieDecoder = decoder;
+			this.uriTagValue = uriTagValue;
 		}
 
 		@Override
@@ -473,7 +483,7 @@ final class HttpServerBind extends HttpServer
 				ChannelMetricsRecorder channelMetricsRecorder = ((ChannelMetricsHandler) handler).recorder();
 				if (channelMetricsRecorder instanceof HttpServerMetricsRecorder) {
 					p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.HttpMetricsHandler,
-							new HttpServerMetricsHandler((HttpServerMetricsRecorder) channelMetricsRecorder));
+							new HttpServerMetricsHandler((HttpServerMetricsRecorder) channelMetricsRecorder, uriTagValue));
 				}
 			}
 		}
@@ -591,6 +601,7 @@ final class HttpServerBind extends HttpServer
 		final boolean                                            forwarded;
 		final ServerCookieEncoder                                cookieEncoder;
 		final ServerCookieDecoder                                cookieDecoder;
+		final Function<String, String>                           uriTagValue;
 
 		Http1OrH2Initializer(
 				int line,
@@ -602,7 +613,8 @@ final class HttpServerBind extends HttpServer
 				@Nullable BiPredicate<HttpServerRequest, HttpServerResponse> compressPredicate,
 				boolean forwarded,
 				ServerCookieEncoder encoder,
-				ServerCookieDecoder decoder) {
+				ServerCookieDecoder decoder,
+				@Nullable Function<String, String> uriTagValue) {
 			this.line = line;
 			this.header = header;
 			this.chunk = chunk;
@@ -613,6 +625,7 @@ final class HttpServerBind extends HttpServer
 			this.forwarded = forwarded;
 			this.cookieEncoder = encoder;
 			this.cookieDecoder = decoder;
+			this.uriTagValue = uriTagValue;
 		}
 
 		@Override
@@ -685,7 +698,7 @@ final class HttpServerBind extends HttpServer
 					ChannelMetricsRecorder channelMetricsRecorder = ((ChannelMetricsHandler) handler).recorder();
 					if (channelMetricsRecorder instanceof HttpServerMetricsRecorder) {
 						p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.HttpMetricsHandler,
-								new HttpServerMetricsHandler((HttpServerMetricsRecorder) channelMetricsRecorder));
+								new HttpServerMetricsHandler((HttpServerMetricsRecorder) channelMetricsRecorder, parent.uriTagValue));
 					}
 				}
 				return;

--- a/src/main/java/reactor/netty/http/server/HttpServerConfiguration.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerConfiguration.java
@@ -25,6 +25,8 @@ import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
 import io.netty.util.AttributeKey;
 import reactor.netty.http.HttpProtocol;
 
+import javax.annotation.Nullable;
+
 /**
  * @author Stephane Maldini
  */
@@ -43,6 +45,8 @@ final class HttpServerConfiguration {
 	ServerCookieEncoder    cookieEncoder      = ServerCookieEncoder.STRICT;
 	ServerCookieDecoder    cookieDecoder      = ServerCookieDecoder.STRICT;
 	int                    protocols          = h11;
+
+	Function<String, String> uriTagValue      = null;
 
 
 	static HttpServerConfiguration getAndClean(ServerBootstrap b) {
@@ -135,6 +139,11 @@ final class HttpServerConfiguration {
 		HttpServerConfiguration conf = getOrCreate(b);
 		conf.cookieEncoder = encoder;
 		conf.cookieDecoder = decoder;
+		return b;
+	}
+
+	static ServerBootstrap uriTagValue(ServerBootstrap b, @Nullable Function<String, String> uriTagValue) {
+		getOrCreate(b).uriTagValue = uriTagValue;
 		return b;
 	}
 

--- a/src/test/java/reactor/netty/channel/AddressResolverGroupMetricsTest.java
+++ b/src/test/java/reactor/netty/channel/AddressResolverGroupMetricsTest.java
@@ -71,7 +71,7 @@ public class AddressResolverGroupMetricsTest {
 		              conn.channel()
 		                  .closeFuture()
 		                  .addListener(f -> latch.countDown()))
-		          .metrics(true)
+		          .metrics(true, s -> s)
 		          .get()
 		          .uri("http://localhost:" + server.port())
 		          .responseContent()

--- a/src/test/java/reactor/netty/channel/ByteBufAllocatorMetricsTest.java
+++ b/src/test/java/reactor/netty/channel/ByteBufAllocatorMetricsTest.java
@@ -84,7 +84,7 @@ public class ByteBufAllocatorMetricsTest {
 		          .doOnResponse((res, conn) -> conn.channel()
 		                                           .closeFuture()
 		                                           .addListener(f -> latch.countDown()))
-		          .metrics(true)
+		          .metrics(true, s -> s)
 		          .get()
 		          .uri("/")
 		          .responseContent()

--- a/src/test/java/reactor/netty/resources/PooledConnectionProviderMetricsTest.java
+++ b/src/test/java/reactor/netty/resources/PooledConnectionProviderMetricsTest.java
@@ -128,7 +128,7 @@ public class PooledConnectionProviderMetricsTest {
 			              metrics2.set(true);
 			          }
 		          })
-		          .metrics(clientMetricsEnabled)
+		          .metrics(clientMetricsEnabled, s -> s)
 		          .get()
 		          .uri("/")
 		          .responseContent()


### PR DESCRIPTION
The new API is a variant of HttpServer/HttpClient#metrics(boolean) that also accepts
a function that receives the actual uri and returns the uri tag value
that will be used for the metrics with Metrics#URI tag.

Related to #1010