### PR TITLE
Retry the request once if the connection was closed before sending the actual request

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -267,7 +267,10 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 		}
 		listener().onStateChange(this, HttpClientState.RESPONSE_INCOMPLETE);
 		if (responseState == null) {
-			if (markSentBody()) {
+			if (markSentHeaderAndBody()) {
+				listener().onUncaughtException(this, AbortedException.beforeSend());
+			}
+			else if (markSentBody()) {
 				listener().onUncaughtException(this, new PrematureCloseException("Connection has been closed BEFORE response, while sending request body"));
 			}
 			else {


### PR DESCRIPTION
With this change the request will be retried if for some reason the connection close event
appears after acquiring the connection from the pool and before sending the actual request.