### PR TITLE
Added possibility to use a custom logging handler. #436

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
@@ -137,8 +137,8 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 		if (enable) {
 			if (!Metrics.isInstrumentationAvailable()) {
 				throw new UnsupportedOperationException(
-						"To enable metrics, you must add the dependency `io.micrometer:micrometer-core`" +
-								" to the class path first");
+					"To enable metrics, you must add the dependency `io.micrometer:micrometer-core`" +
+						" to the class path first");
 			}
 			T dup = duplicate();
 			dup.configuration().metricsRecorder = () -> configuration().defaultMetricsRecorder();
@@ -326,8 +326,19 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 		Objects.requireNonNull(category, "category");
 		Objects.requireNonNull(level, "level");
 		Objects.requireNonNull(format, "format");
+		return wiretap(new LoggingHandler(category, level, format));
+	}
+
+	/**
+	 * Apply a wire logger configuration using a logging handler.
+	 *
+	 * @param loggingHandler the logging handler
+	 * @return a new {@link Transport} reference
+	 */
+	public final T wiretap(LoggingHandler loggingHandler) {
+		Objects.requireNonNull(loggingHandler, "customLoggingHandler");
 		T dup = duplicate();
-		dup.configuration().loggingHandler = new LoggingHandler(category, level, format);
+		dup.configuration().loggingHandler = loggingHandler;
 		return dup;
 	}
 

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/TransportTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/TransportTest.java
@@ -21,6 +21,8 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.handler.logging.ByteBufFormat;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
+
+import org.junit.Before;
 import org.junit.Test;
 import reactor.netty.ChannelPipelineConfigurer;
 import reactor.netty.ConnectionObserver;
@@ -37,11 +39,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class TransportTest {
 
+	private TestTransport transport;
+
+	@Before
+	public void setUp() throws Exception {
+		TestTransportConfig config = new TestTransportConfig(Collections.emptyMap());
+		transport = new TestTransport(config);
+	}
+
 	@Test
 	public void testWiretap() {
-		TestTransportConfig config = new TestTransportConfig(Collections.emptyMap());
-		TestTransport transport = new TestTransport(config);
-
 		doTestWiretap(transport.wiretap(true), LogLevel.DEBUG, ByteBufFormat.HEX_DUMP);
 		doTestWiretap(transport.wiretap("category"), LogLevel.DEBUG, ByteBufFormat.HEX_DUMP);
 		doTestWiretap(transport.wiretap("category", LogLevel.DEBUG), LogLevel.DEBUG, ByteBufFormat.HEX_DUMP);
@@ -55,6 +62,15 @@ public class TransportTest {
 
 		assertThat(loggingHandler.level()).isSameAs(expectedLevel);
 		assertThat(loggingHandler.byteBufFormat()).isSameAs(expectedFormat);
+	}
+
+	@Test
+	public void testWiretapWithCustomLogginHandler() {
+		CustomLoggingHandler customLoggingHandler = new CustomLoggingHandler();
+
+		final TestTransport modifiedTransport = transport.wiretap(customLoggingHandler);
+
+		assertThat(modifiedTransport.config.loggingHandler).isSameAs(customLoggingHandler);
 	}
 
 	static final class TestTransport extends Transport<TestTransport, TestTransportConfig> {
@@ -123,4 +139,9 @@ public class TransportTest {
 			return null;
 		}
 	}
+
+	static final class CustomLoggingHandler extends LoggingHandler {
+
+	}
+
 }


### PR DESCRIPTION
It's a pretty straight forward and simple solution. I added an additional "wiretap" method to Transport that takes a LoggingHandler. 

Another way would be to pass a class that extends ChannelDuplexHandler instead of LoggingHandler.

Let me know what you think about it. We can also discuss different solutions.
