### PR TITLE
When searching for native transport, try first to load epoll

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNativeDetector.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNativeDetector.java
@@ -29,11 +29,11 @@ final class DefaultLoopNativeDetector {
 	static {
 		NIO = new DefaultLoopNIO();
 
-		if (DefaultLoopKQueue.kqueue) {
-			INSTANCE = new DefaultLoopKQueue();
-		}
-		else if (DefaultLoopEpoll.epoll) {
+		if (DefaultLoopEpoll.epoll) {
 			INSTANCE = new DefaultLoopEpoll();
+		}
+		else if (DefaultLoopKQueue.kqueue) {
+			INSTANCE = new DefaultLoopKQueue();
 		}
 		else {
 			INSTANCE = NIO;


### PR DESCRIPTION
Reactor Netty has compile dependency on `netty-transport-native-epoll`
and an optional dependency on `netty-transport-native-kqueue`.