### PR TITLE
fix #1257 Target host should not be resolved when proxy is configured (1.0.0)

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
@@ -79,7 +79,7 @@ public abstract class TransportConfig {
 
 	public int channelHash() {
 		return Objects.hash(attrs, bindAddress != null ? bindAddress.get() : 0, channelGroup, doOnChannelInit,
-				loggingHandler, loopResources, metricsRecorder, observer, options, preferNative);
+				loggingHandler, loopResources, metricsRecorder != null ? metricsRecorder.get() : 0, observer, options, preferNative);
 	}
 
 	/**


### PR DESCRIPTION
A forward merge of the fix for #1257 (0.9.x) cannot be achieved because of
the changes in the implementation, so the fix for 1.0.0 is done separately.