### PR TITLE
Ensure "aggregateJavadoc" task configuration is the same as the "javadoc" task configuration

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -17,7 +17,7 @@ if (project.name == 'reactor-netty-examples') {
 	return
 }
 
-javadoc {
+project.tasks.withType(Javadoc) {
 	dependsOn jar
 	group = "Reactor Netty Javadoc"
 


### PR DESCRIPTION
Since 1.0.0, the javadoc produced doesn't follow the same styling as reactor-core and 0.9.x javadocs due to the way the aggregation of individual modules javadocs is configured.
Notably, the CSS is different and links to javadocs of external classes (like JDK classes or `Flux`/`Mono`) don't appear.
This change fixes that.