### PR TITLE
Fix connection prematurely closed error

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
@@ -359,7 +359,7 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 	 * @return true if inbound traffic is not expected anymore
 	 */
 	public final boolean isInboundCancelled() {
-		return inbound.isCancelled();
+		return inbound.isCancelled() || inbound.isChannelInboundEverCanceled();
 	}
 
 	/**


### PR DESCRIPTION
Related to https://github.com/reactor/reactor-netty/issues/1331
Related to https://github.com/reactor/reactor-netty/issues/1201

Test scene description:
1、We are doing a perfomance test using **Spring Cloud Gateway**
2、The request is **HTTP POST** which body size is less than 1k Bytes
3、The backend service return a **response 200 OK** as a result 

The bug is easy to reproduce when **closing large number of HTTP client connections to SCG**
in my case, using wrk tool with the following command:
`wrk -t 1 -c 400 -d 3s http://localhost:8080/api/test -s post.lua`

Bug description:
Exception appears in spring cloud gateway in Very Small Probability as below:
_reactor.netty.http.client.PrematureCloseException: Connection has been closed BEFORE response, while sending request body_

Exception cause:
After diving into reactor-netty source code, I found the exception comes in these key conditions:
1、ChannelOperationsHandler.java : channelInactive -> ops.onInboundClose() 
ops must be **HttpClientOperations**
2、HttpClientOperations.java: onInboundClose -> isInboundCancelled() 
isInboundCancelled result must be **False**

When a normal channel inactive, the inbound in ChannelOperations will be marked as canceled and isInboundCancelled() return true; In small probability, inbound will be replaced with another one as HttpClientOperations is newly created, which will be bind to channel, so the isInboundCancelled() function will return false as the inbound never called cancel(); 
that's the root cause of the exception.

Here is a firgure for better understanding:

![1608839340551](https://user-images.githubusercontent.com/17958623/103104768-32546e00-4664-11eb-89af-a6c7b011e154.jpg)

The easist fix is to mark the parent channel when an inboud is canceled. when next time invoke isInboundCancelled() will also check the channel if once received inbound cancel event.


