### PR TITLE
Rephrase `responseTimeout` Javadoc

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/FailedHttpClientRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/FailedHttpClientRequest.java
@@ -138,7 +138,7 @@ final class FailedHttpClientRequest implements HttpClientRequest {
 	}
 
 	@Override
-	public HttpClientRequest responseTimeout(Duration timeout) {
+	public HttpClientRequest responseTimeout(Duration maxReadOperationInterval) {
 		throw new UnsupportedOperationException("Should not add request timeout");
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1310,7 +1310,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 
 	/**
 	 * Specifies the response timeout duration in milliseconds.
-	 * This is time that takes to receive a response after sending a request.
+	 * This is the timeout for the read data operation, i.e., the maximum inactive time.
 	 * If the {@code timeout} is {@code null}, any previous setting will be removed and no response timeout
 	 * will be applied.
 	 * If the {@code timeout} is less than {@code 1ms}, then {@code 1ms} will be the response timeout.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1309,12 +1309,15 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	}
 
 	/**
-	 * Specifies the response timeout duration.
-	 * If the {@code timeout} is {@code null}, any previous setting will be removed and no response timeout
-	 * will be applied.
-	 * If the {@code timeout} is less than {@code 1ms}, then {@code 1ms} will be the response timeout.
-	 * The response timeout setting on {@link HttpClientRequest} level overrides any response timeout
-	 * setting on {@link HttpClient} level.
+	 * Specifies the maximum interval allowed between read operations (resolution: ms).
+	 * {@link io.netty.handler.timeout.ReadTimeoutHandler} is added to the channel pipeline after sending the request
+	 * and is removed when the response is fully received.
+	 * If the {@code maxReadOperationInterval} is {@code null}, any previous setting will be removed and no
+	 * {@code maxReadOperationInterval} will be applied.
+	 * If the {@code maxReadOperationInterval} is less than {@code 1ms}, then {@code 1ms} will be the
+	 * {@code maxReadOperationInterval}.
+	 * The {@code maxReadOperationInterval} setting on {@link HttpClientRequest} level overrides any
+	 * {@code maxReadOperationInterval} setting on {@link HttpClient} level.
 	 *
 	 * @param maxReadOperationInterval the maximum interval allowed between read operations (resolution: ms).
 	 * @return a new {@link HttpClient}
@@ -1322,7 +1325,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @see io.netty.handler.timeout.ReadTimeoutHandler
 	 */
 	public final HttpClient responseTimeout(Duration maxReadOperationInterval) {
-		Objects.requireNonNull(maxReadOperationInterval, "timeout");
+		Objects.requireNonNull(maxReadOperationInterval, "maxReadOperationInterval");
 		if (Objects.equals(maxReadOperationInterval, configuration().responseTimeout)) {
 			return this;
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1309,25 +1309,25 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	}
 
 	/**
-	 * Specifies the response timeout duration in milliseconds.
-	 * This is the timeout for the read data operation, i.e., the maximum inactive time.
+	 * Specifies the response timeout duration.
 	 * If the {@code timeout} is {@code null}, any previous setting will be removed and no response timeout
 	 * will be applied.
 	 * If the {@code timeout} is less than {@code 1ms}, then {@code 1ms} will be the response timeout.
 	 * The response timeout setting on {@link HttpClientRequest} level overrides any response timeout
 	 * setting on {@link HttpClient} level.
 	 *
-	 * @param timeout the response timeout duration (resolution: ms)
+	 * @param maxReadOperationInterval the maximum interval allowed between read operations (resolution: ms).
 	 * @return a new {@link HttpClient}
 	 * @since 0.9.11
+	 * @see io.netty.handler.timeout.ReadTimeoutHandler
 	 */
-	public final HttpClient responseTimeout(Duration timeout) {
-		Objects.requireNonNull(timeout, "timeout");
-		if (Objects.equals(timeout, configuration().responseTimeout)) {
+	public final HttpClient responseTimeout(Duration maxReadOperationInterval) {
+		Objects.requireNonNull(maxReadOperationInterval, "timeout");
+		if (Objects.equals(maxReadOperationInterval, configuration().responseTimeout)) {
 			return this;
 		}
 		HttpClient dup = duplicate();
-		dup.configuration().responseTimeout = timeout;
+		dup.configuration().responseTimeout = maxReadOperationInterval;
 		return dup;
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1309,9 +1309,9 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	}
 
 	/**
-	 * Specifies the maximum interval allowed between read operations (resolution: ms).
-	 * {@link io.netty.handler.timeout.ReadTimeoutHandler} is added to the channel pipeline after sending the request
-	 * and is removed when the response is fully received.
+	 * Specifies the maximum duration allowed between each network-level read operation while reading a given response
+	 * (resolution: ms). In other words, {@link io.netty.handler.timeout.ReadTimeoutHandler} is added to the channel
+	 * pipeline after sending the request and is removed when the response is fully received.
 	 * If the {@code maxReadOperationInterval} is {@code null}, any previous setting will be removed and no
 	 * {@code maxReadOperationInterval} will be applied.
 	 * If the {@code maxReadOperationInterval} is less than {@code 1ms}, then {@code 1ms} will be the
@@ -1319,7 +1319,8 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * The {@code maxReadOperationInterval} setting on {@link HttpClientRequest} level overrides any
 	 * {@code maxReadOperationInterval} setting on {@link HttpClient} level.
 	 *
-	 * @param maxReadOperationInterval the maximum interval allowed between read operations (resolution: ms).
+	 * @param maxReadOperationInterval the maximum duration allowed between each network-level read operations
+	 *                                 (resolution: ms).
 	 * @return a new {@link HttpClient}
 	 * @since 0.9.11
 	 * @see io.netty.handler.timeout.ReadTimeoutHandler

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -334,9 +334,9 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 	}
 
 	@Override
-	public HttpClientRequest responseTimeout(Duration timeout) {
+	public HttpClientRequest responseTimeout(Duration maxReadOperationInterval) {
 		if (!hasSentHeaders()) {
-			this.responseTimeout = timeout;
+			this.responseTimeout = maxReadOperationInterval;
 		}
 		else {
 			throw new IllegalStateException("Status and headers already sent");

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientRequest.java
@@ -76,7 +76,7 @@ public interface HttpClientRequest extends HttpClientInfos {
 
 	/**
 	 * Specifies the response timeout duration in milliseconds.
-	 * This is time that takes to receive a response after sending a request.
+	 * This is the timeout for the read data operation, i.e., the maximum inactive time.
 	 * If the {@code timeout} is {@code null}, any previous setting will be removed and no response timeout
 	 * will be applied.
 	 * If the {@code timeout} is less than {@code 1ms}, then {@code 1ms} will be the response timeout.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientRequest.java
@@ -75,9 +75,9 @@ public interface HttpClientRequest extends HttpClientInfos {
 	boolean isFollowRedirect();
 
 	/**
-	 * Specifies the maximum interval allowed between read operations (resolution: ms).
-	 * {@link io.netty.handler.timeout.ReadTimeoutHandler} is added to the channel pipeline after sending the request
-	 * and is removed when the response is fully received.
+	 * Specifies the maximum duration allowed between each network-level read operation while reading a given response
+	 * (resolution: ms). In other words, {@link io.netty.handler.timeout.ReadTimeoutHandler} is added to the channel
+	 * pipeline after sending the request and is removed when the response is fully received.
 	 * If the {@code maxReadOperationInterval} is {@code null}, any previous setting will be removed and no
 	 * {@code maxReadOperationInterval} will be applied.
 	 * If the {@code maxReadOperationInterval} is less than {@code 1ms}, then {@code 1ms} will be the
@@ -85,7 +85,8 @@ public interface HttpClientRequest extends HttpClientInfos {
 	 * The {@code maxReadOperationInterval} setting on {@link HttpClientRequest} level overrides any
 	 * {@code maxReadOperationInterval} setting on {@link HttpClient} level.
 	 *
-	 * @param maxReadOperationInterval the maximum interval allowed between read operations (resolution: ms).
+	 * @param maxReadOperationInterval the maximum duration allowed between each network-level read operations
+	 *                                 (resolution: ms).
 	 * @return this outbound
 	 * @since 0.9.11
 	 * @see io.netty.handler.timeout.ReadTimeoutHandler

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientRequest.java
@@ -75,12 +75,15 @@ public interface HttpClientRequest extends HttpClientInfos {
 	boolean isFollowRedirect();
 
 	/**
-	 * Specifies the response timeout duration.
-	 * If the {@code timeout} is {@code null}, any previous setting will be removed and no response timeout
-	 * will be applied.
-	 * If the {@code timeout} is less than {@code 1ms}, then {@code 1ms} will be the response timeout.
-	 * The response timeout setting on {@link HttpClientRequest} level overrides any response timeout
-	 * setting on {@link HttpClient} level.
+	 * Specifies the maximum interval allowed between read operations (resolution: ms).
+	 * {@link io.netty.handler.timeout.ReadTimeoutHandler} is added to the channel pipeline after sending the request
+	 * and is removed when the response is fully received.
+	 * If the {@code maxReadOperationInterval} is {@code null}, any previous setting will be removed and no
+	 * {@code maxReadOperationInterval} will be applied.
+	 * If the {@code maxReadOperationInterval} is less than {@code 1ms}, then {@code 1ms} will be the
+	 * {@code maxReadOperationInterval}.
+	 * The {@code maxReadOperationInterval} setting on {@link HttpClientRequest} level overrides any
+	 * {@code maxReadOperationInterval} setting timeout setting on {@link HttpClient} level.
 	 *
 	 * @param maxReadOperationInterval the maximum interval allowed between read operations (resolution: ms).
 	 * @return this outbound

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientRequest.java
@@ -83,7 +83,7 @@ public interface HttpClientRequest extends HttpClientInfos {
 	 * If the {@code maxReadOperationInterval} is less than {@code 1ms}, then {@code 1ms} will be the
 	 * {@code maxReadOperationInterval}.
 	 * The {@code maxReadOperationInterval} setting on {@link HttpClientRequest} level overrides any
-	 * {@code maxReadOperationInterval} setting timeout setting on {@link HttpClient} level.
+	 * {@code maxReadOperationInterval} setting on {@link HttpClient} level.
 	 *
 	 * @param maxReadOperationInterval the maximum interval allowed between read operations (resolution: ms).
 	 * @return this outbound

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientRequest.java
@@ -75,17 +75,17 @@ public interface HttpClientRequest extends HttpClientInfos {
 	boolean isFollowRedirect();
 
 	/**
-	 * Specifies the response timeout duration in milliseconds.
-	 * This is the timeout for the read data operation, i.e., the maximum inactive time.
+	 * Specifies the response timeout duration.
 	 * If the {@code timeout} is {@code null}, any previous setting will be removed and no response timeout
 	 * will be applied.
 	 * If the {@code timeout} is less than {@code 1ms}, then {@code 1ms} will be the response timeout.
 	 * The response timeout setting on {@link HttpClientRequest} level overrides any response timeout
 	 * setting on {@link HttpClient} level.
 	 *
-	 * @param timeout the response timeout duration
+	 * @param maxReadOperationInterval the maximum interval allowed between read operations (resolution: ms).
 	 * @return this outbound
 	 * @since 0.9.11
+	 * @see io.netty.handler.timeout.ReadTimeoutHandler
 	 */
-	HttpClientRequest responseTimeout(Duration timeout);
+	HttpClientRequest responseTimeout(Duration maxReadOperationInterval);
 }


### PR DESCRIPTION
The `#responseTimeout` Javadoc and Netty's [`ReadTimeoutHandler` Javadoc](https://netty.io/4.0/api/io/netty/handler/timeout/ReadTimeoutHandler.html) don't seem to match.

> Raises a `ReadTimeoutException` when no data was read within a certain period of time.

This PR tries to clarify the response timeout configuration.

Also, does it make sense to introduce `#readTimeout` and deprecate these methods as their name is misleading?