### PR TITLE
fix #1434 When UDS, the scheme is determined by SslHandler availability in the pipeline

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
@@ -102,10 +102,11 @@ final class Http2StreamBridgeServerHandler extends ChannelDuplexHandler {
 						                    forwardedHeaderHandler),
 						cookieEncoder,
 						cookieDecoder,
-						mapHandle);
+						mapHandle,
+						secured);
 			}
 			catch (RuntimeException e) {
-				HttpServerOperations.sendDecodingFailures(ctx, listener, e, msg);
+				HttpServerOperations.sendDecodingFailures(ctx, listener, secured, e, msg);
 				return;
 			}
 			ops.bind();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -196,7 +196,8 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 							                    forwardedHeaderHandler),
 							cookieEncoder,
 							cookieDecoder,
-							mapHandle);
+							mapHandle,
+							secure);
 				}
 				catch (RuntimeException e) {
 					sendDecodingFailures(e, msg);
@@ -254,7 +255,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 
 	void sendDecodingFailures(Throwable t, Object msg) {
 		persistentConnection = false;
-		HttpServerOperations.sendDecodingFailures(ctx, listener, t, msg);
+		HttpServerOperations.sendDecodingFailures(ctx, listener, secure, t, msg);
 	}
 
 	void doPipeline(ChannelHandlerContext ctx, Object msg) {
@@ -381,7 +382,8 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 						                    forwardedHeaderHandler),
 						cookieEncoder,
 						cookieDecoder,
-						mapHandle);
+						mapHandle,
+						secure);
 				ops.bind();
 				listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED);
 			}


### PR DESCRIPTION
Extend the UDS test to check also the scheme.

Fixes #1434 