### PR TITLE
Ensure Forwarded header is parsed according to the specification

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/transport/AddressUtils.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/AddressUtils.java
@@ -88,30 +88,46 @@ public final class AddressUtils {
 	}
 
 	/**
-	 * Parse unresolved InetSocketAddress. Numeric IP addresses will be detected and
-	 * resolved.
+	 * Parse unresolved InetSocketAddress. Numeric IP addresses will be detected and resolved.
 	 *
 	 * @param address ip-address or hostname
 	 * @param defaultPort the default port
-	 * @return InetSocketAddress for given parameters
+	 * @return {@link InetSocketAddress} for given parameters, only numeric IP addresses will be resolved
 	 */
 	public static InetSocketAddress parseAddress(String address, int defaultPort) {
+		return parseAddress(address, defaultPort, false);
+	}
+
+	/**
+	 * Parse unresolved InetSocketAddress. Numeric IP addresses will be detected and resolved.
+	 *
+	 * @param address ip-address or hostname
+	 * @param defaultPort the default port
+	 * @param strict if true throws an exception when the address cannot be parsed
+	 * @return {@link InetSocketAddress} for given parameters, only numeric IP addresses will be resolved
+	 */
+	public static InetSocketAddress parseAddress(String address, int defaultPort, boolean strict) {
 		requireNonNull(address, "address");
+		String host = address;
+		int port = defaultPort;
 		int separatorIdx = address.lastIndexOf(':');
 		int ipV6HostSeparatorIdx = address.lastIndexOf(']');
 		if (separatorIdx > ipV6HostSeparatorIdx) {
 			if (separatorIdx == address.indexOf(':') || ipV6HostSeparatorIdx > -1) {
-				String port = address.substring(separatorIdx + 1);
-				if (port.chars().allMatch(Character::isDigit)) {
-					return AddressUtils.createUnresolved(address.substring(0, separatorIdx),
-							Integer.parseInt(port));
+				host = address.substring(0, separatorIdx);
+				String portStr = address.substring(separatorIdx + 1);
+				if (!portStr.isEmpty() && portStr.chars().allMatch(Character::isDigit)) {
+					port = Integer.parseInt(portStr);
 				}
-				else {
-					return AddressUtils.createUnresolved(address.substring(0, separatorIdx), defaultPort);
+				else if (strict) {
+					throw new IllegalArgumentException("Failed to parse a port from " + address);
 				}
 			}
+			else if (strict) {
+				throw new IllegalArgumentException("Invalid IPv4 address " + address);
+			}
 		}
-		return AddressUtils.createUnresolved(address, defaultPort);
+		return AddressUtils.createUnresolved(host, port);
 	}
 
 	/**

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/AddressUtils.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/AddressUtils.java
@@ -102,7 +102,8 @@ public final class AddressUtils {
 	 * Parse unresolved InetSocketAddress. Numeric IP addresses will be detected and resolved.
 	 *
 	 * @param address ip-address or hostname
-	 * @param defaultPort is used when the host is parseable but not the port
+	 * @param defaultPort is used if the address does not contain a port,
+	 * or if the port cannot be parsed in non-strict mode
 	 * @param strict if true throws an exception when the address cannot be parsed,
 	 * otherwise an unresolved {@link InetSocketAddress} is returned. It can include the case of the host
 	 * having been parsed but not the port (replaced by {@code defaultPort})
@@ -118,11 +119,13 @@ public final class AddressUtils {
 			if (separatorIdx == address.indexOf(':') || ipV6HostSeparatorIdx > -1) {
 				host = address.substring(0, separatorIdx);
 				String portStr = address.substring(separatorIdx + 1);
-				if (!portStr.isEmpty() && portStr.chars().allMatch(Character::isDigit)) {
-					port = Integer.parseInt(portStr);
-				}
-				else if (strict) {
-					throw new IllegalArgumentException("Failed to parse a port from " + address);
+				if (!portStr.isEmpty()) {
+					if (portStr.chars().allMatch(Character::isDigit)) {
+						port = Integer.parseInt(portStr);
+					}
+					else if (strict) {
+						throw new IllegalArgumentException("Failed to parse a port from " + address);
+					}
 				}
 			}
 			else if (strict) {

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/AddressUtils.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/AddressUtils.java
@@ -102,8 +102,10 @@ public final class AddressUtils {
 	 * Parse unresolved InetSocketAddress. Numeric IP addresses will be detected and resolved.
 	 *
 	 * @param address ip-address or hostname
-	 * @param defaultPort the default port
-	 * @param strict if true throws an exception when the address cannot be parsed
+	 * @param defaultPort is used when the host is parseable but not the port
+	 * @param strict if true throws an exception when the address cannot be parsed,
+	 * otherwise an unresolved {@link InetSocketAddress} is returned. It can include the case of the host
+	 * having been parsed but not the port (replaced by {@code defaultPort})
 	 * @return {@link InetSocketAddress} for given parameters, only numeric IP addresses will be resolved
 	 */
 	public static InetSocketAddress parseAddress(String address, int defaultPort, boolean strict) {

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/AddressUtilsTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/AddressUtilsTest.java
@@ -148,7 +148,7 @@ class AddressUtilsTest {
 	}
 
 	@Test
-	void shouldParseAddressForIPv6WithoutBrackets_Strict() {
+	void shouldNotParseAddressForIPv6WithoutBrackets_Strict() {
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> AddressUtils.parseAddress("1abc:2abc:3abc:0:0:0:5abc:6abc", 80, true))
 				.withMessage("Invalid IPv4 address 1abc:2abc:3abc:0:0:0:5abc:6abc");
@@ -164,7 +164,7 @@ class AddressUtilsTest {
 	}
 
 	@Test
-	void shouldParseAddressForIPv6WithNotNumericPort_Strict() {
+	void shouldNotParseAddressForIPv6WithNotNumericPort_Strict() {
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> AddressUtils.parseAddress("[1abc:2abc:3abc:0:0:0:5abc:6abc]:abc42", 80, true))
 				.withMessage("Failed to parse a port from [1abc:2abc:3abc:0:0:0:5abc:6abc]:abc42");
@@ -180,7 +180,7 @@ class AddressUtilsTest {
 	}
 
 	@Test
-	void shouldParseAddressForIPv6WithoutPort_Strict() {
+	void shouldNotParseAddressForIPv6WithoutPort_Strict() {
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> AddressUtils.parseAddress("[1abc:2abc:3abc:0:0:0:5abc:6abc]:", 80, true))
 				.withMessage("Failed to parse a port from [1abc:2abc:3abc:0:0:0:5abc:6abc]:");

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/AddressUtilsTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/AddressUtilsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 class AddressUtilsTest {
 
@@ -147,12 +148,42 @@ class AddressUtilsTest {
 	}
 
 	@Test
+	void shouldParseAddressForIPv6WithoutBrackets_Strict() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> AddressUtils.parseAddress("1abc:2abc:3abc:0:0:0:5abc:6abc", 80, true))
+				.withMessage("Invalid IPv4 address 1abc:2abc:3abc:0:0:0:5abc:6abc");
+	}
+
+	@Test
 	void shouldParseAddressForIPv6WithNotNumericPort() {
 		InetSocketAddress socketAddress = AddressUtils.parseAddress("[1abc:2abc:3abc::5ABC:6abc]:abc42", 80);
 		assertThat(socketAddress.isUnresolved()).isFalse();
 		assertThat(socketAddress.getAddress().getHostAddress()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
 		assertThat(socketAddress.getPort()).isEqualTo(80);
 		assertThat(socketAddress.getHostString()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
+	}
+
+	@Test
+	void shouldParseAddressForIPv6WithNotNumericPort_Strict() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> AddressUtils.parseAddress("[1abc:2abc:3abc:0:0:0:5abc:6abc]:abc42", 80, true))
+				.withMessage("Failed to parse a port from [1abc:2abc:3abc:0:0:0:5abc:6abc]:abc42");
+	}
+
+	@Test
+	void shouldParseAddressForIPv6WithoutPort() {
+		InetSocketAddress socketAddress = AddressUtils.parseAddress("[1abc:2abc:3abc::5ABC:6abc]:", 80);
+		assertThat(socketAddress.isUnresolved()).isFalse();
+		assertThat(socketAddress.getAddress().getHostAddress()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
+		assertThat(socketAddress.getPort()).isEqualTo(80);
+		assertThat(socketAddress.getHostString()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
+	}
+
+	@Test
+	void shouldParseAddressForIPv6WithoutPort_Strict() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> AddressUtils.parseAddress("[1abc:2abc:3abc:0:0:0:5abc:6abc]:", 80, true))
+				.withMessage("Failed to parse a port from [1abc:2abc:3abc:0:0:0:5abc:6abc]:");
 	}
 
 	@Test

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/AddressUtilsTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/AddressUtilsTest.java
@@ -180,10 +180,12 @@ class AddressUtilsTest {
 	}
 
 	@Test
-	void shouldNotParseAddressForIPv6WithoutPort_Strict() {
-		assertThatIllegalArgumentException()
-				.isThrownBy(() -> AddressUtils.parseAddress("[1abc:2abc:3abc:0:0:0:5abc:6abc]:", 80, true))
-				.withMessage("Failed to parse a port from [1abc:2abc:3abc:0:0:0:5abc:6abc]:");
+	void shouldParseAddressForIPv6WithoutPort_Strict() {
+		InetSocketAddress socketAddress = AddressUtils.parseAddress("[1abc:2abc:3abc::5ABC:6abc]:", 80);
+		assertThat(socketAddress.isUnresolved()).isFalse();
+		assertThat(socketAddress.getAddress().getHostAddress()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
+		assertThat(socketAddress.getPort()).isEqualTo(80);
+		assertThat(socketAddress.getHostString()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
 	}
 
 	@Test

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
@@ -78,10 +78,13 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 		if (hostHeader != null) {
 			String portHeader = request.headers().get(X_FORWARDED_PORT_HEADER);
 			int port = connectionInfo.getHostAddress().getPort();
-			if (portHeader != null) {
+			if (portHeader != null && !portHeader.isEmpty()) {
 				String portStr = portHeader.split(",", 2)[0].trim();
-				if (!portStr.isEmpty() && portStr.chars().allMatch(Character::isDigit)) {
+				if (portStr.chars().allMatch(Character::isDigit)) {
 					port = Integer.parseInt(portStr);
+				}
+				else {
+					throw new IllegalArgumentException("Failed to parse a port from " + portHeader);
 				}
 			}
 			connectionInfo = connectionInfo.withHostAddress(

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
@@ -15,7 +15,6 @@
  */
 package reactor.netty.http.server;
 
-import java.net.InetSocketAddress;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -55,7 +54,7 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 		Matcher hostMatcher = FORWARDED_HOST_PATTERN.matcher(forwarded);
 		if (hostMatcher.find()) {
 			connectionInfo = connectionInfo.withHostAddress(
-					AddressUtils.parseAddress(hostMatcher.group(1), connectionInfo.getHostAddress().getPort()));
+					AddressUtils.parseAddress(hostMatcher.group(1), connectionInfo.getHostAddress().getPort(), true));
 		}
 		Matcher protoMatcher = FORWARDED_PROTO_PATTERN.matcher(forwarded);
 		if (protoMatcher.find()) {
@@ -64,7 +63,7 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 		Matcher forMatcher = FORWARDED_FOR_PATTERN.matcher(forwarded);
 		if (forMatcher.find()) {
 			connectionInfo = connectionInfo.withRemoteAddress(
-					AddressUtils.parseAddress(forMatcher.group(1).trim(), connectionInfo.getRemoteAddress().getPort()));
+					AddressUtils.parseAddress(forMatcher.group(1).trim(), connectionInfo.getRemoteAddress().getPort(), true));
 		}
 		return connectionInfo;
 	}
@@ -72,30 +71,21 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 	private ConnectionInfo parseXForwardedInfo(ConnectionInfo connectionInfo, HttpRequest request) {
 		String ipHeader = request.headers().get(X_FORWARDED_IP_HEADER);
 		if (ipHeader != null) {
-			InetSocketAddress remoteAddress = AddressUtils.parseAddress(ipHeader.split(",", 2)[0], connectionInfo.getRemoteAddress().getPort());
-			connectionInfo = connectionInfo.withRemoteAddress(remoteAddress);
+			connectionInfo = connectionInfo.withRemoteAddress(
+					AddressUtils.parseAddress(ipHeader.split(",", 2)[0], connectionInfo.getRemoteAddress().getPort()));
 		}
 		String hostHeader = request.headers().get(X_FORWARDED_HOST_HEADER);
 		if (hostHeader != null) {
 			String portHeader = request.headers().get(X_FORWARDED_PORT_HEADER);
-			InetSocketAddress hostAddress = connectionInfo.getHostAddress();
+			int port = connectionInfo.getHostAddress().getPort();
 			if (portHeader != null) {
-				int port;
-				try {
-					port = Integer.parseInt(portHeader.split(",", 2)[0].trim());
+				String portStr = portHeader.split(",", 2)[0].trim();
+				if (!portStr.isEmpty() && portStr.chars().allMatch(Character::isDigit)) {
+					port = Integer.parseInt(portStr);
 				}
-				catch (NumberFormatException e) {
-					port = hostAddress.getPort();
-				}
-				hostAddress = AddressUtils.createUnresolved(
-						hostHeader.split(",", 2)[0].trim(), port);
 			}
-			else {
-				hostAddress = AddressUtils.createUnresolved(
-						hostHeader.split(",", 2)[0].trim(),
-						hostAddress.getPort());
-			}
-			connectionInfo = connectionInfo.withHostAddress(hostAddress);
+			connectionInfo = connectionInfo.withHostAddress(
+					AddressUtils.createUnresolved(hostHeader.split(",", 2)[0].trim(), port));
 		}
 		String protoHeader = request.headers().get(X_FORWARDED_PROTO_HEADER);
 		if (protoHeader != null) {


### PR DESCRIPTION
```
Forwarded: by=<identifier>;for=<identifier>;host=<host>;proto=<http|https>

<identifier>
an IP address (v4 or v6, optionally with a port, and ipv6 quoted and enclosed in square brackets)
```