### PR TITLE
fix #1478 Schedule the first channel.read() once the HttpHeaders are sent

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
@@ -197,7 +197,8 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 					throw e;
 				}
 
-				return channel().writeAndFlush(msg);
+				return channel().writeAndFlush(msg)
+				                .addListener(f -> onHeadersSent());
 			}
 			else {
 				return channel().newSucceededFuture();
@@ -208,6 +209,8 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 	protected abstract void beforeMarkSentHeaders();
 
 	protected abstract void afterMarkSentHeaders();
+
+	protected abstract void onHeadersSent();
 
 	protected abstract HttpMessage newFullBodyMessage(ByteBuf body);
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -525,6 +525,14 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 	}
 
 	@Override
+	protected void onHeadersSent() {
+		channel().read();
+		if (channel().parent() != null) {
+			channel().parent().read();
+		}
+	}
+
+	@Override
 	@SuppressWarnings("FutureReturnValueIgnored")
 	protected void onOutboundComplete() {
 		if (isWebsocket() || isInboundCancelled()) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -577,6 +577,11 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 	}
 
 	@Override
+	protected void onHeadersSent() {
+		//noop
+	}
+
+	@Override
 	protected void onOutboundComplete() {
 		if (isWebsocket()) {
 			return;


### PR DESCRIPTION
There are use cases when the target server may want to reject the incoming
request immediately and to close the connection. Instead of scheduling
the first channel.read() when the request body is sent, the first channel.read()
will be scheduled once the HttpHeaders are sent.

Fixes #1478