### PR TITLE
Add HttpServer/HttpClient#tcpConfiguration and HttpServer/HttpClient#from

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -55,6 +55,7 @@ import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.resources.LoopResources;
 import reactor.netty.tcp.SslProvider;
 import reactor.netty.transport.ClientTransportConfig;
+import reactor.netty.transport.ProxyProvider;
 import reactor.util.annotation.Nullable;
 
 /**
@@ -334,8 +335,18 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 	}
 
 	@Override
+	protected void loggingHandler(LoggingHandler loggingHandler) {
+		super.loggingHandler(loggingHandler);
+	}
+
+	@Override
 	protected void metricsRecorder(@Nullable Supplier<? extends ChannelMetricsRecorder> metricsRecorder) {
 		super.metricsRecorder(metricsRecorder);
+	}
+
+	@Override
+	protected void proxyProvider(ProxyProvider proxyProvider) {
+		super.proxyProvider(proxyProvider);
 	}
 
 	@Override

--- a/src/main/java/reactor/netty/http/client/HttpClientTcpConfig.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientTcpConfig.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.client;
+
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.handler.logging.LogLevel;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.util.AttributeKey;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+import reactor.netty.ChannelPipelineConfigurer;
+import reactor.netty.Connection;
+import reactor.netty.ConnectionObserver;
+import reactor.netty.NettyInbound;
+import reactor.netty.NettyOutbound;
+import reactor.netty.channel.ChannelMetricsRecorder;
+import reactor.netty.resources.LoopResources;
+import reactor.netty.tcp.SslProvider;
+import reactor.netty.tcp.TcpClient;
+import reactor.netty.tcp.TcpClientConfig;
+import reactor.netty.transport.ProxyProvider;
+import reactor.util.annotation.Nullable;
+
+import java.net.SocketAddress;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * This class provides a migration for the {@link HttpClient#tcpConfiguration(Function)} in 0.9.x
+ *
+ * @author Violeta Georgieva
+ * @deprecated
+ */
+@Deprecated
+final class HttpClientTcpConfig extends TcpClient {
+	HttpClient httpClient;
+
+	HttpClientTcpConfig(HttpClient httpClient) {
+		this.httpClient = httpClient;
+	}
+
+	@Override
+	public <A> TcpClient attr(AttributeKey<A> key, @Nullable A value) {
+		httpClient = httpClient.attr(key, value);
+		return this;
+	}
+
+	@Override
+	public TcpClient bindAddress(Supplier<? extends SocketAddress> bindAddressSupplier) {
+		httpClient = httpClient.bindAddress(bindAddressSupplier);
+		return this;
+	}
+
+	@Override
+	public TcpClient channelGroup(ChannelGroup channelGroup) {
+		httpClient = httpClient.channelGroup(channelGroup);
+		return this;
+	}
+
+	@Override
+	public TcpClientConfig configuration() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<? extends Connection> connect() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public TcpClient doOnChannelInit(ChannelPipelineConfigurer doOnChannelInit) {
+		httpClient = httpClient.doOnChannelInit(doOnChannelInit);
+		return this;
+	}
+
+	@Override
+	public TcpClient doOnConnect(Consumer<? super TcpClientConfig> doOnConnect) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public TcpClient doOnConnected(Consumer<? super Connection> doOnConnected) {
+		httpClient = httpClient.doOnConnected(doOnConnected);
+		return this;
+	}
+
+	@Override
+	public TcpClient doOnDisconnected(Consumer<? super Connection> doOnDisconnected) {
+		httpClient = httpClient.doOnDisconnected(doOnDisconnected);
+		return this;
+	}
+
+	@Override
+	public TcpClient handle(BiFunction<? super NettyInbound, ? super NettyOutbound, ? extends Publisher<Void>> handler) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public TcpClient host(String host) {
+		httpClient = httpClient.host(host);
+		return this;
+	}
+
+	@Override
+	public TcpClient metrics(boolean enable) {
+		httpClient = httpClient.metrics(enable, Function.identity());
+		return this;
+	}
+
+	@Override
+	public TcpClient metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder) {
+		httpClient = httpClient.metrics(enable, recorder);
+		return this;
+	}
+
+	@Override
+	public TcpClient noProxy() {
+		httpClient = httpClient.noProxy();
+		return this;
+	}
+
+	@Override
+	public TcpClient noSSL() {
+		httpClient = httpClient.noSSL();
+		return this;
+	}
+
+	@Override
+	public TcpClient observe(ConnectionObserver observer) {
+		httpClient = httpClient.observe(observer);
+		return this;
+	}
+
+	@Override
+	public <O> TcpClient option(ChannelOption<O> key, @Nullable O value) {
+		httpClient = httpClient.option(key, value);
+		return this;
+	}
+
+	@Override
+	public TcpClient port(int port) {
+		httpClient = httpClient.port(port);
+		return this;
+	}
+
+	@Override
+	public TcpClient proxy(Consumer<? super ProxyProvider.TypeSpec> proxyOptions) {
+		httpClient = httpClient.proxy(proxyOptions);
+		return this;
+	}
+
+	@Override
+	public TcpClient remoteAddress(Supplier<? extends SocketAddress> remoteAddressSupplier) {
+		httpClient = httpClient.remoteAddress(remoteAddressSupplier);
+		return this;
+	}
+
+	@Override
+	public TcpClient resolver(AddressResolverGroup<?> resolver) {
+		httpClient = httpClient.resolver(resolver);
+		return this;
+	}
+
+	@Override
+	public TcpClient runOn(EventLoopGroup eventLoopGroup) {
+		httpClient = httpClient.runOn(eventLoopGroup);
+		return this;
+	}
+
+	@Override
+	public TcpClient runOn(LoopResources channelResources) {
+		httpClient = httpClient.runOn(channelResources);
+		return this;
+	}
+
+	@Override
+	public TcpClient runOn(LoopResources loopResources, boolean preferNative) {
+		httpClient = httpClient.runOn(loopResources, preferNative);
+		return this;
+	}
+
+	@Override
+	public TcpClient secure() {
+		httpClient = httpClient.secure();
+		return this;
+	}
+
+	@Override
+	public TcpClient secure(Consumer<? super SslProvider.SslContextSpec> sslProviderBuilder) {
+		httpClient = httpClient.secure(sslProviderBuilder);
+		return this;
+	}
+
+	@Override
+	public TcpClient secure(SslProvider sslProvider) {
+		httpClient = httpClient.secure(sslProvider);
+		return this;
+	}
+
+	@Override
+	public TcpClient wiretap(boolean enable) {
+		httpClient = httpClient.wiretap(enable);
+		return this;
+	}
+
+	@Override
+	public TcpClient wiretap(String category) {
+		httpClient = httpClient.wiretap(category);
+		return this;
+	}
+
+	@Override
+	public TcpClient wiretap(String category, LogLevel level) {
+		httpClient = httpClient.wiretap(category, level);
+		return this;
+	}
+
+	@Override
+	protected TcpClient duplicate() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -36,6 +36,8 @@ import reactor.netty.ConnectionObserver;
 import reactor.netty.channel.ChannelMetricsRecorder;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.tcp.SslProvider;
+import reactor.netty.tcp.TcpServer;
+import reactor.netty.tcp.TcpServerConfig;
 import reactor.netty.transport.ServerTransport;
 import reactor.util.Logger;
 import reactor.util.Loggers;
@@ -70,6 +72,17 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 */
 	public static HttpServer create() {
 		return HttpServerBind.INSTANCE;
+	}
+
+	/**
+	 * Prepare an {@link HttpServer}
+	 *
+	 * @return a new {@link HttpServer}
+	 * @deprecated Use {@link HttpServer} methods for TCP level configurations.
+	 */
+	@Deprecated
+	public static HttpServer from(TcpServer tcpServer) {
+		return HttpServerBind.applyTcpServerConfig(tcpServer.configuration());
 	}
 
 	@Override
@@ -423,6 +436,25 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 		HttpServer dup = duplicate();
 		dup.configuration().sslProvider = sslProvider;
 		return dup;
+	}
+
+	/**
+	 * Apply a {@link TcpServer} mapping function to update TCP configuration and
+	 * return an enriched {@link HttpServer} to use.
+	 *
+	 * @param tcpMapper A {@link TcpServer} mapping function to update TCP configuration and
+	 * return an enriched {@link HttpServer} to use.
+	 * @return a new {@link HttpServer}
+	 * @deprecated Use {@link HttpServer} methods for TCP level configurations.
+	 */
+	@Deprecated
+	@SuppressWarnings("ReturnValueIgnored")
+	public final HttpServer tcpConfiguration(Function<? super TcpServer, ? extends TcpServer> tcpMapper) {
+		Objects.requireNonNull(tcpMapper, "tcpMapper");
+		HttpServerTcpConfig tcpServer = new HttpServerTcpConfig(this);
+		// ReturnValueIgnored is deliberate
+		tcpMapper.apply(tcpServer);
+		return tcpServer.httpServer;
 	}
 
 	@Override

--- a/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -247,6 +247,11 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 	}
 
 	@Override
+	protected void loggingHandler(LoggingHandler loggingHandler) {
+		super.loggingHandler(loggingHandler);
+	}
+
+	@Override
 	protected void metricsRecorder(@Nullable Supplier<? extends ChannelMetricsRecorder> metricsRecorder) {
 		super.metricsRecorder(metricsRecorder);
 	}

--- a/src/main/java/reactor/netty/http/server/HttpServerTcpConfig.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerTcpConfig.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.handler.logging.LogLevel;
+import io.netty.util.AttributeKey;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+import reactor.netty.ChannelPipelineConfigurer;
+import reactor.netty.Connection;
+import reactor.netty.ConnectionObserver;
+import reactor.netty.DisposableServer;
+import reactor.netty.NettyInbound;
+import reactor.netty.NettyOutbound;
+import reactor.netty.channel.ChannelMetricsRecorder;
+import reactor.netty.resources.LoopResources;
+import reactor.netty.tcp.SslProvider;
+import reactor.netty.tcp.TcpServer;
+import reactor.netty.tcp.TcpServerConfig;
+import reactor.util.annotation.Nullable;
+
+import java.net.SocketAddress;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * This class provides a migration for the {@link HttpServer#tcpConfiguration(Function)} in 0.9.x
+ *
+ * @author Violeta Georgieva
+ * @deprecated
+ */
+@Deprecated
+final class HttpServerTcpConfig extends TcpServer {
+	HttpServer httpServer;
+
+	HttpServerTcpConfig(HttpServer httpServer) {
+		this.httpServer = httpServer;
+	}
+
+	@Override
+	public <A> TcpServer attr(AttributeKey<A> key, @Nullable A value) {
+		httpServer = httpServer.attr(key, value);
+		return this;
+	}
+
+	@Override
+	public Mono<? extends DisposableServer> bind() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public TcpServer bindAddress(Supplier<? extends SocketAddress> bindAddressSupplier) {
+		httpServer = httpServer.bindAddress(bindAddressSupplier);
+		return this;
+	}
+
+	@Override
+	public TcpServer channelGroup(ChannelGroup channelGroup) {
+		httpServer = httpServer.channelGroup(channelGroup);
+		return this;
+	}
+
+	@Override
+	public <A> TcpServer childAttr(AttributeKey<A> key, @Nullable A value) {
+		httpServer = httpServer.childAttr(key, value);
+		return this;
+	}
+
+	@Override
+	public TcpServer childObserve(ConnectionObserver observer) {
+		httpServer = httpServer.childObserve(observer);
+		return this;
+	}
+
+	@Override
+	public <A> TcpServer childOption(ChannelOption<A> key, @Nullable A value) {
+		httpServer = httpServer.childOption(key, value);
+		return this;
+	}
+
+	@Override
+	public TcpServerConfig configuration() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public TcpServer doOnBind(Consumer<? super TcpServerConfig> doOnBind) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public TcpServer doOnBound(Consumer<? super DisposableServer> doOnBound) {
+		httpServer = httpServer.doOnBound(doOnBound);
+		return this;
+	}
+
+	@Override
+	public TcpServer doOnChannelInit(ChannelPipelineConfigurer doOnChannelInit) {
+		httpServer = httpServer.doOnChannelInit(doOnChannelInit);
+		return this;
+	}
+
+	@Override
+	public TcpServer doOnConnection(Consumer<? super Connection> doOnConnection) {
+		httpServer = httpServer.doOnConnection(doOnConnection);
+		return this;
+	}
+
+	@Override
+	public TcpServer doOnUnbound(Consumer<? super DisposableServer> doOnUnbound) {
+		httpServer = httpServer.doOnUnbound(doOnUnbound);
+		return this;
+	}
+
+	@Override
+	public TcpServer handle(BiFunction<? super NettyInbound, ? super NettyOutbound, ? extends Publisher<Void>> handler) {
+		httpServer = httpServer.handle(handler);
+		return this;
+	}
+
+	@Override
+	public TcpServer host(String host) {
+		httpServer = httpServer.host(host);
+		return this;
+	}
+
+	@Override
+	public TcpServer metrics(boolean enable) {
+		httpServer = httpServer.metrics(enable, Function.identity());
+		return this;
+	}
+
+	@Override
+	public TcpServer metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder) {
+		httpServer = httpServer.metrics(enable, recorder);
+		return this;
+	}
+
+	@Override
+	public TcpServer observe(ConnectionObserver observer) {
+		httpServer = httpServer.observe(observer);
+		return this;
+	}
+
+	@Override
+	public <O> TcpServer option(ChannelOption<O> key, @Nullable O value) {
+		httpServer = httpServer.option(key, value);
+		return this;
+	}
+
+	@Override
+	public TcpServer noSSL() {
+		httpServer = httpServer.noSSL();
+		return this;
+	}
+
+	@Override
+	public TcpServer port(int port) {
+		httpServer = httpServer.port(port);
+		return this;
+	}
+
+	@Override
+	public TcpServer runOn(EventLoopGroup eventLoopGroup) {
+		httpServer = httpServer.runOn(eventLoopGroup);
+		return this;
+	}
+
+	@Override
+	public TcpServer runOn(LoopResources channelResources) {
+		httpServer = httpServer.runOn(channelResources);
+		return this;
+	}
+
+	@Override
+	public TcpServer runOn(LoopResources loopResources, boolean preferNative) {
+		httpServer = httpServer.runOn(loopResources, preferNative);
+		return this;
+	}
+
+	@Override
+	public TcpServer secure(Consumer<? super SslProvider.SslContextSpec> sslProviderBuilder) {
+		httpServer = httpServer.secure(sslProviderBuilder);
+		return this;
+	}
+
+	@Override
+	public TcpServer secure(SslProvider sslProvider) {
+		httpServer = httpServer.secure(sslProvider);
+		return this;
+	}
+
+	@Override
+	public TcpServer wiretap(boolean enable) {
+		httpServer = httpServer.wiretap(enable);
+		return this;
+	}
+
+	@Override
+	public TcpServer wiretap(String category) {
+		httpServer = httpServer.wiretap(category);
+		return this;
+	}
+
+	@Override
+	public TcpServer wiretap(String category, LogLevel level) {
+		httpServer = httpServer.wiretap(category, level);
+		return this;
+	}
+
+	@Override
+	protected TcpServer duplicate() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -100,12 +100,12 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 	}
 
 	@Override
-	public final <A> TcpClient attr(AttributeKey<A> key, @Nullable A value) {
+	public <A> TcpClient attr(AttributeKey<A> key, @Nullable A value) {
 		return super.attr(key, value);
 	}
 
 	@Override
-	public final Mono<? extends Connection> connect() {
+	public Mono<? extends Connection> connect() {
 		return super.connect();
 	}
 
@@ -120,17 +120,17 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 	}
 
 	@Override
-	public final TcpClient doOnConnect(Consumer<? super TcpClientConfig> doOnConnect) {
+	public TcpClient doOnConnect(Consumer<? super TcpClientConfig> doOnConnect) {
 		return super.doOnConnect(doOnConnect);
 	}
 
 	@Override
-	public final TcpClient doOnConnected(Consumer<? super Connection> doOnConnected) {
+	public TcpClient doOnConnected(Consumer<? super Connection> doOnConnected) {
 		return super.doOnConnected(doOnConnected);
 	}
 
 	@Override
-	public final TcpClient doOnDisconnected(Consumer<? super Connection> doOnDisconnected) {
+	public TcpClient doOnDisconnected(Consumer<? super Connection> doOnDisconnected) {
 		return super.doOnDisconnected(doOnDisconnected);
 	}
 
@@ -142,74 +142,29 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 	 *
 	 * @return a new {@link TcpClient}
 	 */
-	public final TcpClient handle(BiFunction<? super NettyInbound, ? super NettyOutbound, ? extends Publisher<Void>> handler) {
+	public TcpClient handle(BiFunction<? super NettyInbound, ? super NettyOutbound, ? extends Publisher<Void>> handler) {
 		Objects.requireNonNull(handler, "handler");
 		return doOnConnected(new OnConnectedHandle(handler));
 	}
 
 	@Override
-	public final TcpClient host(String host) {
+	public TcpClient host(String host) {
 		return super.host(host);
 	}
 
 	@Override
-	public final TcpClient metrics(boolean enable) {
+	public TcpClient metrics(boolean enable) {
 		return super.metrics(enable);
 	}
 
 	@Override
-	public final TcpClient metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder) {
+	public TcpClient metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder) {
 		return super.metrics(enable, recorder);
 	}
 
 	@Override
-	public final TcpClient noProxy() {
+	public TcpClient noProxy() {
 		return super.noProxy();
-	}
-
-	@Override
-	public final TcpClient observe(ConnectionObserver observer) {
-		return super.observe(observer);
-	}
-
-	@Override
-	public final <O> TcpClient option(ChannelOption<O> key, @Nullable O value) {
-		return super.option(key, value);
-	}
-
-	@Override
-	public final TcpClient port(int port) {
-		return super.port(port);
-	}
-
-	@Override
-	public final TcpClient proxy(Consumer<? super ProxyProvider.TypeSpec> proxyOptions) {
-		return super.proxy(proxyOptions);
-	}
-
-	@Override
-	public final TcpClient remoteAddress(Supplier<? extends SocketAddress> remoteAddressSupplier) {
-		return super.remoteAddress(remoteAddressSupplier);
-	}
-
-	@Override
-	public final TcpClient resolver(AddressResolverGroup<?> resolver) {
-		return super.resolver(resolver);
-	}
-
-	@Override
-	public final TcpClient runOn(EventLoopGroup eventLoopGroup) {
-		return super.runOn(eventLoopGroup);
-	}
-
-	@Override
-	public final TcpClient runOn(LoopResources channelResources) {
-		return super.runOn(channelResources);
-	}
-
-	@Override
-	public final TcpClient runOn(LoopResources loopResources, boolean preferNative) {
-		return super.runOn(loopResources, preferNative);
 	}
 
 	/**
@@ -217,13 +172,58 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 	 *
 	 * @return a new {@link TcpClient}
 	 */
-	public final TcpClient noSSL() {
+	public TcpClient noSSL() {
 		if (configuration().isSecure()) {
 			TcpClient dup = duplicate();
 			dup.configuration().sslProvider = null;
 			return dup;
 		}
 		return this;
+	}
+
+	@Override
+	public TcpClient observe(ConnectionObserver observer) {
+		return super.observe(observer);
+	}
+
+	@Override
+	public <O> TcpClient option(ChannelOption<O> key, @Nullable O value) {
+		return super.option(key, value);
+	}
+
+	@Override
+	public TcpClient port(int port) {
+		return super.port(port);
+	}
+
+	@Override
+	public TcpClient proxy(Consumer<? super ProxyProvider.TypeSpec> proxyOptions) {
+		return super.proxy(proxyOptions);
+	}
+
+	@Override
+	public TcpClient remoteAddress(Supplier<? extends SocketAddress> remoteAddressSupplier) {
+		return super.remoteAddress(remoteAddressSupplier);
+	}
+
+	@Override
+	public TcpClient resolver(AddressResolverGroup<?> resolver) {
+		return super.resolver(resolver);
+	}
+
+	@Override
+	public TcpClient runOn(EventLoopGroup eventLoopGroup) {
+		return super.runOn(eventLoopGroup);
+	}
+
+	@Override
+	public TcpClient runOn(LoopResources channelResources) {
+		return super.runOn(channelResources);
+	}
+
+	@Override
+	public TcpClient runOn(LoopResources loopResources, boolean preferNative) {
+		return super.runOn(loopResources, preferNative);
 	}
 
 	/**
@@ -234,7 +234,7 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 	 *
 	 * @return a new {@link TcpClient}
 	 */
-	public final TcpClient secure() {
+	public TcpClient secure() {
 		TcpClient dup = duplicate();
 		dup.configuration().sslProvider = SslProvider.defaultClientProvider();
 		return dup;
@@ -250,7 +250,7 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 	 *
 	 * @return a new {@link TcpClient}
 	 */
-	public final TcpClient secure(Consumer<? super SslProvider.SslContextSpec> sslProviderBuilder) {
+	public TcpClient secure(Consumer<? super SslProvider.SslContextSpec> sslProviderBuilder) {
 		Objects.requireNonNull(sslProviderBuilder, "sslProviderBuilder");
 		TcpClient dup = duplicate();
 		SslProvider.SslContextSpec builder = SslProvider.builder();
@@ -266,7 +266,7 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 	 *
 	 * @return a new {@link TcpClient}
 	 */
-	public final TcpClient secure(SslProvider sslProvider) {
+	public TcpClient secure(SslProvider sslProvider) {
 		Objects.requireNonNull(sslProvider, "sslProvider");
 		TcpClient dup = duplicate();
 		dup.configuration().sslProvider = sslProvider;
@@ -274,17 +274,17 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 	}
 
 	@Override
-	public final TcpClient wiretap(boolean enable) {
+	public TcpClient wiretap(boolean enable) {
 		return super.wiretap(enable);
 	}
 
 	@Override
-	public final TcpClient wiretap(String category) {
+	public TcpClient wiretap(String category) {
 		return super.wiretap(category);
 	}
 
 	@Override
-	public final TcpClient wiretap(String category, LogLevel level) {
+	public TcpClient wiretap(String category, LogLevel level) {
 		return super.wiretap(category, level);
 	}
 

--- a/src/main/java/reactor/netty/tcp/TcpServer.java
+++ b/src/main/java/reactor/netty/tcp/TcpServer.java
@@ -74,32 +74,32 @@ public abstract class TcpServer extends ServerTransport<TcpServer, TcpServerConf
 	}
 
 	@Override
-	public final TcpServer bindAddress(Supplier<? extends SocketAddress> bindAddressSupplier) {
+	public TcpServer bindAddress(Supplier<? extends SocketAddress> bindAddressSupplier) {
 		return super.bindAddress(bindAddressSupplier);
 	}
 
 	@Override
-	public final TcpServer channelGroup(ChannelGroup channelGroup) {
+	public TcpServer channelGroup(ChannelGroup channelGroup) {
 		return super.channelGroup(channelGroup);
 	}
 
 	@Override
-	public final TcpServer doOnBind(Consumer<? super TcpServerConfig> doOnBind) {
+	public TcpServer doOnBind(Consumer<? super TcpServerConfig> doOnBind) {
 		return super.doOnBind(doOnBind);
 	}
 
 	@Override
-	public final TcpServer doOnBound(Consumer<? super DisposableServer> doOnBound) {
+	public TcpServer doOnBound(Consumer<? super DisposableServer> doOnBound) {
 		return super.doOnBound(doOnBound);
 	}
 
 	@Override
-	public final TcpServer doOnConnection(Consumer<? super Connection> doOnConnection) {
+	public TcpServer doOnConnection(Consumer<? super Connection> doOnConnection) {
 		return super.doOnConnection(doOnConnection);
 	}
 
 	@Override
-	public final TcpServer doOnUnbound(Consumer<? super DisposableServer> doOnUnbound) {
+	public TcpServer doOnUnbound(Consumer<? super DisposableServer> doOnUnbound) {
 		return super.doOnUnbound(doOnUnbound);
 	}
 
@@ -111,23 +111,23 @@ public abstract class TcpServer extends ServerTransport<TcpServer, TcpServerConf
 	 *
 	 * @return a new {@link TcpServer}
 	 */
-	public final TcpServer handle(BiFunction<? super NettyInbound, ? super NettyOutbound, ? extends Publisher<Void>> handler) {
+	public TcpServer handle(BiFunction<? super NettyInbound, ? super NettyOutbound, ? extends Publisher<Void>> handler) {
 		Objects.requireNonNull(handler, "handler");
 		return doOnConnection(new OnConnectionHandle(handler));
 	}
 
 	@Override
-	public final TcpServer host(String host) {
+	public TcpServer host(String host) {
 		return super.host(host);
 	}
 
 	@Override
-	public final TcpServer metrics(boolean enable) {
+	public TcpServer metrics(boolean enable) {
 		return super.metrics(enable);
 	}
 
 	@Override
-	public final TcpServer metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder) {
+	public TcpServer metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder) {
 		return super.metrics(enable, recorder);
 	}
 
@@ -136,7 +136,7 @@ public abstract class TcpServer extends ServerTransport<TcpServer, TcpServerConf
 	 *
 	 * @return a new {@link TcpServer}
 	 */
-	public final TcpServer noSSL() {
+	public TcpServer noSSL() {
 		if (configuration().isSecure()) {
 			TcpServer dup = duplicate();
 			dup.configuration().sslProvider = null;
@@ -146,22 +146,22 @@ public abstract class TcpServer extends ServerTransport<TcpServer, TcpServerConf
 	}
 
 	@Override
-	public final TcpServer port(int port) {
+	public TcpServer port(int port) {
 		return super.port(port);
 	}
 
 	@Override
-	public final TcpServer runOn(EventLoopGroup eventLoopGroup) {
+	public TcpServer runOn(EventLoopGroup eventLoopGroup) {
 		return super.runOn(eventLoopGroup);
 	}
 
 	@Override
-	public final TcpServer runOn(LoopResources channelResources) {
+	public TcpServer runOn(LoopResources channelResources) {
 		return super.runOn(channelResources);
 	}
 
 	@Override
-	public final TcpServer runOn(LoopResources loopResources, boolean preferNative) {
+	public TcpServer runOn(LoopResources loopResources, boolean preferNative) {
 		return super.runOn(loopResources, preferNative);
 	}
 
@@ -185,7 +185,7 @@ public abstract class TcpServer extends ServerTransport<TcpServer, TcpServerConf
 	 * @param sslProviderBuilder builder callback for further customization of SslContext.
 	 * @return a new {@link TcpServer}
 	 */
-	public final TcpServer secure(Consumer<? super SslProvider.SslContextSpec> sslProviderBuilder) {
+	public TcpServer secure(Consumer<? super SslProvider.SslContextSpec> sslProviderBuilder) {
 		Objects.requireNonNull(sslProviderBuilder, "sslProviderBuilder");
 		TcpServer dup = duplicate();
 		SslProvider.SslContextSpec builder = SslProvider.builder();
@@ -212,7 +212,7 @@ public abstract class TcpServer extends ServerTransport<TcpServer, TcpServerConf
 	 *
 	 * @return a new {@link TcpServer}
 	 */
-	public final TcpServer secure(SslProvider sslProvider) {
+	public TcpServer secure(SslProvider sslProvider) {
 		Objects.requireNonNull(sslProvider, "sslProvider");
 		TcpServer dup = duplicate();
 		dup.configuration().sslProvider = sslProvider;
@@ -220,17 +220,17 @@ public abstract class TcpServer extends ServerTransport<TcpServer, TcpServerConf
 	}
 
 	@Override
-	public final TcpServer wiretap(boolean enable) {
+	public TcpServer wiretap(boolean enable) {
 		return super.wiretap(enable);
 	}
 
 	@Override
-	public final TcpServer wiretap(String category) {
+	public TcpServer wiretap(String category) {
 		return super.wiretap(category);
 	}
 
 	@Override
-	public final TcpServer wiretap(String category, LogLevel level) {
+	public TcpServer wiretap(String category, LogLevel level) {
 		return super.wiretap(category, level);
 	}
 

--- a/src/main/java/reactor/netty/transport/ClientTransportConfig.java
+++ b/src/main/java/reactor/netty/transport/ClientTransportConfig.java
@@ -185,6 +185,10 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 		return loopResources().onClient(isPreferNative());
 	}
 
+	protected void proxyProvider(ProxyProvider proxyProvider) {
+		this.proxyProvider = proxyProvider;
+	}
+
 	@SuppressWarnings("unchecked")
 	protected AddressResolverGroup<?> resolverInternal() {
 		if (metricsRecorder != null) {

--- a/src/main/java/reactor/netty/transport/ServerTransport.java
+++ b/src/main/java/reactor/netty/transport/ServerTransport.java
@@ -192,7 +192,7 @@ public abstract class ServerTransport<T extends ServerTransport<T, CONF>,
 	 * @return a new {@link ServerTransport} reference
 	 * @see ServerBootstrap#childAttr(AttributeKey, Object)
 	 */
-	public final <A> T childAttr(AttributeKey<A> key, @Nullable A value) {
+	public <A> T childAttr(AttributeKey<A> key, @Nullable A value) {
 		Objects.requireNonNull(key, "key");
 		T dup = duplicate();
 		dup.configuration().childAttrs = TransportConfig.updateMap(configuration().childAttrs, key, value);
@@ -205,7 +205,7 @@ public abstract class ServerTransport<T extends ServerTransport<T, CONF>,
 	 * @param observer the {@link ConnectionObserver} addition
 	 * @return a new {@link ServerTransport} reference
 	 */
-	public final T childObserve(ConnectionObserver observer) {
+	public T childObserve(ConnectionObserver observer) {
 		Objects.requireNonNull(observer, "observer");
 		T dup = duplicate();
 		ConnectionObserver current = configuration().childObserver;
@@ -226,7 +226,7 @@ public abstract class ServerTransport<T extends ServerTransport<T, CONF>,
 	 * @see ServerBootstrap#childOption(ChannelOption, Object)
 	 */
 	@SuppressWarnings("ReferenceEquality")
-	public final <A> T childOption(ChannelOption<A> key, @Nullable A value) {
+	public <A> T childOption(ChannelOption<A> key, @Nullable A value) {
 		Objects.requireNonNull(key, "key");
 		// Reference comparison is deliberate
 		if (ChannelOption.AUTO_READ == key) {

--- a/src/main/java/reactor/netty/transport/ServerTransportConfig.java
+++ b/src/main/java/reactor/netty/transport/ServerTransportConfig.java
@@ -52,7 +52,7 @@ public abstract class ServerTransportConfig<CONF extends TransportConfig> extend
 	 *
 	 * @return the read-only default channel attributes for each remote connection
 	 */
-	public final Map<AttributeKey<?>, Object> childAttributes() {
+	public final Map<AttributeKey<?>, ?> childAttributes() {
 		if (childAttrs == null) {
 			return Collections.emptyMap();
 		}
@@ -75,7 +75,7 @@ public abstract class ServerTransportConfig<CONF extends TransportConfig> extend
 	 *
 	 * @return the read-only {@link ChannelOption} map for each remote connection
 	 */
-	public final Map<ChannelOption<?>, Object> childOptions() {
+	public final Map<ChannelOption<?>, ?> childOptions() {
 		if (childOptions == null) {
 			return Collections.emptyMap();
 		}

--- a/src/main/java/reactor/netty/transport/Transport.java
+++ b/src/main/java/reactor/netty/transport/Transport.java
@@ -108,7 +108,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param doOnChannelInit configure the channel pipeline while initializing the channel
 	 * @return a new {@link Transport} reference
 	 */
-	public final T doOnChannelInit(ChannelPipelineConfigurer doOnChannelInit) {
+	public T doOnChannelInit(ChannelPipelineConfigurer doOnChannelInit) {
 		Objects.requireNonNull(doOnChannelInit, "doOnChannelInit");
 		T dup = duplicate();
 		ChannelPipelineConfigurer current = configuration().doOnChannelInit;

--- a/src/main/java/reactor/netty/transport/TransportConfig.java
+++ b/src/main/java/reactor/netty/transport/TransportConfig.java
@@ -167,7 +167,7 @@ public abstract class TransportConfig {
 	 */
 	@Nullable
 	public final Supplier<? extends ChannelMetricsRecorder> metricsRecorder() {
-		return  this.metricsRecorder;
+		return this.metricsRecorder;
 	}
 
 	/**
@@ -304,6 +304,10 @@ public abstract class TransportConfig {
 	 * @return the configured {@link EventLoopGroup}
 	 */
 	protected abstract EventLoopGroup eventLoopGroup();
+
+	protected void loggingHandler(LoggingHandler loggingHandler) {
+		this.loggingHandler = loggingHandler;
+	}
 
 	protected void metricsRecorder(@Nullable Supplier<? extends ChannelMetricsRecorder> metricsRecorder) {
 		this.metricsRecorder = metricsRecorder;

--- a/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -93,6 +93,7 @@ import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.resources.LoopResources;
 import reactor.netty.tcp.SslProvider;
 import reactor.netty.tcp.TcpServer;
+import reactor.netty.transport.TransportConfig;
 import reactor.test.StepVerifier;
 import reactor.util.Logger;
 import reactor.util.Loggers;
@@ -2207,5 +2208,39 @@ public class HttpClientTest {
 		          .responseContent()
 		          .aggregate()
 		          .block(Duration.ofSeconds(30));
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	@SuppressWarnings("deprecation")
+	public void testTcpConfigurationUnsupported_1() {
+		HttpClient.create()
+		          .tcpConfiguration(tcp -> tcp.doOnConnect(TransportConfig::attributes));
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	@SuppressWarnings("deprecation")
+	public void testTcpConfigurationUnsupported_2() {
+		HttpClient.create()
+		          .tcpConfiguration(tcp -> tcp.handle((req, res) -> res.sendString(Mono.just("test"))));
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	@SuppressWarnings("deprecation")
+	public void testTcpConfigurationUnsupported_3() {
+		HttpClient.create()
+		          .tcpConfiguration(tcp -> {
+		              tcp.connect();
+		              return tcp;
+		          });
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	@SuppressWarnings("deprecation")
+	public void testTcpConfigurationUnsupported_4() {
+		HttpClient.create()
+		          .tcpConfiguration(tcp -> {
+		              tcp.configuration();
+		              return tcp;
+		          });
 	}
 }


### PR DESCRIPTION
Add deprecated `HttpServer/HttpClient#tcpConfiguration` and `HttpServer/HttpClient#from`
in order to keep the backwards compatibility.
The methods implementation invokes the corresponding `HttpServer`/`HttpClient` methods.