### PR TITLE
API for disabling force retry support for HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ With `Gradle` from [repo.spring.io](https://repo.spring.io) or `Maven Central` r
     }
 
     dependencies {
-      //compile "io.projectreactor.netty:reactor-netty:0.9.17.BUILD-SNAPSHOT"
-      compile "io.projectreactor.netty:reactor-netty:0.9.16.RELEASE"
+      compile "io.projectreactor.netty:reactor-netty:0.9.16.BUILD-SNAPSHOT"
+      compile "io.projectreactor.netty:reactor-netty:0.9.15.RELEASE"
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ With `Gradle` from [repo.spring.io](https://repo.spring.io) or `Maven Central` r
     }
 
     dependencies {
-      //compile "io.projectreactor.netty:reactor-netty:0.9.16.BUILD-SNAPSHOT"
-      compile "io.projectreactor.netty:reactor-netty:0.9.15.RELEASE"
+      //compile "io.projectreactor.netty:reactor-netty:0.9.17.BUILD-SNAPSHOT"
+      compile "io.projectreactor.netty:reactor-netty:0.9.16.RELEASE"
     }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-reactorPoolVersion=0.1.8.BUILD-SNAPSHOT
+reactorPoolVersion=0.1.8.RELEASE
 version=0.9.16.BUILD-SNAPSHOT
-reactorCoreVersion=3.3.13.BUILD-SNAPSHOT
+reactorCoreVersion=3.3.13.RELEASE
 compatibleVersion=0.9.0.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-reactorPoolVersion=0.1.8.RELEASE
+reactorPoolVersion=0.1.9.BUILD-SNAPSHOT
 version=0.9.17.BUILD-SNAPSHOT
-reactorCoreVersion=3.3.13.RELEASE
+reactorCoreVersion=3.3.14.BUILD-SNAPSHOT
 compatibleVersion=0.9.0.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-reactorPoolVersion=0.1.9.BUILD-SNAPSHOT
-version=0.9.17.BUILD-SNAPSHOT
-reactorCoreVersion=3.3.14.BUILD-SNAPSHOT
+reactorPoolVersion=0.1.8.BUILD-SNAPSHOT
+version=0.9.16.BUILD-SNAPSHOT
+reactorCoreVersion=3.3.13.BUILD-SNAPSHOT
 compatibleVersion=0.9.0.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 reactorPoolVersion=0.1.8.RELEASE
-version=0.9.16.RELEASE
+version=0.9.17.BUILD-SNAPSHOT
 reactorCoreVersion=3.3.13.RELEASE
 compatibleVersion=0.9.0.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 reactorPoolVersion=0.1.8.RELEASE
-version=0.9.16.BUILD-SNAPSHOT
+version=0.9.16.RELEASE
 reactorCoreVersion=3.3.13.RELEASE
 compatibleVersion=0.9.0.RELEASE

--- a/src/main/java/reactor/netty/channel/AbortedException.java
+++ b/src/main/java/reactor/netty/channel/AbortedException.java
@@ -28,6 +28,10 @@ import java.net.SocketException;
 public class AbortedException extends RuntimeException {
 	static final String CONNECTION_CLOSED_BEFORE_SEND = "Connection has been closed BEFORE send operation";
 
+	static final String CONNECTION_CLOSED_BEFORE_RESPONSE = "Connection has been closed BEFORE response, while sending request body";
+
+	static final String CONNECTION_PREMATURELY_CLOSED_BEFORE_RESPONSE = "Connection prematurely closed BEFORE response";
+
 	public AbortedException(String message) {
 		super(message);
 	}
@@ -56,8 +60,30 @@ public class AbortedException extends RuntimeException {
 		                                             .contains("Connection reset by peer"));
 	}
 
+	public static boolean isConnectionResetWithForcingRetry(Throwable err) {
+		return (err instanceof AbortedException && CONNECTION_CLOSED_BEFORE_SEND.equals(err.getMessage())) ||
+				(err instanceof AbortedException && CONNECTION_CLOSED_BEFORE_RESPONSE.equals(err.getMessage())) ||
+				(err instanceof AbortedException && CONNECTION_PREMATURELY_CLOSED_BEFORE_RESPONSE.equals(err.getMessage())) ||
+				(err instanceof IOException && (err.getMessage() == null ||
+						err.getMessage()
+								.contains("Broken pipe") ||
+						err.getMessage()
+								.contains("Connection reset by peer"))) ||
+				(err instanceof SocketException && err.getMessage() != null &&
+						err.getMessage()
+								.contains("Connection reset by peer"));
+	}
+
 	public static AbortedException beforeSend() {
 		return new AbortedException(CONNECTION_CLOSED_BEFORE_SEND);
+	}
+
+	public static AbortedException beforeResponse() {
+		return new AbortedException(CONNECTION_CLOSED_BEFORE_RESPONSE);
+	}
+
+	public static AbortedException prematurelyBeforeResponse() {
+		return new AbortedException(CONNECTION_PREMATURELY_CLOSED_BEFORE_RESPONSE);
 	}
 
 	private static final long serialVersionUID = 6091789064032301718L;

--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -792,6 +792,27 @@ public abstract class HttpClient {
 	}
 
 	/**
+	 * Option to disable {@code force retry once} support for the outgoing requests that fail with
+	 * {@link reactor.netty.channel.AbortedException#isConnectionResetWithForcingRetry(Throwable)}.
+	 * <p>By default this is set to true in which case {@code force retry once} is disable.
+	 * <p>If disableForceRetry is set to false, the request may be sent repeatedly.
+	 *
+	 * @param disableForceRetry true to disable {@code retry once}, false to enable it only if
+	 * disableRetry{@link reactor.netty.http.client.HttpClient#disableRetry(boolean)}is alse
+	 * set to false.
+	 *
+	 * @return a new {@link HttpClient}
+	 */
+	public final HttpClient disableForceRetry(boolean disableForceRetry) {
+		if (disableForceRetry) {
+			return tcpConfiguration(FORCE_RETRY_ATTR_CONFIG);
+		}
+		else {
+			return tcpConfiguration(FORCE_RETRY_ATTR_DISABLE);
+		}
+	}
+
+	/**
 	 * Specifies whether HTTP status 301|302|307|308 auto-redirect support is enabled.
 	 *
 	 * <p><strong>Note:</strong> The sensitive headers {@link #followRedirect(boolean, Consumer) followRedirect}
@@ -1413,6 +1434,14 @@ public abstract class HttpClient {
 	@SuppressWarnings("deprecation")
 	static final Function<TcpClient, TcpClient> RETRY_ATTR_DISABLE =
 			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_NO_RETRY);
+
+	@SuppressWarnings("deprecation")
+	static final Function<TcpClient, TcpClient> FORCE_RETRY_ATTR_CONFIG =
+			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_FORCE_RETRY);
+
+	@SuppressWarnings("deprecation")
+	static final Function<TcpClient, TcpClient> FORCE_RETRY_ATTR_DISABLE =
+			tcp -> tcp.bootstrap(HttpClientConfiguration.MAP_NO_FORCE_RETRY);
 
 	@SuppressWarnings("deprecation")
 	static final Function<TcpClient, TcpClient> FOLLOW_REDIRECT_ATTR_DISABLE =

--- a/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientConfiguration.java
@@ -58,6 +58,7 @@ final class HttpClientConfiguration {
 	HttpMethod                    method                         = HttpMethod.GET;
 	WebsocketClientSpec           websocketClientSpec            = null;
 	boolean                       retryDisabled                  = false;
+	boolean                       forceRetryDisabled             = true;
 	int                           protocols                      = h11;
 	HttpResponseDecoderSpec       decoder                        = new HttpResponseDecoderSpec();
 
@@ -94,6 +95,7 @@ final class HttpClientConfiguration {
 		this.method = from.method;
 		this.websocketClientSpec = from.websocketClientSpec;
 		this.retryDisabled = from.retryDisabled;
+		this.forceRetryDisabled = from.forceRetryDisabled;
 		this.body = from.body;
 		this.protocols = from.protocols;
 		this.deferredConf = from.deferredConf;
@@ -169,6 +171,17 @@ final class HttpClientConfiguration {
 
 	static final Function<Bootstrap, Bootstrap> MAP_NO_RETRY = b -> {
 		getOrCreate(b).retryDisabled = true;
+		return b;
+	};
+
+	static final Function<Bootstrap, Bootstrap> MAP_FORCE_RETRY = b -> {
+		getOrCreate(b).forceRetryDisabled = false;
+		return b;
+	};
+
+
+	static final Function<Bootstrap, Bootstrap> MAP_NO_FORCE_RETRY = b -> {
+		getOrCreate(b).forceRetryDisabled = true;
 		return b;
 	};
 

--- a/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -281,10 +281,10 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 				listener().onUncaughtException(this, AbortedException.beforeSend());
 			}
 			else if (markSentBody()) {
-				listener().onUncaughtException(this, new PrematureCloseException("Connection has been closed BEFORE response, while sending request body"));
+				listener().onUncaughtException(this, AbortedException.beforeResponse());
 			}
 			else {
-				listener().onUncaughtException(this, new PrematureCloseException("Connection prematurely closed BEFORE response"));
+				listener().onUncaughtException(this, AbortedException.prematurelyBeforeResponse());
 			}
 			return;
 		}


### PR DESCRIPTION
# Motivation
although reactor-netty's HttpClient has a retry-once on connection-reset behavior and It is effective to prevent  problems in some scenarios ,for example connection prematurely closed BEFORE response, but it can not prevent this problem in all scenarios, as you said in this pr :https://github.com/reactor/reactor-netty/pull/1183#issuecomment-739917771.
In most cases, netty serves as a high-performance API gateway server,so it is mainly responsible for forwarding requests and request is stateless, In some extreme high concurrency scenarios, the probability of connection closed BEFORE response is very high, which seriously affects the user experience. It is necessary for reactor-netty to provide an api to ensure that it will try again when there is a problem.
Our system requests more than 200 million times a day, After adding the mandatory request to try again, this problem is completely solved, and the effect is very obvious
# solution
Only if retryDisable and forceRetryDisable are set to false, the forced retry function can be enabled.
