### PR TITLE
When running on MacOS use MacOSDnsServerAddressStreamProvider

### DIFF
--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 	compile "io.netty:netty-handler:$nettyVersion"
 	compile "io.netty:netty-handler-proxy:$nettyVersion"
 	compile "io.netty:netty-resolver-dns:$nettyVersion"
+	compile "io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
 	//transport resolution: typical build forces epoll but not kqueue transitively
 	//on the other hand, if we want to make transport-specific tests, we'll make all
 	// native optional at compile time and add correct native/nio to testRuntime

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
@@ -17,8 +17,12 @@ package reactor.netty.transport;
 
 import io.netty.handler.logging.LogLevel;
 import io.netty.resolver.ResolvedAddressTypes;
+import io.netty.resolver.dns.DnsServerAddressStreamProviders;
+import io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import reactor.netty.resources.LoopResources;
 import reactor.netty.tcp.TcpResources;
 
@@ -241,5 +245,12 @@ public class NameResolverProviderTest {
 
 		assertThatExceptionOfType(NullPointerException.class)
 				.isThrownBy(() -> builder.trace("category", null));
+	}
+
+	@Test
+	@EnabledOnOs(OS.MAC)
+	void testMacOsResolver() {
+		assertThat(DnsServerAddressStreamProviders.platformDefault())
+				.isInstanceOf(MacOSDnsServerAddressStreamProvider.class);
 	}
 }

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 	compile "io.netty:netty-codec-http:$nettyVersion"
 	compile "io.netty:netty-codec-http2:$nettyVersion"
 	compile "io.netty:netty-resolver-dns:$nettyVersion"
+	compile "io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
 	optional "io.netty:netty-codec-haproxy:$nettyVersion"
 	//transport resolution: typical build forces epoll but not kqueue transitively
 	//on the other hand, if we want to make transport-specific tests, we'll make all


### PR DESCRIPTION
When running on `MacOS` and `MacOSDnsServerAddressStreamProvider`
is `NOT` available the log below with `WARN` log level will appear.

Related to https://github.com/netty/netty/pull/10848

11:55:45.619 [Test worker] WARN  i.n.r.d.DnsServerAddressStreamProviders -
Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider,
fallback to system defaults. This may result in incorrect DNS resolutions on MacOS.
java.lang.ClassNotFoundException: io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:355)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at io.netty.resolver.dns.DnsServerAddressStreamProviders$1.run(DnsServerAddressStreamProviders.java:50)
	at java.security.AccessController.doPrivileged(Native Method)