### PR TITLE
fix #989 Add wiretap(String, LogLevel, ByteBufFormat)

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
@@ -20,9 +20,11 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.group.ChannelGroup;
+import io.netty.handler.logging.ByteBufFormat;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.util.AttributeKey;
@@ -261,8 +263,8 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	}
 
 	/**
-	 * Apply or remove a wire logger configuration using {@link Transport} category
-	 * and {@code DEBUG} logger level.
+	 * Apply or remove a wire logger configuration using {@link Transport} category,
+	 * {@code DEBUG} logger level and {@link ByteBufFormat#HEX_DUMP} for {@link ByteBuf} format.
 	 *
 	 * @param enable specifies whether the wire logger configuration will be added to the pipeline
 	 * @return a new {@link Transport} reference
@@ -286,8 +288,8 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	}
 
 	/**
-	 * Apply a wire logger configuration using the specified category
-	 * and {@code DEBUG} logger level.
+	 * Apply a wire logger configuration using the specified category,
+	 * {@code DEBUG} logger level and {@link ByteBufFormat#HEX_DUMP} for {@link ByteBuf} format.
 	 *
 	 * @param category the logger category
 	 * @return a new {@link Transport} reference
@@ -298,8 +300,8 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	}
 
 	/**
-	 * Apply a wire logger configuration using the specified category
-	 * and logger level.
+	 * Apply a wire logger configuration using the specified category,
+	 * logger level and {@link ByteBufFormat#HEX_DUMP} for {@link ByteBuf} format.
 	 *
 	 * @param category the logger category
 	 * @param level the logger level
@@ -308,8 +310,24 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	public T wiretap(String category, LogLevel level) {
 		Objects.requireNonNull(category, "category");
 		Objects.requireNonNull(level, "level");
+		return wiretap(category, LogLevel.DEBUG, ByteBufFormat.HEX_DUMP);
+	}
+
+	/**
+	 * Apply a wire logger configuration using the specified category,
+	 * logger level and {@link ByteBuf} format.
+	 *
+	 * @param category the logger category
+	 * @param level the logger level
+	 * @param format the {@link ByteBuf} format
+	 * @return a new {@link Transport} reference
+	 */
+	public final T wiretap(String category, LogLevel level, ByteBufFormat format) {
+		Objects.requireNonNull(category, "category");
+		Objects.requireNonNull(level, "level");
+		Objects.requireNonNull(format, "format");
 		T dup = duplicate();
-		dup.configuration().loggingHandler = new LoggingHandler(category, level);
+		dup.configuration().loggingHandler = new LoggingHandler(category, level, format);
 		return dup;
 	}
 

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/TransportTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/TransportTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.transport;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.handler.logging.ByteBufFormat;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import org.junit.Test;
+import reactor.netty.ChannelPipelineConfigurer;
+import reactor.netty.ConnectionObserver;
+import reactor.netty.channel.ChannelMetricsRecorder;
+import reactor.netty.resources.LoopResources;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Violeta Georgieva
+ */
+public class TransportTest {
+
+	@Test
+	public void testWiretap() {
+		TestTransportConfig config = new TestTransportConfig(Collections.emptyMap());
+		TestTransport transport = new TestTransport(config);
+
+		doTestWiretap(transport.wiretap(true), LogLevel.DEBUG, ByteBufFormat.HEX_DUMP);
+		doTestWiretap(transport.wiretap("category"), LogLevel.DEBUG, ByteBufFormat.HEX_DUMP);
+		doTestWiretap(transport.wiretap("category", LogLevel.DEBUG), LogLevel.DEBUG, ByteBufFormat.HEX_DUMP);
+		doTestWiretap(transport.wiretap("category", LogLevel.INFO, ByteBufFormat.HEX_DUMP), LogLevel.INFO, ByteBufFormat.HEX_DUMP);
+		doTestWiretap(transport.wiretap("category", LogLevel.DEBUG, ByteBufFormat.SIMPLE), LogLevel.DEBUG, ByteBufFormat.SIMPLE);
+	}
+
+	private void doTestWiretap(TestTransport transport, LogLevel expectedLevel, ByteBufFormat expectedFormat) {
+		LoggingHandler loggingHandler = transport.config.loggingHandler;
+
+		assertThat(loggingHandler.level()).isSameAs(expectedLevel);
+		assertThat(loggingHandler.byteBufFormat()).isSameAs(expectedFormat);
+	}
+
+	static final class TestTransport extends Transport<TestTransport, TestTransportConfig> {
+
+		final TestTransportConfig config;
+
+		TestTransport(TestTransportConfig config) {
+			this.config = config;
+		}
+
+		@Override
+		public TestTransportConfig configuration() {
+			return config;
+		}
+
+		@Override
+		protected TestTransport duplicate() {
+			return new TestTransport(new TestTransportConfig(config));
+		}
+	}
+
+	static final class TestTransportConfig extends TransportConfig {
+
+		static final LoggingHandler LOGGING_HANDLER = new LoggingHandler(TestTransport.class);
+
+		TestTransportConfig(Map<ChannelOption<?>, ?> options) {
+			super(options);
+		}
+
+		TestTransportConfig(TransportConfig parent) {
+			super(parent);
+		}
+
+		@Override
+		protected Class<? extends Channel> channelType(boolean isDomainSocket) {
+			return null;
+		}
+
+		@Override
+		protected ConnectionObserver defaultConnectionObserver() {
+			return null;
+		}
+
+		@Override
+		protected LoggingHandler defaultLoggingHandler() {
+			return LOGGING_HANDLER;
+		}
+
+		@Override
+		protected LoopResources defaultLoopResources() {
+			return null;
+		}
+
+		@Override
+		protected ChannelMetricsRecorder defaultMetricsRecorder() {
+			return null;
+		}
+
+		@Override
+		protected ChannelPipelineConfigurer defaultOnChannelInit() {
+			return null;
+		}
+
+		@Override
+		protected EventLoopGroup eventLoopGroup() {
+			return null;
+		}
+	}
+}

--- a/reactor-netty-core/src/test/resources/logback.xml
+++ b/reactor-netty-core/src/test/resources/logback.xml
@@ -23,7 +23,7 @@
             </pattern>
         </encoder>
     </appender>
-    <!--appender-- name="file" class="ch.qos.logback.core.FileAppender">
+    <!--appender name="file" class="ch.qos.logback.core.FileAppender">
        <file>testFile.log</file>
         <append>false</append>
         <encoder>


### PR DESCRIPTION
`ByteBufFormat` controls the format and verbosity of logging for `ByteBuf` and `ByteBufHolder`

Fixes #989 