### PR TITLE
Artifact produced by shadowJar is published automatically to local maven repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,6 @@ updates:
   labels:
   - type/dependency-upgrade
   ignore:
-  - dependency-name: com.github.johnrengelman.shadow
-    versions:
-    - ">= 6.a"
-    - "< 7"
   - dependency-name: io.micrometer:micrometer-core
     versions:
     - "> 1.5.0"

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ plugins {
 	id 'org.asciidoctor.convert' version '2.4.0'
 	id 'com.google.osdetector' version '1.6.2'
 	id 'org.gradle.test-retry' version '1.1.9'
-	id 'com.github.johnrengelman.shadow' version '5.2.0' apply false
+	id 'com.github.johnrengelman.shadow' version '6.1.0' apply false
 	id 'com.jfrog.artifactory' version '4.16.1' apply false
 	id 'me.champeau.gradle.japicmp' version '0.2.9' apply false
 	id 'de.undercouch.download' version '4.1.1' apply false

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -182,9 +182,6 @@ task relocateShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.Co
 
 tasks.shadowJar.dependsOn(relocateShadowJar)
 
-//add shadowJar to the publication
-publishing.publications.mavenJava.artifact(shadowJar)
-
 task jarFileTest(type: Test) {
 	testClassesDirs = sourceSets.jarFileTest.output.classesDirs
 	classpath = sourceSets.jarFileTest.runtimeClasspath


### PR DESCRIPTION
There is no need to add manually to the maven publications the artifact produced by shadowJar.
This is related to a change between version 5.2.0->6.0.0
https://github.com/johnrengelman/shadow/issues/586