### PR TITLE
fix #1345 Add API HttpServer#idleTimeout (for Reactor Netty version 0.9.x)

### DIFF
--- a/src/main/java/reactor/netty/NettyPipeline.java
+++ b/src/main/java/reactor/netty/NettyPipeline.java
@@ -59,6 +59,7 @@ public interface NettyPipeline {
 	String HttpDecompressor   = LEFT + "decompressor";
 	String HttpAggregator     = LEFT + "httpAggregator";
 	String HttpTrafficHandler = LEFT + "httpTrafficHandler";
+	String IdleTimeoutHandler = LEFT + "idleTimeoutHandler";
 	/**
 	 * @deprecated as of 0.9.8. Not used in 1.0.0 version.
 	 */

--- a/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -506,6 +506,24 @@ public abstract class HttpServer {
 	}
 
 	/**
+	 * Specifies an idle timeout on the connection when it is waiting for an HTTP request (resolution: ms).
+	 * Once the timeout is reached the connection will be closed.
+	 * <p>If an {@code idleTimeout} is not specified, this indicates no timeout (i.e. infinite),
+	 * which means the connection will be closed only if one of the peers decides to close it.
+	 * <p>If the {@code idleTimeout} is less than {@code 1ms}, then {@code 1ms} will be the idle timeout.
+	 * <p>By default {@code idleTimeout} is not specified.
+	 *
+	 * @param idleTimeout an idle timeout on the connection when it is waiting for an HTTP request (resolution: ms)
+	 * @return a new {@link HttpServer}
+	 * @since 0.9.14
+	 */
+	@SuppressWarnings("deprecation")
+	public final HttpServer idleTimeout(Duration idleTimeout) {
+		Objects.requireNonNull(idleTimeout, "idleTimeout");
+		return tcpConfiguration(tcp -> tcp.bootstrap(b -> HttpServerConfiguration.idleTimeout(b, idleTimeout)));
+	}
+
+	/**
 	 * Configure the
 	 * {@link ServerCookieEncoder}; {@link ServerCookieDecoder} will be
 	 * chosen based on the encoder

--- a/src/main/java/reactor/netty/http/server/HttpServerConfiguration.java
+++ b/src/main/java/reactor/netty/http/server/HttpServerConfiguration.java
@@ -16,6 +16,7 @@
 
 package reactor.netty.http.server;
 
+import java.time.Duration;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
@@ -47,6 +48,7 @@ final class HttpServerConfiguration {
 	ServerCookieEncoder    cookieEncoder      = ServerCookieEncoder.STRICT;
 	ServerCookieDecoder    cookieDecoder      = ServerCookieDecoder.STRICT;
 	int                    protocols          = h11;
+	Duration               idleTimeout        = null;
 
 	Function<String, String> uriTagValue      = null;
 
@@ -141,6 +143,11 @@ final class HttpServerConfiguration {
 
 	static ServerBootstrap uriTagValue(ServerBootstrap b, @Nullable Function<String, String> uriTagValue) {
 		getOrCreate(b).uriTagValue = uriTagValue;
+		return b;
+	}
+
+	static ServerBootstrap idleTimeout(ServerBootstrap b, @Nullable Duration idleTimeout) {
+		getOrCreate(b).idleTimeout = idleTimeout;
 		return b;
 	}
 

--- a/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1923,4 +1923,81 @@ public class HttpServerTests {
 		assertThat(collectedUris).isNotEmpty()
 		                         .containsOnly("/stream/{n}");
 	}
+
+	@Test
+	void testIdleTimeout() throws Exception {
+		doTestIdleTimeout(false);
+		doTestIdleTimeout(true);
+	}
+
+	private void doTestIdleTimeout(boolean applyTimeout) throws Exception {
+		CountDownLatch latch = new CountDownLatch(1);
+		HttpServer server =
+				HttpServer.create()
+				          .port(0)
+				          .handle((req, resp) -> {
+				              req.withConnection(conn -> conn.onDispose(latch::countDown));
+				              return resp.sendString(Mono.just("doTestIdleTimeout"));
+				          })
+				          .wiretap(true);
+
+		if (applyTimeout) {
+			server = server.idleTimeout(Duration.ofMillis(200));
+		}
+
+		disposableServer = server.bindNow(Duration.ofSeconds(30));
+
+		HttpClient.create()
+		          .port(disposableServer.port())
+		          .wiretap(true)
+		          .get()
+		          .uri("/")
+		          .responseContent()
+		          .aggregate()
+		          .block(Duration.ofSeconds(30));
+
+		assertThat(latch.await(500, TimeUnit.MILLISECONDS)).isEqualTo(applyTimeout);
+	}
+
+	@Test
+	void testIdleTimeout_DelayFirstRequest() throws Exception {
+		doTestIdleTimeout_DelayFirstRequest(false);
+		doTestIdleTimeout_DelayFirstRequest(true);
+	}
+
+	private void doTestIdleTimeout_DelayFirstRequest(boolean withSecurity) throws Exception {
+		HttpServer server =
+				HttpServer.create()
+				          .port(0)
+				          .idleTimeout(Duration.ofMillis(200))
+				          .handle((req, resp) -> resp.send(req.receive().retain()))
+				          .wiretap(true);
+
+		HttpClient client =
+				HttpClient.create()
+				          .remoteAddress(() -> disposableServer.address())
+				          .wiretap(true)
+				          .disableRetry(true);
+
+		if (withSecurity) {
+			SelfSignedCertificate cert = new SelfSignedCertificate();
+			SslContextBuilder serverCtx = SslContextBuilder.forServer(cert.certificate(), cert.privateKey());
+			SslContextBuilder clientCtx = SslContextBuilder.forClient()
+			                                               .trustManager(InsecureTrustManagerFactory.INSTANCE);
+			server = server.secure(spec -> spec.sslContext(serverCtx));
+			client = client.secure(spec -> spec.sslContext(clientCtx));
+		}
+
+		disposableServer = server.bindNow(Duration.ofSeconds(30));
+
+		client.post()
+		      .uri("/")
+		      .send((req, out) -> out.sendString(Mono.just("doTestIdleTimeout_DelayFirstRequest")
+		                                             .delaySubscription(Duration.ofMillis(500))))
+		      .responseContent()
+		      .aggregate()
+		      .as(StepVerifier::create)
+		      .expectErrorMatches(t -> t instanceof IOException || t instanceof AbortedException)
+		      .verify(Duration.ofSeconds(30));
+	}
 }


### PR DESCRIPTION
An API for specifying an idle timeout on the connection when it is waiting for an HTTP request.