### PR TITLE
Reactor Netty client will try to establish a connection again if the …

### DIFF
--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -483,6 +483,9 @@ than this min time to live, this resolver ignores the time to live from
 the DNS server and uses this min time to live.
 Default: 0.
 | `cacheNegativeTimeToLive` | The time to live of the cache for the failed DNS queries (resolution: seconds). Default: 0.
+| `completeOncePreferredResolved` | When this setting is enabled, the resolver notifies as soon as all queries for the preferred address type are complete.
+When this setting is disabled, the resolver notifies when all possible address types are complete.
+This configuration is applicable for `DnsNameResolver#resolveAll(String)`. By default, this setting is enabled.
 | `disableOptionalRecord` | Disables the automatic inclusion of an optional record that tries to give a hint to the remote DNS server about
 how much data the resolver can read per response. By default, this setting is enabled.
 | `disableRecursionDesired` | Specifies whether this resolver has to send a DNS query with the recursion desired (RD) flag set.

--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -426,6 +426,9 @@ The following listing shows the available configurations:
  the DNS server and uses this min time to live.
  Default: 0.
 | `cacheNegativeTimeToLive` | The time to live of the cache for the failed DNS queries (resolution: seconds). Default: 0.
+| `completeOncePreferredResolved` | When this setting is enabled, the resolver notifies as soon as all queries for the preferred address type are complete.
+When this setting is disabled, the resolver notifies when all possible address types are complete.
+This configuration is applicable for `DnsNameResolver#resolveAll(String)`. By default, this setting is enabled.
 | `disableOptionalRecord` | Disables the automatic inclusion of an optional record that tries to give a hint to the remote DNS server about
  how much data the resolver can read per response. By default, this setting is enabled.
 | `disableRecursionDesired` | Specifies whether this resolver has to send a DNS query with the recursion desired (RD) flag set.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
@@ -110,6 +110,14 @@ class NameResolverProviderTest {
 	}
 
 	@Test
+	void completeOncePreferredResolved() {
+		assertThat(builder.build().isCompleteOncePreferredResolved()).isTrue();
+
+		builder.completeOncePreferredResolved(false);
+		assertThat(builder.build().isCompleteOncePreferredResolved()).isFalse();
+	}
+
+	@Test
 	void disableOptionalRecord() {
 		assertThat(builder.build().isDisableOptionalRecord()).isFalse();
 


### PR DESCRIPTION
…first IP address is not accessible and the host provides another IP address

By default `NameResolverProvider.NameResolverSpec#completeOncePreferredResolved` is enabled.
One can configure `NameResolverProvider` to complete after all are resolved.

Fixes #1568