### PR TITLE
fix #1247 When graceful shutdown close immediately the connections with no active requests

### DIFF
--- a/src/main/java/reactor/netty/tcp/TcpServerBind.java
+++ b/src/main/java/reactor/netty/tcp/TcpServerBind.java
@@ -174,6 +174,7 @@ final class TcpServerBind extends TcpServer {
 		}
 
 		@Override
+		@SuppressWarnings("FutureReturnValueIgnored")
 		public void disposeNow(Duration timeout) {
 			if (isDisposed()) {
 				return;
@@ -190,7 +191,11 @@ final class TcpServerBind extends TcpServer {
 				channelGroup.forEach(channel -> {
 					ChannelOperations<?, ?> ops = ChannelOperations.get(channel);
 					if (ops != null) {
-						channels.add(ops.onTerminate());
+						channels.add(ops.onTerminate().doFinally(sig -> ops.dispose()));
+					}
+					else {
+						//"FutureReturnValueIgnored" this is deliberate
+						channel.close();
 					}
 				});
 				if (!channels.isEmpty()) {

--- a/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1718,11 +1718,11 @@ public class HttpServerTests {
 		// Stop accepting incoming requests, wait at most 3s for the active requests to finish
 		disposableServer.disposeNow();
 
+		assertThat(latch2.await(30, TimeUnit.SECONDS)).isTrue();
+
 		// Dispose the event loop
 		loop.disposeLater()
 		    .block(Duration.ofSeconds(30));
-
-		assertThat(latch2.await(30, TimeUnit.SECONDS)).isTrue();
 
 		StepVerifier.create(result)
 		            .expectNext("delay500delay1000")


### PR DESCRIPTION
Wait for the connections with active requests to finish for the given time and then close the connections
no matter if the requests finished successfully or are interrupted because of a timeout.

Fixes #1247 