### PR TITLE
Check for backwards compatibility against the previous release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 reactorPoolVersion=0.1.10.BUILD-SNAPSHOT
 version=0.9.19.BUILD-SNAPSHOT
 reactorCoreVersion=3.3.16.BUILD-SNAPSHOT
-compatibleVersion=0.9.0.RELEASE
+compatibleVersion=0.9.18.RELEASE


### PR DESCRIPTION
The check for backwards compatibility should be against the previous release
and not GA. Some APIs are added after GA so we need to guarantee backwards
compatibility for these APIs also.