### PR TITLE
fix #1274 Fix NPE when executing parallel requests

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -406,20 +406,7 @@ class HttpClientConnect extends HttpClient {
 			this.decoder = configuration.decoder;
 			this.proxyProvider = configuration.proxyProvider();
 			this.responseTimeout = configuration.responseTimeout;
-
-			HttpHeaders defaultHeaders = configuration.headers;
-			if (compress) {
-				if (defaultHeaders == null) {
-					this.defaultHeaders = new DefaultHttpHeaders();
-				}
-				else {
-					this.defaultHeaders = defaultHeaders;
-				}
-				this.defaultHeaders.set(HttpHeaderNames.ACCEPT_ENCODING, HttpHeaderValues.GZIP);
-			}
-			else {
-				this.defaultHeaders = defaultHeaders;
-			}
+			this.defaultHeaders = configuration.headers;
 
 			String baseUrl = configuration.baseUrl;
 
@@ -473,7 +460,7 @@ class HttpClientConnect extends HttpClient {
 
 				ch.path = HttpOperations.resolvePath(ch.uri());
 
-				if (defaultHeaders != null) {
+				if (!defaultHeaders.isEmpty()) {
 					headers.set(defaultHeaders);
 				}
 


### PR DESCRIPTION
The headers on `HttpClient` level are initialised when the `HttpClient` configuration
is created, no need to initialise it when preparing the request.
`ACCEPT_ENCODING` header is properly set when the compression is enabled,
no need to set it when preparing the request.