### PR TITLE
Add TcpClient#bootstrap

### DIFF
--- a/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -21,8 +21,10 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
+import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.logging.LogLevel;
@@ -102,6 +104,25 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 	@Override
 	public <A> TcpClient attr(AttributeKey<A> key, @Nullable A value) {
 		return super.attr(key, value);
+	}
+
+	/**
+	 * Apply a {@link Bootstrap} mapping function to update {@link TcpClient} configuration and
+	 * return an enriched {@link TcpClient} to use.
+	 *
+	 * @param bootstrapMapper A {@link Bootstrap} mapping function to update {@link TcpClient} configuration and
+	 * return an enriched {@link TcpClient} to use.
+	 * @return a new {@link TcpClient}
+	 * @deprecated Use {@link TcpClient} methods for configurations.
+	 */
+	@Deprecated
+	@SuppressWarnings("ReturnValueIgnored")
+	public final TcpClient bootstrap(Function<? super Bootstrap, ? extends Bootstrap> bootstrapMapper) {
+		Objects.requireNonNull(bootstrapMapper, "bootstrapMapper");
+		TcpClientBootstrap tcpClientBootstrap = new TcpClientBootstrap(this);
+		// ReturnValueIgnored is deliberate
+		bootstrapMapper.apply(tcpClientBootstrap);
+		return tcpClientBootstrap.tcpClient;
 	}
 
 	@Override

--- a/src/main/java/reactor/netty/tcp/TcpClientBootstrap.java
+++ b/src/main/java/reactor/netty/tcp/TcpClientBootstrap.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.tcp;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ChannelFactory;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.util.AttributeKey;
+import io.netty.util.internal.SocketUtils;
+import reactor.netty.NettyPipeline;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.function.Function;
+
+/**
+ * This class provides a migration for the {@link TcpClient#bootstrap(Function)} in 0.9.x
+ *
+ * @author Violeta Georgieva
+ * @deprecated Use {@link TcpClient} methods for configurations.
+ */
+@Deprecated
+final class TcpClientBootstrap extends Bootstrap {
+	TcpClient tcpClient;
+
+	TcpClientBootstrap(TcpClient tcpClient) {
+		this.tcpClient = tcpClient;
+	}
+
+	@Override
+	public <T> Bootstrap attr(AttributeKey<T> key, T value) {
+		tcpClient = tcpClient.attr(key, value);
+		return this;
+	}
+
+	@Override
+	public ChannelFuture bind() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture bind(InetAddress inetHost, int inetPort) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture bind(int inetPort) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture bind(SocketAddress localAddress) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture bind(String inetHost, int inetPort) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Bootstrap channel(Class<? extends Channel> channelClass) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Bootstrap channelFactory(ChannelFactory<? extends Channel> channelFactory) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Bootstrap channelFactory(io.netty.channel.ChannelFactory<? extends Channel> channelFactory) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Bootstrap clone() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Bootstrap clone(EventLoopGroup group) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture connect() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture connect(InetAddress inetHost, int inetPort) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture connect(SocketAddress remoteAddress) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ChannelFuture connect(String inetHost, int inetPort) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected void finalize() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Bootstrap group(EventLoopGroup group) {
+		tcpClient = tcpClient.runOn(group);
+		return this;
+	}
+
+	@Override
+	public Bootstrap handler(ChannelHandler handler) {
+		tcpClient = tcpClient.doOnChannelInit((connectionObserver, channel, remoteAddress) ->
+				channel.pipeline().addBefore(NettyPipeline.ReactiveBridge, null, handler));
+		return this;
+	}
+
+	@Override
+	public int hashCode() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Bootstrap localAddress(InetAddress inetHost, int inetPort) {
+		tcpClient = tcpClient.bindAddress(() -> new InetSocketAddress(inetHost, inetPort));
+		return this;
+	}
+
+	@Override
+	public Bootstrap localAddress(int inetPort) {
+		tcpClient = tcpClient.bindAddress(() -> new InetSocketAddress(inetPort));
+		return this;
+	}
+
+	@Override
+	public Bootstrap localAddress(SocketAddress localAddress) {
+		tcpClient = tcpClient.bindAddress(() -> localAddress);
+		return this;
+	}
+
+	@Override
+	public Bootstrap localAddress(String inetHost, int inetPort) {
+		tcpClient = tcpClient.bindAddress(() -> SocketUtils.socketAddress(inetHost, inetPort));
+		return this;
+	}
+
+	@Override
+	public <T> Bootstrap option(ChannelOption<T> option, T value) {
+		tcpClient = tcpClient.option(option, value);
+		return this;
+	}
+
+	@Override
+	public ChannelFuture register() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Bootstrap remoteAddress(InetAddress inetHost, int inetPort) {
+		tcpClient = tcpClient.remoteAddress(() -> new InetSocketAddress(inetHost, inetPort));
+		return this;
+	}
+
+	@Override
+	public Bootstrap remoteAddress(SocketAddress remoteAddress) {
+		tcpClient = tcpClient.remoteAddress(() -> remoteAddress);
+		return this;
+	}
+
+	@Override
+	public Bootstrap remoteAddress(String inetHost, int inetPort) {
+		tcpClient = tcpClient.host(inetHost).port(inetPort);
+		return this;
+	}
+
+	@Override
+	public Bootstrap resolver(AddressResolverGroup<?> resolver) {
+		tcpClient = tcpClient.resolver(resolver);
+		return this;
+	}
+
+	@Override
+	public String toString() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Bootstrap validate() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/src/test/java/reactor/netty/tcp/TcpClientTests.java
+++ b/src/test/java/reactor/netty/tcp/TcpClientTests.java
@@ -35,15 +35,23 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.handler.codec.LineBasedFrameDecoder;
+import io.netty.resolver.DefaultAddressResolverGroup;
+import io.netty.util.AttributeKey;
+import io.netty.util.NetUtil;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
@@ -65,6 +73,7 @@ import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.retry.Retry;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
@@ -1061,5 +1070,160 @@ public class TcpClientTests {
 		         .remoteAddress(() -> new DomainSocketAddress("/tmp/test.sock"))
 		         .port(1234)
 		         .connectNow();
+	}
+
+	@Test
+	@SuppressWarnings({"deprecation", "FutureReturnValueIgnored"})
+	public void testBootstrapUnsupported() {
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					// FutureReturnValueIgnored is deliberate
+					b.bind();
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					// FutureReturnValueIgnored is deliberate
+					b.bind(NetUtil.LOCALHOST, 8000);
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					// FutureReturnValueIgnored is deliberate
+					b.bind(8000);
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					// FutureReturnValueIgnored is deliberate
+					b.bind(new InetSocketAddress("localhost", 8000));
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					// FutureReturnValueIgnored is deliberate
+					b.bind("localhost", 8000);
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> b.channel(io.netty.channel.socket.SocketChannel.class)));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(Bootstrap::clone));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					// FutureReturnValueIgnored is deliberate
+					b.connect();
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					// FutureReturnValueIgnored is deliberate
+					b.connect(NetUtil.LOCALHOST, 8000);
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					// FutureReturnValueIgnored is deliberate
+					b.connect(new InetSocketAddress("localhost", 8000));
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					// FutureReturnValueIgnored is deliberate
+					b.connect(new InetSocketAddress("localhost", 8001), new InetSocketAddress("localhost", 8002));
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					// FutureReturnValueIgnored is deliberate
+					b.connect("localhost", 8000);
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					b.equals(new Bootstrap());
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					b.hashCode();
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					// FutureReturnValueIgnored is deliberate
+					b.register();
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(b -> {
+					b.toString();
+					return b;
+				}));
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+				.isThrownBy(() -> TcpClient.create().bootstrap(Bootstrap::validate));
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void testBootstrap() {
+		DisposableServer server =
+				TcpServer.create()
+				         .port(0)
+				         .handle((req, res) -> res.send(req.receive()
+				                                           .retain()))
+				         .wiretap(true)
+				         .bindNow();
+
+		AtomicInteger invoked = new AtomicInteger();
+		Connection conn =
+				TcpClient.create()
+				         .bootstrap(b ->
+				             b.attr(AttributeKey.valueOf("testBootstrap"), "testBootstrap")
+				              .group(new NioEventLoopGroup())
+				              .option(ChannelOption.valueOf("testBootstrap"), "testBootstrap")
+				              .remoteAddress(server.address())
+				              .resolver(DefaultAddressResolverGroup.INSTANCE)
+				              .handler(new ChannelInboundHandlerAdapter() {
+				                  @Override
+				                  public void channelActive(ChannelHandlerContext ctx) throws Exception {
+				                      invoked.set(1);
+				                      super.channelActive(ctx);
+				                  }
+				              }))
+				         .connectNow();
+
+		conn.outbound()
+		    .sendString(Mono.just("testBootstrap"))
+		    .then()
+		    .subscribe();
+
+		String result =
+				conn.inbound()
+				    .receive()
+				    .asString()
+				    .blockFirst();
+
+		assertEquals("testBootstrap", result);
+		assertEquals(1, invoked.get());
+
+		conn.disposeNow();
+		server.disposeNow();
 	}
 }


### PR DESCRIPTION
Add deprecated TcpClient#bootstrap in order to keep the backwards compatibility.
The method implementation invokes the corresponding TcpClient methods.