### PR TITLE
Add workaround for "ConnectTimeoutException: connection timed out" on GitHub Actions

### DIFF
--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -19,6 +19,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Update /etc/hosts file
+        if: matrix.os == 'ubuntu-20.04'
+        # /etc/hosts file needs to be updated as a workaround for
+        # https://github.com/actions/virtual-environments/issues/3185
+        run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Update /etc/hosts file
-        if: matrix.os == 'ubuntu-20.04'
+        if: startsWith(matrix.os, 'ubuntu-')
         # /etc/hosts file needs to be updated as a workaround for
         # https://github.com/actions/virtual-environments/issues/3185
         run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,10 @@ jobs:
       versionType: ${{ steps.version.outputs.versionType }}
     steps:
       - uses: actions/checkout@v2
+      - name: Update /etc/hosts file
+        # /etc/hosts file needs to be updated as a workaround for
+        # https://github.com/actions/virtual-environments/issues/3185
+        run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - name: setup java
         uses: actions/setup-java@v1
         with:
@@ -46,6 +50,10 @@ jobs:
     environment: snapshots
     steps:
       - uses: actions/checkout@v2
+      - name: Update /etc/hosts file
+        # /etc/hosts file needs to be updated as a workaround for
+        # https://github.com/actions/virtual-environments/issues/3185
+        run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - uses: actions/setup-java@v1
         with:
           java-version: 8
@@ -65,6 +73,10 @@ jobs:
     environment: releases
     steps:
       - uses: actions/checkout@v2
+      - name: Update /etc/hosts file
+        # /etc/hosts file needs to be updated as a workaround for
+        # https://github.com/actions/virtual-environments/issues/3185
+        run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - uses: actions/setup-java@v1
         with:
           java-version: 8


### PR DESCRIPTION
Sporadic failures are observed on GitHub Actions when running on Ubuntu 20.04/18.04
Related to https://github.com/actions/virtual-environments/issues/3185