### PR TITLE
Ensure client transports use one and the same name resolver when no custom configuration

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConfig.java
@@ -18,6 +18,7 @@ package reactor.netty.tcp;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.logging.LoggingHandler;
+import io.netty.resolver.AddressResolverGroup;
 import reactor.netty.ChannelPipelineConfigurer;
 import reactor.netty.ConnectionObserver;
 import reactor.netty.ReactorNetty;
@@ -86,6 +87,11 @@ public final class TcpClientConfig extends ClientTransportConfig<TcpClientConfig
 	TcpClientConfig(TcpClientConfig parent) {
 		super(parent);
 		this.sslProvider = parent.sslProvider;
+	}
+
+	@Override
+	protected AddressResolverGroup<?> defaultAddressResolverGroup() {
+		return TcpResources.get().getOrCreateDefaultResolver();
 	}
 
 	@Override

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConfig.java
@@ -89,6 +89,13 @@ public final class TcpClientConfig extends ClientTransportConfig<TcpClientConfig
 		this.sslProvider = parent.sslProvider;
 	}
 
+	/**
+	 * Provides a global {@link AddressResolverGroup} from {@link TcpResources}
+	 * that is shared amongst all TCP clients. {@link AddressResolverGroup} uses the global
+	 * {@link LoopResources} from {@link TcpResources}.
+	 *
+	 * @return the global {@link AddressResolverGroup}
+	 */
 	@Override
 	protected AddressResolverGroup<?> defaultAddressResolverGroup() {
 		return TcpResources.get().getOrCreateDefaultResolver();

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpResources.java
@@ -31,6 +31,7 @@ import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
 import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.resources.LoopResources;
+import reactor.netty.transport.NameResolverProvider;
 import reactor.netty.transport.TransportConfig;
 import reactor.util.Logger;
 import reactor.util.Loggers;
@@ -141,12 +142,14 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 		return getOrCreate(tcpResources, loops, null, ON_TCP_NEW, "tcp");
 	}
 
-	final ConnectionProvider defaultProvider;
-	final LoopResources      defaultLoops;
+	final LoopResources                            defaultLoops;
+	final ConnectionProvider                       defaultProvider;
+	final AtomicReference<AddressResolverGroup<?>> defaultResolver;
 
 	protected TcpResources(LoopResources defaultLoops, ConnectionProvider defaultProvider) {
 		this.defaultLoops = defaultLoops;
 		this.defaultProvider = defaultProvider;
+		this.defaultResolver = new AtomicReference<>();
 	}
 
 	@Override
@@ -266,6 +269,7 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 	 */
 	protected void _dispose() {
 		defaultProvider.dispose();
+		_disposeResolver();
 		defaultLoops.dispose();
 	}
 
@@ -281,7 +285,37 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 	 * @return the Mono that represents the end of disposal
 	 */
 	protected Mono<Void> _disposeLater(Duration quietPeriod, Duration timeout) {
-		return Mono.when(defaultLoops.disposeLater(quietPeriod, timeout), defaultProvider.disposeLater());
+		return Mono.when(
+				_disposeResolverLater(),
+				defaultLoops.disposeLater(quietPeriod, timeout),
+				defaultProvider.disposeLater());
+	}
+
+	protected AddressResolverGroup<?> getOrCreateDefaultResolver() {
+		AddressResolverGroup<?> resolverGroup = defaultResolver.get();
+		if (resolverGroup == null) {
+			AddressResolverGroup<?> newResolverGroup =
+					DEFAULT_NAME_RESOLVER_PROVIDER.newNameResolverGroup(defaultLoops, LoopResources.DEFAULT_NATIVE);
+			defaultResolver.compareAndSet(null, newResolverGroup);
+			resolverGroup = getOrCreateDefaultResolver();
+		}
+		return resolverGroup;
+	}
+
+	void _disposeResolver() {
+		AddressResolverGroup<?> addressResolverGroup = defaultResolver.get();
+		if (addressResolverGroup != null) {
+			addressResolverGroup.close();
+		}
+	}
+
+	Mono<Void> _disposeResolverLater() {
+		Mono<Void> disposeResolver = Mono.empty();
+		AddressResolverGroup<?> addressResolverGroup = defaultResolver.get();
+		if (addressResolverGroup != null) {
+			disposeResolver = Mono.fromRunnable(addressResolverGroup::close);
+		}
+		return disposeResolver;
 	}
 
 	/**
@@ -313,6 +347,7 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 								log.warn("[{}] resources will use a new LoopResources: {}, " +
 										"the previous LoopResources will be disposed", name, loops);
 							}
+							resources._disposeResolver();
 							resources.defaultLoops.dispose();
 						}
 						if (provider != null) {
@@ -360,6 +395,8 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 		return onNew.apply(loops, provider);
 	}
 
+	static final NameResolverProvider                                        DEFAULT_NAME_RESOLVER_PROVIDER;
+
 	static final Logger                                                      log = Loggers.getLogger(TcpResources.class);
 
 	static final BiFunction<LoopResources, ConnectionProvider, TcpResources> ON_TCP_NEW;
@@ -367,6 +404,7 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 	static final AtomicReference<TcpResources>                               tcpResources;
 
 	static {
+		DEFAULT_NAME_RESOLVER_PROVIDER = NameResolverProvider.builder().build();
 		ON_TCP_NEW = TcpResources::new;
 		tcpResources = new AtomicReference<>();
 	}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
@@ -307,6 +307,10 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 		if (conf.nameResolverProvider != null) {
 			conf.resolver = conf.nameResolverProvider.newNameResolverGroup(conf.loopResources(), conf.preferNative);
 		}
+		else {
+			conf.resolver = ClientTransportConfig.DEFAULT_NAME_RESOLVER_PROVIDER
+					.newNameResolverGroup(conf.loopResources(), conf.preferNative);
+		}
 		return dup;
 	}
 

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
@@ -18,7 +18,6 @@ package reactor.netty.transport;
 import java.net.SocketAddress;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -154,14 +153,12 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 	ProxyProvider                            proxyProvider;
 	Supplier<? extends SocketAddress>        remoteAddress;
 	AddressResolverGroup<?>                  resolver;
-	final AtomicReference<AddressResolverGroup<?>> defaultResolver;
 
 	protected ClientTransportConfig(ConnectionProvider connectionProvider, Map<ChannelOption<?>, ?> options,
 			Supplier<? extends SocketAddress> remoteAddress) {
 		super(options);
 		this.connectionProvider = Objects.requireNonNull(connectionProvider, "connectionProvider");
 		this.remoteAddress = Objects.requireNonNull(remoteAddress, "remoteAddress");
-		this.defaultResolver = new AtomicReference<>();
 	}
 
 	protected ClientTransportConfig(ClientTransportConfig<CONF> parent) {
@@ -177,13 +174,14 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 		this.proxyProvider = parent.proxyProvider;
 		this.remoteAddress = parent.remoteAddress;
 		this.resolver = parent.resolver;
-		this.defaultResolver = parent.defaultResolver;
 	}
 
 	@Override
 	protected Class<? extends Channel> channelType(boolean isDomainSocket) {
 		return isDomainSocket ? DomainSocketChannel.class : SocketChannel.class;
 	}
+
+	protected abstract AddressResolverGroup<?> defaultAddressResolverGroup();
 
 	@Override
 	protected ConnectionObserver defaultConnectionObserver() {
@@ -213,7 +211,7 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 	}
 
 	protected AddressResolverGroup<?> resolverInternal() {
-		AddressResolverGroup<?> resolverGroup = resolver != null ? resolver : getOrCreateDefaultResolver();
+		AddressResolverGroup<?> resolverGroup = resolver != null ? resolver : defaultAddressResolverGroup();
 		if (metricsRecorder != null) {
 			return new AddressResolverGroupMetrics<>(resolverGroup,
 					Objects.requireNonNull(metricsRecorder.get(), "Metrics recorder supplier returned null"));
@@ -221,17 +219,6 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 		else {
 			return resolverGroup;
 		}
-	}
-
-	AddressResolverGroup<?> getOrCreateDefaultResolver() {
-		AddressResolverGroup<?> resolverGroup = defaultResolver.get();
-		if (resolverGroup == null) {
-			AddressResolverGroup<?> newResolverGroup =
-					DEFAULT_NAME_RESOLVER_PROVIDER.newNameResolverGroup(loopResources(), preferNative);
-			defaultResolver.compareAndSet(null, newResolverGroup);
-			resolverGroup = getOrCreateDefaultResolver();
-		}
-		return resolverGroup;
 	}
 
 	static final NameResolverProvider DEFAULT_NAME_RESOLVER_PROVIDER = NameResolverProvider.builder().build();

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
@@ -181,6 +181,11 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 		return isDomainSocket ? DomainSocketChannel.class : SocketChannel.class;
 	}
 
+	/**
+	 * Provides a global {@link AddressResolverGroup} that is shared amongst all clients.
+	 *
+	 * @return the global {@link AddressResolverGroup}
+	 */
 	protected abstract AddressResolverGroup<?> defaultAddressResolverGroup();
 
 	@Override

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConfig.java
@@ -95,6 +95,13 @@ public final class UdpClientConfig extends ClientTransportConfig<UdpClientConfig
 		}
 	}
 
+	/**
+	 * Provides a global {@link AddressResolverGroup} from {@link UdpResources}
+	 * that is shared amongst all UDP clients. {@link AddressResolverGroup} uses the global
+	 * {@link LoopResources} from {@link UdpResources}.
+	 *
+	 * @return the global {@link AddressResolverGroup}
+	 */
 	@Override
 	protected AddressResolverGroup<?> defaultAddressResolverGroup() {
 		return UdpResources.get().getOrCreateDefaultResolver();

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConfig.java
@@ -23,6 +23,7 @@ import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.logging.LoggingHandler;
+import io.netty.resolver.AddressResolverGroup;
 import reactor.netty.channel.ChannelMetricsRecorder;
 import reactor.netty.channel.ChannelOperations;
 import reactor.netty.channel.MicrometerChannelMetricsRecorder;
@@ -92,6 +93,11 @@ public final class UdpClientConfig extends ClientTransportConfig<UdpClientConfig
 		else {
 			return () -> new NioDatagramChannel(family());
 		}
+	}
+
+	@Override
+	protected AddressResolverGroup<?> defaultAddressResolverGroup() {
+		return UdpResources.get().getOrCreateDefaultResolver();
 	}
 
 	@Override

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpResources.java
@@ -228,12 +228,22 @@ public class UdpResources implements LoopResources {
 		return Mono.when(_disposeResolverLater(), defaultLoops.disposeLater(quietPeriod, timeout));
 	}
 
+	/**
+	 * Safely checks whether a name resolver exists and proceed with a creation if it does not exist.
+	 * The name resolver uses as an event loop group the {@link LoopResources} that are configured.
+	 * Guarantees that always one and the same instance is returned for a given {@link LoopResources}
+	 * and if the {@link LoopResources} is updated the name resolver is also updated.
+	 *
+	 * @return an existing or new {@link AddressResolverGroup}
+	 */
 	AddressResolverGroup<?> getOrCreateDefaultResolver() {
 		AddressResolverGroup<?> resolverGroup = defaultResolver.get();
 		if (resolverGroup == null) {
 			AddressResolverGroup<?> newResolverGroup =
 					DEFAULT_NAME_RESOLVER_PROVIDER.newNameResolverGroup(defaultLoops, LoopResources.DEFAULT_NATIVE);
-			defaultResolver.compareAndSet(null, newResolverGroup);
+			if (!defaultResolver.compareAndSet(null, newResolverGroup)) {
+				newResolverGroup.close();
+			}
 			resolverGroup = getOrCreateDefaultResolver();
 		}
 		return resolverGroup;

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
@@ -40,6 +40,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.DefaultAddressResolverGroup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
@@ -418,6 +419,11 @@ class DefaultPooledConnectionProviderTest {
 		@Override
 		protected ChannelMetricsRecorder defaultMetricsRecorder() {
 			return null;
+		}
+
+		@Override
+		protected AddressResolverGroup<?> defaultAddressResolverGroup() {
+			return DefaultAddressResolverGroup.INSTANCE;
 		}
 
 		@Override

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/PooledConnectionProviderCustomMetricsTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/PooledConnectionProviderCustomMetricsTest.java
@@ -29,6 +29,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.DefaultAddressResolverGroup;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -121,6 +122,11 @@ class PooledConnectionProviderCustomMetricsTest {
 		@Override
 		protected ChannelMetricsRecorder defaultMetricsRecorder() {
 			return null;
+		}
+
+		@Override
+		protected AddressResolverGroup<?> defaultAddressResolverGroup() {
+			return DefaultAddressResolverGroup.INSTANCE;
 		}
 
 		@Override

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/BlockingConnectionTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/BlockingConnectionTest.java
@@ -25,6 +25,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.logging.LoggingHandler;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.DefaultAddressResolverGroup;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -257,6 +259,11 @@ class BlockingConnectionTest {
 		@Override
 		protected ChannelMetricsRecorder defaultMetricsRecorder() {
 			return null;
+		}
+
+		@Override
+		protected AddressResolverGroup<?> defaultAddressResolverGroup() {
+			return DefaultAddressResolverGroup.INSTANCE;
 		}
 
 		@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpResources.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpResources.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
+import io.netty.resolver.AddressResolverGroup;
 import reactor.core.publisher.Mono;
 import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.resources.LoopResources;
@@ -132,6 +133,11 @@ public final class HttpResources extends TcpResources {
 
 	HttpResources(LoopResources loops, ConnectionProvider provider) {
 		super(loops, provider);
+	}
+
+	@Override
+	public AddressResolverGroup<?> getOrCreateDefaultResolver() {
+		return super.getOrCreateDefaultResolver();
 	}
 
 	static final BiFunction<LoopResources, ConnectionProvider, HttpResources> ON_HTTP_NEW;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -366,6 +366,13 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		this.websocketClientSpec = parent.websocketClientSpec;
 	}
 
+	/**
+	 * Provides a global {@link AddressResolverGroup} from {@link HttpResources}
+	 * that is shared amongst all HTTP clients. {@link AddressResolverGroup} uses the global
+	 * {@link LoopResources} from {@link HttpResources}.
+	 *
+	 * @return the global {@link AddressResolverGroup}
+	 */
 	@Override
 	public AddressResolverGroup<?> defaultAddressResolverGroup() {
 		return HttpResources.get().getOrCreateDefaultResolver();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -367,6 +367,11 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 	}
 
 	@Override
+	public AddressResolverGroup<?> defaultAddressResolverGroup() {
+		return HttpResources.get().getOrCreateDefaultResolver();
+	}
+
+	@Override
 	protected ConnectionObserver defaultConnectionObserver() {
 		if (doAfterRequest == null && doAfterResponseSuccess == null && doOnRedirect == null &&
 					doOnRequest == null && doOnRequestError == null && doOnResponse == null && doOnResponseError == null) {


### PR DESCRIPTION
When there isn't a custom name resolver and the global LoopResources
are in use then all client transports will share one and the same name resolver.

Fixes #1515