### PR TITLE
Adds notes in Brave integration tests

### DIFF
--- a/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpServerDecoratorTest.java
+++ b/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpServerDecoratorTest.java
@@ -105,7 +105,7 @@ public class ITTracingHttpServerDecoratorTest extends ITHttpServer {
 	}
 
 	@Override
-	@Ignore
+	@Ignore("TODO: mention why you can't have different HTTP status on uncaught")
 	public void httpStatusCodeSettable_onUncaughtException() {
 	}
 


### PR DESCRIPTION
This makes the currentTraceContext test idiomatic, showing that it isn't working.

reactor-netty probably relies on some hook to have the trace context continue, and that should be a dependency of all users of it otherwise traces will break.