### PR TITLE
Print in the logs SSLEngine instance in use

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -527,16 +527,14 @@ public final class SslProvider {
 					.newHandler(channel.alloc(), sniInfo.getHostString(), sniInfo.getPort());
 
 			if (log.isDebugEnabled()) {
-				log.debug(format(channel, "SSL enabled using engine {} and SNI {}"),
-						sslHandler.engine().getClass().getSimpleName(), sniInfo);
+				log.debug(format(channel, "SSL enabled using engine {} and SNI {}"), sslHandler.engine(), sniInfo);
 			}
 		}
 		else {
 			sslHandler = getSslContext().newHandler(channel.alloc());
 
 			if (log.isDebugEnabled()) {
-				log.debug(format(channel, "SSL enabled using engine {}"),
-						sslHandler.engine().getClass().getSimpleName());
+				log.debug(format(channel, "SSL enabled using engine {}"), sslHandler.engine());
 			}
 		}
 


### PR DESCRIPTION
Print in the logs SSLEngine instance in use and not only the name of the class.