### PR TITLE
Expose an API for applying the SslContext's default configuration prior any other configuration

### DIFF
--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -651,7 +651,7 @@ To customize the default settings, you can configure `HttpClient` as follows:
 [source,java,indent=0]
 .{examplesdir}/security/custom/Application.java
 ----
-include::{examplesdir}/security/custom/Application.java[lines=18..47]
+include::{examplesdir}/security/custom/Application.java[lines=18..45]
 ----
 <1> Configures the SSL handshake timeout to 30 seconds.
 <2> Configures the SSL `close_notify` flush timeout to 10 seconds.

--- a/docs/asciidoc/tcp-server.adoc
+++ b/docs/asciidoc/tcp-server.adoc
@@ -241,7 +241,7 @@ The following example uses `SslContextBuilder`:
 [source,java,indent=0]
 .{examplesdir}/security/Application.java
 ----
-include::{examplesdir}/security/Application.java[lines=18..39]
+include::{examplesdir}/security/Application.java[lines=18..40]
 ----
 ====
 

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/AbstractProtocolSslContextSpec.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/AbstractProtocolSslContextSpec.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.tcp;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+
+import javax.net.ssl.SSLException;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * SslContext builder that provides, specific for protocol, default configuration.
+ *
+ * @author Violeta Georgieva
+ * @since 1.0.6
+ */
+public abstract class AbstractProtocolSslContextSpec<T extends AbstractProtocolSslContextSpec<T>>
+		implements SslProvider.ProtocolSslContextSpec, Supplier<T> {
+
+	final SslContextBuilder sslContextBuilder;
+
+	protected AbstractProtocolSslContextSpec(SslContextBuilder sslContextBuilder) {
+		this.sslContextBuilder = sslContextBuilder;
+		configure(defaultConfiguration());
+	}
+
+	protected abstract Consumer<SslContextBuilder> defaultConfiguration();
+
+	@Override
+	public T configure(Consumer<SslContextBuilder> sslCtxBuilder) {
+		Objects.requireNonNull(sslCtxBuilder, "sslCtxBuilder");
+		sslCtxBuilder.accept(sslContextBuilder);
+		return get();
+	}
+
+	@Override
+	public SslContext sslContext() throws SSLException {
+		return sslContextBuilder.build();
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/DefaultSslContextSpec.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/DefaultSslContextSpec.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.tcp;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import java.io.File;
+import java.io.InputStream;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.function.Consumer;
+
+/**
+ * SslContext builder that does not provide any default configuration.
+ *
+ * @author Violeta Georgieva
+ * @since 1.0.6
+ */
+public final class DefaultSslContextSpec extends AbstractProtocolSslContextSpec<DefaultSslContextSpec> {
+
+	/**
+	 * Creates a builder for new client-side {@link SslContext}.
+	 *
+	 * @return {@literal this}
+	 */
+	public static DefaultSslContextSpec forClient() {
+		return new DefaultSslContextSpec(SslContextBuilder.forClient());
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(File, File)
+	 */
+	public static DefaultSslContextSpec forServer(File keyCertChainFile, File keyFile) {
+		return new DefaultSslContextSpec(SslContextBuilder.forServer(keyCertChainFile, keyFile));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(File, File, String)
+	 */
+	public static DefaultSslContextSpec forServer(File keyCertChainFile, File keyFile, String keyPassword) {
+		return new DefaultSslContextSpec(SslContextBuilder.forServer(keyCertChainFile, keyFile, keyPassword));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(InputStream, InputStream)
+	 */
+	public static DefaultSslContextSpec forServer(InputStream keyCertChainInputStream, InputStream keyInputStream) {
+		return new DefaultSslContextSpec(SslContextBuilder.forServer(keyCertChainInputStream, keyInputStream));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(InputStream, InputStream, String)
+	 */
+	public static DefaultSslContextSpec forServer(
+			InputStream keyCertChainInputStream, InputStream keyInputStream, String keyPassword) {
+		return new DefaultSslContextSpec(SslContextBuilder.forServer(keyCertChainInputStream, keyInputStream, keyPassword));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(KeyManager)
+	 */
+	public static DefaultSslContextSpec forServer(KeyManager keyManager) {
+		return new DefaultSslContextSpec(SslContextBuilder.forServer(keyManager));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(KeyManagerFactory)
+	 */
+	public static DefaultSslContextSpec forServer(KeyManagerFactory keyManagerFactory) {
+		return new DefaultSslContextSpec(SslContextBuilder.forServer(keyManagerFactory));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, Iterable)
+	 */
+	public static DefaultSslContextSpec forServer(PrivateKey key, Iterable<? extends X509Certificate> keyCertChain) {
+		return new DefaultSslContextSpec(SslContextBuilder.forServer(key, keyCertChain));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, String, Iterable)
+	 */
+	public static DefaultSslContextSpec forServer(
+			PrivateKey key, String keyPassword, Iterable<? extends X509Certificate> keyCertChain) {
+		return new DefaultSslContextSpec(SslContextBuilder.forServer(key, keyPassword, keyCertChain));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, String, X509Certificate...)
+	 */
+	public static DefaultSslContextSpec forServer(PrivateKey key, String keyPassword, X509Certificate... keyCertChain) {
+		return new DefaultSslContextSpec(SslContextBuilder.forServer(key, keyPassword, keyCertChain));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, X509Certificate...)
+	 */
+	public static DefaultSslContextSpec forServer(PrivateKey key, X509Certificate... keyCertChain) {
+		return new DefaultSslContextSpec(SslContextBuilder.forServer(key, keyCertChain));
+	}
+
+	DefaultSslContextSpec(SslContextBuilder sslContextBuilder) {
+		super(sslContextBuilder);
+	}
+
+	@Override
+	public DefaultSslContextSpec get() {
+		return this;
+	}
+
+	@Override
+	protected Consumer<SslContextBuilder> defaultConfiguration() {
+		return DEFAULT_CONFIGURATOR;
+	}
+
+	static final Consumer<SslContextBuilder> DEFAULT_CONFIGURATOR = sslCtxBuilder -> {};
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -224,6 +224,17 @@ public final class SslProvider {
 	public interface SslContextSpec {
 
 		/**
+		 * SslContext builder that provides, specific for the protocol, default configuration
+		 * e.g. {@link DefaultSslContextSpec}, {@link TcpSslContextSpec} etc.
+		 * As opposed to {@link #sslContext(SslContextBuilder)}, the default configuration is applied before
+		 * any other custom configuration.
+		 *
+		 * @param spec SslContext builder that provides, specific for the protocol, default configuration
+		 * @return a new {@link SslContext}
+		 */
+		Builder sslContext(ProtocolSslContextSpec spec);
+
+		/**
 		 * The SslContext to set when configuring SSL
 		 *
 		 * @param sslContext The context to set when configuring SSL
@@ -233,12 +244,16 @@ public final class SslProvider {
 		Builder sslContext(SslContext sslContext);
 
 		/**
-		 * The SslContextBuilder for building a new {@link SslContext}.
+		 * The SslContextBuilder for building a new {@link SslContext}. The default configuration is applied after
+		 * the custom configuration.
 		 *
 		 * @return {@literal this}
+		 * @deprecated as of 1.0.6. Prefer {@link #sslContext(ProtocolSslContextSpec)}, where the default
+		 * configuration is applied before any other custom configuration.
+		 * This method will be removed in version 1.2.0.
 		 */
+		@Deprecated
 		DefaultConfigurationSpec sslContext(SslContextBuilder sslCtxBuilder);
-
 	}
 
 	/**
@@ -277,6 +292,31 @@ public final class SslProvider {
 		Builder defaultConfiguration(DefaultConfigurationType type);
 	}
 
+	/**
+	 * SslContext builder that provides, specific for the protocol, default configuration.
+	 * The default configuration is applied prior any other custom configuration.
+	 *
+	 * @since 1.0.6
+	 */
+	public interface ProtocolSslContextSpec {
+
+		/**
+		 * Configures the underlying {@link SslContextBuilder}.
+		 *
+		 * @param sslCtxBuilder a callback for configuring the underlying {@link SslContextBuilder}
+		 * @return {@code this}
+		 */
+		ProtocolSslContextSpec configure(Consumer<SslContextBuilder> sslCtxBuilder);
+
+		/**
+		 * Create a new {@link SslContext} instance with the configured settings.
+		 *
+		 * @return a new {@link SslContext} instance
+		 * @throws SSLException thrown when {@link SslContext} instance cannot be created
+		 */
+		SslContext sslContext() throws SSLException;
+	}
+
 	final SslContext                   sslContext;
 	final SslContextBuilder            sslContextBuilder;
 	final DefaultConfigurationType     type;
@@ -297,6 +337,14 @@ public final class SslProvider {
 				}
 				try {
 					this.sslContext = sslContextBuilder.build();
+				}
+				catch (SSLException e) {
+					throw Exceptions.propagate(e);
+				}
+			}
+			else if (builder.protocolSslContextSpec != null) {
+				try {
+					this.sslContext = builder.protocolSslContextSpec.sslContext();
 				}
 				catch (SSLException e) {
 					throw Exceptions.propagate(e);
@@ -547,6 +595,7 @@ public final class SslProvider {
 						"10000"));
 
 		SslContextBuilder sslCtxBuilder;
+		ProtocolSslContextSpec protocolSslContextSpec;
 		DefaultConfigurationType type;
 		SslContext sslContext;
 		Consumer<? super SslHandler> handlerConfigurator;
@@ -559,8 +608,16 @@ public final class SslProvider {
 		// SslContextSpec
 
 		@Override
+		public Builder sslContext(ProtocolSslContextSpec protocolSslContextSpec) {
+			this.protocolSslContextSpec = protocolSslContextSpec;
+			this.type = DefaultConfigurationType.NONE;
+			return this;
+		}
+
+		@Override
 		public final Builder sslContext(SslContext sslContext) {
 			this.sslContext = Objects.requireNonNull(sslContext, "sslContext");
+			this.type = DefaultConfigurationType.NONE;
 			return this;
 		}
 
@@ -685,14 +742,15 @@ public final class SslProvider {
 					Objects.equals(sslContext, build.sslContext) &&
 					Objects.equals(handlerConfigurator, build.handlerConfigurator) &&
 					Objects.equals(serverNames, build.serverNames) &&
-					confPerDomainName.equals(build.confPerDomainName);
+					confPerDomainName.equals(build.confPerDomainName) &&
+					Objects.equals(protocolSslContextSpec, build.protocolSslContextSpec);
 		}
 
 		@Override
 		public int hashCode() {
 			return Objects.hash(sslCtxBuilder, type, sslContext, handlerConfigurator,
 					handshakeTimeoutMillis, closeNotifyFlushTimeoutMillis, closeNotifyReadTimeoutMillis,
-					serverNames, confPerDomainName);
+					serverNames, confPerDomainName, protocolSslContextSpec);
 		}
 
 		void addInternal(String domainName, Consumer<? super SslProvider.SslContextSpec> sslProviderBuilder) {

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -259,7 +259,9 @@ public final class SslProvider {
 	/**
 	 * Default configuration that will be applied to the provided
 	 * {@link SslContextBuilder}
+	 * @deprecated as of 1.0.6
 	 */
+	@Deprecated
 	public enum DefaultConfigurationType {
 		/**
 		 * There will be no default configuration
@@ -280,6 +282,10 @@ public final class SslProvider {
 		H2
 	}
 
+	/**
+	 * @deprecated as of 1.0.6
+	 */
+	@Deprecated
 	public interface DefaultConfigurationSpec {
 
 		/**

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientSecure.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientSecure.java
@@ -16,8 +16,6 @@
 
 package reactor.netty.tcp;
 
-import io.netty.handler.ssl.SslContextBuilder;
-
 /**
  * Initializes the default {@link SslProvider} for the TCP client.
  *
@@ -33,8 +31,7 @@ final class TcpClientSecure {
 		try {
 			sslProvider =
 					SslProvider.builder()
-					           .sslContext(SslContextBuilder.forClient())
-					           .defaultConfiguration(SslProvider.DefaultConfigurationType.TCP)
+					           .sslContext(TcpSslContextSpec.forClient())
 					           .build();
 		}
 		catch (Exception e) {

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServer.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServer.java
@@ -178,9 +178,9 @@ public abstract class TcpServer extends ServerTransport<TcpServer, TcpServerConf
 	 * <pre>
 	 * {@code
 	 *     SelfSignedCertificate cert = new SelfSignedCertificate();
-	 *     SslContextBuilder sslContextBuilder =
-	 *             SslContextBuilder.forServer(cert.certificate(), cert.privateKey());
-	 *     secure(sslContextSpec -> sslContextSpec.sslContext(sslContextBuilder));
+	 *     TcpSslContextSpec tcpSslContextSpec =
+	 *             TcpSslContextSpec.forServer(cert.certificate(), cert.privateKey());
+	 *     secure(sslContextSpec -> sslContextSpec.sslContext(tcpSslContextSpec));
 	 * }
 	 * </pre>
 	 *
@@ -204,9 +204,9 @@ public abstract class TcpServer extends ServerTransport<TcpServer, TcpServerConf
 	 * <pre>
 	 * {@code
 	 *     SelfSignedCertificate cert = new SelfSignedCertificate();
-	 *     SslContextBuilder sslContextBuilder =
-	 *             SslContextBuilder.forServer(cert.certificate(), cert.privateKey());
-	 *     secure(sslContextSpec -> sslContextSpec.sslContext(sslContextBuilder));
+	 *     TcpSslContextSpec tcpSslContextSpec =
+	 *             TcpSslContextSpec.forServer(cert.certificate(), cert.privateKey());
+	 *     secure(sslContextSpec -> sslContextSpec.sslContext(tcpSslContextSpec));
 	 * }
 	 * </pre>
 	 *

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServerBind.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServerBind.java
@@ -52,6 +52,7 @@ final class TcpServerBind extends TcpServer {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Mono<? extends DisposableServer> bind() {
 		if (config.sslProvider != null && config.sslProvider.getDefaultConfigurationType() == null) {
 			config.sslProvider = SslProvider.updateDefaultConfiguration(config.sslProvider, SslProvider.DefaultConfigurationType.TCP);

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpSslContextSpec.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpSslContextSpec.java
@@ -32,7 +32,7 @@ import static io.netty.handler.ssl.SslProvider.JDK;
 import static io.netty.handler.ssl.SslProvider.OPENSSL;
 
 /**
- * SslContext builder that provides, specific for TCP, default configuration.
+ * SslContext builder that provides default configuration specific to TCP as follows:
  * <ul>
  *     <li>{@link io.netty.handler.ssl.SslProvider} will be set depending on {@code OpenSsl.isAvailable()}</li>
  *     <li>The default cipher suites will be used</li>

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpSslContextSpec.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpSslContextSpec.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.tcp;
+
+import io.netty.handler.ssl.IdentityCipherSuiteFilter;
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import java.io.File;
+import java.io.InputStream;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.function.Consumer;
+
+import static io.netty.handler.ssl.SslProvider.JDK;
+import static io.netty.handler.ssl.SslProvider.OPENSSL;
+
+/**
+ * SslContext builder that provides, specific for TCP, default configuration.
+ * <ul>
+ *     <li>{@link io.netty.handler.ssl.SslProvider} will be set depending on {@code OpenSsl.isAvailable()}</li>
+ *     <li>The default cipher suites will be used</li>
+ *     <li>Application protocol negotiation configuration is disabled</li>
+ * </ul>
+ * <p>The default configuration is applied prior any other custom configuration.</p>
+ *
+ * @author Violeta Georgieva
+ * @since 1.0.6
+ */
+public final class TcpSslContextSpec extends AbstractProtocolSslContextSpec<TcpSslContextSpec> {
+
+	/**
+	 * Creates a builder for new client-side {@link SslContext}.
+	 *
+	 * @return {@literal this}
+	 */
+	public static TcpSslContextSpec forClient() {
+		return new TcpSslContextSpec(SslContextBuilder.forClient());
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(File, File)
+	 */
+	public static TcpSslContextSpec forServer(File keyCertChainFile, File keyFile) {
+		return new TcpSslContextSpec(SslContextBuilder.forServer(keyCertChainFile, keyFile));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(File, File, String)
+	 */
+	public static TcpSslContextSpec forServer(File keyCertChainFile, File keyFile, String keyPassword) {
+		return new TcpSslContextSpec(SslContextBuilder.forServer(keyCertChainFile, keyFile, keyPassword));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(InputStream, InputStream)
+	 */
+	public static TcpSslContextSpec forServer(InputStream keyCertChainInputStream, InputStream keyInputStream) {
+		return new TcpSslContextSpec(SslContextBuilder.forServer(keyCertChainInputStream, keyInputStream));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(InputStream, InputStream, String)
+	 */
+	public static TcpSslContextSpec forServer(
+			InputStream keyCertChainInputStream, InputStream keyInputStream, String keyPassword) {
+		return new TcpSslContextSpec(SslContextBuilder.forServer(keyCertChainInputStream, keyInputStream, keyPassword));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(KeyManager)
+	 */
+	public static TcpSslContextSpec forServer(KeyManager keyManager) {
+		return new TcpSslContextSpec(SslContextBuilder.forServer(keyManager));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(KeyManagerFactory)
+	 */
+	public static TcpSslContextSpec forServer(KeyManagerFactory keyManagerFactory) {
+		return new TcpSslContextSpec(SslContextBuilder.forServer(keyManagerFactory));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, Iterable)
+	 */
+	public static TcpSslContextSpec forServer(PrivateKey key, Iterable<? extends X509Certificate> keyCertChain) {
+		return new TcpSslContextSpec(SslContextBuilder.forServer(key, keyCertChain));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, String, Iterable)
+	 */
+	public static TcpSslContextSpec forServer(
+			PrivateKey key, String keyPassword, Iterable<? extends X509Certificate> keyCertChain) {
+		return new TcpSslContextSpec(SslContextBuilder.forServer(key, keyPassword, keyCertChain));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, String, X509Certificate...)
+	 */
+	public static TcpSslContextSpec forServer(PrivateKey key, String keyPassword, X509Certificate... keyCertChain) {
+		return new TcpSslContextSpec(SslContextBuilder.forServer(key, keyPassword, keyCertChain));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, X509Certificate...)
+	 */
+	public static TcpSslContextSpec forServer(PrivateKey key, X509Certificate... keyCertChain) {
+		return new TcpSslContextSpec(SslContextBuilder.forServer(key, keyCertChain));
+	}
+
+	TcpSslContextSpec(SslContextBuilder sslContextBuilder) {
+		super(sslContextBuilder);
+	}
+
+	@Override
+	public TcpSslContextSpec get() {
+		return this;
+	}
+
+	@Override
+	protected Consumer<SslContextBuilder> defaultConfiguration() {
+		return DEFAULT_CONFIGURATOR;
+	}
+
+	static final Consumer<SslContextBuilder> DEFAULT_CONFIGURATOR =
+			sslCtxBuilder ->
+					sslCtxBuilder.sslProvider(OpenSsl.isAvailable() ? OPENSSL : JDK)
+					             .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
+					             .applicationProtocolConfig(null);
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/security/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/security/Application.java
@@ -15,17 +15,17 @@
  */
 package reactor.netty.examples.documentation.http.client.security;
 
-import io.netty.handler.ssl.SslContextBuilder;
+import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.client.HttpClient;
 
 public class Application {
 
 	public static void main(String[] args) {
-		SslContextBuilder sslContextBuilder = SslContextBuilder.forClient();
+		Http11SslContextSpec http11SslContextSpec = Http11SslContextSpec.forClient();
 
 		HttpClient client =
 				HttpClient.create()
-				          .secure(spec -> spec.sslContext(sslContextBuilder));
+				          .secure(spec -> spec.sslContext(http11SslContextSpec));
 
 		client.get()
 		      .uri("https://example.com/")

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/security/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/security/custom/Application.java
@@ -15,21 +15,19 @@
  */
 package reactor.netty.examples.documentation.http.client.security.custom;
 
-import io.netty.handler.ssl.SslContextBuilder;
+import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.client.HttpClient;
-import reactor.netty.tcp.SslProvider;
 
 import java.time.Duration;
 
 public class Application {
 
 	public static void main(String[] args) {
-		SslContextBuilder sslContextBuilder = SslContextBuilder.forClient();
+		Http11SslContextSpec http11SslContextSpec = Http11SslContextSpec.forClient();
 
 		HttpClient client =
 				HttpClient.create()
-				          .secure(spec -> spec.sslContext(sslContextBuilder)
-				                              .defaultConfiguration(SslProvider.DefaultConfigurationType.TCP)
+				          .secure(spec -> spec.sslContext(http11SslContextSpec)
 				                              .handshakeTimeout(Duration.ofSeconds(30))         //<1>
 				                              .closeNotifyFlushTimeout(Duration.ofSeconds(10))  //<2>
 				                              .closeNotifyReadTimeout(Duration.ofSeconds(10))); //<3>

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/http2/H2Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/http2/H2Application.java
@@ -15,9 +15,9 @@
  */
 package reactor.netty.examples.documentation.http.server.http2;
 
-import io.netty.handler.ssl.SslContextBuilder;
 import reactor.core.publisher.Mono;
 import reactor.netty.DisposableServer;
+import reactor.netty.http.Http2SslContextSpec;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.server.HttpServer;
 import java.io.File;
@@ -28,13 +28,13 @@ public class H2Application {
 		File cert = new File("certificate.crt");
 		File key = new File("private.key");
 
-		SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(cert, key);
+		Http2SslContextSpec http2SslContextSpec = Http2SslContextSpec.forServer(cert, key);
 
 		DisposableServer server =
 				HttpServer.create()
 				          .port(8080)
-				          .protocol(HttpProtocol.H2)                          //<1>
-				          .secure(spec -> spec.sslContext(sslContextBuilder)) //<2>
+				          .protocol(HttpProtocol.H2)                            //<1>
+				          .secure(spec -> spec.sslContext(http2SslContextSpec)) //<2>
 				          .handle((request, response) -> response.sendString(Mono.just("hello")))
 				          .bindNow();
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/security/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/security/Application.java
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.documentation.http.server.security;
 
-import io.netty.handler.ssl.SslContextBuilder;
 import reactor.netty.DisposableServer;
+import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.server.HttpServer;
 import java.io.File;
 
@@ -26,11 +26,11 @@ public class Application {
 		File cert = new File("certificate.crt");
 		File key = new File("private.key");
 
-		SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(cert, key);
+		Http11SslContextSpec http11SslContextSpec = Http11SslContextSpec.forServer(cert, key);
 
 		DisposableServer server =
 				HttpServer.create()
-				          .secure(spec -> spec.sslContext(sslContextBuilder))
+				          .secure(spec -> spec.sslContext(http11SslContextSpec))
 				          .bindNow();
 
 		server.onDispose()

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/security/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/security/Application.java
@@ -15,20 +15,20 @@
  */
 package reactor.netty.examples.documentation.tcp.client.security;
 
-import io.netty.handler.ssl.SslContextBuilder;
 import reactor.netty.Connection;
 import reactor.netty.tcp.TcpClient;
+import reactor.netty.tcp.TcpSslContextSpec;
 
 public class Application {
 
 	public static void main(String[] args) {
-		SslContextBuilder sslContextBuilder = SslContextBuilder.forClient();
+		TcpSslContextSpec tcpSslContextSpec = TcpSslContextSpec.forClient();
 
 		Connection connection =
 				TcpClient.create()
 				         .host("example.com")
 				         .port(443)
-				         .secure(spec -> spec.sslContext(sslContextBuilder))
+				         .secure(spec -> spec.sslContext(tcpSslContextSpec))
 				         .connectNow();
 
 		connection.onDispose()

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/security/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/security/Application.java
@@ -15,9 +15,10 @@
  */
 package reactor.netty.examples.documentation.tcp.server.security;
 
-import io.netty.handler.ssl.SslContextBuilder;
 import reactor.netty.DisposableServer;
 import reactor.netty.tcp.TcpServer;
+import reactor.netty.tcp.TcpSslContextSpec;
+
 import java.io.File;
 
 public class Application {
@@ -26,11 +27,11 @@ public class Application {
 		File cert = new File("certificate.crt");
 		File key = new File("private.key");
 
-		SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(cert, key);
+		TcpSslContextSpec tcpSslContextSpec = TcpSslContextSpec.forServer(cert, key);
 
 		DisposableServer server =
 				TcpServer.create()
-				         .secure(spec -> spec.sslContext(sslContextBuilder))
+				         .secure(spec -> spec.sslContext(tcpSslContextSpec))
 				         .bindNow();
 
 		server.onDispose()

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoClient.java
@@ -15,10 +15,10 @@
  */
 package reactor.netty.examples.http.echo;
 
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import reactor.core.publisher.Mono;
 import reactor.netty.ByteBufFlux;
+import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.client.HttpClient;
 
 /**
@@ -42,8 +42,10 @@ public final class EchoClient {
 				          .compress(COMPRESS);
 
 		if (SECURE) {
-			client = client.secure(
-					spec -> spec.sslContext(SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE)));
+			Http11SslContextSpec http11SslContextSpec =
+					Http11SslContextSpec.forClient()
+					                    .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+			client = client.secure(spec -> spec.sslContext(http11SslContextSpec));
 		}
 
 		String response =

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoServer.java
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.http.echo;
 
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.server.HttpServer;
 
@@ -49,7 +49,7 @@ public final class EchoServer {
 		if (SECURE) {
 			SelfSignedCertificate ssc = new SelfSignedCertificate();
 			server = server.secure(
-					spec -> spec.sslContext(SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())));
+					spec -> spec.sslContext(Http11SslContextSpec.forServer(ssc.certificate(), ssc.privateKey())));
 		}
 
 		if (HTTP2) {

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldClient.java
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.http.helloworld;
 
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.client.HttpClient;
 
 /**
@@ -39,8 +39,10 @@ public final class HelloWorldClient {
 				          .compress(COMPRESS);
 
 		if (SECURE) {
-			client = client.secure(
-					spec -> spec.sslContext(SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE)));
+			Http11SslContextSpec http11SslContextSpec =
+					Http11SslContextSpec.forClient()
+					                    .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+			client = client.secure(spec -> spec.sslContext(http11SslContextSpec));
 		}
 
 		String response =

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldServer.java
@@ -15,9 +15,9 @@
  */
 package reactor.netty.examples.http.helloworld;
 
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.server.HttpServer;
 
@@ -50,7 +50,7 @@ public final class HelloWorldServer {
 		if (SECURE) {
 			SelfSignedCertificate ssc = new SelfSignedCertificate();
 			server = server.secure(
-					spec -> spec.sslContext(SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())));
+					spec -> spec.sslContext(Http11SslContextSpec.forServer(ssc.certificate(), ssc.privateKey())));
 		}
 
 		if (HTTP2) {

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/discard/DiscardClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/discard/DiscardClient.java
@@ -15,11 +15,11 @@
  */
 package reactor.netty.examples.tcp.discard;
 
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import reactor.core.publisher.Flux;
 import reactor.netty.Connection;
 import reactor.netty.tcp.TcpClient;
+import reactor.netty.tcp.TcpSslContextSpec;
 
 import java.time.Duration;
 
@@ -42,8 +42,10 @@ public final class DiscardClient {
 				         .wiretap(WIRETAP);
 
 		if (SECURE) {
-			client = client.secure(
-					spec -> spec.sslContext(SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE)));
+			TcpSslContextSpec tcpSslContextSpec =
+					TcpSslContextSpec.forClient()
+					                 .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+			client = client.secure(spec -> spec.sslContext(tcpSslContextSpec));
 		}
 
 		Connection connection =

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/discard/DiscardServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/discard/DiscardServer.java
@@ -15,9 +15,9 @@
  */
 package reactor.netty.examples.tcp.discard;
 
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import reactor.netty.tcp.TcpServer;
+import reactor.netty.tcp.TcpSslContextSpec;
 
 /**
  * A TCP server that discards the received data.
@@ -44,7 +44,7 @@ public final class DiscardServer {
 		if (SECURE) {
 			SelfSignedCertificate ssc = new SelfSignedCertificate();
 			server = server.secure(
-					spec -> spec.sslContext(SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())));
+					spec -> spec.sslContext(TcpSslContextSpec.forServer(ssc.certificate(), ssc.privateKey())));
 		}
 
 		server.bindNow()

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/echo/EchoClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/echo/EchoClient.java
@@ -15,13 +15,13 @@
  */
 package reactor.netty.examples.tcp.echo;
 
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.ByteBufFlux;
 import reactor.netty.Connection;
 import reactor.netty.tcp.TcpClient;
+import reactor.netty.tcp.TcpSslContextSpec;
 
 /**
  * A TCP client that sends a package to the TCP server and
@@ -42,8 +42,10 @@ public final class EchoClient {
 				         .wiretap(WIRETAP);
 
 		if (SECURE) {
-			client = client.secure(
-					spec -> spec.sslContext(SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE)));
+			TcpSslContextSpec tcpSslContextSpec =
+					TcpSslContextSpec.forClient()
+					                 .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+			client = client.secure(spec -> spec.sslContext(tcpSslContextSpec));
 		}
 
 		Connection connection =

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/echo/EchoServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/echo/EchoServer.java
@@ -15,9 +15,9 @@
  */
 package reactor.netty.examples.tcp.echo;
 
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import reactor.netty.tcp.TcpServer;
+import reactor.netty.tcp.TcpSslContextSpec;
 
 /**
  * A TCP server that sends back the received content.
@@ -40,7 +40,7 @@ public final class EchoServer {
 		if (SECURE) {
 			SelfSignedCertificate ssc = new SelfSignedCertificate();
 			server = server.secure(
-					spec -> spec.sslContext(SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())));
+					spec -> spec.sslContext(TcpSslContextSpec.forServer(ssc.certificate(), ssc.privateKey())));
 		}
 
 		server.bindNow()

--- a/reactor-netty-http/src/main/java/reactor/netty/http/Http11SslContextSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/Http11SslContextSpec.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http;
+
+import io.netty.handler.ssl.IdentityCipherSuiteFilter;
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import reactor.netty.tcp.AbstractProtocolSslContextSpec;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import java.io.File;
+import java.io.InputStream;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.function.Consumer;
+
+import static io.netty.handler.ssl.SslProvider.JDK;
+import static io.netty.handler.ssl.SslProvider.OPENSSL;
+
+/**
+ * SslContext builder that provides, specific for HTTP/1.x, default configuration.
+ * <ul>
+ *     <li>{@link io.netty.handler.ssl.SslProvider} will be set depending on {@code OpenSsl.isAvailable()}</li>
+ *     <li>The default cipher suites will be used</li>
+ *     <li>Application protocol negotiation configuration is disabled</li>
+ * </ul>
+ * <p>The default configuration is applied prior any other custom configuration.</p>
+ *
+ * @author Violeta Georgieva
+ * @since 1.0.6
+ */
+public final class Http11SslContextSpec extends AbstractProtocolSslContextSpec<Http11SslContextSpec> {
+
+	/**
+	 * Creates a builder for new client-side {@link SslContext}.
+	 *
+	 * @return {@literal this}
+	 */
+	public static Http11SslContextSpec forClient() {
+		return new Http11SslContextSpec(SslContextBuilder.forClient());
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(File, File)
+	 */
+	public static Http11SslContextSpec forServer(File keyCertChainFile, File keyFile) {
+		return new Http11SslContextSpec(SslContextBuilder.forServer(keyCertChainFile, keyFile));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(File, File, String)
+	 */
+	public static Http11SslContextSpec forServer(File keyCertChainFile, File keyFile, String keyPassword) {
+		return new Http11SslContextSpec(SslContextBuilder.forServer(keyCertChainFile, keyFile, keyPassword));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(InputStream, InputStream)
+	 */
+	public static Http11SslContextSpec forServer(InputStream keyCertChainInputStream, InputStream keyInputStream) {
+		return new Http11SslContextSpec(SslContextBuilder.forServer(keyCertChainInputStream, keyInputStream));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(InputStream, InputStream, String)
+	 */
+	public static Http11SslContextSpec forServer(
+			InputStream keyCertChainInputStream, InputStream keyInputStream, String keyPassword) {
+		return new Http11SslContextSpec(SslContextBuilder.forServer(keyCertChainInputStream, keyInputStream, keyPassword));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(KeyManager)
+	 */
+	public static Http11SslContextSpec forServer(KeyManager keyManager) {
+		return new Http11SslContextSpec(SslContextBuilder.forServer(keyManager));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(KeyManagerFactory)
+	 */
+	public static Http11SslContextSpec forServer(KeyManagerFactory keyManagerFactory) {
+		return new Http11SslContextSpec(SslContextBuilder.forServer(keyManagerFactory));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, Iterable)
+	 */
+	public static Http11SslContextSpec forServer(PrivateKey key, Iterable<? extends X509Certificate> keyCertChain) {
+		return new Http11SslContextSpec(SslContextBuilder.forServer(key, keyCertChain));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, String, Iterable)
+	 */
+	public static Http11SslContextSpec forServer(
+			PrivateKey key, String keyPassword, Iterable<? extends X509Certificate> keyCertChain) {
+		return new Http11SslContextSpec(SslContextBuilder.forServer(key, keyPassword, keyCertChain));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, String, X509Certificate...)
+	 */
+	public static Http11SslContextSpec forServer(PrivateKey key, String keyPassword, X509Certificate... keyCertChain) {
+		return new Http11SslContextSpec(SslContextBuilder.forServer(key, keyPassword, keyCertChain));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, X509Certificate...)
+	 */
+	public static Http11SslContextSpec forServer(PrivateKey key, X509Certificate... keyCertChain) {
+		return new Http11SslContextSpec(SslContextBuilder.forServer(key, keyCertChain));
+	}
+
+	Http11SslContextSpec(SslContextBuilder sslContextBuilder) {
+		super(sslContextBuilder);
+	}
+
+	@Override
+	public Http11SslContextSpec get() {
+		return this;
+	}
+
+	@Override
+	protected Consumer<SslContextBuilder> defaultConfiguration() {
+		return DEFAULT_CONFIGURATOR;
+	}
+
+	static final Consumer<SslContextBuilder> DEFAULT_CONFIGURATOR =
+			sslCtxBuilder ->
+					sslCtxBuilder.sslProvider(OpenSsl.isAvailable() ? OPENSSL : JDK)
+					             .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
+					             .applicationProtocolConfig(null);
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/Http11SslContextSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/Http11SslContextSpec.java
@@ -33,7 +33,7 @@ import static io.netty.handler.ssl.SslProvider.JDK;
 import static io.netty.handler.ssl.SslProvider.OPENSSL;
 
 /**
- * SslContext builder that provides, specific for HTTP/1.x, default configuration.
+ * SslContext builder that provides default configuration specific to HTTP/1.x as follows:
  * <ul>
  *     <li>{@link io.netty.handler.ssl.SslProvider} will be set depending on {@code OpenSsl.isAvailable()}</li>
  *     <li>The default cipher suites will be used</li>

--- a/reactor-netty-http/src/main/java/reactor/netty/http/Http2SslContextSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/Http2SslContextSpec.java
@@ -36,7 +36,7 @@ import static io.netty.handler.ssl.SslProvider.JDK;
 import static io.netty.handler.ssl.SslProvider.OPENSSL;
 
 /**
- * SslContext builder that provides, specific for HTTP/2, default configuration.
+ * SslContext builder that provides default configuration specific to HTTP/2 as follows:
  * <ul>
  *     <li>{@link io.netty.handler.ssl.SslProvider} will be set depending on {@code OpenSsl.isAlpnSupported()}</li>
  *     <li>{@link Http2SecurityUtil#CIPHERS}</li>

--- a/reactor-netty-http/src/main/java/reactor/netty/http/Http2SslContextSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/Http2SslContextSpec.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http;
+
+import io.netty.handler.codec.http2.Http2SecurityUtil;
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+import reactor.netty.tcp.AbstractProtocolSslContextSpec;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import java.io.File;
+import java.io.InputStream;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.function.Consumer;
+
+import static io.netty.handler.ssl.SslProvider.JDK;
+import static io.netty.handler.ssl.SslProvider.OPENSSL;
+
+/**
+ * SslContext builder that provides, specific for HTTP/2, default configuration.
+ * <ul>
+ *     <li>{@link io.netty.handler.ssl.SslProvider} will be set depending on {@code OpenSsl.isAlpnSupported()}</li>
+ *     <li>{@link Http2SecurityUtil#CIPHERS}</li>
+ *     <li>Application protocol negotiation configuration is enabled</li>
+ *     <li>HTTP/1.1 and HTTP/2 support in order to support upgrade to HTTP/2</li>
+ * </ul>
+ * <p>The default configuration is applied prior any other custom configuration.</p>
+ *
+ * @author Violeta Georgieva
+ * @since 1.0.6
+ */
+public final class Http2SslContextSpec extends AbstractProtocolSslContextSpec<Http2SslContextSpec> {
+
+	/**
+	 * Creates a builder for new client-side {@link SslContext}.
+	 *
+	 * @return {@literal this}
+	 */
+	public static Http2SslContextSpec forClient() {
+		return new Http2SslContextSpec(SslContextBuilder.forClient());
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(File, File)
+	 */
+	public static Http2SslContextSpec forServer(File keyCertChainFile, File keyFile) {
+		return new Http2SslContextSpec(SslContextBuilder.forServer(keyCertChainFile, keyFile));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(File, File, String)
+	 */
+	public static Http2SslContextSpec forServer(File keyCertChainFile, File keyFile, String keyPassword) {
+		return new Http2SslContextSpec(SslContextBuilder.forServer(keyCertChainFile, keyFile, keyPassword));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(InputStream, InputStream)
+	 */
+	public static Http2SslContextSpec forServer(InputStream keyCertChainInputStream, InputStream keyInputStream) {
+		return new Http2SslContextSpec(SslContextBuilder.forServer(keyCertChainInputStream, keyInputStream));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(InputStream, InputStream, String)
+	 */
+	public static Http2SslContextSpec forServer(
+			InputStream keyCertChainInputStream, InputStream keyInputStream, String keyPassword) {
+		return new Http2SslContextSpec(SslContextBuilder.forServer(keyCertChainInputStream, keyInputStream, keyPassword));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(KeyManager)
+	 */
+	public static Http2SslContextSpec forServer(KeyManager keyManager) {
+		return new Http2SslContextSpec(SslContextBuilder.forServer(keyManager));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(KeyManagerFactory)
+	 */
+	public static Http2SslContextSpec forServer(KeyManagerFactory keyManagerFactory) {
+		return new Http2SslContextSpec(SslContextBuilder.forServer(keyManagerFactory));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, Iterable)
+	 */
+	public static Http2SslContextSpec forServer(PrivateKey key, Iterable<? extends X509Certificate> keyCertChain) {
+		return new Http2SslContextSpec(SslContextBuilder.forServer(key, keyCertChain));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, String, Iterable)
+	 */
+	public static Http2SslContextSpec forServer(
+			PrivateKey key, String keyPassword, Iterable<? extends X509Certificate> keyCertChain) {
+		return new Http2SslContextSpec(SslContextBuilder.forServer(key, keyPassword, keyCertChain));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, String, X509Certificate...)
+	 */
+	public static Http2SslContextSpec forServer(PrivateKey key, String keyPassword, X509Certificate... keyCertChain) {
+		return new Http2SslContextSpec(SslContextBuilder.forServer(key, keyPassword, keyCertChain));
+	}
+
+	/**
+	 * Creates a builder for new server-side {@link SslContext}.
+	 *
+	 * @see SslContextBuilder#forServer(PrivateKey, X509Certificate...)
+	 */
+	public static Http2SslContextSpec forServer(PrivateKey key, X509Certificate... keyCertChain) {
+		return new Http2SslContextSpec(SslContextBuilder.forServer(key, keyCertChain));
+	}
+
+	Http2SslContextSpec(SslContextBuilder sslContextBuilder) {
+		super(sslContextBuilder);
+	}
+
+	@Override
+	public Http2SslContextSpec get() {
+		return this;
+	}
+
+	@Override
+	protected Consumer<SslContextBuilder> defaultConfiguration() {
+		return DEFAULT_CONFIGURATOR;
+	}
+
+	static final Consumer<SslContextBuilder> DEFAULT_CONFIGURATOR =
+			sslCtxBuilder ->
+					sslCtxBuilder.sslProvider(SslProvider.isAlpnSupported(OPENSSL) ? OPENSSL : JDK)
+					             .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+					             .applicationProtocolConfig(new ApplicationProtocolConfig(
+					                     ApplicationProtocolConfig.Protocol.ALPN,
+					                     ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+					                     ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+					                     ApplicationProtocolNames.HTTP_2,
+					                     ApplicationProtocolNames.HTTP_1_1));
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -203,6 +203,7 @@ class HttpClientConnect extends HttpClient {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public void subscribe(CoreSubscriber<? super Connection> actual) {
 			HttpClientHandler handler = new HttpClientHandler(config);
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSecure.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSecure.java
@@ -19,12 +19,8 @@ import java.util.function.Consumer;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 
-import io.netty.handler.codec.http2.Http2SecurityUtil;
-import io.netty.handler.ssl.ApplicationProtocolConfig;
-import io.netty.handler.ssl.ApplicationProtocolNames;
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+import reactor.netty.http.Http2SslContextSpec;
 import reactor.netty.tcp.SslProvider;
 
 /**
@@ -68,23 +64,8 @@ final class HttpClientSecure {
 	static {
 		SslProvider sslProvider;
 		try {
-			io.netty.handler.ssl.SslProvider provider =
-					io.netty.handler.ssl.SslProvider.isAlpnSupported(io.netty.handler.ssl.SslProvider.OPENSSL) ?
-							io.netty.handler.ssl.SslProvider.OPENSSL :
-							io.netty.handler.ssl.SslProvider.JDK;
-			SslContextBuilder sslCtxBuilder =
-					SslContextBuilder.forClient()
-					                 .sslProvider(provider)
-					                 .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
-					                 .applicationProtocolConfig(new ApplicationProtocolConfig(
-					                         ApplicationProtocolConfig.Protocol.ALPN,
-					                         ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
-					                         ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
-					                         ApplicationProtocolNames.HTTP_2,
-					                         ApplicationProtocolNames.HTTP_1_1));
 			sslProvider = SslProvider.builder()
-			                         .sslContext(sslCtxBuilder)
-			                         .defaultConfiguration(SslProvider.DefaultConfigurationType.H2)
+			                         .sslContext(Http2SslContextSpec.forClient())
 			                         .build();
 		}
 		catch (Exception e) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -676,9 +676,9 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 * <pre>
 	 * {@code
 	 *     SelfSignedCertificate cert = new SelfSignedCertificate();
-	 *     SslContextBuilder sslContextBuilder =
-	 *             SslContextBuilder.forServer(cert.certificate(), cert.privateKey());
-	 *     secure(sslContextSpec -> sslContextSpec.sslContext(sslContextBuilder));
+	 *     Http11SslContextSpec http11SslContextSpec =
+	 *             Http11SslContextSpec.forServer(cert.certificate(), cert.privateKey());
+	 *     secure(sslContextSpec -> sslContextSpec.sslContext(http11SslContextSpec));
 	 * }
 	 * </pre>
 	 *
@@ -700,9 +700,9 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 * <pre>
 	 * {@code
 	 *     SelfSignedCertificate cert = new SelfSignedCertificate();
-	 *     SslContextBuilder sslContextBuilder =
-	 *             SslContextBuilder.forServer(cert.certificate(), cert.privateKey());
-	 *     secure(sslContextSpec -> sslContextSpec.sslContext(sslContextBuilder), true);
+	 *     Http11SslContextSpec http11SslContextSpec =
+	 *             Http11SslContextSpec.forServer(cert.certificate(), cert.privateKey());
+	 *     secure(sslContextSpec -> sslContextSpec.sslContext(http11SslContextSpec), true);
 	 * }
 	 * </pre>
 	 *
@@ -731,9 +731,9 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 * <pre>
 	 * {@code
 	 *     SelfSignedCertificate cert = new SelfSignedCertificate();
-	 *     SslContextBuilder sslContextBuilder =
-	 *             SslContextBuilder.forServer(cert.certificate(), cert.privateKey());
-	 *     secure(sslContextSpec -> sslContextSpec.sslContext(sslContextBuilder));
+	 *     Http11SslContextSpec http11SslContextSpec =
+	 *             Http11SslContextSpec.forServer(cert.certificate(), cert.privateKey());
+	 *     secure(sslContextSpec -> sslContextSpec.sslContext(http11SslContextSpec));
 	 * }
 	 * </pre>
 	 *
@@ -753,9 +753,9 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 * <pre>
 	 * {@code
 	 *     SelfSignedCertificate cert = new SelfSignedCertificate();
-	 *     SslContextBuilder sslContextBuilder =
-	 *             SslContextBuilder.forServer(cert.certificate(), cert.privateKey());
-	 *     secure(sslContextSpec -> sslContextSpec.sslContext(sslContextBuilder), true);
+	 *     Http11SslContextSpec http11SslContextSpec =
+	 *             Http11SslContextSpec.forServer(cert.certificate(), cert.privateKey());
+	 *     secure(sslContextSpec -> sslContextSpec.sslContext(http11SslContextSpec), true);
 	 * }
 	 * </pre>
 	 *

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerBind.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerBind.java
@@ -56,6 +56,7 @@ final class HttpServerBind extends HttpServer {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public Mono<? extends DisposableServer> bind() {
 		if (config.sslProvider != null) {
 			if ((config._protocols & HttpServerConfig.h2c) == HttpServerConfig.h2c) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.GZIPInputStream;
 
 import io.netty.handler.codec.http.HttpHeaders;
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.junit.jupiter.api.Test;
@@ -60,9 +59,10 @@ class HttpCompressionClientServerTests extends BaseHttpTest {
 
 	static Object[][] data() throws Exception {
 		SelfSignedCertificate cert = new SelfSignedCertificate();
-		SslContextBuilder serverCtx = SslContextBuilder.forServer(cert.certificate(), cert.privateKey());
-		SslContextBuilder clientCtx = SslContextBuilder.forClient()
-		                                               .trustManager(InsecureTrustManagerFactory.INSTANCE);
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(cert.certificate(), cert.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
 
 		HttpServer server = createServer();
 

--- a/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.BaseHttpTest;
 import reactor.netty.ConnectionObserver;
+import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.internal.shaded.reactor.pool.InstrumentedPool;
 import reactor.test.StepVerifier;
@@ -63,7 +64,7 @@ class DefaultPooledConnectionProviderTest extends BaseHttpTest {
 
 	@Test
 	void testIssue903() {
-		SslContextBuilder serverCtx = SslContextBuilder.forServer(ssc.key(), ssc.cert());
+		Http11SslContextSpec serverCtx = Http11SslContextSpec.forServer(ssc.key(), ssc.cert());
 		disposableServer =
 				createServer()
 				          .secure(s -> s.sslContext(serverCtx))


### PR DESCRIPTION
`SslProvider.SslContextSpec#sslContext(SslProvider.ProtocolSslContextSpec)`
provides, specific for the protocol, default configuration (`DefaultSslContextSpec`,
`TcpSslContextSpec`, `Http11SslContextSpec`, `Http2SslContextSpec`).
As opposed to `SslProvider.SslContextSpec#sslContext(SslContextBuilder)`,
the default configuration is applied before any other custom configuration.

Fixes #1543