### PR TITLE
Add warmup functionality for the servers/clients

### DIFF
--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -55,6 +55,31 @@ include::{examplesdir}/address/Application.java[lines=18..33]
 <2> Configures the `HTTP` port
 ====
 
+== Eager Initialization
+
+By default, the initialization of the `HttpClient` resources happens on demand. This means that the `first
+request` absorbs the extra time needed to initialize and load:
+
+ * the event loop group
+ * the host name resolver
+ * the native transport libraries (when native transport is used)
+ * the native libraries for the security (in case of `OpenSsl`)
+
+When you need to preload these resources, you can configure the `HttpClient` as follows:
+
+====
+[source,java,indent=0]
+.{examplesdir}/warmup/Application.java
+----
+include::{examplesdir}/warmup/Application.java[lines=18..36]
+----
+<1> Initialize and load the event loop group, the host name resolver, the native transport libraries and
+the native libraries for the security
+<2> Host name resolution happens with the first request.
+In this example, a connection pool is used, so with the first request the connection to the URL is established,
+the subsequent requests to the same URL reuse the connections from the pool.
+====
+
 == Writing Data
 
 To send data to a given `HTTP` endpoint, you can provide a `Publisher` by using the

--- a/docs/asciidoc/http-server.adoc
+++ b/docs/asciidoc/http-server.adoc
@@ -47,6 +47,26 @@ include::{examplesdir}/address/Application.java[lines=18..33]
 <2> Configures the `HTTP` server port
 ====
 
+== Eager Initialization
+
+By default, the initialization of the `HttpServer` resources happens on demand. This means that the `bind
+operation` absorbs the extra time needed to initialize and load:
+
+ * the event loop groups
+ * the native transport libraries (when native transport is used)
+ * the native libraries for the security (in case of `OpenSsl`)
+
+When you need to preload these resources, you can configure the `HttpServer` as follows:
+
+====
+[source,java,indent=0]
+.{examplesdir}/warmup/Application.java
+----
+include::{examplesdir}/warmup/Application.java[lines=18..36]
+----
+<1> Initialize and load the event loop groups, the native transport libraries and the native libraries for the security
+====
+
 == Routing HTTP
 
 Defining routes for the `HTTP` server requires configuring the provided

--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -48,6 +48,29 @@ include::{examplesdir}/address/Application.java[lines=18..33]
 <2> Configures the `TCP` port
 ====
 
+== Eager Initialization
+
+By default, the initialization of the `TcpClient` resources happens on demand. This means that the `connect
+operation` absorbs the extra time needed to initialize and load:
+
+ * the event loop group
+ * the host name resolver
+ * the native transport libraries (when native transport is used)
+ * the native libraries for the security (in case of `OpenSsl`)
+
+When you need to preload these resources, you can configure the `TcpClient` as follows:
+
+====
+[source,java,indent=0]
+.{examplesdir}/warmup/Application.java
+----
+include::{examplesdir}/warmup/Application.java[lines=18..39]
+----
+<1> Initialize and load the event loop group, the host name resolver, the native transport libraries and
+the native libraries for the security
+<2> Host name resolution happens when connecting to the remote peer
+====
+
 == Writing Data
 
 To send data to a given endpoint, you must attach an I/O handler.

--- a/docs/asciidoc/tcp-server.adoc
+++ b/docs/asciidoc/tcp-server.adoc
@@ -47,6 +47,26 @@ include::{examplesdir}/address/Application.java[lines=18..33]
 <2> Configures the `TCP` server port
 ====
 
+== Eager Initialization
+
+By default, the initialization of the `TcpServer` resources happens on demand. This means that the `bind
+operation` absorbs the extra time needed to initialize and load:
+
+ * the event loop groups
+ * the native transport libraries (when native transport is used)
+ * the native libraries for the security (in case of `OpenSsl`)
+
+When you need to preload these resources, you can configure the `TcpServer` as follows:
+
+====
+[source,java,indent=0]
+.{examplesdir}/warmup/Application.java
+----
+include::{examplesdir}/warmup/Application.java[lines=18..36]
+----
+<1> Initialize and load the event loop groups, the native transport libraries and the native libraries for the security
+====
+
 == Writing Data
 
 In order to send data to a connected client, you must attach an I/O handler.

--- a/docs/asciidoc/udp-client.adoc
+++ b/docs/asciidoc/udp-client.adoc
@@ -46,6 +46,27 @@ include::{examplesdir}/address/Application.java[lines=18..34]
 <2> Configures the `port` to which this client should connect
 ====
 
+== Eager Initialization
+
+By default, the initialization of the `UdpClient` resources happens on demand. This means that the `connect
+operation` absorbs the extra time needed to initialize and load:
+
+ * the event loop group
+ * the host name resolver
+ * the native transport libraries (when native transport is used)
+
+When you need to preload these resources, you can configure the `UdpClient` as follows:
+
+====
+[source,java,indent=0]
+.{examplesdir}/warmup/Application.java
+----
+include::{examplesdir}/warmup/Application.java[lines=18..40]
+----
+<1> Initialize and load the event loop group, the host name resolver, and the native transport libraries
+<2> Host name resolution happens when connecting to the remote peer
+====
+
 == Writing Data
 
 To send data to a given peer, you must attach an I/O handler.

--- a/docs/asciidoc/udp-server.adoc
+++ b/docs/asciidoc/udp-server.adoc
@@ -46,6 +46,25 @@ include::{examplesdir}/address/Application.java[lines=18..34]
 <2> Configures the `UDP` server port
 ====
 
+== Eager Initialization
+
+By default, the initialization of the `UdpServer` resources happens on demand. This means that the `bind
+operation` absorbs the extra time needed to initialize and load:
+
+ * the event loop group
+ * the native transport libraries (when native transport is used)
+
+When you need to preload these resources, you can configure the `UdpServer` as follows:
+
+====
+[source,java,indent=0]
+.{examplesdir}/warmup/Application.java
+----
+include::{examplesdir}/warmup/Application.java[lines=18..51]
+----
+<1> Initialize and load the event loop group and the native transport libraries
+====
+
 == Writing Data
 
 To send data to the remote peer, you must attach an I/O handler.

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -104,6 +104,10 @@ dependencies {
 	}
 
 	// Testing
+
+	// JSR-305 annotations
+	testCompileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
+
 	testCompile "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
 	testCompile "io.projectreactor:reactor-test:$testAddonVersion"
 	testCompile "org.assertj:assertj-core:$assertJVersion"

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -358,10 +358,14 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 	}
 
 	/**
-	 * Based on the actual configuration, returns a {@link Mono} that triggers an initialization of
-	 * the event loop group, the host name resolver, loads the necessary native libraries for the transport.
-	 * and the necessary native libraries for the security if there is such.
-	 * By default warmup is not performed and all resources are loaded on the first request.
+	 * Based on the actual configuration, returns a {@link Mono} that triggers:
+	 * <ul>
+	 *     <li>an initialization of the event loop group</li>
+	 *     <li>an initialization of the host name resolver</li>
+	 *     <li>loads the necessary native libraries for the transport</li>
+	 *     <li>loads the necessary native libraries for the security if there is such</li>
+	 * </ul>
+	 * By default, when method is not used, the {@code connect operation} absorbs the extra time needed to load resources.
 	 *
 	 * @return a {@link Mono} representing the completion of the warmup
 	 * @since 1.0.3

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -27,6 +27,8 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.logging.LogLevel;
+import io.netty.handler.ssl.JdkSslContext;
+import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.AttributeKey;
@@ -353,6 +355,27 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 		TcpClient dup = duplicate();
 		dup.configuration().sslProvider = sslProvider;
 		return dup;
+	}
+
+	/**
+	 * Based on the actual configuration, returns a {@link Mono} that triggers an initialization of
+	 * the event loop group, the host name resolver, loads the necessary native libraries for the transport.
+	 * and the necessary native libraries for the security if there is such.
+	 * By default warmup is not performed and all resources are loaded on the first request.
+	 *
+	 * @return a {@link Mono} representing the completion of the warmup
+	 * @since 1.0.3
+	 */
+	@Override
+	public Mono<Void> warmup() {
+		return Mono.when(
+				super.warmup(),
+				Mono.fromRunnable(() -> {
+					SslProvider provider = configuration().sslProvider();
+					if (provider != null && !(provider.getSslContext() instanceof JdkSslContext)) {
+						OpenSsl.version();
+					}
+				}));
 	}
 
 	@Override

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServer.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServer.java
@@ -222,10 +222,13 @@ public abstract class TcpServer extends ServerTransport<TcpServer, TcpServerConf
 	}
 
 	/**
-	 * Based on the actual configuration, returns a {@link Mono} that triggers an initialization of
-	 * the event loop groups, loads the necessary native libraries for the transport
-	 * and the necessary native libraries for the security if there is such.
-	 * By default warmup is not performed and all resources are loaded on the first request.
+	 * Based on the actual configuration, returns a {@link Mono} that triggers:
+	 * <ul>
+	 *     <li>an initialization of the event loop groups</li>
+	 *     <li>loads the necessary native libraries for the transport</li>
+	 *     <li>loads the necessary native libraries for the security if there is such</li>
+	 * </ul>
+	 * By default, when method is not used, the {@code bind operation} absorbs the extra time needed to load resources.
 	 *
 	 * @return a {@link Mono} representing the completion of the warmup
 	 * @since 1.0.3

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
@@ -309,4 +309,21 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 		}
 		return dup;
 	}
+
+	/**
+	 * Based on the actual configuration, returns a {@link Mono} that triggers an initialization of
+	 * the event loop group, the host name resolver and loads the necessary native libraries for the transport.
+	 * By default warmup is not performed and all resources are loaded on the first request.
+	 *
+	 * @return a {@link Mono} representing the completion of the warmup
+	 * @since 1.0.3
+	 */
+	public Mono<Void> warmup() {
+		return Mono.fromRunnable(() -> {
+			configuration().eventLoopGroup();
+
+			// By default the host name resolver uses the event loop group configured on client level
+			configuration().resolverInternal();
+		});
+	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
@@ -311,9 +311,14 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	}
 
 	/**
-	 * Based on the actual configuration, returns a {@link Mono} that triggers an initialization of
-	 * the event loop group, the host name resolver and loads the necessary native libraries for the transport.
-	 * By default warmup is not performed and all resources are loaded on the first request.
+	 * Based on the actual configuration, returns a {@link Mono} that triggers:
+	 * <ul>
+	 *     <li>an initialization of the event loop group</li>
+	 *     <li>an initialization of the host name resolver</li>
+	 *     <li>loads the necessary native libraries for the transport</li>
+	 * </ul>
+	 * By default, when method is not used, the {@code connect operation} absorbs the extra time needed to initialize and
+	 * load the resources.
 	 *
 	 * @return a {@link Mono} representing the completion of the warmup
 	 * @since 1.0.3

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
@@ -323,9 +323,12 @@ public abstract class ServerTransport<T extends ServerTransport<T, CONF>,
 	}
 
 	/**
-	 * Based on the actual configuration, returns a {@link Mono} that triggers an initialization of
-	 * the event loop groups and loads the necessary native libraries for the transport.
-	 * By default warmup is not performed and all resources are loaded on the first request.
+	 * Based on the actual configuration, returns a {@link Mono} that triggers:
+	 * <ul>
+	 *     <li>an initialization of the event loop groups</li>
+	 *     <li>loads the necessary native libraries for the transport</li>
+	 * </ul>
+	 * By default, when method is not used, the {@code bind operation} absorbs the extra time needed to load resources.
 	 *
 	 * @return a {@link Mono} representing the completion of the warmup
 	 * @since 1.0.3

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
@@ -322,6 +322,24 @@ public abstract class ServerTransport<T extends ServerTransport<T, CONF>,
 		return bindAddress(() -> AddressUtils.updatePort(configuration().bindAddress(), port));
 	}
 
+	/**
+	 * Based on the actual configuration, returns a {@link Mono} that triggers an initialization of
+	 * the event loop groups and loads the necessary native libraries for the transport.
+	 * By default warmup is not performed and all resources are loaded on the first request.
+	 *
+	 * @return a {@link Mono} representing the completion of the warmup
+	 * @since 1.0.3
+	 */
+	public Mono<Void> warmup() {
+		return Mono.fromRunnable(() -> {
+			// event loop group for the server
+			configuration().childEventLoopGroup();
+
+			// event loop group for the server selector
+			configuration().eventLoopGroup();
+		});
+	}
+
 	static final Logger log = Loggers.getLogger(ServerTransport.class);
 
 	static class Acceptor extends ChannelInboundHandlerAdapter {

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServer.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServer.java
@@ -265,6 +265,21 @@ public abstract class UdpServer extends Transport<UdpServer, UdpServerConfig> {
 		return dup;
 	}
 
+	/**
+	 * Based on the actual configuration, returns a {@link Mono} that triggers:
+	 * <ul>
+	 *     <li>an initialization of the event loop group</li>
+	 *     <li>loads the necessary native libraries for the transport</li>
+	 * </ul>
+	 * By default, when method is not used, the {@code bind operation} absorbs the extra time needed to load resources.
+	 *
+	 * @return a {@link Mono} representing the completion of the warmup
+	 * @since 1.0.3
+	 */
+	public final Mono<Void> warmup() {
+		return Mono.fromRunnable(() -> configuration().eventLoopGroup());
+	}
+
 	@Override
 	public final UdpServer wiretap(boolean enable) {
 		return super.wiretap(enable);

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultLoopResourcesTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultLoopResourcesTest.java
@@ -20,7 +20,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
+import reactor.netty.tcp.TcpClient;
 import reactor.netty.tcp.TcpResources;
+import reactor.netty.tcp.TcpServer;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -98,5 +100,89 @@ class DefaultLoopResourcesTest {
 		}
 
 		static final AtomicReference<TestResources> testResources = new AtomicReference<>();
+	}
+
+	@Test
+	void testClientTransportWarmupNative() {
+		testClientTransportWarmup(true);
+	}
+
+	@Test
+	void testClientTransportWarmupNio() {
+		testClientTransportWarmup(false);
+	}
+
+	private void testClientTransportWarmup(boolean preferNative) {
+		final DefaultLoopResources loop =
+				(DefaultLoopResources) LoopResources.create("testClientTransportWarmup", 1, true);
+		try {
+			TcpClient tcpClient = TcpClient.create()
+			                               .runOn(loop, preferNative);
+
+			Mono<Void> warmupMono = tcpClient.warmup();
+
+			assertThat(loop.cacheNativeClientLoops.get()).isNull();
+			assertThat(loop.clientLoops.get()).isNull();
+
+			warmupMono.block(Duration.ofSeconds(5));
+
+			if (preferNative && LoopResources.hasNativeSupport()) {
+				assertThat(loop.cacheNativeClientLoops.get()).isNotNull();
+				assertThat(loop.clientLoops.get()).isNull();
+			}
+			else {
+				assertThat(loop.cacheNativeClientLoops.get()).isNull();
+				assertThat(loop.clientLoops.get()).isNotNull();
+			}
+		}
+		finally {
+			loop.disposeLater()
+			    .block(Duration.ofSeconds(5));
+		}
+	}
+
+	@Test
+	void testServerTransportWarmupNative() {
+		testServerTransportWarmup(true);
+	}
+
+	@Test
+	void testServerTransportWarmupNio() {
+		testServerTransportWarmup(false);
+	}
+
+	private void testServerTransportWarmup(boolean preferNative) {
+		final DefaultLoopResources loop =
+				(DefaultLoopResources) LoopResources.create("testServerTransportWarmup", 1, true);
+		try {
+			TcpServer tcpServer = TcpServer.create()
+			                               .runOn(loop, preferNative);
+
+			Mono<Void> warmupMono = tcpServer.warmup();
+
+			assertThat(loop.cacheNativeServerLoops.get()).isNull();
+			assertThat(loop.cacheNativeSelectLoops.get()).isNull();
+			assertThat(loop.serverLoops.get()).isNull();
+			assertThat(loop.serverSelectLoops.get()).isNull();
+
+			warmupMono.block(Duration.ofSeconds(5));
+
+			if (preferNative && LoopResources.hasNativeSupport()) {
+				assertThat(loop.cacheNativeServerLoops.get()).isNotNull();
+				assertThat(loop.cacheNativeSelectLoops.get()).isNotNull();
+				assertThat(loop.serverLoops.get()).isNull();
+				assertThat(loop.serverSelectLoops.get()).isNull();
+			}
+			else {
+				assertThat(loop.cacheNativeServerLoops.get()).isNull();
+				assertThat(loop.cacheNativeSelectLoops.get()).isNull();
+				assertThat(loop.serverLoops.get()).isNotNull();
+				assertThat(loop.serverSelectLoops.get()).isNotNull();
+			}
+		}
+		finally {
+			loop.disposeLater()
+			    .block(Duration.ofSeconds(5));
+		}
 	}
 }

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/warmup/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/warmup/Application.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.client.warmup;
+
+import reactor.core.publisher.Mono;
+import reactor.netty.ByteBufFlux;
+import reactor.netty.http.client.HttpClient;
+
+public class Application {
+
+	public static void main(String[] args) {
+		HttpClient client = HttpClient.create();
+
+		client.warmup() //<1>
+		      .block();
+
+		client.post()
+		      .uri("https://example.com/")
+		      .send(ByteBufFlux.fromString(Mono.just("hello")))
+		      .response()
+		      .block(); //<2>
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/warmup/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/warmup/Application.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.server.warmup;
+
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+public class Application {
+
+	public static void main(String[] args) {
+		HttpServer httpServer =
+				HttpServer.create()
+				          .handle((request, response) -> request.receive().then());
+
+		httpServer.warmup() //<1>
+		          .block();
+
+		DisposableServer server = httpServer.bindNow();
+
+		server.onDispose()
+		      .block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/warmup/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/warmup/Application.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.tcp.client.warmup;
+
+import reactor.core.publisher.Mono;
+import reactor.netty.Connection;
+import reactor.netty.tcp.TcpClient;
+
+public class Application {
+
+	public static void main(String[] args) {
+		TcpClient tcpClient =
+				TcpClient.create()
+				         .host("example.com")
+				         .port(80)
+				         .handle((inbound, outbound) -> outbound.sendString(Mono.just("hello")));
+
+		tcpClient.warmup() //<1>
+		         .block();
+
+		Connection connection = tcpClient.connectNow(); //<2>
+
+		connection.onDispose()
+		          .block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/warmup/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/warmup/Application.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.tcp.server.warmup;
+
+import reactor.netty.DisposableServer;
+import reactor.netty.tcp.TcpServer;
+
+public class Application {
+
+	public static void main(String[] args) {
+		TcpServer tcpServer =
+				TcpServer.create()
+				         .handle((inbound, outbound) -> inbound.receive().then());
+
+		tcpServer.warmup() //<1>
+		         .block();
+
+		DisposableServer server = tcpServer.bindNow();
+
+		server.onDispose()
+		      .block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/warmup/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/warmup/Application.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.udp.client.warmup;
+
+import reactor.core.publisher.Mono;
+import reactor.netty.Connection;
+import reactor.netty.udp.UdpClient;
+
+import java.time.Duration;
+
+public class Application {
+
+	public static void main(String[] args) {
+		UdpClient udpClient = UdpClient.create()
+		                               .host("example.com")
+		                               .port(80)
+		                               .handle((udpInbound, udpOutbound) -> udpOutbound.sendString(Mono.just("hello")));
+
+		udpClient.warmup() //<1>
+		         .block();
+
+		Connection connection = udpClient.connectNow(Duration.ofSeconds(30)); //<2>
+
+		connection.onDispose()
+		          .block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/warmup/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/warmup/Application.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.udp.server.warmup;
+
+import io.netty.channel.socket.DatagramPacket;
+import reactor.core.publisher.Mono;
+import reactor.netty.Connection;
+import reactor.netty.udp.UdpServer;
+
+import java.time.Duration;
+
+public class Application {
+
+	public static void main(String[] args) {
+		UdpServer udpServer =
+				UdpServer.create()
+				         .handle((in, out) ->
+				             out.sendObject(
+				                 in.receiveObject()
+				                   .map(o -> {
+				                       if (o instanceof DatagramPacket) {
+				                           DatagramPacket p = (DatagramPacket) o;
+				                           return new DatagramPacket(p.content().retain(), p.sender());
+				                       }
+				                       else {
+				                           return Mono.error(new Exception("Unexpected type of the message: " + o));
+				                       }
+				                   })));
+
+		udpServer.warmup() //<1>
+		         .block();
+
+		Connection server = udpServer.bindNow(Duration.ofSeconds(30));
+
+		server.onDispose()
+		      .block();
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1467,10 +1467,14 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	}
 
 	/**
-	 * Based on the actual configuration, returns a {@link Mono} that triggers an initialization of
-	 * the event loop group, the host name resolver, loads the necessary native libraries for the transport.
-	 * and the necessary native libraries for the security if there is such.
-	 * By default warmup is not performed and all resources are loaded on the first request.
+	 * Based on the actual configuration, returns a {@link Mono} that triggers:
+	 * <ul>
+	 *     <li>an initialization of the event loop group</li>
+	 *     <li>an initialization of the host name resolver</li>
+	 *     <li>loads the necessary native libraries for the transport</li>
+	 *     <li>loads the necessary native libraries for the security if there is such</li>
+	 * </ul>
+	 * By default, when method is not used, the {@code first request} absorbs the extra time needed to load resources.
 	 *
 	 * @return a {@link Mono} representing the completion of the warmup
 	 * @since 1.0.3

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -38,7 +38,6 @@ import io.netty.handler.codec.http.cookie.ClientCookieDecoder;
 import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
-import io.netty.handler.ssl.JdkSslContext;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import org.reactivestreams.Publisher;
@@ -1480,12 +1479,10 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	public Mono<Void> warmup() {
 		return Mono.when(
 				super.warmup(),
-				Mono.fromRunnable(() -> {
-					SslProvider provider = configuration().sslProvider();
-					if (provider != null && !(provider.getSslContext() instanceof JdkSslContext)) {
-						OpenSsl.version();
-					}
-				}));
+				// When the URL scheme is HTTPS and there is no security configured,
+				// the default security will be used thus always try to load the OpenSsl natives
+				// see HttpClientConnect.MonoHttpConnect#subscribe
+				Mono.fromRunnable(OpenSsl::version));
 	}
 
 	/**

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -30,6 +30,8 @@ import io.netty.channel.group.ChannelGroup;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
+import io.netty.handler.ssl.JdkSslContext;
+import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.reactivestreams.Publisher;
@@ -800,6 +802,27 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 		// ReturnValueIgnored is deliberate
 		tcpMapper.apply(tcpServer);
 		return tcpServer.httpServer;
+	}
+
+	/**
+	 * Based on the actual configuration, returns a {@link Mono} that triggers an initialization of
+	 * the event loop groups, loads the necessary native libraries for the transport
+	 * and the necessary native libraries for the security if there is such.
+	 * By default warmup is not performed and all resources are loaded on the first request.
+	 *
+	 * @return a {@link Mono} representing the completion of the warmup
+	 * @since 1.0.3
+	 */
+	@Override
+	public Mono<Void> warmup() {
+		return Mono.when(
+				super.warmup(),
+				Mono.fromRunnable(() -> {
+					SslProvider provider = configuration().sslProvider();
+					if (provider != null && !(provider.getSslContext() instanceof JdkSslContext)) {
+						OpenSsl.version();
+					}
+				}));
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -805,10 +805,13 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	}
 
 	/**
-	 * Based on the actual configuration, returns a {@link Mono} that triggers an initialization of
-	 * the event loop groups, loads the necessary native libraries for the transport
-	 * and the necessary native libraries for the security if there is such.
-	 * By default warmup is not performed and all resources are loaded on the first request.
+	 * Based on the actual configuration, returns a {@link Mono} that triggers:
+	 * <ul>
+	 *     <li>an initialization of the event loop groups</li>
+	 *     <li>loads the necessary native libraries for the transport</li>
+	 *     <li>loads the necessary native libraries for the security if there is such</li>
+	 * </ul>
+	 * By default, when method is not used, the {@code bind operation} absorbs the extra time needed to load resources.
 	 *
 	 * @return a {@link Mono} representing the completion of the warmup
 	 * @since 1.0.3


### PR DESCRIPTION
The warmup triggers an initialisation of the event loop groups, the host name resolver,
loads the necessary native libraries for the transport and native libraries
for the security if security is enabled.

Related to #560, #1023, #1425