### PR TITLE
fix #1485 When CloseWebSocketFrame with -1 status code (undefined/empty), emit WebSocketCloseStatus.EMPTY

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
@@ -147,8 +147,14 @@ final class WebsocketClientOperations extends HttpClientOperations
 			if (log.isDebugEnabled()) {
 				log.debug(format(channel(), "CloseWebSocketFrame detected. Closing Websocket"));
 			}
-			sendCloseNow(new CloseWebSocketFrame(true, ((CloseWebSocketFrame) msg).rsv(),
-					((CloseWebSocketFrame) msg).content()));
+			CloseWebSocketFrame closeFrame = new CloseWebSocketFrame(true, ((CloseWebSocketFrame) msg).rsv(),
+					((CloseWebSocketFrame) msg).content());
+			if (closeFrame.statusCode() != -1) {
+				sendCloseNow(closeFrame);
+			}
+			else {
+				sendCloseNow(closeFrame, WebSocketCloseStatus.EMPTY);
+			}
 			onInboundComplete();
 		}
 		else if (msg != LastHttpContent.EMPTY_LAST_CONTENT) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
@@ -146,9 +146,16 @@ final class WebsocketServerOperations extends HttpServerOperations
 			if (log.isDebugEnabled()) {
 				log.debug(format(channel(), "CloseWebSocketFrame detected. Closing Websocket"));
 			}
-			sendCloseNow(new CloseWebSocketFrame(true, ((CloseWebSocketFrame) frame).rsv(),
-					((CloseWebSocketFrame) frame).content()),
-					f -> terminate()); // terminate() will invoke onInboundComplete()
+			CloseWebSocketFrame closeFrame = new CloseWebSocketFrame(true, ((CloseWebSocketFrame) frame).rsv(),
+					((CloseWebSocketFrame) frame).content());
+			if (closeFrame.statusCode() != -1) {
+				// terminate() will invoke onInboundComplete()
+				sendCloseNow(closeFrame, f -> terminate());
+			}
+			else {
+				// terminate() will invoke onInboundComplete()
+				sendCloseNow(closeFrame, WebSocketCloseStatus.EMPTY, f -> terminate());
+			}
 			return;
 		}
 		if (!this.proxyPing && frame instanceof PingWebSocketFrame) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1247,7 +1247,7 @@ class HttpServerTests extends BaseHttpTest {
 				.isEqualTo(WebSocketCloseStatus.ABNORMAL_CLOSURE);
 
 		assertThat(statusServer.get()).isNotNull()
-				.isEqualTo(new WebSocketCloseStatus(-1, ""));
+				.isEqualTo(WebSocketCloseStatus.EMPTY);
 	}
 
 	@Test
@@ -1295,7 +1295,7 @@ class HttpServerTests extends BaseHttpTest {
 				.isEqualTo(WebSocketCloseStatus.ABNORMAL_CLOSURE);
 
 		assertThat(statusServer.get()).isNotNull()
-				.isEqualTo(new WebSocketCloseStatus(-1, ""));
+				.isEqualTo(WebSocketCloseStatus.EMPTY);
 	}
 
 	@Test
@@ -1336,7 +1336,7 @@ class HttpServerTests extends BaseHttpTest {
 
 		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(statusClient.get()).isNotNull()
-				.isEqualTo(new WebSocketCloseStatus(-1, ""));
+				.isEqualTo(WebSocketCloseStatus.EMPTY);
 
 		assertThat(statusServer.get()).isNotNull()
 				.isEqualTo(WebSocketCloseStatus.ABNORMAL_CLOSURE);
@@ -1383,7 +1383,7 @@ class HttpServerTests extends BaseHttpTest {
 
 		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(statusClient.get()).isNotNull()
-				.isEqualTo(new WebSocketCloseStatus(-1, ""));
+				.isEqualTo(WebSocketCloseStatus.EMPTY);
 
 		assertThat(statusServer.get()).isNotNull()
 				.isEqualTo(WebSocketCloseStatus.ABNORMAL_CLOSURE);


### PR DESCRIPTION
According to the specification the endpoint may echo the received Close frame,
and Reactor Netty echos the received Close frame:

https://tools.ietf.org/html/rfc6455#section-5.5.1
```
If an endpoint receives a Close frame and did not previously send a
Close frame, the endpoint MUST send a Close frame in response.  (When
sending a Close frame in response, the endpoint typically echos the
status code it received.)
```

However for the emitted Close status (the one that is used by the application),
if a status code is not defined or empty, the Close status should be considered 1005,
so Reactor Netty will emit 1005 instead of -1 with `WebsocketInbound#receiveCloseStatus`.

https://tools.ietf.org/html/rfc6455#section-7.1.5
```
If this Close control frame contains no status code, _The WebSocket
Connection Close Code_ is considered to be 1005.
```

Fixes #1485 