### PR TITLE
url java.lang.NullPointerException: null

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClientDoOnError.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientDoOnError.java
@@ -82,7 +82,7 @@ final class HttpClientDoOnError extends HttpClientOperator {
 			this.headers = c.headers;
 			this.cookieDecoder = c.cookieDecoder;
 			this.uri = c.uri == null ? c.uriStr : c.uri.toString();
-			this.path = HttpOperations.resolvePath(this.uri);
+			this.path = this.uri != null ? HttpOperations.resolvePath(this.uri) : null;
 			this.method = c.method;
 			this.isWebsocket = c.websocketClientSpec != null;
 			this.responseTimeout = c.responseTimeout;

--- a/src/test/java/reactor/netty/UrlExceptionTest.java
+++ b/src/test/java/reactor/netty/UrlExceptionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.netty;
 
 import io.netty.handler.codec.http.HttpMethod;
@@ -10,28 +26,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class UrlExceptionTest {
 
-    @Test
-    public void urlExceptionTest() {
-        try {
-            HttpClient.create()
-                    .doOnError((httpClientRequest, throwable) -> {
+	@Test
+	public void urlExceptionTest() {
+		try {
+			HttpClient.create()
+					.doOnError((httpClientRequest, throwable) -> {
 
-                    }, (httpClientResponse, throwable) -> {
+					}, (httpClientResponse, throwable) -> {
 
-                    })
-                    .request(HttpMethod.GET)
-                    .uri(Mono.error(new IllegalArgumentException("URL cannot be resolved")))
-                    .responseSingle((httpClientResponse, byteBufMono) -> {
-                        HttpResponseStatus status = httpClientResponse.status();
-                        if (status.code() != 200) {
-                            return Mono.error(new IllegalStateException(status.toString()));
-                        }
-                        return byteBufMono.asString();
-                    })
-                    .block();
+					})
+					.request(HttpMethod.GET)
+					.uri(Mono.error(new IllegalArgumentException("URL cannot be resolved")))
+					.responseSingle((httpClientResponse, byteBufMono) -> {
+						HttpResponseStatus status = httpClientResponse.status();
+						if (status.code() != 200) {
+							return Mono.error(new IllegalStateException(status.toString()));
+						}
+						return byteBufMono.asString();
+					})
+					.block();
 
-        }catch (IllegalArgumentException e){
-            assertThat(e.getMessage()).isEqualTo("URL cannot be resolved");
-        }
-    }
+		}
+		catch (IllegalArgumentException e){
+			assertThat(e.getMessage()).isEqualTo("URL cannot be resolved");
+		}
+	}
 }

--- a/src/test/java/reactor/netty/UrlExceptionTest.java
+++ b/src/test/java/reactor/netty/UrlExceptionTest.java
@@ -1,0 +1,37 @@
+package reactor.netty;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UrlExceptionTest {
+
+    @Test
+    public void urlExceptionTest() {
+        try {
+            HttpClient.create()
+                    .doOnError((httpClientRequest, throwable) -> {
+
+                    }, (httpClientResponse, throwable) -> {
+
+                    })
+                    .request(HttpMethod.GET)
+                    .uri(Mono.error(new IllegalArgumentException("URL cannot be resolved")))
+                    .responseSingle((httpClientResponse, byteBufMono) -> {
+                        HttpResponseStatus status = httpClientResponse.status();
+                        if (status.code() != 200) {
+                            return Mono.error(new IllegalStateException(status.toString()));
+                        }
+                        return byteBufMono.asString();
+                    })
+                    .block();
+
+        }catch (IllegalArgumentException e){
+            assertThat(e.getMessage()).isEqualTo("URL cannot be resolved");
+        }
+    }
+}


### PR DESCRIPTION
解决当获取url 是出现异常，无法获取正确的异常  
例如
      httpClient
                .request(HttpMethod.GET)
                .uri(Mono.error(new IllegalArgumentException()))
                .responseSingle((httpClientResponse, byteBufMono) -> {
                    HttpResponseStatus status = httpClientResponse.status();
                    if (status.code() != HttpStatus.OK.value()) {
                        throw new HttpServerErrorException(HttpStatus.valueOf(status.code()));
                    }
                    return byteBufMono.asString();
                });
应该获取
 IllegalArgumentException

结果获取到 NullPointerException