### PR TITLE
Ensure an error is propagated in case the client drops the connection

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -71,6 +71,7 @@ import reactor.netty.ConnectionObserver;
 import reactor.netty.FutureMono;
 import reactor.netty.NettyOutbound;
 import reactor.netty.NettyPipeline;
+import reactor.netty.channel.AbortedException;
 import reactor.netty.channel.ChannelOperations;
 import reactor.netty.http.Cookies;
 import reactor.netty.http.HttpOperations;
@@ -558,6 +559,15 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		else {
 			super.onInboundNext(ctx, msg);
 		}
+	}
+
+	@Override
+	protected void onInboundClose() {
+		discardWhenNoReceiver();
+		if (!(isInboundCancelled() || isInboundDisposed())) {
+			onInboundError(new AbortedException("Connection has been closed"));
+		}
+		terminate();
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #1512 

When the server is in `H2` mode, every channel created per stream is always closed.
With this change the terminate functionality is moved as a listener following
`LastHttpContent` instead of waiting for `channelInactive` event.
