### PR TITLE
Do not check tiny cache size

### DIFF
--- a/src/test/java/reactor/netty/channel/ByteBufAllocatorMetricsTest.java
+++ b/src/test/java/reactor/netty/channel/ByteBufAllocatorMetricsTest.java
@@ -120,7 +120,6 @@ public class ByteBufAllocatorMetricsTest {
 		assertThat(getGaugeValue(name + HEAP_ARENAS, tags)).isGreaterThan(0);
 		assertThat(getGaugeValue(name + DIRECT_ARENAS, tags)).isGreaterThan(0);
 		assertThat(getGaugeValue(name + THREAD_LOCAL_CACHES, tags)).isGreaterThan(0);
-		assertThat(getGaugeValue(name + TINY_CACHE_SIZE, tags)).isGreaterThan(0);
 		assertThat(getGaugeValue(name + SMALL_CACHE_SIZE, tags)).isGreaterThan(0);
 		assertThat(getGaugeValue(name + NORMAL_CACHE_SIZE, tags)).isGreaterThan(0);
 		assertThat(getGaugeValue(name + CHUNK_SIZE, tags)).isGreaterThan(0);


### PR DESCRIPTION
Tiny cache size is deprecated in Netty 4.1.52.Final and returns always 0

Related to https://github.com/netty/netty/pull/10267

The CI build agains Netty Snapshot fails as of today
https://github.com/reactor/reactor-netty/actions/runs/171315858