### PR TITLE
fix #1392 Reintroduce OSGi and adapt OSGi Bundle-Version to new Europium scheme

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.gradle.util.VersionNumber
+import java.text.SimpleDateFormat
+
 buildscript {
 	repositories {
 		mavenCentral()
@@ -34,6 +37,7 @@ plugins {
 	id 'de.undercouch.download' version '4.1.1' apply false
 	id 'io.spring.javadoc' version '0.0.1' apply false
 	id 'io.spring.javadoc-aggregate' version '0.0.1' apply false
+	id 'biz.aQute.bnd.builder' version '5.2.0' apply false
 }
 
 description = 'Reactive Streams Netty driver'
@@ -48,6 +52,23 @@ ext {
 			project.version = realVersion
 			println "Building special snapshot ${project.version}"
 		}
+	}
+
+	versionNumber = VersionNumber.parse(version.toString())
+	if (versionNumber.qualifier == null || versionNumber.qualifier.size() == 0) {
+		osgiVersion = "${version}.RELEASE"
+		println "$version is a release, will use $osgiVersion for bnd"
+	}
+	else if (versionNumber.qualifier.equalsIgnoreCase("SNAPSHOT")) {
+		sdf = new SimpleDateFormat("yyyyMMddHHmm");
+		sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+		buildTimestamp = sdf.format(new Date())
+		osgiVersion = "${versionNumber.major}.${versionNumber.minor}.${versionNumber.micro}.BUILD-$buildTimestamp"
+		println "$version is a snapshot, will use $osgiVersion for bnd"
+	}
+	else {
+		osgiVersion = "${versionNumber.major}.${versionNumber.minor}.${versionNumber.micro}.${versionNumber.qualifier}"
+		println "$version is neither release nor snapshot, will use $osgiVersion for bnd"
 	}
 
 	os_suffix = ""

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import aQute.bnd.gradle.BundleTaskConvention
 import me.champeau.gradle.japicmp.JapicmpTask
 
 apply plugin: 'java-test-fixtures'
@@ -20,6 +21,22 @@ apply plugin: 'io.spring.javadoc'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'me.champeau.gradle.japicmp'
 apply plugin: 'de.undercouch.download'
+apply plugin: 'biz.aQute.bnd.builder'
+
+ext {
+	bndOptions = [
+			"Export-Package" : "!reactor.netty.internal*,reactor.netty*;version=$osgiVersion;-noimport:=true",
+			"Import-Package": [
+					"!javax.annotation",
+					"io.netty.channel.kqueue;resolution:=optional;version=\"[4.1,5)\"",
+					"io.micrometer.*;resolution:=optional",
+					"*"
+			].join(","),
+			"Bundle-Name" : "reactor-netty-core",
+			"Bundle-SymbolicName" : "io.projectreactor.netty.reactor-netty-core",
+			"Bundle-Version" : "$osgiVersion"
+	]
+}
 
 sourceSets {
 	jarFileTest
@@ -99,6 +116,7 @@ jar {
 	manifest {
 		attributes("Automatic-Module-Name": "reactor.netty.core")
 	}
+	bnd(bndOptions)
 }
 
 components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) { skip() }
@@ -143,6 +161,14 @@ tasks.japicmp.dependsOn(downloadBaseline)
 tasks.check.dependsOn(japicmp)
 
 shadowJar {
+	configure {
+		it.convention.plugins.bundle = new BundleTaskConvention(it)
+		doLast {
+			buildBundle()
+		}
+	}
+	bnd(bndOptions)
+
 	archiveClassifier.set(null)
 
 	dependsOn(project.tasks.jar)
@@ -181,6 +207,13 @@ task relocateShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.Co
 }
 
 tasks.shadowJar.dependsOn(relocateShadowJar)
+
+//delay the maven publishing so that the OSGi metadata is generated
+//then add shadowJar to the publication
+components.java.withVariantsFromConfiguration(configurations.shadowRuntimeElements) {
+	skip()
+}
+publishing.publications.mavenJava.artifact(shadowJar)
 
 task jarFileTest(type: Test) {
 	testClassesDirs = sourceSets.jarFileTest.output.classesDirs

--- a/reactor-netty-core/src/jarFileTest/java/reactor/netty/JarFileShadingTest.java
+++ b/reactor-netty-core/src/jarFileTest/java/reactor/netty/JarFileShadingTest.java
@@ -72,6 +72,8 @@ public class JarFileShadingTest extends AbstractJarFileTest {
 				.replace("-original.jar", "")
 				.replace(".jar", "");
 
+		String osgiVersion = version.replace("-SNAPSHOT", ".BUILD-");
+
 		try (InputStream inputStream = jar.getInputStream(manifest);
 		     BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, UTF_8))) {
 			String lines = reader.lines()
@@ -82,9 +84,19 @@ public class JarFileShadingTest extends AbstractJarFileTest {
 			assertThat(lines)
 					.as("base content")
 					.contains(
-							"Implementation-Title: reactor-netty",
+							"Implementation-Title: reactor-netty-core",
 							"Implementation-Version: " + version,
-							"Automatic-Module-Name: reactor.netty"
+							"Automatic-Module-Name: reactor.netty.core"
+					);
+			assertThat(lines)
+					.as("OSGI content")
+					.contains(
+							"Bundle-Name: reactor-netty-core",
+							"Bundle-SymbolicName: io.projectreactor.netty.reactor-netty-core",
+							"Import-Package: ", //only assert the section is there
+							"Require-Capability:",
+							"Export-Package:", //only assert the section is there
+							"Bundle-Version: " + osgiVersion
 					);
 		}
 		catch (IOException ioe) {

--- a/reactor-netty-http-brave/build.gradle
+++ b/reactor-netty-http-brave/build.gradle
@@ -18,6 +18,17 @@ import me.champeau.gradle.japicmp.JapicmpTask
 apply plugin: 'io.spring.javadoc'
 apply plugin: 'me.champeau.gradle.japicmp'
 apply plugin: 'de.undercouch.download'
+apply plugin: 'biz.aQute.bnd.builder'
+
+ext {
+	bndOptions = [
+			"Export-Package" : "reactor.netty.http.brave*;version=$osgiVersion;-noimport:=true",
+			"Import-Package" : "!javax.annotation,*",
+			"Bundle-Name" : "reactor-netty-http-brave",
+			"Bundle-SymbolicName" : "io.projectreactor.netty.reactor-netty-http-brave",
+			"Bundle-Version" : "$osgiVersion"
+	]
+}
 
 dependencies {
 	compile project(':reactor-netty-http')
@@ -37,6 +48,7 @@ jar {
 	manifest {
 		attributes("Automatic-Module-Name": "reactor.netty.http.brave")
 	}
+	bnd(bndOptions)
 }
 
 task downloadBaseline(type: Download) {

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -18,6 +18,23 @@ import me.champeau.gradle.japicmp.JapicmpTask
 apply plugin: 'io.spring.javadoc'
 apply plugin: 'me.champeau.gradle.japicmp'
 apply plugin: 'de.undercouch.download'
+apply plugin: 'biz.aQute.bnd.builder'
+
+ext {
+	bndOptions = [
+			"Export-Package" : "reactor.netty.http*;version=$osgiVersion;-noimport:=true",
+			"Import-Package": [
+					"!javax.annotation",
+					"io.netty.channel.kqueue;resolution:=optional;version=\"[4.1,5)\"",
+					"io.netty.handler.codec.haproxy;resolution:=optional;version=\"[4.1,5)\"",
+					"io.micrometer.*;resolution:=optional",
+					"*"
+			].join(","),
+			"Bundle-Name" : "reactor-netty-http",
+			"Bundle-SymbolicName" : "io.projectreactor.netty.reactor-netty-http",
+			"Bundle-Version" : "$osgiVersion"
+	]
+}
 
 dependencies {
 	compile project(path: ':reactor-netty-core', configuration: 'shadow')
@@ -89,6 +106,7 @@ jar {
 	manifest {
 		attributes("Automatic-Module-Name": "reactor.netty.http")
 	}
+	bnd(bndOptions)
 }
 
 task downloadBaseline(type: Download) {


### PR DESCRIPTION
Fixes #1392 

Based on functionality in version `0.9.x`

https://github.com/reactor/reactor-netty/blob/03c22c8fe0c29a204de298f0c16b852d9c7d223a/build.gradle#L90-L95

<details>
<summary>MANIFEST.MF for reactor-netty-core</summary>

```mf
Manifest-Version: 1.0
Automatic-Module-Name: reactor.netty.core
Bnd-LastModified: 1606798238098
Bundle-ManifestVersion: 2
Bundle-Name: reactor-netty-core
Bundle-SymbolicName: io.projectreactor.netty.reactor-netty-core
Bundle-Version: 1.0.2.BUILD-202012010450
Created-By: 1.8.0_261 (Oracle Corporation)
Export-Package: reactor.netty;version="1.0.2.BUILD-202012010450";uses:
 ="io.micrometer.core.instrument,io.netty.buffer,io.netty.channel,io.n
 etty.util.concurrent,org.reactivestreams,reactor.core,reactor.core.pu
 blisher,reactor.util.annotation,reactor.util.context",reactor.netty.c
 hannel;version="1.0.2.BUILD-202012010450";uses:="io.micrometer.core.i
 nstrument,io.netty.buffer,io.netty.channel,org.reactivestreams,reacto
 r.core,reactor.core.publisher,reactor.netty,reactor.util.annotation,r
 eactor.util.context",reactor.netty.resources;version="1.0.2.BUILD-202
 012010450";uses:="io.netty.channel,io.netty.resolver,org.reactivestre
 ams,reactor.core,reactor.core.publisher,reactor.netty,reactor.netty.t
 ransport,reactor.util.annotation",reactor.netty.tcp;version="1.0.2.BU
 ILD-202012010450";uses:="io.netty.bootstrap,io.netty.channel,io.netty
 .channel.group,io.netty.handler.logging,io.netty.handler.ssl,io.netty
 .resolver,io.netty.util,javax.net.ssl,org.reactivestreams,reactor.cor
 e.publisher,reactor.netty,reactor.netty.channel,reactor.netty.resourc
 es,reactor.netty.transport,reactor.util.annotation",reactor.netty.tra
 nsport;version="1.0.2.BUILD-202012010450";uses:="io.netty.channel,io.
 netty.channel.group,io.netty.handler.codec.http,io.netty.handler.logg
 ing,io.netty.handler.proxy,io.netty.resolver,io.netty.resolver.dns,io
 .netty.util,reactor.core.publisher,reactor.netty,reactor.netty.channe
 l,reactor.netty.resources,reactor.netty.transport.logging,reactor.uti
 l.annotation",reactor.netty.transport.logging;version="1.0.2.BUILD-20
 2012010450";uses:="io.netty.handler.logging",reactor.netty.udp;versio
 n="1.0.2.BUILD-202012010450";uses:="io.netty.channel,io.netty.channel
 .socket,io.netty.handler.logging,io.netty.util,org.reactivestreams,re
 actor.core.publisher,reactor.netty,reactor.netty.channel,reactor.nett
 y.resources,reactor.netty.transport,reactor.util.annotation"
Implementation-Title: reactor-netty-core
Implementation-Version: 1.0.2-SNAPSHOT
Import-Package: io.netty.channel.kqueue;resolution:=optional;version="
 [4.1,5)",io.micrometer.core.instrument;resolution:=optional,io.microm
 eter.core.instrument.composite;resolution:=optional,io.micrometer.cor
 e.instrument.noop;resolution:=optional,io.netty.bootstrap;version="[4
 .1,5)",io.netty.buffer;version="[4.1,5)",io.netty.channel;version="[4
 .1,5)",io.netty.channel.epoll;version="[4.1,5)",io.netty.channel.grou
 p;version="[4.1,5)",io.netty.channel.nio;version="[4.1,5)",io.netty.c
 hannel.socket;version="[4.1,5)",io.netty.channel.socket.nio;version="
 [4.1,5)",io.netty.channel.unix;version="[4.1,5)",io.netty.handler.cod
 ec;version="[4.1,5)",io.netty.handler.codec.http;version="[4.1,5)",io
 .netty.handler.logging;version="[4.1,5)",io.netty.handler.proxy;versi
 on="[4.1,5)",io.netty.handler.ssl;version="[4.1,5)",io.netty.handler.
 stream;version="[4.1,5)",io.netty.handler.timeout;version="[4.1,5)",i
 o.netty.resolver;version="[4.1,5)",io.netty.resolver.dns;version="[4.
 1,5)",io.netty.util;version="[4.1,5)",io.netty.util.concurrent;versio
 n="[4.1,5)",io.netty.util.internal;version="[4.1,5)",javax.net.ssl,or
 g.reactivestreams;version="[1.0,2)",reactor.core;version="[3.4,4)",re
 actor.core.publisher;version="[3.4,4)",reactor.core.scheduler;version
 ="[3.4,4)",reactor.util;version="[3.4,4)",reactor.util.annotation;ver
 sion="[3.4,4)",reactor.util.concurrent;version="[3.4,4)",reactor.util
 .context;version="[3.4,4)"
Private-Package: reactor.netty.internal.shaded.reactor.pool
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
Tool: Bnd-5.2.0.202010142003
```

</details>

<details>
<summary>MANIFEST.MF for reactor-netty-http</summary>

```mf
Manifest-Version: 1.0
Automatic-Module-Name: reactor.netty.http
Bnd-LastModified: 1606798241113
Bundle-ManifestVersion: 2
Bundle-Name: reactor-netty-http
Bundle-SymbolicName: io.projectreactor.netty.reactor-netty-http
Bundle-Version: 1.0.2.BUILD-202012010450
Created-By: 1.8.0_261 (Oracle Corporation)
Export-Package: reactor.netty.http;version="1.0.2.BUILD-202012010450";
 uses:="io.micrometer.core.instrument,io.netty.buffer,io.netty.channel
 ,io.netty.handler.codec.http,io.netty.handler.codec.http.cookie,org.r
 eactivestreams,reactor.core.publisher,reactor.netty,reactor.netty.cha
 nnel,reactor.netty.resources,reactor.netty.tcp,reactor.util.annotatio
 n",reactor.netty.http.client;version="1.0.2.BUILD-202012010450";uses:
 ="io.netty.buffer,io.netty.handler.codec.http,io.netty.handler.codec.
 http.cookie,io.netty.handler.codec.http.multipart,io.netty.handler.lo
 gging,io.netty.resolver,org.reactivestreams,reactor.core.publisher,re
 actor.netty,reactor.netty.channel,reactor.netty.http,reactor.netty.ht
 tp.websocket,reactor.netty.resources,reactor.netty.tcp,reactor.netty.
 transport,reactor.util.annotation,reactor.util.context",reactor.netty
 .http.server;version="1.0.2.BUILD-202012010450";uses:="io.netty.chann
 el.group,io.netty.handler.codec.http,io.netty.handler.codec.http.cook
 ie,io.netty.handler.logging,org.reactivestreams,reactor.core.publishe
 r,reactor.netty,reactor.netty.channel,reactor.netty.http,reactor.nett
 y.http.server.logging,reactor.netty.http.websocket,reactor.netty.reso
 urces,reactor.netty.tcp,reactor.netty.transport,reactor.util.annotati
 on",reactor.netty.http.server.logging;version="1.0.2.BUILD-2020120104
 50";uses:="io.netty.channel,reactor.util.annotation",reactor.netty.ht
 tp.websocket;version="1.0.2.BUILD-202012010450";uses:="io.netty.buffe
 r,io.netty.handler.codec.http,io.netty.handler.codec.http.websocketx,
 org.reactivestreams,reactor.core.publisher,reactor.netty,reactor.util
 .annotation"
Implementation-Title: reactor-netty-http
Implementation-Version: 1.0.2-SNAPSHOT
Import-Package: io.netty.handler.codec.haproxy;resolution:=optional;ve
 rsion="[4.1,5)",io.micrometer.core.instrument;resolution:=optional,io
 .netty.buffer;version="[4.1,5)",io.netty.channel;version="[4.1,5)",io
 .netty.channel.group;version="[4.1,5)",io.netty.channel.socket;versio
 n="[4.1,5)",io.netty.channel.unix;version="[4.1,5)",io.netty.handler.
 codec;version="[4.1,5)",io.netty.handler.codec.http;version="[4.1,5)"
 ,io.netty.handler.codec.http.cookie;version="[4.1,5)",io.netty.handle
 r.codec.http.multipart;version="[4.1,5)",io.netty.handler.codec.http.
 websocketx;version="[4.1,5)",io.netty.handler.codec.http.websocketx.e
 xtensions.compression;version="[4.1,5)",io.netty.handler.codec.http2;
 version="[4.1,5)",io.netty.handler.logging;version="[4.1,5)",io.netty
 .handler.ssl;version="[4.1,5)",io.netty.handler.stream;version="[4.1,
 5)",io.netty.handler.timeout;version="[4.1,5)",io.netty.resolver;vers
 ion="[4.1,5)",io.netty.util;version="[4.1,5)",io.netty.util.concurren
 t;version="[4.1,5)",io.netty.util.internal;version="[4.1,5)",javax.ne
 t.ssl,org.reactivestreams;version="[1.0,2)",reactor.core;version="[3.
 4,4)",reactor.core.publisher;version="[3.4,4)",reactor.netty;version=
 "[1.0,2)",reactor.netty.channel;version="[1.0,2)",reactor.netty.inter
 nal.shaded.reactor.pool,reactor.netty.resources;version="[1.0,2)",rea
 ctor.netty.tcp;version="[1.0,2)",reactor.netty.transport;version="[1.
 0,2)",reactor.util;version="[3.4,4)",reactor.util.annotation;version=
 "[3.4,4)",reactor.util.concurrent;version="[3.4,4)",reactor.util.cont
 ext;version="[3.4,4)",reactor.util.retry;version="[3.4,4)",io.netty.c
 hannel.kqueue;resolution:=optional;version="[4.1,5)"
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
Tool: Bnd-5.2.0.202010142003
```

</details>

<details>
<summary>MANIFEST.MF for reactor-netty-http-brave</summary>

```mf
Manifest-Version: 1.0
Automatic-Module-Name: reactor.netty.http.brave
Bnd-LastModified: 1606798241971
Bundle-ManifestVersion: 2
Bundle-Name: reactor-netty-http-brave
Bundle-SymbolicName: io.projectreactor.netty.reactor-netty-http-brave
Bundle-Version: 1.0.2.BUILD-202012010450
Created-By: 1.8.0_261 (Oracle Corporation)
Export-Package: reactor.netty.http.brave;version="1.0.2.BUILD-20201201
 0450";uses:="brave.http,reactor.netty.http.client,reactor.netty.http.
 server"
Implementation-Title: reactor-netty-http-brave
Implementation-Version: 1.0.2-SNAPSHOT
Import-Package: brave;version="[5.13,6)",brave.http;version="[5.13,6)"
 ,brave.propagation;version="[5.13,6)",io.netty.channel;version="[4.1,
 5)",io.netty.handler.codec.http;version="[4.1,5)",io.netty.util;versi
 on="[4.1,5)",reactor.core.publisher;version="[3.4,4)",reactor.netty;v
 ersion="[1.0,2)",reactor.netty.http.client;version="[1.0,2)",reactor.
 netty.http.server;version="[1.0,2)",reactor.netty.transport;version="
 [1.0,2)",reactor.util.annotation;version="[3.4,4)",reactor.util.conte
 xt;version="[3.4,4)"
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
Tool: Bnd-5.2.0.202010142003
```

</details>