### PR TITLE
Do not cache NoopMeter

### DIFF
--- a/src/main/java/reactor/netty/http/MicrometerHttpMetricsRecorder.java
+++ b/src/main/java/reactor/netty/http/MicrometerHttpMetricsRecorder.java
@@ -93,26 +93,32 @@ public class MicrometerHttpMetricsRecorder extends MicrometerChannelMetricsRecor
 	public void recordDataReceived(SocketAddress remoteAddress, String uri, long bytes) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
 		DistributionSummary dataReceived = dataReceivedCache.computeIfAbsent(new MeterKey(uri, address, null, null),
-				key -> dataReceivedBuilder.tags(REMOTE_ADDRESS, address, URI, uri)
-				                          .register(REGISTRY));
-		dataReceived.record(bytes);
+				key -> filter(dataReceivedBuilder.tags(REMOTE_ADDRESS, address, URI, uri)
+				                                 .register(REGISTRY)));
+		if (dataReceived != null) {
+			dataReceived.record(bytes);
+		}
 	}
 
 	@Override
 	public void recordDataSent(SocketAddress remoteAddress, String uri, long bytes) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
 		DistributionSummary dataSent = dataSentCache.computeIfAbsent(new MeterKey(uri, address, null, null),
-				key -> dataSentBuilder.tags(REMOTE_ADDRESS, address, URI, uri)
-				                      .register(REGISTRY));
-		dataSent.record(bytes);
+				key -> filter(dataSentBuilder.tags(REMOTE_ADDRESS, address, URI, uri)
+				                             .register(REGISTRY)));
+		if (dataSent != null) {
+			dataSent.record(bytes);
+		}
 	}
 
 	@Override
 	public void incrementErrorsCount(SocketAddress remoteAddress, String uri) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
 		Counter errors = errorsCache.computeIfAbsent(new MeterKey(uri, address, null, null),
-				key -> errorsBuilder.tags(REMOTE_ADDRESS, address, URI, uri)
-				                    .register(REGISTRY));
-		errors.increment();
+				key -> filter(errorsBuilder.tags(REMOTE_ADDRESS, address, URI, uri)
+				                           .register(REGISTRY)));
+		if (errors != null) {
+			errors.increment();
+		}
 	}
 }

--- a/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
+++ b/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
@@ -46,26 +46,32 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 	public void recordDataReceivedTime(SocketAddress remoteAddress, String uri, String method, String status, Duration time) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
 		Timer dataReceivedTime = dataReceivedTimeCache.computeIfAbsent(new MeterKey(uri, address, method, status),
-				key -> dataReceivedTimeBuilder.tags(REMOTE_ADDRESS, address, URI, uri, METHOD, method, STATUS, status)
-				                              .register(REGISTRY));
-		dataReceivedTime.record(time);
+				key -> filter(dataReceivedTimeBuilder.tags(REMOTE_ADDRESS, address, URI, uri, METHOD, method, STATUS, status)
+				                                     .register(REGISTRY)));
+		if (dataReceivedTime != null) {
+			dataReceivedTime.record(time);
+		}
 	}
 
 	@Override
 	public void recordDataSentTime(SocketAddress remoteAddress, String uri, String method, Duration time) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
 		Timer dataSentTime = dataSentTimeCache.computeIfAbsent(new MeterKey(uri, address, method, null),
-				key -> dataSentTimeBuilder.tags(REMOTE_ADDRESS, address, URI, uri, METHOD, method)
-				                          .register(REGISTRY));
-		dataSentTime.record(time);
+				key -> filter(dataSentTimeBuilder.tags(REMOTE_ADDRESS, address, URI, uri, METHOD, method)
+				                                 .register(REGISTRY)));
+		if (dataSentTime != null) {
+			dataSentTime.record(time);
+		}
 	}
 
 	@Override
 	public void recordResponseTime(SocketAddress remoteAddress, String uri, String method, String status, Duration time) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
 		Timer responseTime = responseTimeCache.computeIfAbsent(new MeterKey(uri, address, method, status),
-				key -> responseTimeBuilder.tags(REMOTE_ADDRESS, address, URI, uri, METHOD, method, STATUS, status)
-				                          .register(REGISTRY));
-		responseTime.record(time);
+				key -> filter(responseTimeBuilder.tags(REMOTE_ADDRESS, address, URI, uri, METHOD, method, STATUS, status)
+				                                 .register(REGISTRY)));
+		if (responseTime != null) {
+			responseTime.record(time);
+		}
 	}
 }

--- a/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsRecorder.java
+++ b/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsRecorder.java
@@ -42,24 +42,30 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 	@Override
 	public void recordDataReceivedTime(String uri, String method, Duration time) {
 		Timer dataReceivedTime = dataReceivedTimeCache.computeIfAbsent(new MeterKey(uri, null, method, null),
-				key -> dataReceivedTimeBuilder.tags(URI, uri, METHOD, method)
-				                              .register(REGISTRY));
-		dataReceivedTime.record(time);
+				key -> filter(dataReceivedTimeBuilder.tags(URI, uri, METHOD, method)
+				                                     .register(REGISTRY)));
+		if (dataReceivedTime != null) {
+			dataReceivedTime.record(time);
+		}
 	}
 
 	@Override
 	public void recordDataSentTime(String uri, String method, String status, Duration time) {
 		Timer dataSentTime = dataSentTimeCache.computeIfAbsent(new MeterKey(uri, null, method, status),
-				key -> dataSentTimeBuilder.tags(URI, uri, METHOD, method, STATUS, status)
-				                          .register(REGISTRY));
-		dataSentTime.record(time);
+				key -> filter(dataSentTimeBuilder.tags(URI, uri, METHOD, method, STATUS, status)
+				                                 .register(REGISTRY)));
+		if (dataSentTime != null) {
+			dataSentTime.record(time);
+		}
 	}
 
 	@Override
 	public void recordResponseTime(String uri, String method, String status, Duration time) {
 		Timer responseTime = responseTimeCache.computeIfAbsent(new MeterKey(uri, null, method, status),
-				key -> responseTimeBuilder.tags(URI, uri, METHOD, method, STATUS, status)
-				                          .register(REGISTRY));
-		responseTime.record(time);
+				key -> filter(responseTimeBuilder.tags(URI, uri, METHOD, method, STATUS, status)
+				                                 .register(REGISTRY)));
+		if (responseTime != null) {
+			responseTime.record(time);
+		}
 	}
 }


### PR DESCRIPTION
When MeterFilter.maximumAllowableTags configuration is available
on the system and the action onMaxReached is DENY, Micrometer will return
NoopMeter. Such meters will not be cached and thus OOM will be prevented.

Related to #1010