### PR TITLE
do not set cipher suites while configuring HTTP/2

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClientSecure.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientSecure.java
@@ -21,13 +21,11 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 
-import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import reactor.netty.tcp.SslProvider;
 import reactor.netty.tcp.TcpClient;
 
@@ -82,7 +80,6 @@ final class HttpClientSecure extends HttpClientOperator {
 			sslCtx =
 					SslContextBuilder.forClient()
 					                 .sslProvider(provider)
-					                 .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
 					                 .applicationProtocolConfig(new ApplicationProtocolConfig(
 							                 ApplicationProtocolConfig.Protocol.ALPN,
 							                 ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,

--- a/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -32,7 +32,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.OpenSsl;
@@ -40,7 +39,6 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
-import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import reactor.core.Exceptions;
 import reactor.netty.ConnectionObserver;
 import reactor.netty.NettyPipeline;
@@ -76,6 +74,8 @@ public final class SslProvider {
 	 * configurator callback to inject default settings to an existing provider
 	 * configuration.
 	 *
+	 * @param provider ssl provider to use
+	 * @param handlerConfigurator ssl configuration handler to use
 	 * @return a new SslProvider
 	 */
 	public static SslProvider addHandlerConfigurator(
@@ -103,6 +103,7 @@ public final class SslProvider {
 	/**
 	 * Add Ssl support on the given client bootstrap
 	 * @param b a given bootstrap to enrich
+	 * @param sslProvider ssl provider to use
 	 *
 	 * @return an enriched bootstrap
 	 */
@@ -248,6 +249,8 @@ public final class SslProvider {
 		/**
 		 * The SslContextBuilder for building a new {@link SslContext}.
 		 *
+		 * @param sslCtxBuilder The SslContextBuilder to use for building a new {@link SslContext}.
+		 * 
 		 * @return {@literal this}
 		 */
 		DefaultConfigurationSpec sslContext(SslContextBuilder sslCtxBuilder);
@@ -271,7 +274,6 @@ public final class SslProvider {
 		/**
 		 * {@link io.netty.handler.ssl.SslProvider} will be set depending on
 		 * <code>OpenSsl.isAlpnSupported()</code>,
-		 * {@link Http2SecurityUtil#CIPHERS},
 		 * ALPN support,
 		 * HTTP/1.1 and HTTP/2 support
 		 *
@@ -375,7 +377,6 @@ public final class SslProvider {
 				                     io.netty.handler.ssl.SslProvider.isAlpnSupported(io.netty.handler.ssl.SslProvider.OPENSSL) ?
 				                             io.netty.handler.ssl.SslProvider.OPENSSL :
 				                             io.netty.handler.ssl.SslProvider.JDK)
-				                 .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
 				                 .applicationProtocolConfig(new ApplicationProtocolConfig(
 				                     ApplicationProtocolConfig.Protocol.ALPN,
 				                     ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,

--- a/src/test/java/reactor/netty/tcp/SslProviderTests.java
+++ b/src/test/java/reactor/netty/tcp/SslProviderTests.java
@@ -46,7 +46,7 @@ public class SslProviderTests {
 	static final String PROTOCOL_TLS_V1_3 = "TLSv1.3";
 
 	// expected TLSv1.3 cipher suites commonly used by JDK 11+ and OpenSSL
-    static final String[] TLSV13_CIPHER_SUITES = { "TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384" };
+	static final String[] TLSV13_CIPHER_SUITES = { "TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384" };
 
 	// expected cipher suites that are mandatory for HTTP/2
 	static final String[] HTTP2_MANDATORY_CIPHER_SUITES = { "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" };


### PR DESCRIPTION
the cipher list from `Http2SecurityUtil.CIPHERS` does not contain ciphers for TLSv1.3 supported by JDK 11+, namely TLS_AES_128_GCM_SHA256 and TLS_AES_256_GCM_SHA384.
the list contains TLS_CHACHA20_POLY1305_SHA256 which is only supported by OpenSSL.
this results in TLSv1.3 being unavailable when HTTP/2 is enabled and JDK 11+ is used as SSL provider.

leave it up to Netty to set appropriate default ciphers (see `JdkSslContext`, `ReferenceCountedOpenSslContext` and `SslUtils`).

**bonus**:
- use of the unstable api `Http2SecurityUtil` removed
- users can define their own list of ciphers in `SslContextBuilder` and still use `DefaultConfigurationType.H2`

fixes gh-issue #1224

p.s.
A word about why I removed `JdkSslContext` from `SslProviderTests`. Since netty-tcnative-boringssl-static is part of the test runtime, all these checks on `OpenSslContext` or `JdkSslContext` always returned `OpenSslContext`. If one day this test no longer uses netty-tcnative-boringssl-static, then further changes are required anyway.