### PR TITLE
fix example code by setting the SSL context of the `SslContextSpec`

### DIFF
--- a/src/docs/asciidoc/http-server.adoc
+++ b/src/docs/asciidoc/http-server.adoc
@@ -628,8 +628,8 @@ public class Application {
                           .port(8080)
                           .protocol(HttpProtocol.H2) <1>
                           .secure(spec ->            <2>
-                                  SslContextBuilder.forServer(new File("certificate.crt"),
-                                                              new File("private.key")))
+                                  spec.sslContext(SslContextBuilder.forServer(new File("certificate.crt"),
+                                                              new File("private.key"))))
                           .handle((request, response) -> response.sendString(Mono.just("hello")))
                           .bindNow();
 


### PR DESCRIPTION
closes #1225 