### PR TITLE
Access log must contain only the remote IP without a port

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/BaseAccessLogHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/BaseAccessLogHandler.java
@@ -30,7 +30,7 @@ import static reactor.netty.http.server.logging.AbstractAccessLogArgProvider.MIS
 class BaseAccessLogHandler extends ChannelDuplexHandler {
 
 	static final String DEFAULT_LOG_FORMAT =
-			"{} - {} [{}] \"{} {} {}\" {} {} {} ms";
+			"{} - {} [{}] \"{} {} {}\" {} {} {}";
 
 	@SuppressWarnings("deprecation")
 	static final Function<AccessLogArgProvider, AccessLog> DEFAULT_ACCESS_LOG =
@@ -45,13 +45,7 @@ class BaseAccessLogHandler extends ChannelDuplexHandler {
 	}
 
 	static String applyAddress(@Nullable SocketAddress socketAddress) {
-		if (socketAddress instanceof InetSocketAddress) {
-			InetSocketAddress inetSocketAddress = (InetSocketAddress) socketAddress;
-			return inetSocketAddress.getHostString() + ":" + inetSocketAddress.getPort();
-		}
-		else {
-			return MISSING;
-		}
+		return socketAddress instanceof InetSocketAddress ? ((InetSocketAddress) socketAddress).getHostString() : MISSING;
 	}
 
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/BaseAccessLogHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/BaseAccessLogHandlerTests.java
@@ -41,8 +41,7 @@ class BaseAccessLogHandlerTests {
 
 	@Test
 	void applyAddress() {
-		assertThat(BaseAccessLogHandler.applyAddress(new InetSocketAddress("127.0.0.1", 8080)))
-				.isEqualTo("127.0.0.1:8080");
+		assertThat(BaseAccessLogHandler.applyAddress(new InetSocketAddress("127.0.0.1", 8080))).isEqualTo("127.0.0.1");
 		assertThat(BaseAccessLogHandler.applyAddress(null)).isEqualTo(MISSING);
 	}
 


### PR DESCRIPTION
- Common log format must contain the IP address of the client (remote host)
which made the request to the server.
- Response duration must be without "ms".