### PR TITLE
Fix NoClassDefFoundError: LaQute/bnd/build/Project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ import me.champeau.gradle.japicmp.JapicmpTask
 buildscript {
   repositories {
 	maven { url "https://repo.spring.io/plugins-release" }
+	jcenter()
   }
   dependencies {
 	classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7',


### PR DESCRIPTION
Bnd plugin is not available from Spring's plugins repository