### PR TITLE
When HttpServer in H2 mode, check the parent channel for SslHandler presence

### DIFF
--- a/src/main/java/reactor/netty/http/server/Http2StreamBridgeHandler.java
+++ b/src/main/java/reactor/netty/http/server/Http2StreamBridgeHandler.java
@@ -63,7 +63,7 @@ final class Http2StreamBridgeHandler extends ChannelDuplexHandler {
 	@Override
 	public void channelRead(ChannelHandlerContext ctx, Object msg) {
 		if (secured == null) {
-			secured = ctx.channel().pipeline().get(SslHandler.class) != null;
+			secured = ctx.channel().parent().pipeline().get(SslHandler.class) != null;
 		}
 		if (remoteAddress == null) {
 			remoteAddress =


### PR DESCRIPTION
When the server is configured to support H2, SslHandler is configured
on the connection level and not on the stream level.

A test will be provided as part of `Http2 for HttpClient` implementation.