### PR TITLE
fix #453 Deprecate LoopResources #onChannel/onServerChannel/onDatagramChannel

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -125,6 +125,7 @@ final class HttpClientConnect extends HttpClient {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public Mono<? extends Connection> connect(Bootstrap b) {
 			SslProvider ssl = SslProvider.findSslSupport(b);
 

--- a/src/main/java/reactor/netty/http/server/HttpServerBind.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerBind.java
@@ -101,6 +101,7 @@ final class HttpServerBind extends HttpServer
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public ServerBootstrap apply(ServerBootstrap b) {
 		HttpServerConfiguration conf = HttpServerConfiguration.getAndClean(b);
 

--- a/src/main/java/reactor/netty/resources/DefaultLoop.java
+++ b/src/main/java/reactor/netty/resources/DefaultLoop.java
@@ -19,34 +19,19 @@ import java.util.concurrent.ThreadFactory;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.ServerChannel;
-import io.netty.channel.socket.DatagramChannel;
-import io.netty.channel.socket.nio.NioDatagramChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.channel.socket.nio.NioSocketChannel;
 
 /**
+ * An {@link EventLoopGroup} with associated {@link io.netty.channel.Channel} factory.
+ *
  * @author Violeta Georgieva
  */
 interface DefaultLoop {
 
-	default EventLoopGroup newEventLoopGroup(int threads, ThreadFactory factory) {
-		throw new IllegalStateException("Missing Epoll/KQueue on current system");
-	}
+	<CHANNEL extends Channel> CHANNEL getChannel(Class<CHANNEL> channelClass);
 
-	default Class<? extends ServerChannel> getServerChannel(EventLoopGroup group) {
-		return NioServerSocketChannel.class;
-	}
+	String getName();
 
-	default Class<? extends Channel> getChannel(EventLoopGroup group) {
-		return NioSocketChannel.class;
-	}
+	EventLoopGroup newEventLoopGroup(int threads, ThreadFactory factory);
 
-	default Class<? extends DatagramChannel> getDatagramChannel(EventLoopGroup group) {
-		return NioDatagramChannel.class;
-	}
-
-	default String getName() {
-		return "nio";
-	}
+	boolean supportGroup(EventLoopGroup group);
 }

--- a/src/main/java/reactor/netty/resources/DefaultLoopNIO.java
+++ b/src/main/java/reactor/netty/resources/DefaultLoopNIO.java
@@ -19,73 +19,49 @@ import java.util.concurrent.ThreadFactory;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollDatagramChannel;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.epoll.EpollServerSocketChannel;
-import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
-import reactor.util.Logger;
-import reactor.util.Loggers;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
 
 /**
- * {@link DefaultLoop} that uses {@code Epoll} transport.
+ * {@link DefaultLoop} that uses {@code NIO} transport.
  *
  * @author Stephane Maldini
  * @author Violeta Georgieva
+ * @since 0.9.8
  */
-final class DefaultLoopEpoll implements DefaultLoop {
+final class DefaultLoopNIO implements DefaultLoop {
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public <CHANNEL extends Channel> CHANNEL getChannel(Class<CHANNEL> channelClass) {
 		if (channelClass.equals(SocketChannel.class)) {
-			return (CHANNEL) new EpollSocketChannel();
+			return (CHANNEL) new NioSocketChannel();
 		}
 		if (channelClass.equals(ServerSocketChannel.class)) {
-			return (CHANNEL) new EpollServerSocketChannel();
+			return (CHANNEL) new NioServerSocketChannel();
 		}
 		if (channelClass.equals(DatagramChannel.class)) {
-			return (CHANNEL) new EpollDatagramChannel();
+			return (CHANNEL) new NioDatagramChannel();
 		}
 		throw new IllegalArgumentException("Unsupported channel type: " + channelClass.getSimpleName());
 	}
 
 	@Override
 	public String getName() {
-		return "epoll";
+		return "nio";
 	}
 
 	@Override
 	public EventLoopGroup newEventLoopGroup(int threads, ThreadFactory factory) {
-		return new EpollEventLoopGroup(threads, factory);
+		throw new IllegalStateException("Missing Epoll/KQueue on current system");
 	}
 
 	@Override
 	public boolean supportGroup(EventLoopGroup group) {
-		if (group instanceof ColocatedEventLoopGroup) {
-			group = ((ColocatedEventLoopGroup) group).get();
-		}
-		return group instanceof EpollEventLoopGroup;
-	}
-
-	static final Logger log = Loggers.getLogger(DefaultLoopEpoll.class);
-
-	static final boolean epoll;
-
-	static {
-		boolean epollCheck = false;
-		try {
-			Class.forName("io.netty.channel.epoll.Epoll");
-			epollCheck = Epoll.isAvailable();
-		}
-		catch (ClassNotFoundException cnfe) {
-		}
-		epoll = epollCheck;
-		if (log.isDebugEnabled()) {
-			log.debug("Default Epoll support : " + epoll);
-		}
+		return false;
 	}
 }

--- a/src/main/java/reactor/netty/resources/DefaultLoopNativeDetector.java
+++ b/src/main/java/reactor/netty/resources/DefaultLoopNativeDetector.java
@@ -16,25 +16,27 @@
 package reactor.netty.resources;
 
 /**
+ * Provides an {@link DefaultLoop} instance based on the available transport.
+ *
  * @author Violeta Georgieva
  */
 final class DefaultLoopNativeDetector {
 
-	private static final DefaultLoop INSTANCE;
+	static final DefaultLoop INSTANCE;
+
+	static final DefaultLoop NIO;
 
 	static {
-		if (DefaultLoopKQueue.hasKQueue()) {
+		NIO = new DefaultLoopNIO();
+
+		if (DefaultLoopKQueue.kqueue) {
 			INSTANCE = new DefaultLoopKQueue();
 		}
-		else if (DefaultLoopEpoll.hasEpoll()) {
+		else if (DefaultLoopEpoll.epoll) {
 			INSTANCE = new DefaultLoopEpoll();
 		}
 		else {
-			INSTANCE = new DefaultLoop() {};
+			INSTANCE = NIO;
 		}
-	}
-
-	public static DefaultLoop getInstance() {
-		return INSTANCE;
 	}
 }

--- a/src/main/java/reactor/netty/resources/DefaultLoopResources.java
+++ b/src/main/java/reactor/netty/resources/DefaultLoopResources.java
@@ -144,6 +144,7 @@ final class DefaultLoopResources extends AtomicLong implements LoopResources {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public EventLoopGroup onServerSelect(boolean useNative) {
 		if (useNative && preferNative()) {
 			return cacheNativeSelectLoops();
@@ -171,6 +172,7 @@ final class DefaultLoopResources extends AtomicLong implements LoopResources {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public EventLoopGroup onServer(boolean useNative) {
 		if (useNative && preferNative()) {
 			return cacheNativeServerLoops();
@@ -194,6 +196,7 @@ final class DefaultLoopResources extends AtomicLong implements LoopResources {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public EventLoopGroup onClient(boolean useNative) {
 		if (useNative && preferNative()) {
 			return cacheNativeClientLoops();
@@ -231,7 +234,7 @@ final class DefaultLoopResources extends AtomicLong implements LoopResources {
 
 		EventLoopGroup eventLoopGroup = cacheNativeSelectLoops.get();
 		if (null == eventLoopGroup) {
-			DefaultLoop defaultLoop = DefaultLoopNativeDetector.getInstance();
+			DefaultLoop defaultLoop = DefaultLoopNativeDetector.INSTANCE;
 			EventLoopGroup newEventLoopGroup = defaultLoop.newEventLoopGroup(
 					selectCount,
 					threadFactory(this, "select-" + defaultLoop.getName()));
@@ -248,7 +251,7 @@ final class DefaultLoopResources extends AtomicLong implements LoopResources {
 	EventLoopGroup cacheNativeServerLoops() {
 		EventLoopGroup eventLoopGroup = cacheNativeServerLoops.get();
 		if (null == eventLoopGroup) {
-			DefaultLoop defaultLoop = DefaultLoopNativeDetector.getInstance();
+			DefaultLoop defaultLoop = DefaultLoopNativeDetector.INSTANCE;
 			EventLoopGroup newEventLoopGroup = defaultLoop.newEventLoopGroup(
 					workerCount,
 					threadFactory(this, defaultLoop.getName()));

--- a/src/main/java/reactor/netty/resources/LoopResources.java
+++ b/src/main/java/reactor/netty/resources/LoopResources.java
@@ -22,6 +22,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
@@ -160,18 +162,35 @@ public interface LoopResources extends Disposable {
 	 * @param group the source {@link EventLoopGroup} to assign a loop from
 	 *
 	 * @return a {@link Class} target for the underlying {@link Channel} factory
+	 * @deprecated as of 0.9.8. See {@link #onChannel(Class, EventLoopGroup)}
 	 */
+	@Deprecated
 	default Class<? extends Channel> onChannel(EventLoopGroup group) {
-		return preferNative() ? DefaultLoopNativeDetector.getInstance().getChannel(group) :
+		return preferNative() ? onChannel(SocketChannel.class, group).getClass() :
 				NioSocketChannel.class;
+	}
+
+	/**
+	 * Callback for a {@link Channel} selection.
+	 *
+	 * @param channelType the channel type
+	 * @param group the source {@link EventLoopGroup} to assign a loop from
+	 * @param <CHANNEL> the {@link Channel} implementation
+	 * @return a {@link Channel} instance
+	 */
+	default <CHANNEL extends Channel> CHANNEL onChannel(Class<CHANNEL> channelType, EventLoopGroup group) {
+		DefaultLoop channelFactory =
+				DefaultLoopNativeDetector.INSTANCE.supportGroup(group) ?
+						DefaultLoopNativeDetector.INSTANCE :
+						DefaultLoopNativeDetector.NIO;
+
+		return channelFactory.getChannel(channelType);
 	}
 
 	/**
 	 * Callback for client {@link EventLoopGroup} creation.
 	 *
-	 * @param useNative should use native group if current {@link #preferNative()} is also
-	 * true
-	 *
+	 * @param useNative should use native group if current environment supports it
 	 * @return a new {@link EventLoopGroup}
 	 */
 	default EventLoopGroup onClient(boolean useNative) {
@@ -184,18 +203,19 @@ public interface LoopResources extends Disposable {
 	 * @param group the source {@link EventLoopGroup} to assign a loop from
 	 *
 	 * @return a {@link Class} target for the underlying {@link Channel} factory
+	 * @deprecated as of 0.9.8. See {@link #onChannel(Class, EventLoopGroup)}
 	 */
+	@Deprecated
 	default Class<? extends DatagramChannel> onDatagramChannel(EventLoopGroup group) {
-		return preferNative() ? DefaultLoopNativeDetector.getInstance().getDatagramChannel(group) :
+		return preferNative() ? onChannel(DatagramChannel.class, group).getClass() :
 				NioDatagramChannel.class;
 	}
 
 	/**
-	 * Callback for server {@link EventLoopGroup} creation.
+	 * Callback for server {@link EventLoopGroup} creation,
+	 * this is the {@link EventLoopGroup} for the child channel.
 	 *
-	 * @param useNative should use native group if current {@link #preferNative()} is also
-	 * true
-	 *
+	 * @param useNative should use native group if current environment supports it
 	 * @return a new {@link EventLoopGroup}
 	 */
 	EventLoopGroup onServer(boolean useNative);
@@ -206,18 +226,19 @@ public interface LoopResources extends Disposable {
 	 * @param group the source {@link EventLoopGroup} to assign a loop from
 	 *
 	 * @return a {@link Class} target for the underlying {@link ServerChannel} factory
+	 * @deprecated as of 0.9.8. See {@link #onChannel(Class, EventLoopGroup)}
 	 */
+	@Deprecated
 	default Class<? extends ServerChannel> onServerChannel(EventLoopGroup group) {
-		return preferNative() ? DefaultLoopNativeDetector.getInstance().getServerChannel(group) :
+		return preferNative() ? onChannel(ServerSocketChannel.class, group).getClass() :
 				NioServerSocketChannel.class;
 	}
 
 	/**
-	 * Create a server select {@link EventLoopGroup} for servers to be used
+	 * Callback for server select {@link EventLoopGroup} creation,
+	 * this is the {@link EventLoopGroup} for the acceptor channel.
 	 *
-	 * @param useNative should use native group if current {@link #preferNative()} is also
-	 * true
-	 *
+	 * @param useNative should use native group if current environment supports it
 	 * @return a new {@link EventLoopGroup}
 	 */
 	default EventLoopGroup onServerSelect(boolean useNative) {
@@ -228,9 +249,11 @@ public interface LoopResources extends Disposable {
 	 * Return true if should default to native {@link EventLoopGroup} and {@link Channel}
 	 *
 	 * @return true if should default to native {@link EventLoopGroup} and {@link Channel}
+	 * @deprecated as of 0.9.8. Use {@link #hasNativeSupport()}
 	 */
+	@Deprecated
 	default boolean preferNative() {
-		return DefaultLoopEpoll.hasEpoll() || DefaultLoopKQueue.hasKQueue();
+		return hasNativeSupport();
 	}
 
 	/**
@@ -281,5 +304,14 @@ public interface LoopResources extends Disposable {
 	default Mono<Void> disposeLater(Duration quietPeriod, Duration timeout) {
 		//noop default
 		return Mono.empty();
+	}
+
+	/**
+	 * Returns true if native transport is available.
+	 *
+	 * @return true if native transport is available
+	 */
+	static boolean hasNativeSupport() {
+		return DefaultLoopNativeDetector.INSTANCE != DefaultLoopNativeDetector.NIO;
 	}
 }

--- a/src/main/java/reactor/netty/tcp/TcpClientRunOn.java
+++ b/src/main/java/reactor/netty/tcp/TcpClientRunOn.java
@@ -45,6 +45,7 @@ final class TcpClientRunOn extends TcpClientOperator {
 		return b;
 	}
 
+	@SuppressWarnings("deprecation")
 	static void configure(Bootstrap b,
 			boolean preferNative,
 			LoopResources resources) {

--- a/src/main/java/reactor/netty/tcp/TcpResources.java
+++ b/src/main/java/reactor/netty/tcp/TcpResources.java
@@ -210,6 +210,7 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Class<? extends Channel> onChannel(EventLoopGroup group) {
 		return defaultLoops.onChannel(group);
 	}
@@ -220,6 +221,7 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Class<? extends DatagramChannel> onDatagramChannel(EventLoopGroup group) {
 		return defaultLoops.onDatagramChannel(group);
 	}
@@ -230,6 +232,7 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Class<? extends ServerChannel> onServerChannel(EventLoopGroup group) {
 		return defaultLoops.onServerChannel(group);
 	}
@@ -240,6 +243,7 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean preferNative() {
 		return defaultLoops.preferNative();
 	}

--- a/src/main/java/reactor/netty/tcp/TcpServerRunOn.java
+++ b/src/main/java/reactor/netty/tcp/TcpServerRunOn.java
@@ -45,6 +45,7 @@ final class TcpServerRunOn extends TcpServerOperator {
 		return b;
 	}
 
+	@SuppressWarnings("deprecation")
 	static void configure(ServerBootstrap b,
 			boolean preferNative,
 			LoopResources resources) {

--- a/src/main/java/reactor/netty/udp/UdpClientRunOn.java
+++ b/src/main/java/reactor/netty/udp/UdpClientRunOn.java
@@ -44,6 +44,7 @@ final class UdpClientRunOn extends UdpClientOperator {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	protected Bootstrap configure() {
 		Bootstrap b = source.configure();
 

--- a/src/main/java/reactor/netty/udp/UdpResources.java
+++ b/src/main/java/reactor/netty/udp/UdpResources.java
@@ -167,6 +167,7 @@ public class UdpResources implements LoopResources {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Class<? extends Channel> onChannel(EventLoopGroup group) {
 		return defaultLoops.onChannel(group);
 	}
@@ -177,6 +178,7 @@ public class UdpResources implements LoopResources {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Class<? extends DatagramChannel> onDatagramChannel(EventLoopGroup group) {
 		return defaultLoops.onDatagramChannel(group);
 	}
@@ -187,6 +189,7 @@ public class UdpResources implements LoopResources {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Class<? extends ServerChannel> onServerChannel(EventLoopGroup group) {
 		return defaultLoops.onServerChannel(group);
 	}
@@ -197,6 +200,7 @@ public class UdpResources implements LoopResources {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public boolean preferNative() {
 		return defaultLoops.preferNative();
 	}

--- a/src/main/java/reactor/netty/udp/UdpServerRunOn.java
+++ b/src/main/java/reactor/netty/udp/UdpServerRunOn.java
@@ -44,6 +44,7 @@ final class UdpServerRunOn extends UdpServerOperator {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	protected Bootstrap configure() {
 		Bootstrap b = source.configure();
 

--- a/src/test/java/reactor/netty/resources/DefaultLoopResourcesTest.java
+++ b/src/test/java/reactor/netty/resources/DefaultLoopResourcesTest.java
@@ -40,6 +40,7 @@ public class DefaultLoopResourcesTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void disposeLaterSubsequentIsQuick() {
 		DefaultLoopResources loopResources = new DefaultLoopResources(
 				"test", 0, false);


### PR DESCRIPTION
In favour of LoopResources#onChannel(Class, EventLoopGroup)
This is in preparation for Unix Domain Sockets support

Fixes #453 