### PR TITLE
fix #1039 Revise when trowing AbortedException, PrematureCloseExcepti…

### DIFF
--- a/src/main/java/reactor/netty/FutureMono.java
+++ b/src/main/java/reactor/netty/FutureMono.java
@@ -29,6 +29,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
+import reactor.netty.channel.AbortedException;
 import reactor.util.context.Context;
 
 /**
@@ -263,7 +264,7 @@ public abstract class FutureMono extends Mono<Void> {
 		@Override
 		@SuppressWarnings("unchecked")
 		public void operationComplete(F future) {
-			if (!future.isSuccess()) {//Avoid singleton
+			if (!future.isSuccess()) {
 				s.onError(wrapError(future.cause()));
 			}
 			else {
@@ -272,10 +273,10 @@ public abstract class FutureMono extends Mono<Void> {
 		}
 
 		private static Throwable wrapError(Throwable error) {
-			if(error instanceof ClosedChannelException) {
-				//Update with a common aborted exception?
-				return ReactorNetty.wrapException(error);
-			} else {
+			if (error instanceof ClosedChannelException) {
+				return new AbortedException(error);
+			}
+			else {
 				return error;
 			}
 		}

--- a/src/main/java/reactor/netty/channel/AbortedException.java
+++ b/src/main/java/reactor/netty/channel/AbortedException.java
@@ -26,9 +26,14 @@ import java.net.SocketException;
  * @since 0.6
  */
 public class AbortedException extends RuntimeException {
+	static final String CONNECTION_CLOSED_BEFORE_SEND = "Connection has been closed BEFORE send operation";
 
 	public AbortedException(String message) {
 		super(message);
+	}
+
+	public AbortedException(Throwable throwable) {
+		super(throwable);
 	}
 
 	/**
@@ -40,7 +45,7 @@ public class AbortedException extends RuntimeException {
 	 * @return true if connection has been simply aborted on a tcp level
 	 */
 	public static boolean isConnectionReset(Throwable err) {
-		return err instanceof AbortedException ||
+		return (err instanceof AbortedException && CONNECTION_CLOSED_BEFORE_SEND.equals(err.getMessage())) ||
 		       (err instanceof IOException && (err.getMessage() == null ||
 		                                       err.getMessage()
 		                                          .contains("Broken pipe") ||
@@ -49,5 +54,9 @@ public class AbortedException extends RuntimeException {
 		       (err instanceof SocketException && err.getMessage() != null &&
 		                                          err.getMessage()
 		                                             .contains("Connection reset by peer"));
+	}
+
+	public static AbortedException beforeSend() {
+		return new AbortedException(CONNECTION_CLOSED_BEFORE_SEND);
 	}
 }

--- a/src/main/java/reactor/netty/channel/FluxReceive.java
+++ b/src/main/java/reactor/netty/channel/FluxReceive.java
@@ -32,7 +32,6 @@ import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Operators;
-import reactor.netty.ReactorNetty;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.concurrent.Queues;
@@ -385,7 +384,7 @@ final class FluxReceive extends Flux<Object> implements Subscription, Disposable
 		}
 
 		if (err instanceof OutOfMemoryError) {
-			this.inboundError = ReactorNetty.wrapException(err);
+			this.inboundError = parent.wrapInboundError(err);
 			try {
 				if (receiver != null) {
 					// propagate java.lang.OutOfMemoryError: Direct buffer memory
@@ -399,14 +398,14 @@ final class FluxReceive extends Flux<Object> implements Subscription, Disposable
 			}
 		}
 		else if (err instanceof ClosedChannelException) {
-			this.inboundError = ReactorNetty.wrapException(err);
+			this.inboundError = parent.wrapInboundError(err);
 		}
 		else {
 			this.inboundError = err;
 		}
 
 		if (receiverFastpath && receiver != null) {
-			receiver.onError(err);
+			receiver.onError(inboundError);
 		}
 		else {
 			drainReceiver();

--- a/src/main/java/reactor/netty/channel/MonoSendMany.java
+++ b/src/main/java/reactor/netty/channel/MonoSendMany.java
@@ -161,7 +161,7 @@ final class MonoSendMany<I, O> extends MonoSend<I, O> implements Scannable {
 			}
 
 			if (t instanceof ClosedChannelException) {
-				t = ReactorNetty.wrapException(t);
+				t = new AbortedException(t);
 			}
 
 			terminalSignal = t;

--- a/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/src/main/java/reactor/netty/http/HttpOperations.java
@@ -100,7 +100,7 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 	@SuppressWarnings("unchecked")
 	public NettyOutbound send(Publisher<? extends ByteBuf> source) {
 		if (!channel().isActive()) {
-			return then(Mono.error(new AbortedException("Connection has been closed BEFORE send operation")));
+			return then(Mono.error(AbortedException.beforeSend()));
 		}
 		if (source instanceof Mono) {
 			return new PostHeadersNettyOutbound(((Mono<ByteBuf>)source)
@@ -132,7 +132,7 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 	public NettyOutbound sendObject(Object message) {
 		if (!channel().isActive()) {
 			ReactorNetty.safeRelease(message);
-			return then(Mono.error(new AbortedException("Connection has been closed BEFORE send operation")));
+			return then(Mono.error(AbortedException.beforeSend()));
 		}
 		if (!(message instanceof ByteBuf)) {
 			return super.sendObject(message);
@@ -162,7 +162,7 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 	@Override
 	public Mono<Void> then() {
 		if (!channel().isActive()) {
-			return Mono.error(new AbortedException("Connection has been closed BEFORE send operation"));
+			return Mono.error(AbortedException.beforeSend());
 		}
 
 		if (hasSentHeaders()) {

--- a/src/main/java/reactor/netty/http/client/PrematureCloseException.java
+++ b/src/main/java/reactor/netty/http/client/PrematureCloseException.java
@@ -16,10 +16,16 @@
 
 package reactor.netty.http.client;
 
+import io.netty.channel.ChannelInboundHandler;
+import reactor.netty.channel.ChannelOperations;
+
 import java.io.IOException;
 
 /**
  * An error for signalling that the connection was closed prematurely
+ * {@link ChannelInboundHandler#channelInactive(io.netty.channel.ChannelHandlerContext)},
+ * {@link ChannelOperations#onInboundClose()},
+ * {@link ChannelOperations#onInboundError()}
  *
  * @author Violeta Georgieva
  */
@@ -48,6 +54,10 @@ public final class PrematureCloseException extends IOException {
 
 	PrematureCloseException(String message) {
 		super(message);
+	}
+
+	PrematureCloseException(Throwable throwable) {
+		super(throwable);
 	}
 
 	@Override

--- a/src/test/java/reactor/netty/FutureMonoTest.java
+++ b/src/test/java/reactor/netty/FutureMonoTest.java
@@ -17,6 +17,7 @@ package reactor.netty;
 
 import io.netty.util.concurrent.*;
 import org.junit.Test;
+import reactor.netty.channel.AbortedException;
 import reactor.test.StepVerifier;
 
 import java.nio.channels.ClosedChannelException;
@@ -31,7 +32,7 @@ public class FutureMonoTest {
 		Future<Void> promise = eventExecutor.newFailedFuture(new ClosedChannelException());
 
 		StepVerifier.create(FutureMono.from(promise))
-		            .expectError(ReactorNetty.InternalNettyException.class)
+		            .expectError(AbortedException.class)
 		            .verify(Duration.ofSeconds(30));
 	}
 
@@ -45,7 +46,7 @@ public class FutureMonoTest {
 		StepVerifier.create(FutureMono.from(promise))
 		            .expectSubscription()
 		            .then(() -> promise.setFailure(new ClosedChannelException()))
-		            .expectError(ReactorNetty.InternalNettyException.class)
+		            .expectError(AbortedException.class)
 		            .verify(Duration.ofSeconds(30));
 	}
 
@@ -55,7 +56,7 @@ public class FutureMonoTest {
 		Supplier<Future<Void>> promiseSupplier = () -> eventExecutor.newFailedFuture(new ClosedChannelException());
 
 		StepVerifier.create(FutureMono.deferFuture(promiseSupplier))
-		            .expectError(ReactorNetty.InternalNettyException.class)
+		            .expectError(AbortedException.class)
 		            .verify(Duration.ofSeconds(30));
 	}
 
@@ -70,7 +71,7 @@ public class FutureMonoTest {
 		StepVerifier.create(FutureMono.deferFuture(promiseSupplier))
 		            .expectSubscription()
 		            .then(() -> promise.setFailure(new ClosedChannelException()))
-		            .expectError(ReactorNetty.InternalNettyException.class)
+		            .expectError(AbortedException.class)
 		            .verify(Duration.ofSeconds(30));
 	}
 }


### PR DESCRIPTION
…on and InternalNettyException

In case of outbound failed with `ClosedChannelException`,
the server/client will re-thrown as `AbortedException`.
The client **will** retry such request

In case of inbound failed with `ClosedChannelException`,
- the server will re-thrown as `AbortedException`
- the client will re-thrown as `PrematureCloseException`,
the client **will NOT** retry such request

Fixes #1039