### PR TITLE
Add HttpDecoderSpec#allowDuplicateContentLengths(boolean)

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -537,7 +537,8 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 						decoder.failOnMissingResponse,
 						decoder.validateHeaders(),
 						decoder.initialBufferSize(),
-						decoder.parseHttpAfterConnectRequest);
+						decoder.parseHttpAfterConnectRequest,
+						decoder.allowDuplicateContentLengths());
 
 		Http2FrameCodecBuilder http2FrameCodecBuilder =
 				Http2FrameCodecBuilder.forClient()
@@ -589,7 +590,8 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 						decoder.failOnMissingResponse,
 						decoder.validateHeaders(),
 						decoder.initialBufferSize(),
-						decoder.parseHttpAfterConnectRequest));
+						decoder.parseHttpAfterConnectRequest,
+						decoder.allowDuplicateContentLengths()));
 
 		if (acceptGzip) {
 			p.addAfter(NettyPipeline.HttpCodec, NettyPipeline.HttpDecompressor, new HttpContentDecompressor());

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpResponseDecoderSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpResponseDecoderSpec.java
@@ -109,6 +109,7 @@ public final class HttpResponseDecoderSpec extends HttpDecoderSpec<HttpResponseD
 		decoder.maxHeaderSize = maxHeaderSize;
 		decoder.maxInitialLineLength = maxInitialLineLength;
 		decoder.validateHeaders = validateHeaders;
+		decoder.allowDuplicateContentLengths = allowDuplicateContentLengths;
 		decoder.failOnMissingResponse = failOnMissingResponse;
 		decoder.parseHttpAfterConnectRequest = parseHttpAfterConnectRequest;
 		decoder.h2cMaxContentLength = h2cMaxContentLength;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRequestDecoderSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRequestDecoderSpec.java
@@ -57,6 +57,7 @@ public final class HttpRequestDecoderSpec extends HttpDecoderSpec<HttpRequestDec
 		decoder.maxHeaderSize = maxHeaderSize;
 		decoder.maxInitialLineLength = maxInitialLineLength;
 		decoder.validateHeaders = validateHeaders;
+		decoder.allowDuplicateContentLengths = allowDuplicateContentLengths;
 		decoder.h2cMaxContentLength = h2cMaxContentLength;
 		return decoder;
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -476,7 +476,8 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 			@Nullable Duration idleTimeout) {
 		HttpServerCodec httpServerCodec =
 				new HttpServerCodec(decoder.maxInitialLineLength(), decoder.maxHeaderSize(),
-						decoder.maxChunkSize(), decoder.validateHeaders(), decoder.initialBufferSize());
+						decoder.maxChunkSize(), decoder.validateHeaders(), decoder.initialBufferSize(),
+						decoder.allowDuplicateContentLengths());
 
 		Http11OrH2CleartextCodec
 				upgrader = new Http11OrH2CleartextCodec(compressPredicate, cookieDecoder, cookieEncoder,
@@ -537,7 +538,8 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		p.addBefore(NettyPipeline.ReactiveBridge,
 		            NettyPipeline.HttpCodec,
 		            new HttpServerCodec(decoder.maxInitialLineLength(), decoder.maxHeaderSize(),
-		                    decoder.maxChunkSize(), decoder.validateHeaders(), decoder.initialBufferSize()))
+		                    decoder.maxChunkSize(), decoder.validateHeaders(), decoder.initialBufferSize(),
+		                    decoder.allowDuplicateContentLengths()))
 		 .addBefore(NettyPipeline.ReactiveBridge,
 		            NettyPipeline.HttpTrafficHandler,
 		            new HttpTrafficHandler(listener, forwardedHeaderHandler, compressPredicate, cookieEncoder,

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpDecoderSpecTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpDecoderSpecTest.java
@@ -32,16 +32,17 @@ class HttpDecoderSpecTest {
 
 	@Test
 	void maxInitialLineLength() {
-		assertThat(conf.maxInitialLineLength()).as("default initial line length").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_INITIAL_LINE_LENGTH);
+		checkDefaultMaxInitialLineLength(conf);
 
 		conf.maxInitialLineLength(123);
 
 		assertThat(conf.maxInitialLineLength()).as("initial line length").isEqualTo(123);
 
-		assertThat(conf.maxHeaderSize()).as("default header size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_HEADER_SIZE);
-		assertThat(conf.maxChunkSize()).as("default chunk size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_CHUNK_SIZE);
-		assertThat(conf.validateHeaders()).as("default validate headers").isEqualTo(HttpDecoderSpec.DEFAULT_VALIDATE_HEADERS);
-		assertThat(conf.initialBufferSize()).as("default initial buffer sizes").isEqualTo(HttpDecoderSpec.DEFAULT_INITIAL_BUFFER_SIZE);
+		checkDefaultMaxHeaderSize(conf);
+		checkDefaultMaxChunkSize(conf);
+		checkDefaultValidateHeaders(conf);
+		checkDefaultInitialBufferSize(conf);
+		checkDefaultAllowDuplicateContentLengths(conf);
 	}
 
 	@Test
@@ -59,16 +60,17 @@ class HttpDecoderSpecTest {
 
 	@Test
 	void maxHeaderSize() {
-		assertThat(conf.maxHeaderSize()).as("default header size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_HEADER_SIZE);
+		checkDefaultMaxHeaderSize(conf);
 
 		conf.maxHeaderSize(123);
 
 		assertThat(conf.maxHeaderSize()).as("header size").isEqualTo(123);
 
-		assertThat(conf.maxInitialLineLength()).as("default initial line length").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_INITIAL_LINE_LENGTH);
-		assertThat(conf.maxChunkSize()).as("default chunk size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_CHUNK_SIZE);
-		assertThat(conf.validateHeaders()).as("default validate headers").isEqualTo(HttpDecoderSpec.DEFAULT_VALIDATE_HEADERS);
-		assertThat(conf.initialBufferSize()).as("default initial buffer sizes").isEqualTo(HttpDecoderSpec.DEFAULT_INITIAL_BUFFER_SIZE);
+		checkDefaultMaxInitialLineLength(conf);
+		checkDefaultMaxChunkSize(conf);
+		checkDefaultValidateHeaders(conf);
+		checkDefaultInitialBufferSize(conf);
+		checkDefaultAllowDuplicateContentLengths(conf);
 	}
 
 	@Test
@@ -86,16 +88,17 @@ class HttpDecoderSpecTest {
 
 	@Test
 	void maxChunkSize() {
-		assertThat(conf.maxChunkSize()).as("default chunk size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_CHUNK_SIZE);
+		checkDefaultMaxChunkSize(conf);
 
 		conf.maxChunkSize(123);
 
 		assertThat(conf.maxChunkSize()).as("chunk size").isEqualTo(123);
 
-		assertThat(conf.maxInitialLineLength()).as("default initial line length").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_INITIAL_LINE_LENGTH);
-		assertThat(conf.maxHeaderSize()).as("default header size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_HEADER_SIZE);
-		assertThat(conf.validateHeaders()).as("default validate headers").isEqualTo(HttpDecoderSpec.DEFAULT_VALIDATE_HEADERS);
-		assertThat(conf.initialBufferSize()).as("default initial buffer sizes").isEqualTo(HttpDecoderSpec.DEFAULT_INITIAL_BUFFER_SIZE);
+		checkDefaultMaxInitialLineLength(conf);
+		checkDefaultMaxHeaderSize(conf);
+		checkDefaultValidateHeaders(conf);
+		checkDefaultInitialBufferSize(conf);
+		checkDefaultAllowDuplicateContentLengths(conf);
 	}
 
 	@Test
@@ -113,30 +116,32 @@ class HttpDecoderSpecTest {
 
 	@Test
 	void validateHeaders() {
-		assertThat(conf.validateHeaders()).as("default validate headers").isTrue();
+		checkDefaultValidateHeaders(conf);
 
 		conf.validateHeaders(false);
 
 		assertThat(conf.validateHeaders()).as("validate headers").isFalse();
 
-		assertThat(conf.maxInitialLineLength()).as("default initial line length").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_INITIAL_LINE_LENGTH);
-		assertThat(conf.maxHeaderSize()).as("default header size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_HEADER_SIZE);
-		assertThat(conf.maxChunkSize()).as("default chunk size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_CHUNK_SIZE);
-		assertThat(conf.initialBufferSize()).as("default initial buffer sizes").isEqualTo(HttpDecoderSpec.DEFAULT_INITIAL_BUFFER_SIZE);
+		checkDefaultMaxInitialLineLength(conf);
+		checkDefaultMaxHeaderSize(conf);
+		checkDefaultMaxChunkSize(conf);
+		checkDefaultInitialBufferSize(conf);
+		checkDefaultAllowDuplicateContentLengths(conf);
 	}
 
 	@Test
 	void initialBufferSize() {
-		assertThat(conf.initialBufferSize()).as("default initial buffer sizes").isEqualTo(HttpDecoderSpec.DEFAULT_INITIAL_BUFFER_SIZE);
+		checkDefaultInitialBufferSize(conf);
 
 		conf.initialBufferSize(123);
 
 		assertThat(conf.initialBufferSize()).as("initial buffer size").isEqualTo(123);
 
-		assertThat(conf.maxInitialLineLength()).as("default initial line length").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_INITIAL_LINE_LENGTH);
-		assertThat(conf.maxHeaderSize()).as("default header size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_HEADER_SIZE);
-		assertThat(conf.maxChunkSize()).as("default chunk size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_CHUNK_SIZE);
-		assertThat(conf.validateHeaders()).as("default validate headers").isEqualTo(HttpDecoderSpec.DEFAULT_VALIDATE_HEADERS);
+		checkDefaultMaxInitialLineLength(conf);
+		checkDefaultMaxHeaderSize(conf);
+		checkDefaultMaxChunkSize(conf);
+		checkDefaultValidateHeaders(conf);
+		checkDefaultAllowDuplicateContentLengths(conf);
 	}
 
 	@Test
@@ -154,16 +159,53 @@ class HttpDecoderSpecTest {
 
 	@Test
 	void allowDuplicateContentLengths() {
-		assertThat(conf.allowDuplicateContentLengths()).as("default allow duplicate Content-Length headers").isFalse();
+		checkDefaultAllowDuplicateContentLengths(conf);
 
 		conf.allowDuplicateContentLengths(true);
 
 		assertThat(conf.allowDuplicateContentLengths()).as("allow duplicate Content-Length headers").isTrue();
 
-		assertThat(conf.maxInitialLineLength()).as("default initial line length").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_INITIAL_LINE_LENGTH);
-		assertThat(conf.maxHeaderSize()).as("default header size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_HEADER_SIZE);
-		assertThat(conf.maxChunkSize()).as("default chunk size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_CHUNK_SIZE);
-		assertThat(conf.initialBufferSize()).as("default initial buffer sizes").isEqualTo(HttpDecoderSpec.DEFAULT_INITIAL_BUFFER_SIZE);
+		checkDefaultMaxInitialLineLength(conf);
+		checkDefaultMaxHeaderSize(conf);
+		checkDefaultMaxChunkSize(conf);
+		checkDefaultValidateHeaders(conf);
+		checkDefaultInitialBufferSize(conf);
+	}
+
+	private static void checkDefaultMaxInitialLineLength(HttpDecoderSpecImpl conf) {
+		assertThat(conf.maxInitialLineLength()).as("default initial line length")
+				.isEqualTo(HttpDecoderSpec.DEFAULT_MAX_INITIAL_LINE_LENGTH)
+				.isEqualTo(4096);
+	}
+
+	private static void checkDefaultMaxHeaderSize(HttpDecoderSpecImpl conf) {
+		assertThat(conf.maxHeaderSize()).as("default header size")
+				.isEqualTo(HttpDecoderSpec.DEFAULT_MAX_HEADER_SIZE)
+				.isEqualTo(8192);
+	}
+
+	private static void checkDefaultMaxChunkSize(HttpDecoderSpecImpl conf) {
+		assertThat(conf.maxChunkSize()).as("default chunk size")
+				.isEqualTo(HttpDecoderSpec.DEFAULT_MAX_CHUNK_SIZE)
+				.isEqualTo(8192);
+	}
+
+	private static void checkDefaultValidateHeaders(HttpDecoderSpecImpl conf) {
+		assertThat(conf.validateHeaders()).as("default validate headers")
+				.isEqualTo(HttpDecoderSpec.DEFAULT_VALIDATE_HEADERS)
+				.isTrue();
+	}
+
+	private static void checkDefaultInitialBufferSize(HttpDecoderSpecImpl conf) {
+		assertThat(conf.initialBufferSize()).as("default initial buffer sizes")
+				.isEqualTo(HttpDecoderSpec.DEFAULT_INITIAL_BUFFER_SIZE)
+				.isEqualTo(128);
+	}
+
+	private static void checkDefaultAllowDuplicateContentLengths(HttpDecoderSpecImpl conf) {
+		assertThat(conf.allowDuplicateContentLengths()).as("default allow duplicate Content-Length headers")
+				.isEqualTo(HttpDecoderSpec.DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS)
+				.isFalse();
 	}
 
 	private static final class HttpDecoderSpecImpl extends HttpDecoderSpec<HttpDecoderSpecImpl> {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpDecoderSpecTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpDecoderSpecTest.java
@@ -32,6 +32,8 @@ class HttpDecoderSpecTest {
 
 	@Test
 	void maxInitialLineLength() {
+		assertThat(conf.maxInitialLineLength()).as("default initial line length").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_INITIAL_LINE_LENGTH);
+
 		conf.maxInitialLineLength(123);
 
 		assertThat(conf.maxInitialLineLength()).as("initial line length").isEqualTo(123);
@@ -57,6 +59,8 @@ class HttpDecoderSpecTest {
 
 	@Test
 	void maxHeaderSize() {
+		assertThat(conf.maxHeaderSize()).as("default header size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_HEADER_SIZE);
+
 		conf.maxHeaderSize(123);
 
 		assertThat(conf.maxHeaderSize()).as("header size").isEqualTo(123);
@@ -82,6 +86,8 @@ class HttpDecoderSpecTest {
 
 	@Test
 	void maxChunkSize() {
+		assertThat(conf.maxChunkSize()).as("default chunk size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_CHUNK_SIZE);
+
 		conf.maxChunkSize(123);
 
 		assertThat(conf.maxChunkSize()).as("chunk size").isEqualTo(123);
@@ -107,6 +113,8 @@ class HttpDecoderSpecTest {
 
 	@Test
 	void validateHeaders() {
+		assertThat(conf.validateHeaders()).as("default validate headers").isTrue();
+
 		conf.validateHeaders(false);
 
 		assertThat(conf.validateHeaders()).as("validate headers").isFalse();
@@ -119,6 +127,8 @@ class HttpDecoderSpecTest {
 
 	@Test
 	void initialBufferSize() {
+		assertThat(conf.initialBufferSize()).as("default initial buffer sizes").isEqualTo(HttpDecoderSpec.DEFAULT_INITIAL_BUFFER_SIZE);
+
 		conf.initialBufferSize(123);
 
 		assertThat(conf.initialBufferSize()).as("initial buffer size").isEqualTo(123);
@@ -140,6 +150,20 @@ class HttpDecoderSpecTest {
 				.isThrownBy(() -> conf.initialBufferSize(-1))
 				.as("rejects negative")
 				.withMessage("initialBufferSize must be strictly positive");
+	}
+
+	@Test
+	void allowDuplicateContentLengths() {
+		assertThat(conf.allowDuplicateContentLengths()).as("default allow duplicate Content-Length headers").isFalse();
+
+		conf.allowDuplicateContentLengths(true);
+
+		assertThat(conf.allowDuplicateContentLengths()).as("allow duplicate Content-Length headers").isTrue();
+
+		assertThat(conf.maxInitialLineLength()).as("default initial line length").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_INITIAL_LINE_LENGTH);
+		assertThat(conf.maxHeaderSize()).as("default header size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_HEADER_SIZE);
+		assertThat(conf.maxChunkSize()).as("default chunk size").isEqualTo(HttpDecoderSpec.DEFAULT_MAX_CHUNK_SIZE);
+		assertThat(conf.initialBufferSize()).as("default initial buffer sizes").isEqualTo(HttpDecoderSpec.DEFAULT_INITIAL_BUFFER_SIZE);
 	}
 
 	private static final class HttpDecoderSpecImpl extends HttpDecoderSpec<HttpDecoderSpecImpl> {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -1607,9 +1607,9 @@ class HttpClientTest extends BaseHttpTest {
 	@Test
 	void httpClientResponseConfigInjectAttributes() {
 		AtomicReference<Channel> channelRef = new AtomicReference<>();
-		AtomicReference<Boolean> validate = new AtomicReference<>();
-		AtomicReference<Integer> chunkSize = new AtomicReference<>();
-		AtomicReference<Boolean> allowDuplicateContentLengths = new AtomicReference<>();
+		AtomicBoolean validate = new AtomicBoolean();
+		AtomicInteger chunkSize = new AtomicInteger();
+		AtomicBoolean allowDuplicateContentLengths = new AtomicBoolean();
 		disposableServer =
 				createServer()
 				          .handle((req, resp) -> req.receive()
@@ -1644,10 +1644,9 @@ class HttpClientTest extends BaseHttpTest {
 		        .block(Duration.ofSeconds(30));
 
 		assertThat(channelRef.get()).isNotNull();
-
-		assertThat(chunkSize.get()).as("line length").isEqualTo(789);
-		assertThat(validate.get()).as("validate headers").isFalse();
-		assertThat(allowDuplicateContentLengths.get()).as("allow duplicate Content-Length").isTrue();
+		assertThat(chunkSize).as("line length").hasValue(789);
+		assertThat(validate).as("validate headers").isFalse();
+		assertThat(allowDuplicateContentLengths).as("allow duplicate Content-Length").isTrue();
 	}
 
 	private Object getValueReflection(Object obj, String fieldName, int superLevel) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -1609,7 +1609,7 @@ class HttpClientTest extends BaseHttpTest {
 		AtomicReference<Channel> channelRef = new AtomicReference<>();
 		AtomicReference<Boolean> validate = new AtomicReference<>();
 		AtomicReference<Integer> chunkSize = new AtomicReference<>();
-
+		AtomicReference<Boolean> allowDuplicateContentLengths = new AtomicReference<>();
 		disposableServer =
 				createServer()
 				          .handle((req, resp) -> req.receive()
@@ -1623,7 +1623,8 @@ class HttpClientTest extends BaseHttpTest {
 		                                       .validateHeaders(false)
 		                                       .initialBufferSize(10)
 		                                       .failOnMissingResponse(true)
-		                                       .parseHttpAfterConnectRequest(true))
+		                                       .parseHttpAfterConnectRequest(true)
+		                                       .allowDuplicateContentLengths(true))
 		        .doOnConnected(c -> {
 		                    channelRef.set(c.channel());
 		                    HttpClientCodec codec = c.channel()
@@ -1632,6 +1633,7 @@ class HttpClientTest extends BaseHttpTest {
 		                    HttpObjectDecoder decoder = (HttpObjectDecoder) getValueReflection(codec, "inboundHandler", 1);
 		                    chunkSize.set((Integer) getValueReflection(decoder, "maxChunkSize", 2));
 		                    validate.set((Boolean) getValueReflection(decoder, "validateHeaders", 2));
+		                    allowDuplicateContentLengths.set((Boolean) getValueReflection(decoder, "allowDuplicateContentLengths", 2));
 		                })
 		        .post()
 		        .uri("/")
@@ -1645,6 +1647,7 @@ class HttpClientTest extends BaseHttpTest {
 
 		assertThat(chunkSize.get()).as("line length").isEqualTo(789);
 		assertThat(validate.get()).as("validate headers").isFalse();
+		assertThat(allowDuplicateContentLengths.get()).as("allow duplicate Content-Length").isTrue();
 	}
 
 	private Object getValueReflection(Object obj, String fieldName, int superLevel) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
@@ -840,9 +841,9 @@ class HttpServerTests extends BaseHttpTest {
 	@Test
 	void httpServerRequestConfigInjectAttributes() {
 		AtomicReference<Channel> channelRef = new AtomicReference<>();
-		AtomicReference<Boolean> validate = new AtomicReference<>();
-		AtomicReference<Integer> chunkSize = new AtomicReference<>();
-		AtomicReference<Boolean> allowDuplicateContentLengths = new AtomicReference<>();
+		AtomicBoolean validate = new AtomicBoolean();
+		AtomicInteger chunkSize = new AtomicInteger();
+		AtomicBoolean allowDuplicateContentLengths = new AtomicBoolean();
 		disposableServer =
 				createServer()
 				          .httpRequestDecoder(opt -> opt.maxInitialLineLength(123)
@@ -874,9 +875,9 @@ class HttpServerTests extends BaseHttpTest {
 		          .block();
 
 		assertThat(channelRef.get()).isNotNull();
-		assertThat(chunkSize.get()).as("line length").isEqualTo(789);
-		assertThat(validate.get()).as("validate headers").isFalse();
-		assertThat(allowDuplicateContentLengths.get()).as("allow duplicate Content-Length").isTrue();
+		assertThat(chunkSize).as("line length").hasValue(789);
+		assertThat(validate).as("validate headers").isFalse();
+		assertThat(allowDuplicateContentLengths).as("allow duplicate Content-Length").isTrue();
 	}
 
 	private Object getValueReflection(Object obj, String fieldName, int superLevel) {


### PR DESCRIPTION
API for configuring whether or not to allow duplicate `Content-Length` headers with the same value.
By default this is not allowed and such messages are rejected.
When this is configured to allow duplicate `Content-Length` headers, they have to have the same value,
otherwise such messages are rejected. The duplicated `Content-Length` headers are replaced
with a single valid `Content-Length` header.

Fixes #1636