### PR TITLE
Deprecate #bootstrap in favour of methods exposed on client/server level

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -432,6 +432,7 @@ public abstract class HttpClient {
 	 *
 	 * @return the appropriate sending or receiving contract
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpClient baseUrl(String baseUrl) {
 		Objects.requireNonNull(baseUrl, "baseUrl");
 		return tcpConfiguration(tcp -> tcp.bootstrap(b -> HttpClientConfiguration.baseUrl(b, baseUrl)));
@@ -557,6 +558,7 @@ public abstract class HttpClient {
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpClient cookieCodec(ClientCookieEncoder encoder, ClientCookieDecoder decoder) {
 		return tcpConfiguration(tcp -> tcp.bootstrap(
 				b -> HttpClientConfiguration.cookieCodec(b, encoder, decoder)));
@@ -878,6 +880,7 @@ public abstract class HttpClient {
 	 * @return a new {@link HttpClient}
 	 * @since 0.9.5
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpClient followRedirect(BiPredicate<HttpClientRequest, HttpClientResponse> predicate,
 			@Nullable Consumer<HttpClientRequest> redirectRequestConsumer) {
 		Objects.requireNonNull(predicate, "predicate");
@@ -943,6 +946,7 @@ public abstract class HttpClient {
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpClient protocol(HttpProtocol... supportedProtocols) {
 		return tcpConfiguration(tcpClient -> tcpClient.bootstrap(b -> HttpClientConfiguration.protocols(b, supportedProtocols)));
 	}
@@ -964,6 +968,7 @@ public abstract class HttpClient {
 	 *
 	 * @return a {@link RequestSender} ready to finalize request and consume for response
 	 */
+	@SuppressWarnings("deprecation")
 	public RequestSender request(HttpMethod method) {
 		Objects.requireNonNull(method, "method");
 		TcpClient tcpConfiguration = tcpConfiguration().bootstrap(b -> HttpClientConfiguration.method(b, method));
@@ -1023,6 +1028,7 @@ public abstract class HttpClient {
 	 *               the pipeline
 	 * @return a new {@link HttpClient}
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpClient wiretap(boolean enable) {
 		if (enable) {
 			return tcpConfiguration(tcpClient -> tcpClient.bootstrap(b -> BootstrapHandlers.updateLogSupport(b, LOGGING_HANDLER)));
@@ -1080,6 +1086,7 @@ public abstract class HttpClient {
 	 * @return a new {@link HttpClient}
 	 * @since 0.9.7
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpClient metrics(boolean metricsEnabled, @Nullable Function<String, String> uriTagValue) {
 		if (metricsEnabled) {
 			if (!Metrics.isInstrumentationAvailable()) {
@@ -1129,6 +1136,7 @@ public abstract class HttpClient {
 	 * @return a new {@link HttpClient}
 	 * @since 0.9.7
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpClient metrics(boolean metricsEnabled, Supplier<? extends HttpClientMetricsRecorder> recorder) {
 		return tcpConfiguration(tcpClient ->
 			tcpClient.metrics(metricsEnabled, recorder)
@@ -1163,6 +1171,7 @@ public abstract class HttpClient {
 	 * @return a {@link WebsocketSender} ready to consume for response
 	 * @since 0.9.7
 	 */
+	@SuppressWarnings("deprecation")
 	public final WebsocketSender websocket(WebsocketClientSpec websocketClientSpec) {
 		Objects.requireNonNull(websocketClientSpec, "websocketClientSpec");
 		TcpClient tcpConfiguration =
@@ -1271,24 +1280,31 @@ public abstract class HttpClient {
 
 	static final LoggingHandler LOGGING_HANDLER = new LoggingHandler(HttpClient.class);
 
+	@SuppressWarnings("deprecation")
 	static final Function<TcpClient, TcpClient> COMPRESS_ATTR_CONFIG =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_COMPRESS);
 
+	@SuppressWarnings("deprecation")
 	static final Function<TcpClient, TcpClient> COMPRESS_ATTR_DISABLE =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_NO_COMPRESS);
 
+	@SuppressWarnings("deprecation")
 	static final Function<TcpClient, TcpClient> KEEPALIVE_ATTR_CONFIG =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_KEEPALIVE);
 
+	@SuppressWarnings("deprecation")
 	static final Function<TcpClient, TcpClient> KEEPALIVE_ATTR_DISABLE =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_NO_KEEPALIVE);
 
+	@SuppressWarnings("deprecation")
 	static final Function<TcpClient, TcpClient> RETRY_ATTR_CONFIG =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_RETRY);
 
+	@SuppressWarnings("deprecation")
 	static final Function<TcpClient, TcpClient> RETRY_ATTR_DISABLE =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_NO_RETRY);
 
+	@SuppressWarnings("deprecation")
 	static final Function<TcpClient, TcpClient> FOLLOW_REDIRECT_ATTR_DISABLE =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_NO_REDIRECT);
 

--- a/src/main/java/reactor/netty/http/client/HttpClientCookie.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientCookie.java
@@ -53,6 +53,7 @@ final class HttpClientCookie extends HttpClientOperator
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	protected TcpClient tcpConfiguration() {
 		return source.tcpConfiguration().bootstrap(this);
 	}

--- a/src/main/java/reactor/netty/http/client/HttpClientCookieWhen.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientCookieWhen.java
@@ -45,6 +45,7 @@ final class HttpClientCookieWhen extends HttpClientOperator
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	protected TcpClient tcpConfiguration() {
 		return source.tcpConfiguration()
 		             .bootstrap(this);

--- a/src/main/java/reactor/netty/http/client/HttpClientDoOn.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientDoOn.java
@@ -98,6 +98,7 @@ final class HttpClientDoOn extends HttpClientOperator implements ConnectionObser
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	protected TcpClient tcpConfiguration() {
 		return source.tcpConfiguration().bootstrap(this);
 	}

--- a/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
@@ -53,16 +53,19 @@ final class HttpClientFinalizer extends HttpClient implements HttpClient.Request
 	// UriConfiguration methods
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public HttpClient.RequestSender uri(String uri) {
 		return new HttpClientFinalizer(cachedConfiguration.bootstrap(b -> HttpClientConfiguration.uri(b, uri)));
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public HttpClient.RequestSender uri(Mono<String> uri) {
 		return new HttpClientFinalizer(cachedConfiguration.bootstrap(b -> HttpClientConfiguration.deferredConf(b, conf -> uri.map(conf::uri))));
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public RequestSender uri(URI uri) {
 		if (!uri.isAbsolute()) {
 			throw new IllegalArgumentException("URI is not absolute: " + uri);
@@ -115,7 +118,9 @@ final class HttpClientFinalizer extends HttpClient implements HttpClient.Request
 		Objects.requireNonNull(requestBody, "requestBody");
 		return send((req, out) -> out.send(requestBody));
 	}
+
 	@Override
+	@SuppressWarnings("deprecation")
 	public HttpClientFinalizer send(BiFunction<? super HttpClientRequest, ?
 			super NettyOutbound, ? extends Publisher<Void>> sender) {
 		Objects.requireNonNull(sender, "requestBody");

--- a/src/main/java/reactor/netty/http/client/HttpClientHeaders.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientHeaders.java
@@ -39,6 +39,7 @@ final class HttpClientHeaders extends HttpClientOperator
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	protected TcpClient tcpConfiguration() {
 		return source.tcpConfiguration().bootstrap(this);
 	}

--- a/src/main/java/reactor/netty/http/client/HttpClientHeadersWhen.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientHeadersWhen.java
@@ -41,6 +41,7 @@ final class HttpClientHeadersWhen extends HttpClientOperator
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	protected TcpClient tcpConfiguration() {
 		return source.tcpConfiguration()
 		             .bootstrap(this);

--- a/src/main/java/reactor/netty/http/client/HttpClientObserve.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientObserve.java
@@ -37,6 +37,7 @@ final class HttpClientObserve extends HttpClientOperator
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	protected TcpClient tcpConfiguration() {
 		return source.tcpConfiguration().bootstrap(this);
 	}

--- a/src/main/java/reactor/netty/http/client/HttpResponseDecoderSpec.java
+++ b/src/main/java/reactor/netty/http/client/HttpResponseDecoderSpec.java
@@ -71,6 +71,7 @@ public final class HttpResponseDecoderSpec extends HttpDecoderSpec<HttpResponseD
 	 * Build a {@link Function} that applies the http response decoder configuration to a
 	 * {@link TcpClient} by enriching its attributes.
 	 */
+	@SuppressWarnings("deprecation")
 	Function<TcpClient, TcpClient> build() {
 		HttpResponseDecoderSpec decoder = new HttpResponseDecoderSpec();
 		decoder.initialBufferSize = initialBufferSize;

--- a/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
+++ b/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
@@ -43,16 +43,19 @@ final class WebsocketFinalizer extends HttpClient implements HttpClient.Websocke
 	// UriConfiguration methods
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public WebsocketSender uri(String uri) {
 		return new WebsocketFinalizer(cachedConfiguration.bootstrap(b -> HttpClientConfiguration.uri(b, uri)));
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public WebsocketSender uri(Mono<String> uri) {
 		return new WebsocketFinalizer(cachedConfiguration.bootstrap(b -> HttpClientConfiguration.deferredConf(b, conf -> uri.map(conf::uri))));
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public WebsocketSender uri(URI uri) {
 		if (!uri.isAbsolute()) {
 			throw new IllegalArgumentException("URI is not absolute: " + uri);
@@ -62,6 +65,7 @@ final class WebsocketFinalizer extends HttpClient implements HttpClient.Websocke
 
 	// WebsocketSender methods
 	@Override
+	@SuppressWarnings("deprecation")
 	public WebsocketFinalizer send(Function<? super HttpClientRequest, ? extends Publisher<Void>> sender) {
 		Objects.requireNonNull(sender, "requestBody");
 		return new WebsocketFinalizer(cachedConfiguration.bootstrap(b -> HttpClientConfiguration.body(b, (req, out) -> sender.apply(req))));

--- a/src/main/java/reactor/netty/http/server/HttpRequestDecoderSpec.java
+++ b/src/main/java/reactor/netty/http/server/HttpRequestDecoderSpec.java
@@ -67,6 +67,7 @@ public final class HttpRequestDecoderSpec extends HttpDecoderSpec<HttpRequestDec
 	 * Build a {@link Function} that applies the http request decoder configuration to a
 	 * {@link TcpServer} by enriching its attributes.
 	 */
+	@SuppressWarnings("deprecation")
 	Function<TcpServer, TcpServer> build() {
 		HttpRequestDecoderSpec decoder = new HttpRequestDecoderSpec();
 		decoder.initialBufferSize = initialBufferSize;

--- a/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -204,6 +204,7 @@ public abstract class HttpServer {
 	 *
 	 * @return a new {@link HttpServer}
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpServer compress(int minResponseSize) {
 		if (minResponseSize < 0) {
 			throw new IllegalArgumentException("minResponseSize must be positive");
@@ -224,6 +225,7 @@ public abstract class HttpServer {
 	 *
 	 * @return a new {@link HttpServer}
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpServer compress(BiPredicate<HttpServerRequest, HttpServerResponse> predicate) {
 		Objects.requireNonNull(predicate, "compressionPredicate");
 		return tcpConfiguration(tcp -> tcp.bootstrap(b -> HttpServerConfiguration.compressPredicate(b, predicate)));
@@ -268,6 +270,7 @@ public abstract class HttpServer {
 	 *
 	 * @return a new {@link HttpServer}
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpServer proxyProtocol(ProxyProtocolSupportType proxyProtocolSupportType) {
 		if (proxyProtocolSupportType == null) {
 			throw new NullPointerException("The parameter: proxyProtocolSupportType must not be null.");
@@ -367,6 +370,7 @@ public abstract class HttpServer {
 	 * @return a new {@link HttpServer}
 	 * @since 0.9.7
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpServer metrics(boolean metricsEnabled, @Nullable Function<String, String> uriTagValue) {
 		if (metricsEnabled) {
 			if (!Metrics.isInstrumentationAvailable()) {
@@ -416,6 +420,7 @@ public abstract class HttpServer {
 	 * @return a new {@link HttpServer}
 	 * @since 0.9.7
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpServer metrics(boolean metricsEnabled, Supplier<? extends HttpServerMetricsRecorder> recorder) {
 		return tcpConfiguration(tcpServer ->
 			tcpServer.metrics(metricsEnabled, recorder)
@@ -470,6 +475,7 @@ public abstract class HttpServer {
 	 *
 	 * @return a new {@link HttpServer}
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpServer cookieCodec(ServerCookieEncoder encoder) {
 		ServerCookieDecoder decoder = encoder == ServerCookieEncoder.LAX ?
 				ServerCookieDecoder.LAX : ServerCookieDecoder.STRICT;
@@ -486,6 +492,7 @@ public abstract class HttpServer {
 	 *
 	 * @return a new {@link HttpServer}
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpServer cookieCodec(ServerCookieEncoder encoder, ServerCookieDecoder decoder) {
 		return tcpConfiguration(tcp -> tcp.bootstrap(
 				b -> HttpServerConfiguration.cookieCodec(b, encoder, decoder)));
@@ -511,6 +518,7 @@ public abstract class HttpServer {
 	 *
 	 * @return a new {@link HttpServer}
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpServer protocol(HttpProtocol... supportedProtocols) {
 		return tcpConfiguration(tcpServer -> tcpServer.bootstrap(b -> HttpServerConfiguration.protocols(b, supportedProtocols)));
 	}
@@ -612,6 +620,7 @@ public abstract class HttpServer {
 	 *               the pipeline
 	 * @return a new {@link HttpServer}
 	 */
+	@SuppressWarnings("deprecation")
 	public final HttpServer wiretap(boolean enable) {
 		if (enable) {
 			return tcpConfiguration(tcpServer ->
@@ -647,15 +656,19 @@ public abstract class HttpServer {
 	static final LoggingHandler LOGGING_HANDLER = new LoggingHandler(HttpServer.class);
 	static final Logger         log             = Loggers.getLogger(HttpServer.class);
 
+	@SuppressWarnings("deprecation")
 	static final Function<TcpServer, TcpServer> COMPRESS_ATTR_CONFIG =
 			tcp -> tcp.bootstrap(HttpServerConfiguration.MAP_COMPRESS);
 
+	@SuppressWarnings("deprecation")
 	static final Function<TcpServer, TcpServer> COMPRESS_ATTR_DISABLE =
 			tcp -> tcp.bootstrap(HttpServerConfiguration.MAP_NO_COMPRESS);
 
+	@SuppressWarnings("deprecation")
 	static final Function<TcpServer, TcpServer> FORWARD_ATTR_CONFIG =
 			tcp -> tcp.bootstrap(HttpServerConfiguration.MAP_FORWARDED);
 
+	@SuppressWarnings("deprecation")
 	static final Function<TcpServer, TcpServer> FORWARD_ATTR_DISABLE =
 			tcp -> tcp.bootstrap(HttpServerConfiguration.MAP_NO_FORWARDED);
 }

--- a/src/main/java/reactor/netty/http/server/HttpServerBind.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerBind.java
@@ -94,6 +94,7 @@ final class HttpServerBind extends HttpServer
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Mono<? extends DisposableServer> bind(TcpServer delegate) {
 		return delegate.bootstrap(this)
 		               .bind()

--- a/src/main/java/reactor/netty/http/server/HttpServerHandle.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerHandle.java
@@ -47,6 +47,7 @@ final class HttpServerHandle extends HttpServerOperator implements ConnectionObs
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	protected TcpServer tcpConfiguration() {
 		return source.tcpConfiguration().bootstrap(this);
 	}

--- a/src/main/java/reactor/netty/http/server/HttpServerObserve.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerObserve.java
@@ -37,6 +37,7 @@ final class HttpServerObserve extends HttpServerOperator
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	protected TcpServer tcpConfiguration() {
 		return source.tcpConfiguration().bootstrap(this);
 	}

--- a/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -156,6 +156,19 @@ public abstract class TcpClient {
 	}
 
 	/**
+	 * The address to which this client should bind on subscribe.
+	 *
+	 * @param bindAddressSupplier A supplier of the address to bind to.
+	 *
+	 * @return a new {@link TcpClient}
+	 * @since 0.9.10
+	 */
+	public final TcpClient bindAddress(Supplier<? extends SocketAddress> bindAddressSupplier) {
+		Objects.requireNonNull(bindAddressSupplier, "bindAddressSupplier");
+		return bootstrap(b -> b.localAddress(bindAddressSupplier.get()));
+	}
+
+	/**
 	 * Apply {@link Bootstrap} configuration given mapper taking currently configured one
 	 * and returning a new one to be ultimately used for socket binding.
 	 * <p> Configuration will apply during {@link #configure()} phase.
@@ -165,7 +178,10 @@ public abstract class TcpClient {
 	 * enriched bootstrap.
 	 *
 	 * @return a new {@link TcpClient}
+	 * @deprecated  as of 0.9.10. Use the methods exposed on {@link TcpClient} level. The method
+	 * will be removed in version 1.1.0.
 	 */
+	@Deprecated
 	public final TcpClient bootstrap(Function<? super Bootstrap, ? extends Bootstrap> bootstrapMapper) {
 		return new TcpClientBootstrap(this, bootstrapMapper);
 	}

--- a/src/main/java/reactor/netty/tcp/TcpServer.java
+++ b/src/main/java/reactor/netty/tcp/TcpServer.java
@@ -141,7 +141,10 @@ public abstract class TcpServer {
 	 * enriched bootstrap.
 	 *
 	 * @return a new {@link TcpServer}
+	 * @deprecated  as of 0.9.10. Use the methods exposed on {@link TcpServer} level. The method
+	 * will be removed in version 1.0.0.
 	 */
+	@Deprecated
 	public final TcpServer bootstrap(Function<? super ServerBootstrap, ? extends ServerBootstrap> bootstrapMapper) {
 		return new TcpServerBootstrap(this, bootstrapMapper);
 	}

--- a/src/main/java/reactor/netty/udp/UdpClient.java
+++ b/src/main/java/reactor/netty/udp/UdpClient.java
@@ -128,6 +128,19 @@ public abstract class UdpClient {
 	}
 
 	/**
+	 * The address to which this client should bind on subscribe.
+	 *
+	 * @param bindAddressSupplier A supplier of the address to bind to.
+	 *
+	 * @return a new {@link UdpClient}
+	 * @since 0.9.10
+	 */
+	public final UdpClient bindAddress(Supplier<? extends SocketAddress> bindAddressSupplier) {
+		Objects.requireNonNull(bindAddressSupplier, "bindAddressSupplier");
+		return bootstrap(b -> b.localAddress(bindAddressSupplier.get()));
+	}
+
+	/**
 	 * Apply {@link Bootstrap} configuration given mapper taking currently configured one
 	 * and returning a new one to be ultimately used for socket binding. <p> Configuration
 	 * will apply during {@link #configure()} phase.
@@ -136,7 +149,10 @@ public abstract class UdpClient {
 	 * enriched bootstrap.
 	 *
 	 * @return a new {@link UdpClient}
+	 * @deprecated  as of 0.9.10. Use the methods exposed on {@link UdpClient} level. The method
+	 * will be removed in version 1.0.0.
 	 */
+	@Deprecated
 	public final UdpClient bootstrap(Function<? super Bootstrap, ? extends Bootstrap> bootstrapMapper) {
 		return new UdpClientBootstrap(this, bootstrapMapper);
 	}

--- a/src/main/java/reactor/netty/udp/UdpServer.java
+++ b/src/main/java/reactor/netty/udp/UdpServer.java
@@ -136,7 +136,10 @@ public abstract class UdpServer {
 	 * enriched bootstrap.
 	 *
 	 * @return a new {@link UdpServer}
+	 * @deprecated  as of 0.9.10. Use the methods exposed on {@link UdpServer} level. The method
+	 * will be removed in version 1.0.0.
 	 */
+	@Deprecated
 	public final UdpServer bootstrap(Function<? super Bootstrap, ? extends Bootstrap> bootstrapMapper) {
 		return new UdpServerBootstrap(this, bootstrapMapper);
 	}

--- a/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -397,7 +397,7 @@ public class ConnectionInfoTests {
 				serverRequest -> Assertions.assertThat(serverRequest.scheme()).isEqualTo("https"),
 				httpClient -> httpClient.secure(ssl -> ssl.sslContext(clientSslContext)),
 				httpServer -> httpServer.tcpConfiguration(tcpServer -> {
-					tcpServer = tcpServer.bootstrap(serverBootstrap ->
+					tcpServer = tcpServer.doOnBind(serverBootstrap ->
 							BootstrapHandlers.updateConfiguration(serverBootstrap, NettyPipeline.SslHandler, (connectionObserver, channel) -> {
 								SslHandler sslHandler = serverSslContext.newHandler(channel.alloc());
 								channel.pipeline().addFirst(NettyPipeline.SslHandler, sslHandler);

--- a/src/test/java/reactor/netty/resources/PooledConnectionProviderTest.java
+++ b/src/test/java/reactor/netty/resources/PooledConnectionProviderTest.java
@@ -590,7 +590,7 @@ public class PooledConnectionProviderTest {
 	private void doTestSslEngineClosed(HttpClient client, AtomicInteger closeCount, Class<? extends Throwable> expectedExc, String expectedMsg) {
 		Mono<String> response =
 				client.tcpConfiguration(tcpClient ->
-				    tcpClient.bootstrap(
+				    tcpClient.doOnConnect(
 				        b -> BootstrapHandlers.updateConfiguration(b, "test",
 				            (o, c) -> {
 				                PooledConnectionProvider.PooledConnectionAllocator.PooledConnectionInitializer initializer =


### PR DESCRIPTION
- options, attributes can be added with `#attr`, `#selectorAttr`, `#option` and `#selectorOption`
- local address can be added with `#bindAddress`
- group can be added with `#runOn`
- remoteAddress can be added with `#remoteAddress`
- resolver can be added with `#resolver`