### PR TITLE
Add the version when the deprecated method will be removed.

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -175,7 +175,8 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 * @param accessLogFactory the {@link Function} that creates an {@link AccessLog} given an {@link AccessLogArgProvider}
 	 * @return a new {@link HttpServer}
 	 * @since 1.0.1
-	 * @deprecated as of 1.0.3. Prefer the {@link #accessLog(boolean, AccessLogFactory) variant} with the {@link AccessLogFactory} interface instead
+	 * @deprecated as of 1.0.3. Prefer the {@link #accessLog(boolean, AccessLogFactory) variant}
+	 * with the {@link AccessLogFactory} interface instead. This method will be removed in version 1.2.0.
 	 */
 	@Deprecated
 	public final HttpServer accessLog(Function<AccessLogArgProvider, AccessLog> accessLogFactory) {


### PR DESCRIPTION
The rest of the deprecated methods already mention the version when they will be removed.
https://projectreactor.io/docs/netty/snapshot/api/deprecated-list.html