### PR TITLE
fix #1152 Ensure newSocketStream() is not invoked when obtaining information for the channel class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -348,6 +348,10 @@ configure(rootProject) { project ->
 		txtOutputFile = file("${project.buildDir}/reports/japi.txt")
 		ignoreMissingClasses = true
 		includeSynthetic = true
+		methodExcludes = [
+			// this is a method with a default implementation
+			"reactor.netty.resources.LoopResources#onChannelClass(java.lang.Class, io.netty.channel.EventLoopGroup)"
+		]
 		onlyIf {"$compatibleVersion" != "SKIP"}
   }
   tasks.japicmp.dependsOn(downloadBaseline)

--- a/src/main/java/reactor/netty/resources/DefaultLoop.java
+++ b/src/main/java/reactor/netty/resources/DefaultLoop.java
@@ -29,6 +29,8 @@ interface DefaultLoop {
 
 	<CHANNEL extends Channel> CHANNEL getChannel(Class<CHANNEL> channelClass);
 
+	<CHANNEL extends Channel> Class<? extends CHANNEL> getChannelClass(Class<CHANNEL> channelClass);
+
 	String getName();
 
 	EventLoopGroup newEventLoopGroup(int threads, ThreadFactory factory);

--- a/src/main/java/reactor/netty/resources/DefaultLoopEpoll.java
+++ b/src/main/java/reactor/netty/resources/DefaultLoopEpoll.java
@@ -54,6 +54,21 @@ final class DefaultLoopEpoll implements DefaultLoop {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
+	public <CHANNEL extends Channel> Class<? extends CHANNEL> getChannelClass(Class<CHANNEL> channelClass) {
+		if (channelClass.equals(SocketChannel.class)) {
+			return (Class<? extends CHANNEL>) EpollSocketChannel.class;
+		}
+		if (channelClass.equals(ServerSocketChannel.class)) {
+			return (Class<? extends CHANNEL>) EpollServerSocketChannel.class;
+		}
+		if (channelClass.equals(DatagramChannel.class)) {
+			return (Class<? extends CHANNEL>) EpollDatagramChannel.class;
+		}
+		throw new IllegalArgumentException("Unsupported channel type: " + channelClass.getSimpleName());
+	}
+
+	@Override
 	public String getName() {
 		return "epoll";
 	}

--- a/src/main/java/reactor/netty/resources/DefaultLoopKQueue.java
+++ b/src/main/java/reactor/netty/resources/DefaultLoopKQueue.java
@@ -53,6 +53,21 @@ final class DefaultLoopKQueue implements DefaultLoop {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
+	public <CHANNEL extends Channel> Class<? extends CHANNEL> getChannelClass(Class<CHANNEL> channelClass) {
+		if (channelClass.equals(SocketChannel.class)) {
+			return (Class<? extends CHANNEL>) KQueueSocketChannel.class;
+		}
+		if (channelClass.equals(ServerSocketChannel.class)) {
+			return (Class<? extends CHANNEL>) KQueueServerSocketChannel.class;
+		}
+		if (channelClass.equals(DatagramChannel.class)) {
+			return (Class<? extends CHANNEL>) KQueueDatagramChannel.class;
+		}
+		throw new IllegalArgumentException("Unsupported channel type: " + channelClass.getSimpleName());
+	}
+
+	@Override
 	public String getName() {
 		return "kqueue";
 	}

--- a/src/main/java/reactor/netty/resources/DefaultLoopNIO.java
+++ b/src/main/java/reactor/netty/resources/DefaultLoopNIO.java
@@ -51,6 +51,21 @@ final class DefaultLoopNIO implements DefaultLoop {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
+	public <CHANNEL extends Channel> Class<? extends CHANNEL> getChannelClass(Class<CHANNEL> channelClass) {
+		if (channelClass.equals(SocketChannel.class)) {
+			return (Class<? extends CHANNEL>) NioSocketChannel.class;
+		}
+		if (channelClass.equals(ServerSocketChannel.class)) {
+			return (Class<? extends CHANNEL>) NioServerSocketChannel.class;
+		}
+		if (channelClass.equals(DatagramChannel.class)) {
+			return (Class<? extends CHANNEL>) NioDatagramChannel.class;
+		}
+		throw new IllegalArgumentException("Unsupported channel type: " + channelClass.getSimpleName());
+	}
+
+	@Override
 	public String getName() {
 		return "nio";
 	}

--- a/src/main/java/reactor/netty/resources/LoopResources.java
+++ b/src/main/java/reactor/netty/resources/LoopResources.java
@@ -166,7 +166,7 @@ public interface LoopResources extends Disposable {
 	 */
 	@Deprecated
 	default Class<? extends Channel> onChannel(EventLoopGroup group) {
-		return preferNative() ? onChannel(SocketChannel.class, group).getClass() :
+		return preferNative() ? onChannelClass(SocketChannel.class, group) :
 				NioSocketChannel.class;
 	}
 
@@ -185,6 +185,23 @@ public interface LoopResources extends Disposable {
 						DefaultLoopNativeDetector.NIO;
 
 		return channelFactory.getChannel(channelType);
+	}
+
+	/**
+	 * Callback for a {@link Channel} class selection.
+	 *
+	 * @param channelType the channel type
+	 * @param group the source {@link EventLoopGroup} to assign a loop from
+	 * @param <CHANNEL> the {@link Channel} implementation
+	 * @return a {@link Channel} class
+	 */
+	default <CHANNEL extends Channel> Class<? extends CHANNEL> onChannelClass(Class<CHANNEL> channelType, EventLoopGroup group) {
+		DefaultLoop channelFactory =
+				DefaultLoopNativeDetector.INSTANCE.supportGroup(group) ?
+						DefaultLoopNativeDetector.INSTANCE :
+						DefaultLoopNativeDetector.NIO;
+
+		return channelFactory.getChannelClass(channelType);
 	}
 
 	/**
@@ -207,7 +224,7 @@ public interface LoopResources extends Disposable {
 	 */
 	@Deprecated
 	default Class<? extends DatagramChannel> onDatagramChannel(EventLoopGroup group) {
-		return preferNative() ? onChannel(DatagramChannel.class, group).getClass() :
+		return preferNative() ? onChannelClass(DatagramChannel.class, group) :
 				NioDatagramChannel.class;
 	}
 
@@ -230,7 +247,7 @@ public interface LoopResources extends Disposable {
 	 */
 	@Deprecated
 	default Class<? extends ServerChannel> onServerChannel(EventLoopGroup group) {
-		return preferNative() ? onChannel(ServerSocketChannel.class, group).getClass() :
+		return preferNative() ? onChannelClass(ServerSocketChannel.class, group) :
 				NioServerSocketChannel.class;
 	}
 

--- a/src/main/java/reactor/netty/tcp/TcpResources.java
+++ b/src/main/java/reactor/netty/tcp/TcpResources.java
@@ -221,6 +221,11 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 	}
 
 	@Override
+	public <CHANNEL extends Channel> Class<? extends CHANNEL> onChannelClass(Class<CHANNEL> channelType, EventLoopGroup group) {
+		return defaultLoops.onChannelClass(channelType, group);
+	}
+
+	@Override
 	public EventLoopGroup onClient(boolean useNative) {
 		return defaultLoops.onClient(useNative);
 	}

--- a/src/main/java/reactor/netty/udp/UdpResources.java
+++ b/src/main/java/reactor/netty/udp/UdpResources.java
@@ -178,6 +178,11 @@ public class UdpResources implements LoopResources {
 	}
 
 	@Override
+	public <CHANNEL extends Channel> Class<? extends CHANNEL> onChannelClass(Class<CHANNEL> channelType, EventLoopGroup group) {
+		return defaultLoops.onChannelClass(channelType, group);
+	}
+
+	@Override
 	public EventLoopGroup onClient(boolean useNative) {
 		return defaultLoops.onClient(useNative);
 	}


### PR DESCRIPTION
This can happen when EpollSocketChannel etc. is constructed.
Fixes #1152 