### PR TITLE
Do not load HttpClientSecure when the protocol is H2C

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1271,7 +1271,8 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		HttpClientConfig config = dup.configuration();
 		config.protocols(supportedProtocols);
 
-		if (HttpClientSecure.hasDefaultSslProvider(config)) {
+		boolean isH2c = config.checkProtocol(HttpClientConfig.h2c);
+		if ((!isH2c || config._protocols > 1) && HttpClientSecure.hasDefaultSslProvider(config)) {
 			dup.configuration().sslProvider = HttpClientSecure.defaultSslProvider(config);
 		}
 		return dup;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -448,6 +448,10 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		this._protocols = _protocols;
 	}
 
+	boolean checkProtocol(int protocol) {
+		return (_protocols & protocol) == protocol;
+	}
+
 	Http2Settings http2Settings() {
 		Http2Settings settings = Http2Settings.defaultSettings();
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -211,13 +211,13 @@ class HttpClientConnect extends HttpClient {
 				if (handler.toURI.isSecure()) {
 					if (_config.sslProvider == null) {
 						_config = new HttpClientConfig(config);
-						if (checkProtocol(_config, HttpClientConfig.h2c) && _config.protocols.length > 1) {
+						if (_config.checkProtocol(HttpClientConfig.h2c) && _config.protocols.length > 1) {
 							removeIncompatibleProtocol(_config, HttpProtocol.H2C);
 						}
 						_config.sslProvider = HttpClientSecure.defaultSslProvider(_config);
 					}
 
-					if (checkProtocol(_config, HttpClientConfig.h2c)) {
+					if (_config.checkProtocol(HttpClientConfig.h2c)) {
 						sink.error(new IllegalArgumentException(
 								"Configured H2 Clear-Text protocol with TLS. " +
 										"Use the non Clear-Text H2 protocol via HttpClient#protocol or disable TLS " +
@@ -226,7 +226,7 @@ class HttpClientConnect extends HttpClient {
 					}
 
 					if (_config.sslProvider.getDefaultConfigurationType() == null) {
-						if (checkProtocol(_config, HttpClientConfig.h2)) {
+						if (_config.checkProtocol(HttpClientConfig.h2)) {
 							_config.sslProvider = SslProvider.updateDefaultConfiguration(_config.sslProvider,
 									SslProvider.DefaultConfigurationType.H2);
 						}
@@ -239,13 +239,13 @@ class HttpClientConnect extends HttpClient {
 				else {
 					if (_config.sslProvider != null) {
 						_config = new HttpClientConfig(config);
-						if (checkProtocol(_config, HttpClientConfig.h2) && _config.protocols.length > 1) {
+						if (_config.checkProtocol(HttpClientConfig.h2) && _config.protocols.length > 1) {
 							removeIncompatibleProtocol(_config, HttpProtocol.H2);
 						}
 						_config.sslProvider = null;
 					}
 
-					if (checkProtocol(_config, HttpClientConfig.h2)) {
+					if (_config.checkProtocol(HttpClientConfig.h2)) {
 						sink.error(new IllegalArgumentException(
 								"Configured H2 protocol without TLS. Use H2 Clear-Text " +
 										"protocol via HttpClient#protocol or configure TLS via HttpClient#secure"));
@@ -277,10 +277,6 @@ class HttpClientConnect extends HttpClient {
 				}
 			}
 			config.protocols(newProtocols.toArray(new HttpProtocol[0]));
-		}
-
-		private boolean checkProtocol(HttpClientConfig config, int protocol) {
-			return (config._protocols & protocol) == protocol;
 		}
 
 		static final class ClientTransportSubscriber implements CoreSubscriber<Connection> {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSecure.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSecure.java
@@ -39,7 +39,7 @@ final class HttpClientSecure {
 	}
 
 	static SslProvider defaultSslProvider(HttpClientConfig config) {
-		if ((config._protocols & HttpClientConfig.h2) == HttpClientConfig.h2) {
+		if (config.checkProtocol(HttpClientConfig.h2)) {
 			return DEFAULT_HTTP2_SSL_PROVIDER;
 		}
 		else {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -97,6 +97,7 @@ import reactor.netty.Connection;
 import reactor.netty.FutureMono;
 import reactor.netty.NettyPipeline;
 import reactor.netty.SocketUtils;
+import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.server.HttpServer;
 import reactor.netty.resources.ConnectionPoolMetrics;
 import reactor.netty.resources.ConnectionProvider;
@@ -2588,5 +2589,57 @@ class HttpClientTest extends BaseHttpTest {
 		          .expectNext(400)
 		          .expectComplete()
 		          .verify(Duration.ofSeconds(5));
+	}
+
+	@Test
+	void testConfigurationSecurityThenProtocols_DefaultHTTP11SslProvider() {
+		HttpClient client = HttpClient.create().secure();
+
+		doTestProtocolsAndDefaultSslProviderAvailability(client.protocol(HttpProtocol.HTTP11),
+				HttpClientSecure.DEFAULT_HTTP_SSL_PROVIDER);
+
+		doTestProtocolsAndDefaultSslProviderAvailability(client.protocol(HttpProtocol.HTTP11, HttpProtocol.H2C),
+				HttpClientSecure.DEFAULT_HTTP_SSL_PROVIDER);
+	}
+
+	@Test
+	void testConfigurationSecurityThenProtocols_DefaultH2SslProvider() {
+		HttpClient client = HttpClient.create().secure();
+
+		doTestProtocolsAndDefaultSslProviderAvailability(client.protocol(HttpProtocol.HTTP11, HttpProtocol.H2),
+				HttpClientSecure.DEFAULT_HTTP2_SSL_PROVIDER);
+
+		doTestProtocolsAndDefaultSslProviderAvailability(client.protocol(HttpProtocol.HTTP11, HttpProtocol.H2, HttpProtocol.H2C),
+				HttpClientSecure.DEFAULT_HTTP2_SSL_PROVIDER);
+
+		doTestProtocolsAndDefaultSslProviderAvailability(client.protocol(HttpProtocol.H2),
+				HttpClientSecure.DEFAULT_HTTP2_SSL_PROVIDER);
+
+		doTestProtocolsAndDefaultSslProviderAvailability(client.protocol(HttpProtocol.H2, HttpProtocol.H2C),
+				HttpClientSecure.DEFAULT_HTTP2_SSL_PROVIDER);
+	}
+
+	@Test
+	void testConfigurationOnlyProtocols_NoDefaultSslProvider() {
+		HttpClient client = HttpClient.create();
+
+		doTestProtocolsAndDefaultSslProviderAvailability(client.protocol(HttpProtocol.HTTP11), null);
+
+		doTestProtocolsAndDefaultSslProviderAvailability(client.protocol(HttpProtocol.HTTP11, HttpProtocol.H2C), null);
+
+		doTestProtocolsAndDefaultSslProviderAvailability(client.protocol(HttpProtocol.HTTP11, HttpProtocol.H2), null);
+
+		doTestProtocolsAndDefaultSslProviderAvailability(
+				client.protocol(HttpProtocol.HTTP11, HttpProtocol.H2, HttpProtocol.H2C), null);
+
+		doTestProtocolsAndDefaultSslProviderAvailability(client.protocol(HttpProtocol.H2), null);
+
+		doTestProtocolsAndDefaultSslProviderAvailability(client.protocol(HttpProtocol.H2, HttpProtocol.H2C), null);
+
+		doTestProtocolsAndDefaultSslProviderAvailability(client.protocol(HttpProtocol.H2C), null);
+	}
+
+	private void doTestProtocolsAndDefaultSslProviderAvailability(HttpClient client, @Nullable SslProvider sslProvider) {
+		assertThat(client.configuration().sslProvider()).isSameAs(sslProvider);
 	}
 }


### PR DESCRIPTION
Loading `HttpClientSecure` will trigger initialisation of the default `SslProvider`,
which in case of `H2C` is not necessary.