### PR TITLE
fix #1194 Ensure custom HOST header is preserved when websocket

### DIFF
--- a/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
@@ -24,7 +24,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.LastHttpContent;
@@ -74,8 +73,7 @@ final class WebsocketClientOperations extends HttpClientOperations
 					WebSocketVersion.V13,
 					subprotocols != null && !subprotocols.isEmpty() ? subprotocols : null,
 					true,
-					replaced.requestHeaders()
-					        .remove(HttpHeaderNames.HOST),
+					replaced.requestHeaders(),
 					websocketClientSpec.maxFramePayloadLength());
 
 		handshaker.handshake(channel)


### PR DESCRIPTION
This fix is in addition to PR#1047
Fixes #1194 