### PR TITLE
Add support to use URI mapper with custom metrics recorder

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1132,6 +1132,24 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		return super.metrics(enable, recorder);
 	}
 
+	public final HttpClient metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder, Function<String, String> uriTagValue) {
+		if (enable) {
+			HttpClient dup = duplicate();
+			dup.configuration().metricsRecorder(recorder);
+			dup.configuration().uriTagValue = uriTagValue;
+			return dup;
+		}
+		else if (configuration().metricsRecorder() != null) {
+			HttpClient dup = duplicate();
+			dup.configuration().metricsRecorder(null);
+			dup.configuration().uriTagValue = null;
+			return dup;
+		}
+		else {
+			return this;
+		}
+	}
+
 	/**
 	 * Removes any previously applied SSL configuration customization
 	 *

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1132,6 +1132,21 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		return super.metrics(enable, recorder);
 	}
 
+	/**
+	 * Specifies whether the metrics are enabled on the {@link HttpClient}.
+	 * All generated metrics are provided to the specified recorder which is only
+	 * instantiated if metrics are being enabled.
+	 * <p>{@code uriTagValue} function receives the actual uri and returns the uri tag value
+	 * that will be used for the metrics with {@link reactor.netty.Metrics#URI} tag.
+	 * For example instead of using the actual uri {@code "/users/1"} as uri tag value, templated uri
+	 * {@code "/users/{id}"} can be used.
+	 *
+	 * @param enable true enables metrics collection; false disables it
+	 * @param recorder a supplier for the metrics recorder that receives the collected metrics
+	 * @param uriTagValue a function that receives the actual uri and returns the uri tag value
+	 * that will be used for the metrics with {@link reactor.netty.Metrics#URI} tag
+	 * @return a new {@link HttpClient}
+	 */
 	public final HttpClient metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder, Function<String, String> uriTagValue) {
 		if (enable) {
 			HttpClient dup = duplicate();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -342,6 +342,24 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 		return super.metrics(enable, recorder);
 	}
 
+	public final HttpServer metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder, Function<String, String> uriTagValue) {
+		if (enable) {
+			HttpServer dup = duplicate();
+			dup.configuration().metricsRecorder(recorder);
+			dup.configuration().uriTagValue = uriTagValue;
+			return dup;
+		}
+		else if (configuration().metricsRecorder() != null) {
+			HttpServer dup = duplicate();
+			dup.configuration().metricsRecorder(null);
+			dup.configuration().uriTagValue = null;
+			return dup;
+		}
+		else {
+			return this;
+		}
+	}
+
 	/**
 	 * Removes any previously applied SSL configuration customization
 	 *

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -342,6 +342,21 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 		return super.metrics(enable, recorder);
 	}
 
+	/**
+	 * Specifies whether the metrics are enabled on the {@link HttpServer}.
+	 * All generated metrics are provided to the specified recorder which is only
+	 * instantiated if metrics are being enabled.
+	 * <p>{@code uriTagValue} function receives the actual uri and returns the uri tag value
+	 * that will be used for the metrics with {@link reactor.netty.Metrics#URI} tag.
+	 * For example instead of using the actual uri {@code "/users/1"} as uri tag value, templated uri
+	 * {@code "/users/{id}"} can be used.
+	 *
+	 * @param enable true enables metrics collection; false disables it
+	 * @param recorder a supplier for the metrics recorder that receives the collected metrics
+	 * @param uriTagValue a function that receives the actual uri and returns the uri tag value
+	 * that will be used for the metrics with {@link reactor.netty.Metrics#URI} tag
+	 * @return a new {@link HttpServer}
+	 */
 	public final HttpServer metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder, Function<String, String> uriTagValue) {
 		if (enable) {
 			HttpServer dup = duplicate();

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -19,6 +19,7 @@ package reactor.netty.http.client;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
@@ -31,6 +32,7 @@ import java.nio.file.Paths;
 import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -2488,5 +2490,89 @@ public class HttpClientTest {
 
 		loop.disposeLater()
 		    .block(Duration.ofSeconds(30));
+	}
+
+	@Test
+	public void testCustomMetricsWithUriMapper() {
+		disposableServer =
+				HttpServer.create()
+							.port(0)
+							.handle((req, resp) -> resp.sendString(Mono.just("OK")))
+							.wiretap(true)
+							.bindNow();
+
+		final List<String> collectedUris = Collections.synchronizedList(new ArrayList<>());
+
+		HttpClient.create()
+				.metrics(true,
+						() -> new HttpClientMetricsRecorder() {
+							@Override
+							public void recordDataReceived(SocketAddress remoteAddress, String uri, long bytes) {
+								collectedUris.add(uri);
+							}
+
+							@Override
+							public void recordDataSent(SocketAddress remoteAddress, String uri, long bytes) {
+								collectedUris.add(uri);
+							}
+
+							@Override
+							public void incrementErrorsCount(SocketAddress remoteAddress, String uri) {
+								collectedUris.add(uri);
+							}
+
+							@Override
+							public void recordDataReceived(SocketAddress remoteAddress, long bytes) {
+							}
+
+							@Override
+							public void recordDataSent(SocketAddress remoteAddress, long bytes) {
+							}
+
+							@Override
+							public void incrementErrorsCount(SocketAddress remoteAddress) {
+							}
+
+							@Override
+							public void recordTlsHandshakeTime(SocketAddress remoteAddress, Duration time, String status) {
+							}
+
+							@Override
+							public void recordConnectTime(SocketAddress remoteAddress, Duration time, String status) {
+							}
+
+							@Override
+							public void recordResolveAddressTime(SocketAddress remoteAddress, Duration time, String status) {
+							}
+
+							@Override
+							public void recordDataReceivedTime(SocketAddress remoteAddress, String uri, String method, String status, Duration time) {
+								collectedUris.add(uri);
+							}
+
+							@Override
+							public void recordDataSentTime(SocketAddress remoteAddress, String uri, String method, Duration time) {
+								collectedUris.add(uri);
+							}
+
+							@Override
+							public void recordResponseTime(SocketAddress remoteAddress, String uri, String method, String status, Duration time) {
+								collectedUris.add(uri);
+							}
+						},
+						s -> s.startsWith("/stream/") ? "/stream/{n}" : s
+				)
+				.get()
+				.uri("http://localhost:" + disposableServer.port() + "/stream/1024")
+				.responseContent()
+				.aggregate()
+				.block(Duration.ofSeconds(30));
+
+		synchronized (collectedUris) {
+			assertThat(collectedUris).isNotEmpty();
+			for(String uri : collectedUris) {
+				assertThat(uri).isEqualTo("/stream/{n}");
+			}
+		}
 	}
 }


### PR DESCRIPTION
Add support to use URI mapper function together with custom metrics recorder. It's more efficient to let HttpClientMetricsHandler and HttpServerMetricsHandler call the mapper function before calling the recorder methods compared to do the mapping in the custom metrics recorder since the handlers will reuse an already mapped value when calling different methods in the recorder.