### PR TITLE
Fix #1159 Expose requestTimeout setting on HttpClient/HttpClientRequest level

### DIFF
--- a/src/main/java/reactor/netty/NettyPipeline.java
+++ b/src/main/java/reactor/netty/NettyPipeline.java
@@ -81,6 +81,7 @@ public interface NettyPipeline {
 	String WsCompressionHandler = LEFT + "wsCompressionHandler";
 	String ProxyProtocolDecoder = LEFT + "proxyProtocolDecoder";
 	String ProxyProtocolReader  = LEFT + "proxyProtocolReader";
+	String RequestTimeoutHandler = LEFT + "requestTimeoutHandler";
 
 	/**
 	 * Create a new {@link ChannelInboundHandler} that will invoke

--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -17,6 +17,7 @@ package reactor.netty.http.client;
 
 import java.net.SocketAddress;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -973,6 +974,24 @@ public abstract class HttpClient {
 		Objects.requireNonNull(method, "method");
 		TcpClient tcpConfiguration = tcpConfiguration().bootstrap(b -> HttpClientConfiguration.method(b, method));
 		return new HttpClientFinalizer(tcpConfiguration);
+	}
+
+	/**
+	 * Specifies the request timeout duration in milliseconds.
+	 * This is time that takes to receive a response after sending a request.
+	 * If the {@code timeout} is {@code null}, any previous setting will be removed and no request timeout
+	 * will be applied.
+	 * If the {@code timeout} is less than {@code 1ms}, then {@code 1ms} will be the request timeout.
+	 * The request timeout setting on {@link HttpClientRequest} level overrides any request timeout
+	 * setting on {@link HttpClient} level.
+	 *
+	 * @param timeout the request timeout duration (resolution: ms)
+	 * @return a new {@link HttpClient}
+	 * @since 0.9.11
+	 */
+	@SuppressWarnings("deprecation")
+	public final HttpClient requestTimeout(Duration timeout) {
+		return tcpConfiguration(tcpClient -> tcpClient.bootstrap(b -> HttpClientConfiguration.requestTimeout(b, timeout)));
 	}
 
 	/**

--- a/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
@@ -17,6 +17,7 @@
 package reactor.netty.http.client;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
@@ -66,6 +67,8 @@ final class HttpClientConfiguration {
 	Consumer<HttpClientRequest> redirectRequestConsumer = null;
 
 	Function<String, String> uriTagValue = null;
+
+	Duration requestTimeout = null;
 
 	Function<Mono<HttpClientConfiguration>, Mono<HttpClientConfiguration>> deferredConf                   = null;
 
@@ -306,6 +309,11 @@ final class HttpClientConfiguration {
 
 	static Bootstrap uriTagValue(Bootstrap b, @Nullable Function<String, String> uriTagValue) {
 		getOrCreate(b).uriTagValue = uriTagValue;
+		return b;
+	}
+
+	static Bootstrap requestTimeout(Bootstrap b, Duration timeout) {
+		getOrCreate(b).requestTimeout = timeout;
 		return b;
 	}
 

--- a/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -18,6 +18,7 @@ package reactor.netty.http.client;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -461,6 +462,7 @@ final class HttpClientConnect extends HttpClient {
 		                              redirectRequestConsumer;
 		final HttpResponseDecoderSpec decoder;
 		final ProxyProvider           proxyProvider;
+		final Duration                requestTimeout;
 
 		volatile UriEndpoint        toURI;
 		volatile UriEndpoint        fromURI;
@@ -478,6 +480,7 @@ final class HttpClientConnect extends HttpClient {
 			this.cookieDecoder = configuration.cookieDecoder;
 			this.decoder = configuration.decoder;
 			this.proxyProvider = proxyProvider;
+			this.requestTimeout = configuration.requestTimeout;
 
 			HttpHeaders defaultHeaders = configuration.headers;
 			if (compress) {
@@ -542,6 +545,7 @@ final class HttpClientConnect extends HttpClient {
 		Publisher<Void> requestWithBody(HttpClientOperations ch) {
 			try {
 				ch.resourceUrl = toURI.toExternalForm();
+				ch.requestTimeout = requestTimeout;
 
 				UriEndpoint uri = toURI;
 				HttpHeaders headers = ch.getNettyRequest()

--- a/src/main/java/reactor/netty/http/client/HttpClientDoOnError.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientDoOnError.java
@@ -16,6 +16,7 @@
 
 package reactor.netty.http.client;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -74,6 +75,7 @@ final class HttpClientDoOnError extends HttpClientOperator {
 		final Context             context;
 		final ClientCookieDecoder cookieDecoder;
 		final boolean             isWebsocket;
+		final Duration            requestTimeout;
 
 		PreparingHttpClientRequest(Context context, HttpClientConfiguration c) {
 			this.context = context;
@@ -83,6 +85,7 @@ final class HttpClientDoOnError extends HttpClientOperator {
 			this.path = HttpOperations.resolvePath(this.uri);
 			this.method = c.method;
 			this.isWebsocket = c.websocketClientSpec != null;
+			this.requestTimeout = c.requestTimeout;
 		}
 
 		@Override
@@ -113,6 +116,11 @@ final class HttpClientDoOnError extends HttpClientOperator {
 		@Override
 		public boolean isFollowRedirect() {
 			return true;
+		}
+
+		@Override
+		public HttpClientRequest requestTimeout(Duration timeout) {
+			throw new UnsupportedOperationException("Should not add request timeout");
 		}
 
 		@Override

--- a/src/main/java/reactor/netty/http/client/HttpClientRequest.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientRequest.java
@@ -19,6 +19,8 @@ package reactor.netty.http.client;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.cookie.Cookie;
 
+import java.time.Duration;
+
 /**
  * An Http Reactive client metadata contract for outgoing requests. It inherits several
  * accessor related to HTTP flow : headers, params, URI, method, websocket...
@@ -71,4 +73,19 @@ public interface HttpClientRequest extends HttpClientInfos {
 	 * @return true if redirected will be followed
 	 */
 	boolean isFollowRedirect();
+
+	/**
+	 * Specifies the request timeout duration in milliseconds.
+	 * This is time that takes to receive a response after sending a request.
+	 * If the {@code timeout} is {@code null}, any previous setting will be removed and no request timeout
+	 * will be applied.
+	 * If the {@code timeout} is less than {@code 1ms}, then {@code 1ms} will be the request timeout.
+	 * The request timeout setting on {@link HttpClientRequest} level overrides any request timeout
+	 * setting on {@link HttpClient} level.
+	 *
+	 * @param timeout the request timeout duration
+	 * @return this outbound
+	 * @since 0.9.11
+	 */
+	HttpClientRequest requestTimeout(Duration timeout);
 }


### PR DESCRIPTION
ReadTimeoutHandler is added when request sending is finished successfully.
The handler is removed before returning the connection to the pool.
The setting on request level overrides the one on client level.
Fixes #1159