### PR TITLE
Add io_uring support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ ext {
 		nettyVersion = forceNettyVersion
 		println "Netty version defined from command line: ${forceNettyVersion}"
 	}
+	nettyIoUringVersion = '0.0.2.Final'
 
 	// Testing
 	jacksonDatabindVersion = '2.12.0'

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -29,6 +29,7 @@ ext {
 			"Import-Package": [
 					"!javax.annotation",
 					"io.netty.channel.kqueue;resolution:=optional;version=\"[4.1,5)\"",
+					"io.netty.incubator.channel.uring;resolution:=optional",
 					"io.micrometer.*;resolution:=optional",
 					"*"
 			].join(","),
@@ -60,6 +61,7 @@ dependencies {
 		//so that the main code compiles
 		optional "io.netty:netty-transport-native-epoll:$nettyVersion"
 		optional "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		optional "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 		//now we explicitly add correctly qualified native, or do nothing if we want to test NIO
 		if (forceTransport == "native") {
 			if (osdetector.os == "osx") {
@@ -69,6 +71,9 @@ dependencies {
 				testRuntime "io.netty:netty-transport-native-epoll:$nettyVersion$os_suffix"
 			}
 		}
+		else if (forceTransport == "io_uring" && osdetector.os == "linux") {
+			testRuntime "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion$os_suffix"
+		}
 		else if (forceTransport != "nio") {
 			throw new InvalidUserDataException("invalid -PforceTranport option " + forceTransport + ", should be native|nio")
 		}
@@ -77,6 +82,7 @@ dependencies {
 		//classic build to be distributed
 		compile "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
 		optional "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		optional "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 	}
 
 	//Metrics

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopIOUring.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopIOUring.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.resources;
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.incubator.channel.uring.IOUring;
+import io.netty.incubator.channel.uring.IOUringDatagramChannel;
+import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
+import io.netty.incubator.channel.uring.IOUringServerSocketChannel;
+import io.netty.incubator.channel.uring.IOUringSocketChannel;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * {@link DefaultLoop} that uses {@code io_uring} transport.
+ *
+ * @author Violeta Georgieva
+ */
+final class DefaultLoopIOUring implements DefaultLoop {
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <CHANNEL extends Channel> CHANNEL getChannel(Class<CHANNEL> channelClass) {
+		if (channelClass.equals(SocketChannel.class)) {
+			return (CHANNEL) new IOUringSocketChannel();
+		}
+		if (channelClass.equals(ServerSocketChannel.class)) {
+			return (CHANNEL) new IOUringServerSocketChannel();
+		}
+		if (channelClass.equals(DatagramChannel.class)) {
+			return (CHANNEL) new IOUringDatagramChannel();
+		}
+		throw new IllegalArgumentException("Unsupported channel type: " + channelClass.getSimpleName());
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <CHANNEL extends Channel> Class<? extends CHANNEL> getChannelClass(Class<CHANNEL> channelClass) {
+		if (channelClass.equals(SocketChannel.class)) {
+			return (Class<? extends CHANNEL>) IOUringSocketChannel.class;
+		}
+		if (channelClass.equals(ServerSocketChannel.class)) {
+			return (Class<? extends CHANNEL>) IOUringServerSocketChannel.class;
+		}
+		if (channelClass.equals(DatagramChannel.class)) {
+			return (Class<? extends CHANNEL>) IOUringDatagramChannel.class;
+		}
+		throw new IllegalArgumentException("Unsupported channel type: " + channelClass.getSimpleName());
+	}
+
+	@Override
+	public String getName() {
+		return "io_uring";
+	}
+
+	@Override
+	public EventLoopGroup newEventLoopGroup(int threads, ThreadFactory factory) {
+		return new IOUringEventLoopGroup(threads, factory);
+	}
+
+	@Override
+	public boolean supportGroup(EventLoopGroup group) {
+		if (group instanceof ColocatedEventLoopGroup) {
+			group = ((ColocatedEventLoopGroup) group).get();
+		}
+		return group instanceof IOUringEventLoopGroup;
+	}
+
+	static final Logger log = Loggers.getLogger(DefaultLoopIOUring.class);
+
+	static final boolean ioUring;
+
+	static {
+		boolean ioUringCheck = false;
+		try {
+			Class.forName("io.netty.incubator.channel.uring.IOUring");
+			ioUringCheck = IOUring.isAvailable();
+		}
+		catch (ClassNotFoundException cnfe) {
+			// noop
+		}
+		ioUring = ioUringCheck;
+		if (log.isDebugEnabled()) {
+			log.debug("Default io_uring support : " + ioUring);
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNativeDetector.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNativeDetector.java
@@ -29,7 +29,10 @@ final class DefaultLoopNativeDetector {
 	static {
 		NIO = new DefaultLoopNIO();
 
-		if (DefaultLoopEpoll.epoll) {
+		if (DefaultLoopIOUring.ioUring) {
+			INSTANCE = new DefaultLoopIOUring();
+		}
+		else if (DefaultLoopEpoll.epoll) {
 			INSTANCE = new DefaultLoopEpoll();
 		}
 		else if (DefaultLoopKQueue.kqueue) {

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -27,6 +27,7 @@ ext {
 					"!javax.annotation",
 					"io.netty.channel.kqueue;resolution:=optional;version=\"[4.1,5)\"",
 					"io.netty.handler.codec.haproxy;resolution:=optional;version=\"[4.1,5)\"",
+					"io.netty.incubator.channel.uring;resolution:=optional",
 					"io.micrometer.*;resolution:=optional",
 					"*"
 			].join(","),
@@ -53,6 +54,7 @@ dependencies {
 		//so that the main code compiles
 		optional "io.netty:netty-transport-native-epoll:$nettyVersion"
 		optional "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		optional "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 		//now we explicitly add correctly qualified native, or do nothing if we want to test NIO
 		if (forceTransport == "native") {
 			if (osdetector.os == "osx") {
@@ -62,6 +64,9 @@ dependencies {
 				testRuntime "io.netty:netty-transport-native-epoll:$nettyVersion$os_suffix"
 			}
 		}
+		else if (forceTransport == "io_uring" && osdetector.os == "linux") {
+			testRuntime "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion$os_suffix"
+		}
 		else if (forceTransport != "nio") {
 			throw new InvalidUserDataException("invalid -PforceTranport option " + forceTransport + ", should be native|nio")
 		}
@@ -70,6 +75,7 @@ dependencies {
 		//classic build to be distributed
 		compile "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
 		optional "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		optional "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 	}
 
 	//Metrics


### PR DESCRIPTION
This PR adds `netty-incubator-transport-native-io_uring` support which is still in the `incubator`.

https://netty.io/news/2020/11/16/io_uring-0-0-1-Final.html

Reactor Netty has only optional dependency to `netty-incubator-transport-native-io_uring` so that it can be built but does not bring `netty-incubator-transport-native-io_uring` as a transitive dependency.

Enabling `io_uring` transport:
- `io_uring` transport requires a dependency (the current version is `0.0.2.Final`)

```
<dependency>
    <groupId>io.netty.incubator</groupId>
    <artifactId>netty-incubator-transport-native-io_uring</artifactId>
    <version>0.0.2.Final</version>
    <classifier>linux-x86_64</classifier>
</dependency>
```

- Linux kernel version 5.9.0 (for more detail see the link above)

If the requirements above are met `io_uring` will be preferred instead of `epoll`.

This change was tested on `Ubuntu 20.04` with updated Linux kernel
```
Linux violetagg 5.9.0-050900-generic #202010112230 SMP Sun Oct 11 22:34:01 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
```

Logs

```
19:56:34.249 [Test worker] DEBUG r.netty.resources.DefaultLoopIOUring - Default io_uring support : true
19:56:34.421 [reactor-http-io_uring-1] DEBUG r.netty.transport.ServerTransport - [id: 0xf545dcb7, L:/0:0:0:0:0:0:0:0%0:39241] Bound new server
...
19:56:34.694 [reactor-http-io_uring-4] DEBUG reactor.netty.http.server.HttpServer - [id: 0xbecfec64, L:/0:0:0:0:0:0:0:1%0:39241 - R:/0:0:0:0:0:0:0:1%0:50144] READ: 134B
             +-------------------------------------------------+
             |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
    +--------+-------------------------------------------------+----------------+
    |00000000| 50 4f 53 54 20 2f 68 69 20 48 54 54 50 2f 31 2e |POST /hi HTTP/1.|
    |00000010| 31 0d 0a 61 63 63 65 70 74 2d 65 6e 63 6f 64 69 |1..accept-encodi|
    |00000020| 6e 67 3a 20 67 7a 69 70 0d 0a 75 73 65 72 2d 61 |ng: gzip..user-a|
    |00000030| 67 65 6e 74 3a 20 52 65 61 63 74 6f 72 4e 65 74 |gent: ReactorNet|
    |00000040| 74 79 2f 64 65 76 0d 0a 68 6f 73 74 3a 20 5b 3a |ty/dev..host: [:|
    |00000050| 3a 31 5d 3a 33 39 32 34 31 0d 0a 61 63 63 65 70 |:1]:39241..accep|
    |00000060| 74 3a 20 2a 2f 2a 0d 0a 74 72 61 6e 73 66 65 72 |t: */*..transfer|
    |00000070| 2d 65 6e 63 6f 64 69 6e 67 3a 20 63 68 75 6e 6b |-encoding: chunk|
    |00000080| 65 64 0d 0a 0d 0a                               |ed....          |
    +--------+-------------------------------------------------+----------------+
```