### PR TITLE
[build] Officially use new versioning scheme for 1.0 Europium

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ With `Gradle` from [repo.spring.io](https://repo.spring.io) or `Maven Central` r
 
 ```groovy
     repositories {
-      //maven { url 'https://repo.spring.io/snapshot' }
+      maven { url 'https://repo.spring.io/snapshot' }
       maven { url 'https://repo.spring.io/release' }
       mavenCentral()
     }
 
     dependencies {
-      //compile "io.projectreactor.netty:reactor-netty:1.0.0.BUILD-SNAPSHOT"
-      compile "io.projectreactor.netty:reactor-netty:0.9.6.RELEASE"
+      compile "io.projectreactor.netty:reactor-netty:1.0.0-SNAPSHOT"
+      //compile "io.projectreactor.netty:reactor-netty:1.0.0"
     }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import aQute.bnd.gradle.BundleTaskConvention
 import me.champeau.gradle.japicmp.JapicmpTask
 
 buildscript {
@@ -22,8 +21,7 @@ buildscript {
   }
   dependencies {
 	classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7',
-			'com.google.gradle:osdetector-gradle-plugin:1.4.0',
-			'biz.aQute.bnd:biz.aQute.bnd.gradle:4.2.0'
+			'com.google.gradle:osdetector-gradle-plugin:1.4.0'
   }
 }
 
@@ -86,13 +84,6 @@ ext {
 				  "https://projectreactor.io/docs/core/release/api/",
 				  "https://netty.io/4.1/api/",
 				  "https://projectreactor.io/docs/netty/release/api/",] as String[]
-
-	bndOptions = [
-			"Export-Package": "!reactor.netty.internal*,reactor.netty.*;-noimport:=true",
-			"Import-Package": '!javax.annotation,io.netty.channel.kqueue;resolution:=optional;version="[4.1,5)",io.netty.handler.codec.haproxy;resolution:=optional;version="[4.1,5)",io.micrometer.*;resolution:=optional,*',
-			"Bundle-Name" : "reactor-netty",
-			"Bundle-SymbolicName" : "io.projectreactor.netty.reactor-netty"
-	]
 }
 
 
@@ -104,7 +95,6 @@ configure(rootProject) { project ->
   apply from: "$gradleScriptDir/releaser.gradle"
   apply from: "$gradleScriptDir/setup.gradle"
   apply plugin: 'propdeps'
-  apply plugin: "biz.aQute.bnd.builder"
   apply from: "${gradleScriptDir}/errorprone.gradle"
   apply plugin: 'com.google.osdetector'
   apply plugin: 'idea'
@@ -323,7 +313,6 @@ configure(rootProject) { project ->
 			  "Implementation-Version": project.version,
 			  "Automatic-Module-Name": "reactor.netty")
 	}
-	bnd(bndOptions)
   }
 
   task downloadBaseline(type: Download) {
@@ -371,14 +360,6 @@ configure(rootProject) { project ->
   check.dependsOn jacocoTestReport
 
   shadowJar {
-	  configure {
-		  it.convention.plugins.bundle = new BundleTaskConvention(it)
-		  doLast {
-			  buildBundle()
-		  }
-	  }
-	  bnd(bndOptions)
-
 	  classifier = null
 
 	  dependsOn(project.tasks.jar)

--- a/build.gradle
+++ b/build.gradle
@@ -39,10 +39,10 @@ plugins {
 description = 'Reactive Streams Netty driver'
 
 ext {
-  if (project.hasProperty('versionBranch') && version.toString().endsWith(".BUILD-SNAPSHOT")) {
+  if (project.hasProperty('versionBranch') && version.toString().endsWith("-SNAPSHOT")) {
 	versionBranch = versionBranch.replaceAll("\"", "").trim()
 	if (!versionBranch.isEmpty()) {
-	  realVersion = version.toString().replace("BUILD-SNAPSHOT", versionBranch + ".BUILD-SNAPSHOT")
+	  realVersion = version.toString() + "-" + versionBranch
 	  project.version = realVersion
 	  println "Building special snapshot ${project.version}"
 	}
@@ -215,7 +215,7 @@ configure(rootProject) { project ->
 
 	repositories {
 	mavenCentral()
-	if (version.endsWith('BUILD-SNAPSHOT')) {
+	if (version.endsWith('-SNAPSHOT') || version.contains('-SNAPSHOT-')) { //classic or customized snapshots
 	  if (System.getenv ()["bamboo_buildNumber"] == null) {
 		mavenLocal()
 	  } else {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-reactorPoolVersion=0.1.4.BUILD-SNAPSHOT
-version=1.0.0.BUILD-SNAPSHOT
-reactorCoreVersion=3.3.6.BUILD-SNAPSHOT
+reactorPoolVersion=0.2.0-SNAPSHOT
+version=1.0.0-SNAPSHOT
+reactorCoreVersion=3.4.0-SNAPSHOT
 # SKIPPING japicmp on master for now until there is a released version to compare against
 compatibleVersion=SKIP

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -44,7 +44,7 @@ task bumpVersionsInReadme(type: Copy, group: "releaser helpers", description: "r
 	def oldVersion = rootProject.findProperty("oldVersion")
 	def currentVersion = rootProject.findProperty("currentVersion")
 	def nextVersion = rootProject.findProperty("nextVersion")
-	def oldSnapshot = currentVersion?.replace("RELEASE", "BUILD-SNAPSHOT")
+	def oldSnapshot = currentVersion + "-SNAPSHOT"
 
 	onlyIf { oldVersion != null && currentVersion != null && nextVersion != null }
 	dependsOn copyReadme

--- a/src/docs/asciidoc/getting-started.adoc
+++ b/src/docs/asciidoc/getting-started.adoc
@@ -27,33 +27,46 @@ It has transitive dependencies on:
 * Netty v4.1.x
 
 [[getting-started-understanding-bom]]
-== Understanding the BOM
+== Understanding the BOM and versioning scheme
 
 `Reactor Netty` is part of the `Project Reactor BOM` (since the `Aluminium` release train).
 This curated list groups artifacts that are meant to work well together, providing
 the relevant versions despite potentially divergent versioning schemes in these artifacts.
 
-The `BOM` (Bill of Materials) is itself versioned, using a release train scheme
-with a codename followed by a qualifier. The following list shows a few examples:
+Note the versioning scheme has changed between 0.9.x and 1.0.x (Dysprosium and Europium).
 
-[verse]
-Aluminium-RELEASE
-Californium-BUILD-SNAPSHOT
-Aluminium-SR1
-Bismuth-RELEASE
-Californium-SR32
+Artifacts follow a versioning scheme of `MAJOR.MINOR.PATCH-QUALIFIER` while the BOM is versioned using a CalVer inspired scheme of `YYYY.MINOR.PATCH-QUALIFIER`, where:
 
-The codenames represent what would traditionally be the `MAJOR.MINOR` number. They (mostly)
+ * `MAJOR` is the current generation of Reactor, where each new generation can bring fundamental changes to the structure of the project (which might imply a more significant migration effort)
+ * `YYYY` is the year of the first GA release in a given release cycle (like 1.0.0 for 1.0.x)
+ * `.MINOR` is a 0-based number incrementing with each new release cycle
+ ** in the case of projects, it generally reflects wider changes and can indicate a moderate migration effort
+ ** in the case of the BOM it allows discerning between release cycles in case two get first released the same year
+ * `.PATCH` is a 0-based number incrementing with each service release
+ * `-QUALIFIER` is a textual qualifier, which is omitted in the case of GA releases (see below)
+
+The first release cycle to follow that convention is thus `2020.0.x`, codename `Europium`.
+The scheme uses the following qualifiers (note the use of dash separator), in order:
+
+ * `-M1`..`-M9`: milestones (we don't expect more than 9 per service release)
+ * `-RC1`..`-RC9`: release candidates (we don't expect more than 9 per service release)
+ * `-SNAPSHOT`: snapshots
+ * _no qualifier_ for GA releases
+
+NOTE: snapshots appear higher in the order above because, conceptually, they're always "the freshest pre-release" of any given PATCH.
+Even though the first deployed artifact of a PATCH cycle will always be a -SNAPSHOT, a similarly named but more up-to-date snapshot
+would also get released after eg. a milestone or between release candidates.
+
+Each release cycle is also given a codename, in continuity with the previous codename-based
+scheme, which can be used to reference it more informally (like in discussions, blog posts, etc...).
+The codenames represent what would traditionally be the MAJOR.MINOR number. They (mostly)
 come from the https://en.wikipedia.org/wiki/Periodic_table#Overview[Periodic Table of
 Elements], in increasing alphabetical order.
 
-The qualifiers are (in chronological order):
-
-* `BUILD-SNAPSHOT`
-* `M1`..`N`: Milestones or developer previews
-* `RELEASE`: The first `GA` (General Availability) release in a codename series
-* `SR1`..`N`: The subsequent `GA` releases in a codename series (equivalent to `PATCH`
-number -- `SR` stands for `Service Release`).
+NOTE: Up until Dysprosium, the BOM was versioned using a release train scheme with a codename followed by a qualifier, and the qualifiers were slightly different.
+For example: Aluminium-RELEASE (first GA release, would now be something like YYYY.0.0), Bismuth-M1, Californium-SR1 (service release
+would now be something like YYYY.0.1), Dysprosium-RC1, Dysprosium-BUILD-SNAPSHOT (after each patch, we'd go back to the same snapshot version. would now be something
+like YYYY.0.X-SNAPSHOT so we get 1 snapshot per PATCH)
 
 [[getting]]
 == Getting Reactor Netty
@@ -194,7 +207,7 @@ Similarly, snapshots are also available in a separate dedicated repository
 (for both Maven and Gradle):
 
 ====
-.BUILD-SNAPSHOTs in Maven
+.-SNAPSHOTs in Maven
 [source,xml]
 ----
 <repositories>
@@ -206,7 +219,7 @@ Similarly, snapshots are also available in a separate dedicated repository
 </repositories>
 ----
 
-.BUILD-SNAPSHOTs in Gradle
+.-SNAPSHOTs in Gradle
 [source,groovy]
 ----
 repositories {

--- a/src/jarFileTest/java/reactor/netty/JarFileShadingTest.java
+++ b/src/jarFileTest/java/reactor/netty/JarFileShadingTest.java
@@ -72,11 +72,6 @@ public class JarFileShadingTest extends AbstractJarFileTest {
 				.replace("reactor-netty-", "")
 				.replace("-original.jar", "")
 				.replace(".jar", "");
-		//for the case where there is a customVersion. OSGI only want 4 components to the version,
-		//so BND would simply remove the 4th dot between customVersion and RELEASE/BUILD-SNAPSHOT.
-		String osgiVersion = Arrays.stream(version.split("\\.", 4))
-		                           .map(comp -> comp.replace(".", ""))
-		                           .collect(Collectors.joining("."));
 
 		try (InputStream inputStream = jar.getInputStream(manifest);
 		     BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, UTF_8))) {
@@ -91,16 +86,6 @@ public class JarFileShadingTest extends AbstractJarFileTest {
 							"Implementation-Title: reactor-netty",
 							"Implementation-Version: " + version,
 							"Automatic-Module-Name: reactor.netty"
-					);
-			assertThat(lines)
-					.as("OSGI content")
-					.contains(
-							"Bundle-Name: reactor-netty",
-							"Bundle-SymbolicName: io.projectreactor.netty.reactor-netty",
-							"Import-Package: ", //only assert the section is there
-							"Require-Capability:",
-							"Export-Package:", //only assert the section is there
-							"Bundle-Version: " + osgiVersion
 					);
 		}
 		catch (IOException ioe) {


### PR DESCRIPTION
This commit introduces the new versioning scheme, using -SNAPSHOT
instead of .BUILD-SNAPSHOT as the qualifier for snapshots.
The whole scheme is detailed in the reference documentation, same as
in core, and adaptations are made to the build script to accommodate it.

See reactor/reactor#683