### PR TITLE
fix #1471 Test existence of an AttributeKey before creation

### DIFF
--- a/src/main/java/reactor/netty/ReactorNetty.java
+++ b/src/main/java/reactor/netty/ReactorNetty.java
@@ -837,9 +837,9 @@ public final class ReactorNetty {
 	static final ConnectionObserver NOOP_LISTENER = (connection, newState) -> {};
 
 	static final Logger log                               = Loggers.getLogger(ReactorNetty.class);
-	static final AttributeKey<Boolean> PERSISTENT_CHANNEL = AttributeKey.newInstance("$PERSISTENT_CHANNEL");
+	static final AttributeKey<Boolean> PERSISTENT_CHANNEL = AttributeKey.valueOf("$PERSISTENT_CHANNEL");
 
-	static final AttributeKey<Connection> CONNECTION = AttributeKey.newInstance("$CONNECTION");
+	static final AttributeKey<Connection> CONNECTION = AttributeKey.valueOf("$CONNECTION");
 
 	static final Consumer<? super FileChannel> fileCloser = fc -> {
 		try {


### PR DESCRIPTION
When ReactorNetty is used in a multi-classloaders context, PERSISTENT_CHANNEL and CONNECTION attributeKey instantitation may throw an IllegalArgumentException. This fix test the existence of the AttributeKeys before creating them.