### PR TITLE
fix #1397 Update the javadoc and the reference documentation

### DIFF
--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -224,6 +224,23 @@ include::{examplesdir}/wiretap/Application.java[lines=18..32]
 <1> Enables the wire logging
 ====
 
+By default, the wire logging uses {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#HEX_DUMP[AdvancedByteBufFormat#HEX_DUMP]
+when printing the content.
+When you need to change this to {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#SIMPLE[AdvancedByteBufFormat#SIMPLE]
+or {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#TEXTUAL[AdvancedByteBufFormat#TEXTUAL],
+you can configure the `HttpClient` as follows:
+
+====
+[source,java,indent=0]
+.{examplesdir}/wiretap/custom/Application.java
+----
+include::{examplesdir}/wiretap/custom/Application.java[lines=18..34]
+----
+<1> Enables the wire logging,
+{javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#TEXTUAL[AdvancedByteBufFormat#TEXTUAL] is used for
+printing the content.
+====
+
 == SSL and TLS
 When you need SSL or TLS, you can apply the configuration shown in the next example.
 By default, if `OpenSSL` is available, a

--- a/docs/asciidoc/http-server.adoc
+++ b/docs/asciidoc/http-server.adoc
@@ -285,6 +285,23 @@ include::{examplesdir}/wiretap/Application.java[lines=18..32]
 <1> Enables the wire logging
 ====
 
+By default, the wire logging uses {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#HEX_DUMP[AdvancedByteBufFormat#HEX_DUMP]
+when printing the content.
+When you need to change this to {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#SIMPLE[AdvancedByteBufFormat#SIMPLE]
+or {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#TEXTUAL[AdvancedByteBufFormat#TEXTUAL],
+you can configure the `HttpServer` as follows:
+
+====
+[source,java,indent=0]
+.{examplesdir}/wiretap/custom/Application.java
+----
+include::{examplesdir}/wiretap/custom/Application.java[lines=18..34]
+----
+<1> Enables the wire logging,
+{javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#TEXTUAL[AdvancedByteBufFormat#TEXTUAL] is used for
+printing the content.
+====
+
 == SSL and TLS
 
 When you need SSL or TLS, you can apply the configuration shown in the next example.

--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -150,6 +150,23 @@ include::{examplesdir}/wiretap/Application.java[lines=18..34]
 <1> Enables the wire logging
 ====
 
+By default, the wire logging uses {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#HEX_DUMP[AdvancedByteBufFormat#HEX_DUMP]
+when printing the content.
+When you need to change this to {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#SIMPLE[AdvancedByteBufFormat#SIMPLE]
+or {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#TEXTUAL[AdvancedByteBufFormat#TEXTUAL],
+you can configure the `TcpClient` as follows:
+
+====
+[source,java,indent=0]
+.{examplesdir}/wiretap/custom/Application.java
+----
+include::{examplesdir}/wiretap/custom/Application.java[lines=18..34]
+----
+<1> Enables the wire logging,
+{javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#TEXTUAL[AdvancedByteBufFormat#TEXTUAL] is used for
+printing the content.
+====
+
 [[client-tcp-level-configurations-event-loop-group]]
 === Event Loop Group
 

--- a/docs/asciidoc/tcp-server.adoc
+++ b/docs/asciidoc/tcp-server.adoc
@@ -150,6 +150,23 @@ include::{examplesdir}/wiretap/Application.java[lines=18..32]
 <1> Enables the wire logging
 ====
 
+By default, the wire logging uses {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#HEX_DUMP[AdvancedByteBufFormat#HEX_DUMP]
+when printing the content.
+When you need to change this to {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#SIMPLE[AdvancedByteBufFormat#SIMPLE]
+or {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#TEXTUAL[AdvancedByteBufFormat#TEXTUAL],
+you can configure the `TcpServer` as follows:
+
+====
+[source,java,indent=0]
+.{examplesdir}/wiretap/custom/Application.java
+----
+include::{examplesdir}/wiretap/custom/Application.java[lines=18..34]
+----
+<1> Enables the wire logging,
+{javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#TEXTUAL[AdvancedByteBufFormat#TEXTUAL] is used for
+printing the content.
+====
+
 [[server-tcp-level-configurations-event-loop-group]]
 === Using an Event Loop Group
 

--- a/docs/asciidoc/udp-client.adoc
+++ b/docs/asciidoc/udp-client.adoc
@@ -151,6 +151,23 @@ include::{examplesdir}/wiretap/Application.java[lines=18..35]
 <1> Enables the wire logging
 ====
 
+By default, the wire logging uses {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#HEX_DUMP[AdvancedByteBufFormat#HEX_DUMP]
+when printing the content.
+When you need to change this to {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#SIMPLE[AdvancedByteBufFormat#SIMPLE]
+or {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#TEXTUAL[AdvancedByteBufFormat#TEXTUAL],
+you can configure the `UdpClient` as follows:
+
+====
+[source,java,indent=0]
+.{examplesdir}/wiretap/custom/Application.java
+----
+include::{examplesdir}/wiretap/custom/Application.java[lines=18..34]
+----
+<1> Enables the wire logging,
+{javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#TEXTUAL[AdvancedByteBufFormat#TEXTUAL] is used for
+printing the content.
+====
+
 [[client-udp-connection-configurations-event-loop-group]]
 === Event Loop Group
 

--- a/docs/asciidoc/udp-server.adoc
+++ b/docs/asciidoc/udp-server.adoc
@@ -150,6 +150,23 @@ include::{examplesdir}/wiretap/Application.java[lines=18..33]
 <1> Enables the wire logging
 ====
 
+By default, the wire logging uses {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#HEX_DUMP[AdvancedByteBufFormat#HEX_DUMP]
+when printing the content.
+When you need to change this to {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#SIMPLE[AdvancedByteBufFormat#SIMPLE]
+or {javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#TEXTUAL[AdvancedByteBufFormat#TEXTUAL],
+you can configure the `UdpServer` as follows:
+
+====
+[source,java,indent=0]
+.{examplesdir}/wiretap/custom/Application.java
+----
+include::{examplesdir}/wiretap/custom/Application.java[lines=18..34]
+----
+<1> Enables the wire logging,
+{javadoc}/reactor/netty/transport/logging/AdvancedByteBufFormat.html#TEXTUAL[AdvancedByteBufFormat#TEXTUAL] is used for
+printing the content.
+====
+
 [[server-udp-connection-configurations-event-loop-group]]
 === Event Loop Group
 

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -129,12 +129,52 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 	/**
 	 * Apply a {@link Bootstrap} mapping function to update {@link TcpClient} configuration and
 	 * return an enriched {@link TcpClient} to use.
+	 * <p>
+	 * <strong>Note:</strong>
+	 * There isn't only one method that replaces this deprecated method.
+	 * The configuration that can be done with this deprecated method,
+	 * can also be done with the other methods exposed by {@link TcpClient}.
+	 * </p>
+	 * <p>Examples:</p>
+	 * <p>Configuration via the deprecated '.bootstrap(...)' method</p>
+	 * <pre>
+	 * {@code
+	 * TcpClient.bootstrap(b ->
+	 *     b.attr(...) // configures the channel attributes
+	 *      .group(...) // configures the event loop group
+	 *      .handler(...) // configures the channel handler
+	 *      .localAddress(...) // configures the bind (local) address
+	 *      .option(...) // configures the channel options
+	 *      .remoteAddress(...) // configures the remote address
+	 *      .resolver(...)) // configures the host names resolver
+	 * }
+	 * </pre>
+	 *
+	 * <p>Configuration via the other methods exposed by {@link TcpClient}</p>
+	 * <pre>
+	 * {@code
+	 * TcpClient.attr(...) // configures the channel attributes
+	 *          .runOn(...) // configures the event loop group
+	 *          .doOnChannelInit(...) // configures the channel handler
+	 *          .bindAddress(...) // configures the bind (local) address
+	 *          .option(...) // configures the channel options
+	 *          .remoteAddress(...) // configures the remote address
+	 *          .resolver(...) // configures the host names resolver
+	 * }
+	 * </pre>
+	 *
+	 * <p>Wire logging in plain text</p>
+	 * <pre>
+	 * {@code
+	 * TcpClient.wiretap("logger", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL)
+	 * }
+	 * </pre>
 	 *
 	 * @param bootstrapMapper A {@link Bootstrap} mapping function to update {@link TcpClient} configuration and
 	 * return an enriched {@link TcpClient} to use.
 	 * @return a new {@link TcpClient}
-	 * @deprecated as of 0.9.10. Use the methods exposed on {@link TcpClient} level. The method
-	 * will be removed in version 1.1.0.
+	 * @deprecated as of 0.9.10. Use the other methods exposed by {@link TcpClient} to achieve the same configurations.
+	 * The method will be removed in version 1.1.0.
 	 */
 	@Deprecated
 	@SuppressWarnings("ReturnValueIgnored")

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
@@ -266,7 +266,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	/**
 	 * Apply or remove a wire logger configuration using {@link Transport} category (logger),
 	 * {@code DEBUG} logger level and {@link AdvancedByteBufFormat#HEX_DUMP} for {@link ByteBuf} format,
-	 * which means all events will be logged and the content will be in hex format.
+	 * which means both events and content will be logged and the content will be in hex format.
 	 *
 	 * @param enable specifies whether the wire logger configuration will be added to the pipeline
 	 * @return a new {@link Transport} reference
@@ -292,7 +292,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	/**
 	 * Apply a wire logger configuration using the specified category (logger),
 	 * {@code DEBUG} logger level and {@link AdvancedByteBufFormat#HEX_DUMP} for {@link ByteBuf} format,
-	 * which means all events will be logged and the content will be in hex format.
+	 * which means both events and content will be logged and the content will be in hex format.
 	 *
 	 * @param category the logger category
 	 * @return a new {@link Transport} reference
@@ -305,7 +305,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	/**
 	 * Apply a wire logger configuration using the specified category (logger),
 	 * logger level and {@link AdvancedByteBufFormat#HEX_DUMP} for {@link ByteBuf} format,
-	 * which means all events will be logged and the content will be in hex format.
+	 * which means both events and content will be logged and the content will be in hex format.
 	 *
 	 * @param category the logger category
 	 * @param level the logger level
@@ -323,8 +323,10 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * Depending on the format:
 	 * <ul>
 	 *     <li>{@link AdvancedByteBufFormat#SIMPLE} - only the events will be logged</li>
-	 *     <li>{@link AdvancedByteBufFormat#HEX_DUMP} - the events will be logged and the content in hex format</li>
-	 *     <li>{@link AdvancedByteBufFormat#TEXTUAL} - the events will be logged and the content in plain text format</li>
+	 *     <li>{@link AdvancedByteBufFormat#HEX_DUMP} - both events and content will be logged,
+	 *     with content in hex format</li>
+	 *     <li>{@link AdvancedByteBufFormat#TEXTUAL} - both events and content will be logged,
+	 *     with content in plain text format</li>
 	 * </ul>
 	 * When {@link AdvancedByteBufFormat#TEXTUAL} is specified, {@link Charset#defaultCharset()} will be used.
 	 *
@@ -341,15 +343,17 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	}
 
 	/**
-	 * Apply a wire logger configuration using the specific category,
+	 * Apply a wire logger configuration using the specific category (logger),
 	 * logger level, {@link ByteBuf} format and charset.
 	 * The charset is relevant in case of {@link AdvancedByteBufFormat#TEXTUAL}
 	 * and a different charset than {@link Charset#defaultCharset()} is required.
 	 * Depending on the format:
 	 * <ul>
 	 *     <li>{@link AdvancedByteBufFormat#SIMPLE} - only the events will be logged</li>
-	 *     <li>{@link AdvancedByteBufFormat#HEX_DUMP} - the events will be logged and the content in hex format</li>
-	 *     <li>{@link AdvancedByteBufFormat#TEXTUAL} - the events will be logged and the content in plain text format</li>
+	 *     <li>{@link AdvancedByteBufFormat#HEX_DUMP} - both events and content will be logged,
+	 *     with content in hex format</li>
+	 *     <li>{@link AdvancedByteBufFormat#TEXTUAL} - both events and content will be logged,
+	 *     with content in plain text format</li>
 	 * </ul>
 	 *
 	 * @param category the logger category

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
@@ -264,8 +264,9 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	}
 
 	/**
-	 * Apply or remove a wire logger configuration using {@link Transport} category,
-	 * {@code DEBUG} logger level and {@link AdvancedByteBufFormat#HEX_DUMP} for {@link ByteBuf} format.
+	 * Apply or remove a wire logger configuration using {@link Transport} category (logger),
+	 * {@code DEBUG} logger level and {@link AdvancedByteBufFormat#HEX_DUMP} for {@link ByteBuf} format,
+	 * which means all events will be logged and the content will be in hex format.
 	 *
 	 * @param enable specifies whether the wire logger configuration will be added to the pipeline
 	 * @return a new {@link Transport} reference
@@ -289,8 +290,9 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	}
 
 	/**
-	 * Apply a wire logger configuration using the specified category,
-	 * {@code DEBUG} logger level and {@link AdvancedByteBufFormat#HEX_DUMP} for {@link ByteBuf} format.
+	 * Apply a wire logger configuration using the specified category (logger),
+	 * {@code DEBUG} logger level and {@link AdvancedByteBufFormat#HEX_DUMP} for {@link ByteBuf} format,
+	 * which means all events will be logged and the content will be in hex format.
 	 *
 	 * @param category the logger category
 	 * @return a new {@link Transport} reference
@@ -301,8 +303,9 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	}
 
 	/**
-	 * Apply a wire logger configuration using the specified category,
-	 * logger level and {@link AdvancedByteBufFormat#HEX_DUMP} for {@link ByteBuf} format.
+	 * Apply a wire logger configuration using the specified category (logger),
+	 * logger level and {@link AdvancedByteBufFormat#HEX_DUMP} for {@link ByteBuf} format,
+	 * which means all events will be logged and the content will be in hex format.
 	 *
 	 * @param category the logger category
 	 * @param level the logger level
@@ -315,8 +318,15 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	}
 
 	/**
-	 * Apply a wire logger configuration using the specified category,
+	 * Apply a wire logger configuration using the specified category (logger),
 	 * logger level and {@link ByteBuf} format.
+	 * Depending on the format:
+	 * <ul>
+	 *     <li>{@link AdvancedByteBufFormat#SIMPLE} - only the events will be logged</li>
+	 *     <li>{@link AdvancedByteBufFormat#HEX_DUMP} - the events will be logged and the content in hex format</li>
+	 *     <li>{@link AdvancedByteBufFormat#TEXTUAL} - the events will be logged and the content in plain text format</li>
+	 * </ul>
+	 * When {@link AdvancedByteBufFormat#TEXTUAL} is specified, {@link Charset#defaultCharset()} will be used.
 	 *
 	 * @param category the logger category
 	 * @param level the logger level
@@ -333,9 +343,14 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	/**
 	 * Apply a wire logger configuration using the specific category,
 	 * logger level, {@link ByteBuf} format and charset.
-	 *
-	 * Relevant in case of {@link AdvancedByteBufFormat#TEXTUAL}
+	 * The charset is relevant in case of {@link AdvancedByteBufFormat#TEXTUAL}
 	 * and a different charset than {@link Charset#defaultCharset()} is required.
+	 * Depending on the format:
+	 * <ul>
+	 *     <li>{@link AdvancedByteBufFormat#SIMPLE} - only the events will be logged</li>
+	 *     <li>{@link AdvancedByteBufFormat#HEX_DUMP} - the events will be logged and the content in hex format</li>
+	 *     <li>{@link AdvancedByteBufFormat#TEXTUAL} - the events will be logged and the content in plain text format</li>
+	 * </ul>
 	 *
 	 * @param category the logger category
 	 * @param level    the logger level

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/logging/AdvancedByteBufFormat.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/logging/AdvancedByteBufFormat.java
@@ -31,8 +31,64 @@ import io.netty.handler.logging.LoggingHandler;
  * @since 1.0.0
  */
 public enum AdvancedByteBufFormat {
+	/**
+	 * When wire logging is enabled with this format, only the events will be logged.
+	 * <p>Examples:</p>
+	 * <pre>
+	 * {@code
+	 * reactor.netty.http.HttpTests - [id: 0x230d3686, L:/0:0:0:0:0:0:0:1:60241 - R:/0:0:0:0:0:0:0:1:60245] REGISTERED
+	 * reactor.netty.http.HttpTests - [id: 0x230d3686, L:/0:0:0:0:0:0:0:1:60241 - R:/0:0:0:0:0:0:0:1:60245] ACTIVE
+	 * reactor.netty.http.HttpTests - [id: 0x230d3686, L:/0:0:0:0:0:0:0:1:60241 - R:/0:0:0:0:0:0:0:1:60245] READ: 145B
+	 * reactor.netty.http.HttpTests - [id: 0x230d3686, L:/0:0:0:0:0:0:0:1:60241 - R:/0:0:0:0:0:0:0:1:60245] WRITE: 38B
+	 * }
+	 * </pre>
+	 */
 	SIMPLE,
+	/**
+	 * When wire logging is enabled with this format, the events will be logged and the content in hex format.
+	 * <p>Examples:</p>
+	 * <pre>
+	 * {@code
+	 * reactor.netty.http.HttpTests - [id: 0xd5230a14, L:/0:0:0:0:0:0:0:1:60267 - R:/0:0:0:0:0:0:0:1:60269] REGISTERED
+	 * reactor.netty.http.HttpTests - [id: 0xd5230a14, L:/0:0:0:0:0:0:0:1:60267 - R:/0:0:0:0:0:0:0:1:60269] ACTIVE
+	 * reactor.netty.http.HttpTests - [id: 0xd5230a14, L:/0:0:0:0:0:0:0:1:60267 - R:/0:0:0:0:0:0:0:1:60269] READ: 145B
+	 *          +-------------------------------------------------+
+	 *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+	 * +--------+-------------------------------------------------+----------------+
+	 * |00000000| 50 4f 53 54 20 2f 74 65 73 74 2f 57 6f 72 6c 64 |POST /test/World|
+	 * |00000010| 20 48 54 54 50 2f 31 2e 31 0d 0a 43 6f 6e 74 65 | HTTP/1.1..Conte|
+	 * |00000020| 6e 74 2d 54 79 70 65 3a 20 74 65 78 74 2f 70 6c |nt-Type: text/pl|
+	 * |00000030| 61 69 6e 0d 0a 75 73 65 72 2d 61 67 65 6e 74 3a |ain..user-agent:|
+	 * |00000040| 20 52 65 61 63 74 6f 72 4e 65 74 74 79 2f 64 65 | ReactorNetty/de|
+	 * ...
+	 * reactor.netty.http.HttpTests - [id: 0xd5230a14, L:/0:0:0:0:0:0:0:1:60267 - R:/0:0:0:0:0:0:0:1:60269] WRITE: 38B
+	 *          +-------------------------------------------------+
+	 *          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+	 * +--------+-------------------------------------------------+----------------+
+	 * |00000000| 48 54 54 50 2f 31 2e 31 20 32 30 30 20 4f 4b 0d |HTTP/1.1 200 OK.|
+	 * |00000010| 0a 63 6f 6e 74 65 6e 74 2d 6c 65 6e 67 74 68 3a |.content-length:|
+	 * |00000020| 20 30 0d 0a 0d 0a                               | 0....          |
+	 * +--------+-------------------------------------------------+----------------+
+	 * }
+	 * </pre>
+	 */
 	HEX_DUMP,
+	/**
+	 * When wire logging is enabled with this format, the events will be logged and the content in plain text format.
+	 * <p>Examples:</p>
+	 * <pre>
+	 * {@code
+	 * reactor.netty.http.HttpTests - [id: 0x02c3db6c, L:/0:0:0:0:0:0:0:1:60317 - R:/0:0:0:0:0:0:0:1:60319] REGISTERED
+	 * reactor.netty.http.HttpTests - [id: 0x02c3db6c, L:/0:0:0:0:0:0:0:1:60317 - R:/0:0:0:0:0:0:0:1:60319] ACTIVE
+	 * reactor.netty.http.HttpTests - [id: 0x02c3db6c, L:/0:0:0:0:0:0:0:1:60317 - R:/0:0:0:0:0:0:0:1:60319] READ: 145B POST /test/World HTTP/1.1
+	 * Content-Type: text/plain
+	 * user-agent: ReactorNetty/dev
+	 * ...
+	 * reactor.netty.http.HttpTests - [id: 0x02c3db6c, L:/0:0:0:0:0:0:0:1:60317 - R:/0:0:0:0:0:0:0:1:60319] WRITE: 38B HTTP/1.1 200 OK
+	 * content-length: 0
+	 * }
+	 * </pre>
+	 */
 	TEXTUAL;
 
 	/**

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/logging/AdvancedByteBufFormat.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/logging/AdvancedByteBufFormat.java
@@ -45,7 +45,8 @@ public enum AdvancedByteBufFormat {
 	 */
 	SIMPLE,
 	/**
-	 * When wire logging is enabled with this format, the events will be logged and the content in hex format.
+	 * When wire logging is enabled with this format, both events and content will be logged.
+	 * The content will be in hex format.
 	 * <p>Examples:</p>
 	 * <pre>
 	 * {@code
@@ -74,7 +75,8 @@ public enum AdvancedByteBufFormat {
 	 */
 	HEX_DUMP,
 	/**
-	 * When wire logging is enabled with this format, the events will be logged and the content in plain text format.
+	 * When wire logging is enabled with this format, both events and content will be logged.
+	 * The content will be in plain text format.
 	 * <p>Examples:</p>
 	 * <pre>
 	 * {@code

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/wiretap/custom/Application.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.client.wiretap.custom;
+
+import io.netty.handler.logging.LogLevel;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.transport.logging.AdvancedByteBufFormat;
+
+public class Application {
+
+	public static void main(String[] args) {
+		HttpClient client =
+				HttpClient.create()
+				          .wiretap("logger-name", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL); //<1>
+
+		client.get()
+		      .uri("http://example.com/")
+		      .response()
+		      .block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/wiretap/custom/Application.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.server.wiretap.custom;
+
+import io.netty.handler.logging.LogLevel;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+import reactor.netty.transport.logging.AdvancedByteBufFormat;
+
+public class Application {
+
+	public static void main(String[] args) {
+		DisposableServer server =
+				HttpServer.create()
+				          .wiretap("logger-name", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL) //<1>
+				          .bindNow();
+
+		server.onDispose()
+		      .block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/wiretap/custom/Application.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.tcp.client.wiretap.custom;
+
+import io.netty.handler.logging.LogLevel;
+import reactor.netty.Connection;
+import reactor.netty.tcp.TcpClient;
+import reactor.netty.transport.logging.AdvancedByteBufFormat;
+
+public class Application {
+
+	public static void main(String[] args) {
+		Connection connection =
+				TcpClient.create()
+				         .wiretap("logger-name", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL) //<1>
+				         .host("example.com")
+				         .port(80)
+				         .connectNow();
+
+		connection.onDispose()
+		          .block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/wiretap/custom/Application.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.tcp.server.wiretap.custom;
+
+import io.netty.handler.logging.LogLevel;
+import reactor.netty.DisposableServer;
+import reactor.netty.tcp.TcpServer;
+import reactor.netty.transport.logging.AdvancedByteBufFormat;
+
+public class Application {
+
+	public static void main(String[] args) {
+		DisposableServer server =
+				TcpServer.create()
+				         .wiretap("logger-name", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL) //<1>
+				         .bindNow();
+
+		server.onDispose()
+		      .block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/wiretap/custom/Application.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.udp.client.wiretap.custom;
+
+import io.netty.handler.logging.LogLevel;
+import reactor.netty.Connection;
+import reactor.netty.transport.logging.AdvancedByteBufFormat;
+import reactor.netty.udp.UdpClient;
+
+import java.time.Duration;
+
+public class Application {
+
+	public static void main(String[] args) {
+		Connection connection =
+				UdpClient.create()
+				         .host("example.com")
+				         .port(80)
+				         .wiretap("logger-name", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL) //<1>
+				         .connectNow(Duration.ofSeconds(30));
+
+		connection.onDispose()
+		          .block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/wiretap/custom/Application.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.udp.server.wiretap.custom;
+
+import io.netty.handler.logging.LogLevel;
+import reactor.netty.Connection;
+import reactor.netty.transport.logging.AdvancedByteBufFormat;
+import reactor.netty.udp.UdpServer;
+
+import java.time.Duration;
+
+public class Application {
+
+	public static void main(String[] args) {
+		Connection server =
+				UdpServer.create()
+				         .wiretap("logger-name", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL) //<1>
+				         .bindNow(Duration.ofSeconds(30));
+
+		server.onDispose()
+		      .block();
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -405,10 +405,66 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 
 	/**
 	 * Prepare an {@link HttpClient}
+	 * <p>
+	 * <strong>Note:</strong>
+	 * There isn't only one method that replaces this deprecated method.
+	 * The configuration that can be done with this deprecated method,
+	 * can also be done with the other methods exposed by {@link HttpClient}.
+	 * </p>
+	 * <p>Examples:</p>
+	 * <p>Configuration via the deprecated '.from(...)' method</p>
+	 * <pre>
+	 * {@code
+	 * HttpClient.from(
+	 *     TcpClient.attr(...) // configures the channel attributes
+	 *              .bindAddress(...) // configures the bind (local) address
+	 *              .channelGroup(...) // configures the channel group
+	 *              .doOnChannelInit(...) // configures the channel handler
+	 *              .doOnConnected(...) // configures the doOnConnected callback
+	 *              .doOnDisconnected(...) // configures the doOnDisconnected callback
+	 *              .metrics(...) // configures the metrics
+	 *              .observe() // configures the connection observer
+	 *              .option(...) // configures the channel options
+	 *              .proxy(...) // configures the proxy
+	 *              .remoteAddress(...) // configures the remote address
+	 *              .resolver(...) // configures the host names resolver
+	 *              .runOn(...) // configures the event loop group
+	 *              .secure() // configures the SSL
+	 *              .wiretap()) // configures the wire logging
+	 * }
+	 * </pre>
+	 *
+	 * <p>Configuration via the other methods exposed by {@link HttpClient}</p>
+	 * <pre>
+	 * {@code
+	 * HttpClient.attr(...) // configures the channel attributes
+	 *           .bindAddress(...) // configures the bind (local) address
+	 *           .channelGroup(...) // configures the channel group
+	 *           .doOnChannelInit(...) // configures the channel handler
+	 *           .doOnConnected(...) // configures the doOnConnected callback
+	 *           .doOnDisconnected(...) // configures the doOnDisconnected callback
+	 *           .metrics(...) // configures the metrics
+	 *           .observe() // configures the connection observer
+	 *           .option(...) // configures the channel options
+	 *           .proxy(...) // configures the proxy
+	 *           .remoteAddress(...) // configures the remote address
+	 *           .resolver(...) // configures the host names resolver
+	 *           .runOn(...) // configures the event loop group
+	 *           .secure() // configures the SSL
+	 *           .wiretap() // configures the wire logging
+	 * }
+	 * </pre>
+	 *
+	 * <p>Wire logging in plain text</p>
+	 * <pre>
+	 * {@code
+	 * HttpClient.wiretap("logger", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL)
+	 * }
+	 * </pre>
 	 *
 	 * @return a new {@link HttpClient}
-	 * @deprecated Use {@link HttpClient} methods for TCP level configurations. This method
-	 * will be removed in version 1.1.0.
+	 * @deprecated Use the other methods exposed by {@link HttpClient} to achieve the same configurations.
+	 * This method will be removed in version 1.1.0.
 	 */
 	@Deprecated
 	public static HttpClient from(TcpClient tcpClient) {
@@ -1328,12 +1384,76 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	/**
 	 * Apply a {@link TcpClient} mapping function to update TCP configuration and
 	 * return an enriched {@link HttpClient} to use.
+	 * <p>
+	 * <strong>Note:</strong>
+	 * There isn't only one method that replaces this deprecated method.
+	 * The configuration that can be done with this deprecated method,
+	 * can also be done with the other methods exposed by {@link HttpClient}.
+	 * </p>
+	 * <p>Examples:</p>
+	 * <p>Configuration via the deprecated '.tcpConfiguration(...)' method</p>
+	 * <pre>
+	 * {@code
+	 * HttpClient.tcpConfiguration(tcpClient ->
+	 *     tcpClient.attr(...) // configures the channel attributes
+	 *              .bindAddress(...) // configures the bind (local) address
+	 *              .channelGroup(...) // configures the channel group
+	 *              .doOnChannelInit(...) // configures the channel handler
+	 *              .doOnConnected(...) // configures the doOnConnected callback
+	 *              .doOnDisconnected(...) // configures the doOnDisconnected callback
+	 *              .host(...) // configures the host name
+	 *              .metrics(...) // configures the metrics
+	 *              .noProxy() // removes proxy configuration
+	 *              .noSSL() // removes SSL configuration
+	 *              .observe() // configures the connection observer
+	 *              .option(...) // configures the channel options
+	 *              .port(...) // configures the port
+	 *              .proxy(...) // configures the proxy
+	 *              .remoteAddress(...) // configures the remote address
+	 *              .resolver(...) // configures the host names resolver
+	 *              .runOn(...) // configures the event loop group
+	 *              .secure() // configures the SSL
+	 *              .wiretap()) // configures the wire logging
+	 * }
+	 * </pre>
+	 *
+	 * <p>Configuration via the other methods exposed by {@link HttpClient}</p>
+	 * <pre>
+	 * {@code
+	 * HttpClient.attr(...) // configures the channel attributes
+	 *           .bindAddress(...) // configures the bind (local) address
+	 *           .channelGroup(...) // configures the channel group
+	 *           .doOnChannelInit(...) // configures the channel handler
+	 *           .doOnConnected(...) // configures the doOnConnected callback
+	 *           .doOnDisconnected(...) // configures the doOnDisconnected callback
+	 *           .host(...) // configures the host name
+	 *           .metrics(...) // configures the metrics
+	 *           .noProxy() // removes proxy configuration
+	 *           .noSSL() // removes SSL configuration
+	 *           .observe() // configures the connection observer
+	 *           .option(...) // configures the channel options
+	 *           .port(...) // configures the port
+	 *           .proxy(...) // configures the proxy
+	 *           .remoteAddress(...) // configures the remote address
+	 *           .resolver(...) // configures the host names resolver
+	 *           .runOn(...) // configures the event loop group
+	 *           .secure() // configures the SSL
+	 *           .wiretap() // configures the wire logging
+	 * }
+	 * </pre>
+	 *
+	 * <p>Wire logging in plain text</p>
+	 * <pre>
+	 * {@code
+	 * HttpClient.wiretap("logger", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL)
+	 * }
+	 * </pre>
 	 *
 	 * @param tcpMapper A {@link TcpClient} mapping function to update TCP configuration and
 	 * return an enriched {@link HttpClient} to use.
 	 * @return a new {@link HttpClient}
-	 * @deprecated Use {@link HttpClient} methods for TCP level configurations. This method
-	 * will be removed in version 1.1.0.
+	 * @deprecated Use the other methods exposed by {@link HttpClient} to achieve the same configurations.
+	 * This method will be removed in version 1.1.0.
 	 */
 	@Deprecated
 	@SuppressWarnings("ReturnValueIgnored")

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -81,10 +81,68 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 
 	/**
 	 * Prepare an {@link HttpServer}
+	 * <p>
+	 * <strong>Note:</strong>
+	 * There isn't only one method that replaces this deprecated method.
+	 * The configuration that can be done with this deprecated method,
+	 * can also be done with the other methods exposed by {@link HttpServer}.
+	 * </p>
+	 * <p>Examples:</p>
+	 * <p>Configuration via the deprecated '.from(...)' method</p>
+	 * <pre>
+	 * {@code
+	 * HttpServer.from(
+	 *     TcpServer.attr(...) // configures the channel attributes
+	 *              .bindAddress(...) // configures the bind (local) address
+	 *              .childAttr(...) // configures the child channel attributes
+	 *              .childObserve() // configures the child channel connection observer
+	 *              .childOption(...) // configures the child channel options
+	 *              .channelGroup(...) // configures the channel group
+	 *              .doOnBound(...) // configures the doOnBound callback
+	 *              .doOnChannelInit(...) // configures the channel handler
+	 *              .doOnConnection(...) // configures the doOnConnection callback
+	 *              .doOnUnbound(...) // configures the doOnUnbound callback
+	 *              .metrics(...) // configures the metrics
+	 *              .observe() // configures the connection observer
+	 *              .option(...) // configures the channel options
+	 *              .runOn(...) // configures the event loop group
+	 *              .secure() // configures the SSL
+	 *              .wiretap()) // configures the wire logging
+	 * }
+	 * </pre>
+	 *
+	 * <p>Configuration via the other methods exposed by {@link HttpServer}</p>
+	 * <pre>
+	 * {@code
+	 * HttpServer.attr(...) // configures the channel attributes
+	 *           .bindAddress(...) // configures the bind (local) address
+	 *           .childAttr(...) // configures the child channel attributes
+	 *           .childObserve() // configures the child channel connection observer
+	 *           .childOption(...) // configures the child channel options
+	 *           .channelGroup(...) // configures the channel group
+	 *           .doOnBound(...) // configures the doOnBound callback
+	 *           .doOnChannelInit(...) // configures the channel handler
+	 *           .doOnConnection(...) // configures the doOnConnection callback
+	 *           .doOnUnbound(...) // configures the doOnUnbound callback
+	 *           .metrics(...) // configures the metrics
+	 *           .observe() // configures the connection observer
+	 *           .option(...) // configures the channel options
+	 *           .runOn(...) // configures the event loop group
+	 *           .secure() // configures the SSL
+	 *           .wiretap() // configures the wire logging
+	 * }
+	 * </pre>
+	 *
+	 * <p>Wire logging in plain text</p>
+	 * <pre>
+	 * {@code
+	 * HttpServer.wiretap("logger", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL)
+	 * }
+	 * </pre>
 	 *
 	 * @return a new {@link HttpServer}
-	 * @deprecated Use {@link HttpServer} methods for TCP level configurations. This method
-	 * will be removed in version 1.1.0.
+	 * @deprecated Use the other methods exposed by {@link HttpServer} to achieve the same configurations.
+	 * This method will be removed in version 1.1.0.
 	 */
 	@Deprecated
 	public static HttpServer from(TcpServer tcpServer) {
@@ -657,12 +715,78 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	/**
 	 * Apply a {@link TcpServer} mapping function to update TCP configuration and
 	 * return an enriched {@link HttpServer} to use.
+	 * <p>
+	 * <strong>Note:</strong>
+	 * There isn't only one method that replaces this deprecated method.
+	 * The configuration that can be done with this deprecated method,
+	 * can also be done with the other methods exposed by {@link HttpServer}.
+	 * </p>
+	 * <p>Examples:</p>
+	 * <p>Configuration via the deprecated '.tcpConfiguration(...)' method</p>
+	 * <pre>
+	 * {@code
+	 * HttpServer.tcpConfiguration(tcpServer ->
+	 *     tcpServer.attr(...) // configures the channel attributes
+	 *              .bindAddress(...) // configures the bind (local) address
+	 *              .channelGroup(...) // configures the channel group
+	 *              .childAttr(...) // configures the child channel attributes
+	 *              .childObserve(...) // configures the child channel connection observer
+	 *              .childOption(...) // configures the child channel options
+	 *              .doOnBound(...) // configures the doOnBound callback
+	 *              .doOnChannelInit(...) // configures the channel handler
+	 *              .doOnConnection(...) // configures the doOnConnection callback
+	 *              .doOnUnbound(...) // configures the doOnUnbound callback
+	 *              .handle(...) // configures the I/O handler
+	 *              .host(...) // configures the host name
+	 *              .metrics(...) // configures the metrics
+	 *              .noSSL() // removes SSL configuration
+	 *              .observe() // configures the connection observer
+	 *              .option(...) // configures the channel options
+	 *              .port(...) // configures the port
+	 *              .runOn(...) // configures the event loop group
+	 *              .secure() // configures the SSL
+	 *              .wiretap()) // configures the wire logging
+	 * }
+	 * </pre>
+	 *
+	 * <p>Configuration via the other methods exposed by {@link HttpServer}</p>
+	 * <pre>
+	 * {@code
+	 * HttpServer.attr(...) // configures the channel attributes
+	 *           .bindAddress(...) // configures the bind (local) address
+	 *           .channelGroup(...) // configures the channel group
+	 *           .childAttr(...) // configures the child channel attributes
+	 *           .childObserve(...) // configures the child channel connection observer
+	 *           .childOption(...) // configures the child channel options
+	 *           .doOnBound(...) // configures the doOnBound callback
+	 *           .doOnChannelInit(...) // configures the channel handler
+	 *           .doOnConnection(...) // configures the doOnConnection callback
+	 *           .doOnUnbound(...) // configures the doOnUnbound callback
+	 *           .handle(...) // configures the I/O handler
+	 *           .host(...) // configures the host name
+	 *           .metrics(...) // configures the metrics
+	 *           .noSSL() // removes SSL configuration
+	 *           .observe() // configures the connection observer
+	 *           .option(...) // configures the channel options
+	 *           .port(...) // configures the port
+	 *           .runOn(...) // configures the event loop group
+	 *           .secure() // configures the SSL
+	 *           .wiretap() // configures the wire logging
+	 * }
+	 * </pre>
+	 *
+	 * <p>Wire logging in plain text</p>
+	 * <pre>
+	 * {@code
+	 * HttpServer.wiretap("logger", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL)
+	 * }
+	 * </pre>
 	 *
 	 * @param tcpMapper A {@link TcpServer} mapping function to update TCP configuration and
 	 * return an enriched {@link HttpServer} to use.
 	 * @return a new {@link HttpServer}
-	 * @deprecated Use {@link HttpServer} methods for TCP level configurations. This method
-	 * will be removed in version 1.1.0.
+	 * @deprecated Use the other methods exposed by {@link HttpServer} to achieve the same configurations.
+	 * This method will be removed in version 1.1.0.
 	 */
 	@Deprecated
 	@SuppressWarnings("ReturnValueIgnored")


### PR DESCRIPTION
- Clarify `replacements for reactor.netty.tcp.TcpClient#bootstrap`
- Clarify `replacements for reactor.netty.http.client.HttpClient#from`
- Clarify `replacements for reactor.netty.http.client.HttpClient#tcpConfiguration`
- Clarify `replacements for reactor.netty.http.server.HttpServer#tcpConfiguration`
- Clarify `replacements for reactor.netty.http.server.HttpServer#from`
- Add a javadoc for
  `reactor.netty.transport.logging.AdvancedByteBufFormat#SIMPLE`
  `reactor.netty.transport.logging.AdvancedByteBufFormat#HEX_DUMP`
  `reactor.netty.transport.logging.AdvancedByteBufFormat#TEXTUAL`
- Update the javadoc for various `reactor.netty.transport.Transport#wiretap` methods
- Update in the wire logging reference documentation

Fixes #1397 