### PR TITLE
fix #1093 When executing graceful shutdown, wait only for the opened …

### DIFF
--- a/src/main/java/reactor/netty/tcp/TcpServerBind.java
+++ b/src/main/java/reactor/netty/tcp/TcpServerBind.java
@@ -187,7 +187,12 @@ final class TcpServerBind extends TcpServer {
 			if (channelGroup != null) {
 				List<Mono<Void>> channels = new ArrayList<>();
 				// Wait for the running requests to finish
-				channelGroup.forEach(channel -> channels.add(Connection.from(channel).onTerminate()));
+				channelGroup.forEach(channel -> {
+					ChannelOperations<?, ?> ops = ChannelOperations.get(channel);
+					if (ops != null) {
+						channels.add(ops.onTerminate());
+					}
+				});
 				if (!channels.isEmpty()) {
 					terminateSignals = Mono.when(channels);
 				}


### PR DESCRIPTION
…channels with `ChannelOperations` bound as attribute.

When there is `ChannelOperations` bound as attribute in the channel this mean that Reactor
Netty currently processing a request, when there is `SimpleConnection` bound as
attribute this means the channel is opened but no request in process.