### PR TITLE
fix #1417 Add helpers for filtering the access log

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -228,7 +228,7 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 *           .route(r -> r.get("/hello",
 	 *                   (req, res) -> res.header(CONTENT_TYPE, TEXT_PLAIN)
 	 *                                    .sendString(Mono.just("Hello World!"))))
-	 *           .accessLog(AccessLogFactory.create(
+	 *           .accessLog(true, AccessLogFactory.createFilter(
 	 *                   args -> String.valueOf(args.uri()).startsWith("/health"),
 	 *                   args -> AccessLog.create("user-agent={}", args.requestHeader("user-agent"))
 	 *            )
@@ -239,7 +239,7 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 * </pre>
 	 * <p>
 	 * The {@link AccessLogFactory} class offers several helper methods to generate such a function,
-	 * notably if one wants to {@link AccessLogFactory#create(Predicate) filter} some requests out of the access log.
+	 * notably if one wants to {@link AccessLogFactory#createFilter(Predicate) filter} some requests out of the access log.
 	 *
 	 * Note that this method takes precedence over the {@value reactor.netty.ReactorNetty#ACCESS_LOG_ENABLED} system property.
 	 *

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -23,6 +23,7 @@ import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import io.netty.channel.group.ChannelGroup;
@@ -227,15 +228,18 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 *           .route(r -> r.get("/hello",
 	 *                   (req, res) -> res.header(CONTENT_TYPE, TEXT_PLAIN)
 	 *                                    .sendString(Mono.just("Hello World!"))))
-	 *           .accessLog(true, AccessLogFactory.create(
+	 *           .accessLog(AccessLogFactory.create(
+	 *                   args -> String.valueOf(args.uri()).startsWith("/health"),
 	 *                   args -> AccessLog.create("user-agent={}", args.requestHeader("user-agent"))
-	 *           )
+	 *            )
 	 *           .bindNow()
 	 *           .onDispose()
 	 *           .block();
 	 * }
 	 * </pre>
 	 * <p>
+	 * The {@link AccessLogFactory} class offers several helper methods to generate such a function,
+	 * notably if one wants to {@link AccessLogFactory#create(Predicate) filter} some requests out of the access log.
 	 *
 	 * Note that this method takes precedence over the {@value reactor.netty.ReactorNetty#ACCESS_LOG_ENABLED} system property.
 	 *

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLog.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLog.java
@@ -22,6 +22,9 @@ import java.util.Objects;
 
 /**
  * Log the http access information into a Logger named {@code reactor.netty.http.server.AccessLog} at INFO level.
+ * <p>
+ * See {@link AccessLogFactory} for convenience methods to create an access log factory to be passed to
+ * {@link reactor.netty.http.server.HttpServer#accessLog(boolean, AccessLogFactory)} during server configuration.
  *
  * @author limaoning
  * @since 1.0.1
@@ -42,6 +45,7 @@ public final class AccessLog {
 	public static AccessLog create(String logFormat, Object... args) {
 		return new AccessLog(logFormat, args);
 	}
+
 
 	void log() {
 		if (LOG.isInfoEnabled()) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLog.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLog.java
@@ -46,7 +46,6 @@ public final class AccessLog {
 		return new AccessLog(logFormat, args);
 	}
 
-
 	void log() {
 		if (LOG.isInfoEnabled()) {
 			LOG.info(logFormat, args);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogFactory.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogFactory.java
@@ -16,18 +16,53 @@
 package reactor.netty.http.server.logging;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
 
-/**
- * An interface to declare more concisely a {@link Function} that apply an {@link AccessLog} by an
- * {@link AccessLogArgProvider}.
- * <p>
- * Can be used in {@link reactor.netty.http.server.HttpServer#accessLog(boolean, AccessLogFactory) accessLog} method
- * for example.
- *
+ /**
  * @author Simon Baslé
  * @author Audrey Neveu
  * @since 1.0.3
  */
 public interface AccessLogFactory extends Function<AccessLogArgProvider, AccessLog> {
+
+	/**
+	 * Helper method to create an access log factory that selectively enables access logs.
+	 * <p>
+	 * Any request (represented as an {@link AccessLogArgProvider}) that doesn't match the
+	 * provided {@link Predicate} is excluded from the access log. Other requests are logged
+	 * using the default format.
+	 *
+	 * @param predicate the filter that returns {@code true} if the request should be logged, {@code false} otherwise
+	 * @return an access log factory {@link Function} to be used in
+	 * {@link reactor.netty.http.server.HttpServer#accessLog(boolean, AccessLogFactory)}
+	 * @since 1.0.3
+	 */
+	static AccessLogFactory create(Predicate<AccessLogArgProvider> predicate) {
+		return input -> predicate.test(input) ? BaseAccessLogHandler.DEFAULT_ACCESS_LOG.apply(input) : null;
+	}
+
+	/**
+	 * Helper method to create an access log factory that selectively enables access logs and customizes
+	 * the format to apply.
+	 * <p>
+	 * Any request (represented as an {@link AccessLogArgProvider}) that doesn't match the
+	 * provided {@link Predicate} is excluded from the access log. Other requests are logged
+	 * using the provided formatting {@link Function}.
+	 * Said function is expected to {@link AccessLog#create(String, Object...) create} an {@link AccessLog} instance,
+	 * defining both the String format and a vararg of the relevant arguments, extracted from the
+	 * {@link AccessLogArgProvider}.
+	 * <p>
+	 *
+	 * @param predicate the filter that returns {@code true} if the request should be logged, {@code false} otherwise
+	 * @param formatFunction the {@link Function} that creates {@link AccessLog} instances, encapsulating the format
+	 * and the extraction of relevant arguments
+	 * @return an access log factory {@link Function} to be used in
+	 * {@link reactor.netty.http.server.HttpServer#accessLog(boolean, AccessLogFactory)}
+	 * @since 1.0.3
+	 */
+	static AccessLogFactory create(Predicate<AccessLogArgProvider> predicate,
+			Function<AccessLogArgProvider, AccessLog> formatFunction) {
+		return input -> predicate.test(input) ? formatFunction.apply(input) : null;
+	}
 
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogFactory.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogFactory.java
@@ -57,7 +57,7 @@ public interface AccessLogFactory extends Function<AccessLogArgProvider, AccessL
 	 * defining both the String format and a vararg of the relevant arguments, extracted from the
 	 * {@link AccessLogArgProvider}.
 	 * <p>
- 	 *
+	 *
 	 * @param predicate the filter that returns {@code true} if the request should be logged, {@code false} otherwise
 	 * @param formatFunction the {@link AccessLogFactory} that creates {@link AccessLog} instances, encapsulating the
 	 * format
@@ -65,7 +65,7 @@ public interface AccessLogFactory extends Function<AccessLogArgProvider, AccessL
 	 * @return an {@link AccessLogFactory} to be used in
 	 * {@link reactor.netty.http.server.HttpServer#accessLog(boolean, AccessLogFactory)}
 	 * @since 1.0.3
- 	 */
+	 */
 	static AccessLogFactory createFilter(Predicate<AccessLogArgProvider> predicate, AccessLogFactory formatFunction) {
 		return input -> predicate.test(input) ? formatFunction.apply(input) : null;
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogFactory.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogFactory.java
@@ -18,7 +18,7 @@ package reactor.netty.http.server.logging;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
- /**
+/**
  * An interface to declare more concisely a {@link Function} that apply an {@link AccessLog} by an
  * {@link AccessLogArgProvider}.
  * <p>
@@ -38,7 +38,7 @@ public interface AccessLogFactory extends Function<AccessLogArgProvider, AccessL
 	 * using the default format.
 	 *
 	 * @param predicate the filter that returns {@code true} if the request should be logged, {@code false} otherwise
-	 * @return an access log factory {@link Function} to be used in
+	 * @return an {@link AccessLogFactory} to be used in
 	 * {@link reactor.netty.http.server.HttpServer#accessLog(boolean, AccessLogFactory)}
 	 * @since 1.0.3
 	 */
@@ -57,14 +57,15 @@ public interface AccessLogFactory extends Function<AccessLogArgProvider, AccessL
 	 * defining both the String format and a vararg of the relevant arguments, extracted from the
 	 * {@link AccessLogArgProvider}.
 	 * <p>
-	 *
+ 	 *
 	 * @param predicate the filter that returns {@code true} if the request should be logged, {@code false} otherwise
-	 * @param formatFunction the {@link Function} that creates {@link AccessLog} instances, encapsulating the format
+	 * @param formatFunction the {@link AccessLogFactory} that creates {@link AccessLog} instances, encapsulating the
+	 * format
 	 * and the extraction of relevant arguments
-	 * @return an access log factory {@link Function} to be used in
+	 * @return an {@link AccessLogFactory} to be used in
 	 * {@link reactor.netty.http.server.HttpServer#accessLog(boolean, AccessLogFactory)}
 	 * @since 1.0.3
-	 */
+ 	 */
 	static AccessLogFactory createFilter(Predicate<AccessLogArgProvider> predicate, AccessLogFactory formatFunction) {
 		return input -> predicate.test(input) ? formatFunction.apply(input) : null;
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogFactory.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogFactory.java
@@ -19,6 +19,11 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
  /**
+ * An interface to declare more concisely a {@link Function} that apply an {@link AccessLog} by an
+ * {@link AccessLogArgProvider}.
+ * <p>
+ * Can be used in {@link reactor.netty.http.server.HttpServer#accessLog(boolean, AccessLogFactory) accessLog} method for example.
+ *
  * @author Simon Baslé
  * @author Audrey Neveu
  * @since 1.0.3
@@ -37,7 +42,7 @@ public interface AccessLogFactory extends Function<AccessLogArgProvider, AccessL
 	 * {@link reactor.netty.http.server.HttpServer#accessLog(boolean, AccessLogFactory)}
 	 * @since 1.0.3
 	 */
-	static AccessLogFactory create(Predicate<AccessLogArgProvider> predicate) {
+	static AccessLogFactory createFilter(Predicate<AccessLogArgProvider> predicate) {
 		return input -> predicate.test(input) ? BaseAccessLogHandler.DEFAULT_ACCESS_LOG.apply(input) : null;
 	}
 
@@ -60,8 +65,7 @@ public interface AccessLogFactory extends Function<AccessLogArgProvider, AccessL
 	 * {@link reactor.netty.http.server.HttpServer#accessLog(boolean, AccessLogFactory)}
 	 * @since 1.0.3
 	 */
-	static AccessLogFactory create(Predicate<AccessLogArgProvider> predicate,
-			Function<AccessLogArgProvider, AccessLog> formatFunction) {
+	static AccessLogFactory createFilter(Predicate<AccessLogArgProvider> predicate, AccessLogFactory formatFunction) {
 		return input -> predicate.test(input) ? formatFunction.apply(input) : null;
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogTest.java
@@ -129,7 +129,7 @@ class AccessLogTest {
 	}
 
 	@Test
-	public void accessLogFiltering(){
+	public void accessLogFiltering() {
 		disposableServer = HttpServer.create()
 				.port(8080)
 				.handle((req, resp) -> {
@@ -152,7 +152,7 @@ class AccessLogTest {
 
 
 	@Test
-	public void accessLogFilteringAndFormatting(){
+	public void accessLogFilteringAndFormatting() {
 		disposableServer = HttpServer.create()
 				.port(8080)
 				.handle((req, resp) -> {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogTest.java
@@ -139,13 +139,13 @@ class AccessLogTest {
 					});
 					return resp.send();
 				})
-				.accessLog(true, AccessLogFactory.create(p -> !String.valueOf(p.uri()).startsWith("/foo/")))
+				.accessLog(true, AccessLogFactory.createFilter(p -> !String.valueOf(p.uri()).startsWith("/filtered/")))
 				.wiretap(true)
 				.bindNow();
 
 		HttpClientResponse response = getHttpClientResponse("/example/test");
 
-		getHttpClientResponse("/foo/test");
+		getHttpClientResponse("/filtered/test");
 
 		assertAccessLogging(response, true, true, null);
 	}
@@ -162,7 +162,7 @@ class AccessLogTest {
 					});
 					return resp.send();
 				})
-				.accessLog(true, AccessLogFactory.create(p -> !String.valueOf(p.uri()).startsWith("/foo/"),
+				.accessLog(true, AccessLogFactory.createFilter(p -> !String.valueOf(p.uri()).startsWith("/filtered/"),
 						args -> AccessLog.create(CUSTOM_FORMAT, args.method(), args.uri())))
 				.wiretap(true)
 				.bindNow();
@@ -173,7 +173,7 @@ class AccessLogTest {
 				.port(disposableServer.port())
 				.wiretap(true)
 				.get()
-				.uri("/foo/test")
+				.uri("/filtered/test")
 				.response()
 				.block();
 
@@ -193,7 +193,7 @@ class AccessLogTest {
 				assertThat(relevantLog.getFormattedMessage()).contains("GET /example/test HTTP/1.1\" 200");
 
 				if (filteringEnabled) {
-					assertThat(relevantLog.getFormattedMessage()).doesNotContain("foo");
+					assertThat(relevantLog.getFormattedMessage()).doesNotContain("filtered");
 				}
 			}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogTest.java
@@ -169,13 +169,7 @@ class AccessLogTest {
 
 		HttpClientResponse response = getHttpClientResponse("/example/test");
 
-		HttpClient.create()
-				.port(disposableServer.port())
-				.wiretap(true)
-				.get()
-				.uri("/filtered/test")
-				.response()
-				.block();
+		getHttpClientResponse("/filtered/test");
 
 		assertAccessLogging(response, true, true, CUSTOM_FORMAT);
 	}


### PR DESCRIPTION
Provides two factories methods into `AccessLog` to allow filtering logs on predicate matching, with or without custom String format.