### PR TITLE
Add more debug info for inbound double subscription use case

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/FluxReceive.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/FluxReceive.java
@@ -177,6 +177,9 @@ final class FluxReceive extends Flux<Object> implements Subscription, Disposable
 				Operators.complete(s);
 			}
 			else {
+				if (log.isDebugEnabled()) {
+					log.debug(format(channel, "{}: Only one connection receive subscriber allowed."), this);
+				}
 				Operators.error(s,
 						new IllegalStateException(
 								"Only one connection receive subscriber allowed."));


### PR DESCRIPTION
I addition to the error propagation add also a debug info with channel info
so that the logs can be correlated.