### PR TITLE
fix #1333: When HEAD request, remove Transfer-Encoding only if there is Content-Length

### DIFF
--- a/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -619,8 +619,8 @@ public class HttpServerTests {
 		doTestContentLengthHeadRequest("/4", disposableServer.address(), HttpMethod.HEAD, sentHeaders, true, false);
 		doTestContentLengthHeadRequest("/5", disposableServer.address(), HttpMethod.HEAD, sentHeaders, false, true);
 		doTestContentLengthHeadRequest("/6", disposableServer.address(), HttpMethod.HEAD, sentHeaders, false, false);
-		doTestContentLengthHeadRequest("/7", disposableServer.address(), HttpMethod.HEAD, sentHeaders, false, false);
-		doTestContentLengthHeadRequest("/8", disposableServer.address(), HttpMethod.HEAD, sentHeaders, false, false);
+		doTestContentLengthHeadRequest("/7", disposableServer.address(), HttpMethod.HEAD, sentHeaders, true, false);
+		doTestContentLengthHeadRequest("/8", disposableServer.address(), HttpMethod.HEAD, sentHeaders, false, true);
 		doTestContentLengthHeadRequest("/9", disposableServer.address(), HttpMethod.HEAD, sentHeaders, false, false);
 		doTestContentLengthHeadRequest("/10", disposableServer.address(), HttpMethod.HEAD, sentHeaders, false, false);
 		doTestContentLengthHeadRequest("/11", disposableServer.address(), HttpMethod.HEAD, sentHeaders, false, false);


### PR DESCRIPTION
Fixes #1333 