### PR TITLE
When HttpServer in H2 mode, release FullHttpRequest in case of failure

### DIFF
--- a/src/main/java/reactor/netty/http/server/Http2StreamBridgeHandler.java
+++ b/src/main/java/reactor/netty/http/server/Http2StreamBridgeHandler.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
@@ -87,6 +88,9 @@ final class Http2StreamBridgeHandler extends ChannelDuplexHandler {
 						cookieDecoder);
 			}
 			catch (RuntimeException e) {
+				if (request instanceof FullHttpRequest) {
+					((FullHttpRequest) request).release();
+				}
 				HttpServerOperations.sendDecodingFailures(ctx, e, msg);
 				return;
 			}


### PR DESCRIPTION
A test will be provided as part of `Http2 for HttpClient` implementation.