### PR TITLE
Ensure endStream=true when responding with 500 ISE when server in HTTP/2 mode

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -686,10 +686,8 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 			log.error(format(channel(), "Error starting response. Replying error status"), err);
 
 			nettyResponse.setStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-			responseHeaders.remove(HttpHeaderNames.TRANSFER_ENCODING)
-			               .setInt(HttpHeaderNames.CONTENT_LENGTH, 0)
-			               .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
-			channel().writeAndFlush(outboundHttpMessage())
+			responseHeaders.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+			channel().writeAndFlush(newFullBodyMessage(EMPTY_BUFFER))
 			         .addListener(ChannelFutureListener.CLOSE);
 			return;
 		}


### PR DESCRIPTION
Reactor Netty always works with HTTP/1.1 abstraction. In order to be able to handle HTTP/2 traffic, special handlers are added to the pipeline, which convert from HTTP/2 <-> HTTP/1.1 when reading and writing. So when Reactor Netty returns `FullHttpResponse` this means that `endStream=true` will be added.