### PR TITLE
fix #1406 When connection is closed abnormally, emit WebSocketCloseStatus.ABNORMAL_CLOSURE

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -56,6 +56,8 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
 import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.util.AsciiString;
 import io.netty.util.ReferenceCountUtil;
@@ -739,7 +741,7 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		public void onComplete() {
 			if (ops.channel()
 			       .isActive()) {
-				ops.sendCloseNow(null, this);
+				ops.sendCloseNow(new CloseWebSocketFrame(WebSocketCloseStatus.NORMAL_CLOSURE), this);
 			}
 		}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1337,7 +1337,7 @@ public class HttpServerTests {
 
 		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(statusClient.get()).isNotNull()
-				.isEqualTo(new WebSocketCloseStatus(-1, ""));
+				.isEqualTo(WebSocketCloseStatus.ABNORMAL_CLOSURE);
 
 		assertThat(statusServer.get()).isNotNull()
 				.isEqualTo(new WebSocketCloseStatus(-1, ""));
@@ -1389,7 +1389,7 @@ public class HttpServerTests {
 
 		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(statusClient.get()).isNotNull()
-				.isEqualTo(new WebSocketCloseStatus(-1, ""));
+				.isEqualTo(WebSocketCloseStatus.ABNORMAL_CLOSURE);
 
 		assertThat(statusServer.get()).isNotNull()
 				.isEqualTo(new WebSocketCloseStatus(-1, ""));
@@ -1440,7 +1440,7 @@ public class HttpServerTests {
 				.isEqualTo(new WebSocketCloseStatus(-1, ""));
 
 		assertThat(statusServer.get()).isNotNull()
-				.isEqualTo(new WebSocketCloseStatus(-1, ""));
+				.isEqualTo(WebSocketCloseStatus.ABNORMAL_CLOSURE);
 	}
 
 	@Test
@@ -1491,7 +1491,7 @@ public class HttpServerTests {
 				.isEqualTo(new WebSocketCloseStatus(-1, ""));
 
 		assertThat(statusServer.get()).isNotNull()
-				.isEqualTo(new WebSocketCloseStatus(-1, ""));
+				.isEqualTo(WebSocketCloseStatus.ABNORMAL_CLOSURE);
 	}
 
 	@Test


### PR DESCRIPTION
According to the specification (below) the emitted WebSocketCloseStatus will be
WebSocketCloseStatus.ABNORMAL_CLOSURE, but the CloseWebSocketFrame
will be still created with status code "-1" as 1006 cannot be set as a status code for
CloseWebSocketFrame.

"1006 is a reserved value and MUST NOT be set as a status code in a
Close control frame by an endpoint.  It is designated for use in
applications expecting a status code to indicate that the
connection was closed abnormally, e.g., without sending or
receiving a Close control frame."

Fixes #1406 