### PR TITLE
support predicates to check for non proxied addresses

### DIFF
--- a/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -508,8 +508,8 @@ public final class ProxyProvider {
 		 * A standard predicate expression for a configured list of hosts that should be reached directly, bypassing
 		 * the proxy.
 		 *
-		 * @param nonProxyHostsPredicate A Predicate {@link Predicate} on {@link SocketAddress} to determine if the
-		 *                               address should not go through the configured proxy
+		 * @param nonProxyHostsPredicate A Predicate {@link Predicate} on {@link SocketAddress} that returns
+		 * {@literal true} if the host should bypass the configured proxy
 		 * @return {@code this}
 		 */
 		Builder nonProxyHostsPredicate(Predicate<SocketAddress> nonProxyHostsPredicate);

--- a/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -322,12 +322,32 @@ public final class ProxyProvider {
 		private final String regex;
 		private Pattern pattern;
 
-		public RegexShouldProxyPredicate(String pattern) {
+        /**
+         * Create a {@link RegexShouldProxyPredicate} based off the provided regular expression.
+         * @param regex The string regular expression
+         * @return a predicate whether we should direct to proxy
+         */
+		public static RegexShouldProxyPredicate fromRegularExpression(String regex) {
+            return new RegexShouldProxyPredicate(regex);
+        }
+
+        /**
+         * Creates a {@link RegexShouldProxyPredicate} based off the provided pattern with possible wildcards as
+         * described in https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html
+         *
+         * @param pattern The string wildcarded expression
+         * @return a predicate whether we should direct to proxy
+         */
+        public static RegexShouldProxyPredicate fromWildcardedPattern(String pattern) {
+            return new RegexShouldProxyPredicate(pattern.replaceAll("\\.", "\\\\.").replaceAll("\\*", "\\.*"));
+		}
+
+		private RegexShouldProxyPredicate(String pattern) {
 			this.regex = pattern;
 		}
 
-		private Pattern getPattern(){
-			if(pattern == null){
+		private Pattern getPattern() {
+			if (pattern == null) {
 				pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
 			}
 			return pattern;
@@ -335,7 +355,7 @@ public final class ProxyProvider {
 
 		@Override
 		public boolean test(SocketAddress socketAddress) {
-			if(!(socketAddress instanceof InetSocketAddress)){
+			if (!(socketAddress instanceof InetSocketAddress)) {
 				return false;
 			}
 			InetSocketAddress isa = (InetSocketAddress) socketAddress;

--- a/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -343,7 +343,7 @@ public final class ProxyProvider {
 	static final class RegexShouldProxyPredicate implements Predicate<SocketAddress> {
 
 		private final String regex;
-		private Pattern pattern;
+		private final Pattern pattern;
 
 		/**
 		 * Create a {@link RegexShouldProxyPredicate} based off the provided regular expression.
@@ -368,13 +368,7 @@ public final class ProxyProvider {
 
 		private RegexShouldProxyPredicate(String pattern) {
 			this.regex = pattern;
-		}
-
-		private Pattern getPattern() {
-			if (pattern == null) {
-				pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
-			}
-			return pattern;
+			this.pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
 		}
 
 		/**
@@ -390,7 +384,7 @@ public final class ProxyProvider {
 				return false;
 			}
 			InetSocketAddress isa = (InetSocketAddress) socketAddress;
-			return isa.getHostString() == null || !getPattern().matcher(isa.getHostString()).matches();
+			return isa.getHostString() == null || !pattern.matcher(isa.getHostString()).matches();
 		}
 
 		@Override

--- a/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -194,9 +194,9 @@ public final class ProxyProvider {
 	 */
 	@Deprecated
 	public boolean shouldProxy(@Nullable String hostName) {
-		return nonProxyHostPredicate == ALWAYS_PROXY || hostName == null ||
-				!((RegexShouldProxyPredicate) nonProxyHostPredicate).pattern.matcher(hostName)
-																			.matches();
+		return nonProxyHostPredicate == ALWAYS_PROXY
+				|| hostName == null
+				|| ((nonProxyHostPredicate instanceof RegexShouldProxyPredicate) && !((RegexShouldProxyPredicate) nonProxyHostPredicate).pattern.matcher(hostName).matches());
 	}
 
 	/**

--- a/src/test/java/reactor/netty/transport/ProxyProviderTest.java
+++ b/src/test/java/reactor/netty/transport/ProxyProviderTest.java
@@ -171,7 +171,7 @@ public class ProxyProviderTest {
 	@Test
 	public void nonProxyHosts_builderDefault_empty(){
 		Predicate<SocketAddress> pred = ProxyProvider.builder().type(ProxyProvider.Proxy.HTTP).host("something").build().getNonProxyHostsPredicate();
-		assertFalse("Default do not proxy", pred.test(someAddress("localhost")));
+		assertFalse("Default should proxy", pred.test(someAddress("localhost")));
 	}
 
 	private ProxyProvider createProxy(InetSocketAddress address, Function<String, String> passwordFunc) {

--- a/src/test/java/reactor/netty/transport/ProxyProviderTest.java
+++ b/src/test/java/reactor/netty/transport/ProxyProviderTest.java
@@ -123,7 +123,7 @@ public class ProxyProviderTest {
 		ProxyProvider.RegexShouldProxyPredicate pred = ProxyProvider.RegexShouldProxyPredicate.fromWildcardedPattern("foo*");
 		assertFalse("Should proxy, nothing matching prefix", pred.test(someAddress("other.foo.com")));
 		assertTrue("Should not proxy, anything in wildcard", pred.test(someAddress("foo.other.com")));
-		assertTrue("Should proxy, nothing in wildcard", pred.test(someAddress("foo.")));
+		assertTrue("Should not proxy, nothing in wildcard", pred.test(someAddress("foo.")));
 	}
 
 	@Test

--- a/src/test/java/reactor/netty/transport/ProxyProviderTest.java
+++ b/src/test/java/reactor/netty/transport/ProxyProviderTest.java
@@ -25,7 +25,10 @@ import java.util.function.Predicate;
 import io.netty.handler.codec.http.HttpHeaders;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ProxyProviderTest {
 
@@ -166,6 +169,13 @@ public class ProxyProviderTest {
 		assertTrue("Should not proxy loopback", defaultPredicate.test(someAddress("127.0.0.2")));
 		assertTrue("Should not proxy default", defaultPredicate.test(someAddress("0.0.0.0")));
 		assertTrue("Should not proxy localhost", defaultPredicate.test(someAddress("localhost")));
+	}
+
+	@Test
+	public void nonProxyHosts_wildcardInTheMiddle() {
+		ProxyProvider.RegexShouldProxyPredicate pred = ProxyProvider.RegexShouldProxyPredicate.fromWildcardedPattern("some.*.com");
+		assertFalse("Should proxy, nothing matching other", pred.test(someAddress("some.other.com")));
+		assertFalse("Should proxy, nothing matching foo", pred.test(someAddress("some.foo.com")));
 	}
 
 	@Test

--- a/src/test/java/reactor/netty/transport/ProxyProviderTest.java
+++ b/src/test/java/reactor/netty/transport/ProxyProviderTest.java
@@ -16,15 +16,14 @@
 
 package reactor.netty.transport;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
 import java.net.InetSocketAddress;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import io.netty.handler.codec.http.HttpHeaders;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class ProxyProviderTest {
 
@@ -101,6 +100,13 @@ public class ProxyProviderTest {
 		                                      .address(ADDRESS_1)
 		                                      .build();
 		assertEquals(10000, provider.connectTimeoutMillis);
+	}
+
+	@Test
+	public void handleWildcardInNonProxyHosts(){
+		ProxyProvider.RegexShouldProxyPredicate pred = ProxyProvider.RegexShouldProxyPredicate.fromWildcardedPattern("*.foo.com");
+		assertTrue("Should proxy", pred.test( new InetSocketAddress("some.other.com", 8080)));
+		assertFalse("Should not proxy", pred.test( new InetSocketAddress("some.foo.com", 8080)));
 	}
 
 	private ProxyProvider createProxy(InetSocketAddress address, Function<String, String> passwordFunc) {


### PR DESCRIPTION
@violetagg open to any suggestions on how to safely add this new method and maintain backwards compatibility. With this change, I'll follow up on our other issue and use this new method when loading configurations from system variables. 

- A new method in ```Builder``` is added to set the predicate directly
- The existing nonProxyHost string is now encapsulated in a predicate object for consistency
  - An implementation is added to support the string presented in #1190 