### PR TITLE
Add API for ContextView aware metrics recorder

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/AbstractChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/AbstractChannelMetricsHandler.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.channel;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.socket.DatagramPacket;
+import reactor.netty.NettyPipeline;
+import reactor.util.annotation.Nullable;
+
+import java.net.SocketAddress;
+
+/**
+ * Base {@link ChannelHandler} for collecting metrics on protocol level.
+ *
+ * @author Violeta Georgieva
+ * @since 1.0.8
+ */
+public abstract class AbstractChannelMetricsHandler extends ChannelDuplexHandler {
+
+	final SocketAddress remoteAddress;
+
+	final boolean onServer;
+
+	protected AbstractChannelMetricsHandler(@Nullable SocketAddress remoteAddress, boolean onServer) {
+		this.remoteAddress = remoteAddress;
+		this.onServer = onServer;
+	}
+
+	@Override
+	public void channelRegistered(ChannelHandlerContext ctx) {
+		if (!onServer) {
+			ctx.pipeline()
+			   .addAfter(NettyPipeline.ChannelMetricsHandler,
+			             NettyPipeline.ConnectMetricsHandler,
+			             connectMetricsHandler());
+		}
+
+		ctx.fireChannelRegistered();
+	}
+
+	@Override
+	public void channelRead(ChannelHandlerContext ctx, Object msg) {
+		if (msg instanceof ByteBuf) {
+			ByteBuf buffer = (ByteBuf) msg;
+			if (buffer.readableBytes() > 0) {
+				recordRead(ctx, remoteAddress, buffer.readableBytes());
+			}
+		}
+		else if (msg instanceof DatagramPacket) {
+			DatagramPacket p = (DatagramPacket) msg;
+			ByteBuf buffer = p.content();
+			if (buffer.readableBytes() > 0) {
+				recordRead(ctx, remoteAddress != null ? remoteAddress : p.sender(), buffer.readableBytes());
+			}
+		}
+
+		ctx.fireChannelRead(msg);
+	}
+
+	@Override
+	@SuppressWarnings("FutureReturnValueIgnored")
+	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+		if (msg instanceof ByteBuf) {
+			ByteBuf buffer = (ByteBuf) msg;
+			if (buffer.readableBytes() > 0) {
+				recordWrite(ctx, remoteAddress, buffer.readableBytes());
+			}
+		}
+		else if (msg instanceof DatagramPacket) {
+			DatagramPacket p = (DatagramPacket) msg;
+			ByteBuf buffer = p.content();
+			if (buffer.readableBytes() > 0) {
+				recordWrite(ctx, remoteAddress != null ? remoteAddress : p.recipient(), buffer.readableBytes());
+			}
+		}
+
+		//"FutureReturnValueIgnored" this is deliberate
+		ctx.write(msg, promise);
+	}
+
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+		recordException(ctx, remoteAddress != null ? remoteAddress : ctx.channel().remoteAddress());
+
+		ctx.fireExceptionCaught(cause);
+	}
+
+	public abstract ChannelHandler connectMetricsHandler();
+
+	public abstract ChannelMetricsRecorder recorder();
+
+	protected void recordException(ChannelHandlerContext ctx, SocketAddress address) {
+		recorder().incrementErrorsCount(address);
+	}
+
+	protected void recordRead(ChannelHandlerContext ctx, SocketAddress address, long bytes) {
+		recorder().recordDataReceived(address, bytes);
+	}
+
+	protected void recordWrite(ChannelHandlerContext ctx, SocketAddress address, long bytes) {
+		recorder().recordDataSent(address, bytes);
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
@@ -70,7 +70,7 @@ public class ChannelMetricsHandler extends AbstractChannelMetricsHandler {
 				recorder.recordConnectTime(
 						remoteAddress,
 						Duration.ofNanos(System.nanoTime() - connectTimeStart),
-						future.isSuccess() ? SUCCESS :  ERROR);
+						future.isSuccess() ? SUCCESS : ERROR);
 			});
 		}
 	}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
@@ -15,14 +15,10 @@
  */
 package reactor.netty.channel;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.socket.DatagramPacket;
-import reactor.netty.NettyPipeline;
 import reactor.util.annotation.Nullable;
 
 import java.net.SocketAddress;
@@ -36,94 +32,21 @@ import static reactor.netty.Metrics.SUCCESS;
  *
  * @author Violeta Georgieva
  */
-public class ChannelMetricsHandler extends ChannelDuplexHandler {
+public class ChannelMetricsHandler extends AbstractChannelMetricsHandler {
+
 	final ChannelMetricsRecorder recorder;
 
-	final SocketAddress remoteAddress;
-
-	final boolean onServer;
-
-
 	ChannelMetricsHandler(ChannelMetricsRecorder recorder, @Nullable SocketAddress remoteAddress, boolean onServer) {
+		super(remoteAddress, onServer);
 		this.recorder = recorder;
-		this.remoteAddress = remoteAddress;
-		this.onServer = onServer;
 	}
 
 	@Override
-	public void channelRegistered(ChannelHandlerContext ctx) {
-		if (!onServer) {
-			ctx.pipeline()
-			   .addAfter(NettyPipeline.ChannelMetricsHandler,
-			             NettyPipeline.ConnectMetricsHandler,
-			             new ConnectMetricsHandler(recorder));
-		}
-
-		ctx.fireChannelRegistered();
+	public ChannelHandler connectMetricsHandler() {
+		return new ConnectMetricsHandler(recorder());
 	}
 
 	@Override
-	public void channelRead(ChannelHandlerContext ctx, Object msg) {
-		if (msg instanceof ByteBuf) {
-			ByteBuf buffer = (ByteBuf) msg;
-			if (buffer.readableBytes() > 0) {
-				recorder.recordDataReceived(remoteAddress, buffer.readableBytes());
-			}
-		}
-		else if (msg instanceof DatagramPacket) {
-			DatagramPacket p = (DatagramPacket) msg;
-			ByteBuf buffer = p.content();
-			if (buffer.readableBytes() > 0) {
-				if (remoteAddress != null) {
-					recorder.recordDataReceived(remoteAddress, buffer.readableBytes());
-				}
-				else {
-					recorder.recordDataReceived(p.sender(), buffer.readableBytes());
-				}
-			}
-		}
-
-		ctx.fireChannelRead(msg);
-	}
-
-	@Override
-	@SuppressWarnings("FutureReturnValueIgnored")
-	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-		if (msg instanceof ByteBuf) {
-			ByteBuf buffer = (ByteBuf) msg;
-			if (buffer.readableBytes() > 0) {
-				recorder.recordDataSent(remoteAddress, buffer.readableBytes());
-			}
-		}
-		else if (msg instanceof DatagramPacket) {
-			DatagramPacket p = (DatagramPacket) msg;
-			ByteBuf buffer = p.content();
-			if (buffer.readableBytes() > 0) {
-				if (remoteAddress != null) {
-					recorder.recordDataSent(remoteAddress, buffer.readableBytes());
-				}
-				else {
-					recorder.recordDataSent(p.recipient(), buffer.readableBytes());
-				}
-			}
-		}
-
-		//"FutureReturnValueIgnored" this is deliberate
-		ctx.write(msg, promise);
-	}
-
-	@Override
-	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-		if (remoteAddress != null) {
-			recorder.incrementErrorsCount(remoteAddress);
-		}
-		else {
-			recorder.incrementErrorsCount(ctx.channel().remoteAddress());
-		}
-
-		ctx.fireExceptionCaught(cause);
-	}
-
 	public ChannelMetricsRecorder recorder() {
 		return recorder;
 	}
@@ -144,17 +67,10 @@ public class ChannelMetricsHandler extends ChannelDuplexHandler {
 			promise.addListener(future -> {
 				ctx.pipeline().remove(this);
 
-				String status;
-				if (future.isSuccess()) {
-					status = SUCCESS;
-				}
-				else {
-					status = ERROR;
-				}
 				recorder.recordConnectTime(
 						remoteAddress,
 						Duration.ofNanos(System.nanoTime() - connectTimeStart),
-						status);
+						future.isSuccess() ? SUCCESS :  ERROR);
 			});
 		}
 	}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
@@ -27,6 +27,7 @@ import java.util.function.Predicate;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.ReferenceCounted;
 import org.reactivestreams.Publisher;
@@ -96,8 +97,11 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 		if (remote == null) {
 			remote = ch.remoteAddress();
 		}
+		ChannelHandler handler = recorder instanceof ContextAwareChannelMetricsRecorder ?
+				new ContextAwareChannelMetricsHandler((ContextAwareChannelMetricsRecorder) recorder, remote, onServer) :
+				new ChannelMetricsHandler(recorder, remote, onServer);
 		ch.pipeline()
-		  .addFirst(NettyPipeline.ChannelMetricsHandler, new ChannelMetricsHandler(recorder, remote, onServer));
+		  .addFirst(NettyPipeline.ChannelMetricsHandler, handler);
 	}
 
 	/**

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.channel;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import reactor.netty.Connection;
+import reactor.netty.ConnectionObserver;
+import reactor.util.annotation.Nullable;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+
+import static reactor.netty.Metrics.ERROR;
+import static reactor.netty.Metrics.SUCCESS;
+
+/**
+ * @author Violeta Georgieva
+ * @since 1.0.8
+ */
+final class ContextAwareChannelMetricsHandler extends AbstractChannelMetricsHandler {
+
+	final ContextAwareChannelMetricsRecorder recorder;
+
+	ContextAwareChannelMetricsHandler(ContextAwareChannelMetricsRecorder recorder,
+			@Nullable SocketAddress remoteAddress, boolean onServer) {
+		super(remoteAddress, onServer);
+		this.recorder = recorder;
+	}
+
+	@Override
+	public ChannelHandler connectMetricsHandler() {
+		return new ContextAwareConnectMetricsHandler(recorder());
+	}
+
+	@Override
+	public ContextAwareChannelMetricsRecorder recorder() {
+		return recorder;
+	}
+
+	@Override
+	protected void recordException(ChannelHandlerContext ctx, SocketAddress address) {
+		Connection connection = Connection.from(ctx.channel());
+		ChannelOperations<?, ?> ops = connection.as(ChannelOperations.class);
+		if (ops != null) {
+			recorder().incrementErrorsCount(ops.currentContext(), address);
+		}
+		else if (connection instanceof ConnectionObserver) {
+			recorder().incrementErrorsCount(((ConnectionObserver) connection).currentContext(), address);
+		}
+		else {
+			super.recordException(ctx, address);
+		}
+	}
+
+	@Override
+	protected void recordRead(ChannelHandlerContext ctx, SocketAddress address, long bytes) {
+		ChannelOperations<?, ?> ops = ChannelOperations.get(ctx.channel());
+		if (ops != null) {
+			recorder().recordDataReceived(ops.currentContext(), address, bytes);
+		}
+		else {
+			super.recordRead(ctx, address, bytes);
+		}
+	}
+
+	@Override
+	protected void recordWrite(ChannelHandlerContext ctx, SocketAddress address, long bytes) {
+		ChannelOperations<?, ?> ops = ChannelOperations.get(ctx.channel());
+		if (ops != null) {
+			recorder().recordDataSent(ops.currentContext(), address, bytes);
+		}
+		else {
+			super.recordWrite(ctx, address, bytes);
+		}
+	}
+
+	static final class ContextAwareConnectMetricsHandler extends ChannelOutboundHandlerAdapter {
+
+		final ContextAwareChannelMetricsRecorder recorder;
+
+		ContextAwareConnectMetricsHandler(ContextAwareChannelMetricsRecorder recorder) {
+			this.recorder = recorder;
+		}
+
+		@Override
+		public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress,
+				SocketAddress localAddress, ChannelPromise promise) throws Exception {
+			long connectTimeStart = System.nanoTime();
+			super.connect(ctx, remoteAddress, localAddress, promise);
+			promise.addListener(future -> {
+				ctx.pipeline().remove(this);
+				recordConnectTime(ctx, remoteAddress, connectTimeStart, future.isSuccess() ? SUCCESS :  ERROR);
+			});
+		}
+
+		void recordConnectTime(ChannelHandlerContext ctx, SocketAddress address, long connectTimeStart, String status) {
+			Connection connection = Connection.from(ctx.channel());
+			if (connection instanceof ConnectionObserver) {
+				recorder.recordConnectTime(
+						((ConnectionObserver) connection).currentContext(),
+						address,
+						Duration.ofNanos(System.nanoTime() - connectTimeStart),
+						status);
+			}
+			else {
+				recorder.recordConnectTime(address, Duration.ofNanos(System.nanoTime() - connectTimeStart), status);
+			}
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
@@ -105,7 +105,7 @@ final class ContextAwareChannelMetricsHandler extends AbstractChannelMetricsHand
 			super.connect(ctx, remoteAddress, localAddress, promise);
 			promise.addListener(future -> {
 				ctx.pipeline().remove(this);
-				recordConnectTime(ctx, remoteAddress, connectTimeStart, future.isSuccess() ? SUCCESS :  ERROR);
+				recordConnectTime(ctx, remoteAddress, connectTimeStart, future.isSuccess() ? SUCCESS : ERROR);
 			});
 		}
 

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsRecorder.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.channel;
+
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+
+/**
+ * {@link ContextView} aware class for recording metrics on protocol level.
+ *
+ * @author Violeta Georgieva
+ * @since 1.0.8
+ */
+public abstract class ContextAwareChannelMetricsRecorder implements ChannelMetricsRecorder {
+
+	/**
+	 * Increments the number of the errors that are occurred
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux pipeline
+	 * @param remoteAddress The remote peer
+	 */
+	public abstract void incrementErrorsCount(ContextView contextView, SocketAddress remoteAddress);
+
+	/**
+	 * Records the time that is spent for connecting to the remote address
+	 * Relevant only when on the client
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux pipeline
+	 * @param remoteAddress The remote peer
+	 * @param time The time in nanoseconds that is spent for connecting to the remote address
+	 * @param status The status of the operation
+	 */
+	public abstract void recordConnectTime(ContextView contextView, SocketAddress remoteAddress, Duration time, String status);
+
+	/**
+	 * Records the amount of the data that is received, in bytes
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux pipeline
+	 * @param remoteAddress The remote peer
+	 * @param bytes The amount of the data that is received, in bytes
+	 */
+	public abstract void recordDataReceived(ContextView contextView, SocketAddress remoteAddress, long bytes);
+
+	/**
+	 * Records the amount of the data that is sent, in bytes
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux pipeline
+	 * @param remoteAddress The remote peer
+	 * @param bytes The amount of the data that is sent, in bytes
+	 */
+	public abstract void recordDataSent(ContextView contextView, SocketAddress remoteAddress, long bytes);
+
+	/**
+	 * Records the time that is spent for TLS handshake
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux pipeline
+	 * @param remoteAddress The remote peer
+	 * @param time The time in nanoseconds that is spent for TLS handshake
+	 * @param status The status of the operation
+	 */
+	public abstract void recordTlsHandshakeTime(ContextView contextView, SocketAddress remoteAddress, Duration time, String status);
+
+	@Override
+	public void incrementErrorsCount(SocketAddress remoteAddress) {
+		incrementErrorsCount(Context.empty(), remoteAddress);
+	}
+
+	@Override
+	public void recordConnectTime(SocketAddress remoteAddress, Duration time, String status) {
+		recordConnectTime(Context.empty(), remoteAddress, time, status);
+	}
+
+	@Override
+	public void recordDataReceived(SocketAddress remoteAddress, long bytes) {
+		recordDataReceived(Context.empty(), remoteAddress, bytes);
+	}
+
+	@Override
+	public void recordDataSent(SocketAddress remoteAddress, long bytes) {
+		recordDataSent(Context.empty(), remoteAddress, bytes);
+	}
+
+	@Override
+	public void recordTlsHandshakeTime(SocketAddress remoteAddress, Duration time, String status) {
+		recordTlsHandshakeTime(Context.empty(), remoteAddress, time, status);
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/ContextAwareHttpMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/ContextAwareHttpMetricsRecorder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http;
+
+import reactor.netty.channel.ContextAwareChannelMetricsRecorder;
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+
+import java.net.SocketAddress;
+
+/**
+ * {@link ContextView} aware class for recording metrics for HTTP protocol.
+ *
+ * @author Violeta Georgieva
+ * @since 1.0.8
+ */
+public abstract class ContextAwareHttpMetricsRecorder extends ContextAwareChannelMetricsRecorder implements HttpMetricsRecorder {
+
+	/**
+	 * Increments the number of the errors that are occurred
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux
+	 * @param remoteAddress The remote peer
+	 * @param uri The requested URI
+	 */
+	public abstract void incrementErrorsCount(ContextView contextView, SocketAddress remoteAddress, String uri);
+
+	/**
+	 * Records the amount of the data that is received, in bytes
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux
+	 * @param remoteAddress The remote peer
+	 * @param uri The requested URI
+	 * @param bytes The amount of the data that is received, in bytes
+	 */
+	public abstract void recordDataReceived(ContextView contextView, SocketAddress remoteAddress, String uri, long bytes);
+
+	/**
+	 * Records the amount of the data that is sent, in bytes
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux
+	 * @param remoteAddress The remote peer
+	 * @param uri The requested URI
+	 * @param bytes The amount of the data that is sent, in bytes
+	 */
+	public abstract void recordDataSent(ContextView contextView, SocketAddress remoteAddress, String uri, long bytes);
+
+	@Override
+	public void recordDataReceived(SocketAddress remoteAddress, String uri, long bytes) {
+		recordDataReceived(Context.empty(), remoteAddress, uri, bytes);
+	}
+
+	@Override
+	public void recordDataSent(SocketAddress remoteAddress, String uri, long bytes) {
+		recordDataSent(Context.empty(), remoteAddress, uri, bytes);
+	}
+
+	@Override
+	public void incrementErrorsCount(SocketAddress remoteAddress, String uri) {
+		incrementErrorsCount(Context.empty(), remoteAddress, uri);
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.client;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.LastHttpContent;
+import reactor.netty.channel.ChannelOperations;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.ContextView;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+import java.util.function.Function;
+
+/**
+ * @author Violeta Georgieva
+ * @since 1.0.8
+ */
+abstract class AbstractHttpClientMetricsHandler extends ChannelDuplexHandler {
+
+	String path;
+
+	String method;
+
+	String status;
+
+	ContextView contextView;
+
+
+	long dataReceived;
+
+	long dataSent;
+
+
+	long dataReceivedTime;
+
+	long dataSentTime;
+
+	final Function<String, String> uriTagValue;
+
+	protected AbstractHttpClientMetricsHandler(@Nullable Function<String, String> uriTagValue) {
+		this.uriTagValue = uriTagValue;
+	}
+
+	@Override
+	@SuppressWarnings("FutureReturnValueIgnored")
+	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+		if (msg instanceof HttpRequest) {
+			method = ((HttpRequest) msg).method().name();
+
+			ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+			if (channelOps instanceof HttpClientOperations) {
+				HttpClientOperations ops = (HttpClientOperations) channelOps;
+				path = uriTagValue == null ? ops.path : uriTagValue.apply(ops.path);
+				contextView = ops.currentContextView();
+			}
+
+			dataSentTime = System.nanoTime();
+		}
+
+		if (msg instanceof ByteBufHolder) {
+			dataSent += ((ByteBufHolder) msg).content().readableBytes();
+		}
+		else if (msg instanceof ByteBuf) {
+			dataSent += ((ByteBuf) msg).readableBytes();
+		}
+
+		if (msg instanceof LastHttpContent) {
+			promise.addListener(future -> recordWrite(ctx.channel().remoteAddress()));
+		}
+		//"FutureReturnValueIgnored" this is deliberate
+		ctx.write(msg, promise);
+	}
+
+	@Override
+	public void channelRead(ChannelHandlerContext ctx, Object msg) {
+		if (msg instanceof HttpResponse) {
+			status = ((HttpResponse) msg).status().codeAsText().toString();
+
+			dataReceivedTime = System.nanoTime();
+		}
+
+		if (msg instanceof ByteBufHolder) {
+			dataReceived += ((ByteBufHolder) msg).content().readableBytes();
+		}
+		else if (msg instanceof ByteBuf) {
+			dataReceived += ((ByteBuf) msg).readableBytes();
+		}
+
+		if (msg instanceof LastHttpContent) {
+			recordRead(ctx.channel().remoteAddress());
+			reset();
+		}
+
+		ctx.fireChannelRead(msg);
+	}
+
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+		recordException(ctx);
+
+		ctx.fireExceptionCaught(cause);
+	}
+
+	protected abstract HttpClientMetricsRecorder recorder();
+
+	protected void recordException(ChannelHandlerContext ctx) {
+		recorder().incrementErrorsCount(ctx.channel().remoteAddress(),
+				path != null ? path : resolveUri(ctx));
+	}
+
+	protected void recordRead(SocketAddress address) {
+		recorder().recordDataReceivedTime(address,
+				path, method, status,
+				Duration.ofNanos(System.nanoTime() - dataReceivedTime));
+
+		recorder().recordResponseTime(address,
+				path, method, status,
+				Duration.ofNanos(System.nanoTime() - dataSentTime));
+
+		recorder().recordDataReceived(address, path, dataReceived);
+	}
+
+	protected void recordWrite(SocketAddress address) {
+		recorder().recordDataSentTime(address,
+				path, method,
+				Duration.ofNanos(System.nanoTime() - dataSentTime));
+
+		recorder().recordDataSent(address, path, dataSent);
+	}
+
+	private String resolveUri(ChannelHandlerContext ctx) {
+		ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+		if (channelOps instanceof HttpClientOperations) {
+			String path = ((HttpClientOperations) channelOps).uri();
+			return uriTagValue == null ? path : uriTagValue.apply(path);
+		}
+		else {
+			return "unknown";
+		}
+	}
+
+	private void reset() {
+		path = null;
+		method = null;
+		status = null;
+		contextView = null;
+		dataReceived = 0;
+		dataSent = 0;
+		dataReceivedTime = 0;
+		dataSentTime = 0;
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.client;
+
+import io.netty.channel.ChannelHandlerContext;
+import reactor.util.annotation.Nullable;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+import java.util.function.Function;
+
+/**
+ * @author Violeta Georgieva
+ * @since 1.0.8
+ */
+final class ContextAwareHttpClientMetricsHandler extends AbstractHttpClientMetricsHandler {
+
+	final ContextAwareHttpClientMetricsRecorder recorder;
+
+	ContextAwareHttpClientMetricsHandler(ContextAwareHttpClientMetricsRecorder recorder,
+			@Nullable Function<String, String> uriTagValue) {
+		super(uriTagValue);
+		this.recorder = recorder;
+	}
+
+	@Override
+	protected ContextAwareHttpClientMetricsRecorder recorder() {
+		return recorder;
+	}
+
+	@Override
+	protected void recordException(ChannelHandlerContext ctx) {
+		if (contextView != null) {
+			recorder().incrementErrorsCount(contextView, ctx.channel().remoteAddress(), path);
+		}
+
+		super.recordException(ctx);
+	}
+
+	@Override
+	protected void recordWrite(SocketAddress address) {
+		if (contextView != null) {
+			recorder.recordDataSentTime(contextView, address,
+					path, method,
+					Duration.ofNanos(System.nanoTime() - dataSentTime));
+
+			recorder.recordDataSent(contextView, address, path, dataSent);
+		}
+		else {
+			super.recordWrite(address);
+		}
+	}
+
+	@Override
+	protected void recordRead(SocketAddress address) {
+		if (contextView != null) {
+			recorder.recordDataReceivedTime(contextView, address,
+					path, method, status,
+					Duration.ofNanos(System.nanoTime() - dataReceivedTime));
+
+			recorder.recordResponseTime(contextView, address,
+					path, method, status,
+					Duration.ofNanos(System.nanoTime() - dataSentTime));
+
+			recorder.recordDataReceived(contextView, address, path, dataReceived);
+		}
+		else {
+			super.recordRead(address);
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsHandler.java
@@ -46,8 +46,9 @@ final class ContextAwareHttpClientMetricsHandler extends AbstractHttpClientMetri
 		if (contextView != null) {
 			recorder().incrementErrorsCount(contextView, ctx.channel().remoteAddress(), path);
 		}
-
-		super.recordException(ctx);
+		else {
+			super.recordException(ctx);
+		}
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsRecorder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.client;
+
+import reactor.netty.http.ContextAwareHttpMetricsRecorder;
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+
+/**
+ * {@link ContextView} aware class for collecting metrics on HTTP client level
+ *
+ * @author Violeta Georgieva
+ * @since 1.0.8
+ */
+public abstract class ContextAwareHttpClientMetricsRecorder extends ContextAwareHttpMetricsRecorder
+		implements HttpClientMetricsRecorder {
+
+	/**
+	 * Records the time that is spent in consuming incoming data
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux
+	 * @param remoteAddress The remote peer
+	 * @param uri The requested URI
+	 * @param method The HTTP method
+	 * @param status The HTTP status
+	 * @param time The time in nanoseconds that is spent in consuming incoming data
+	 */
+	public abstract void recordDataReceivedTime(ContextView contextView, SocketAddress remoteAddress, String uri,
+			String method, String status, Duration time);
+
+	/**
+	 * Records the time that is spent in sending outgoing data
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux
+	 * @param remoteAddress The remote peer
+	 * @param uri The requested URI
+	 * @param method The HTTP method
+	 * @param time The time in nanoseconds that is spent in sending outgoing data
+	 */
+	public abstract void recordDataSentTime(ContextView contextView, SocketAddress remoteAddress, String uri,
+			String method, Duration time);
+
+	/**
+	 * Records the total time for the request/response
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux
+	 * @param remoteAddress The remote peer
+	 * @param uri The requested URI
+	 * @param method The HTTP method
+	 * @param status The HTTP status
+	 * @param time The total time in nanoseconds for the request/response
+	 */
+	public abstract void recordResponseTime(ContextView contextView, SocketAddress remoteAddress, String uri, String method,
+			String status, Duration time);
+
+	@Override
+	public void recordDataReceivedTime(SocketAddress remoteAddress, String uri, String method, String status, Duration time) {
+		recordDataReceivedTime(Context.empty(), remoteAddress, uri, method, status, time);
+	}
+
+	@Override
+	public void recordDataSentTime(SocketAddress remoteAddress, String uri, String method, Duration time) {
+		recordDataSentTime(Context.empty(), remoteAddress, uri, method, time);
+	}
+
+	@Override
+	public void recordResponseTime(SocketAddress remoteAddress, String uri, String method, String status, Duration time) {
+		recordResponseTime(Context.empty(), remoteAddress, uri, method, status, time);
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -566,11 +567,12 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		}
 
 		if (metricsRecorder != null) {
-			ChannelMetricsRecorder channelMetricsRecorder = metricsRecorder.get();
-			if (channelMetricsRecorder instanceof HttpClientMetricsRecorder) {
-				p.addBefore(NettyPipeline.ReactiveBridge,
-						NettyPipeline.HttpMetricsHandler,
-						new HttpClientMetricsHandler((HttpClientMetricsRecorder) channelMetricsRecorder, uriTagValue));
+			ChannelMetricsRecorder recorder = metricsRecorder.get();
+			if (recorder instanceof HttpClientMetricsRecorder) {
+				ChannelHandler handler = recorder instanceof ContextAwareHttpClientMetricsRecorder ?
+						new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) recorder, uriTagValue) :
+						new HttpClientMetricsHandler((HttpClientMetricsRecorder) recorder, uriTagValue);
+				p.addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.HttpMetricsHandler, handler);
 			}
 		}
 
@@ -598,11 +600,12 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		}
 
 		if (metricsRecorder != null) {
-			ChannelMetricsRecorder channelMetricsRecorder = metricsRecorder.get();
-			if (channelMetricsRecorder instanceof HttpClientMetricsRecorder) {
-				p.addBefore(NettyPipeline.ReactiveBridge,
-						NettyPipeline.HttpMetricsHandler,
-						new HttpClientMetricsHandler((HttpClientMetricsRecorder) channelMetricsRecorder, uriTagValue));
+			ChannelMetricsRecorder recorder = metricsRecorder.get();
+			if (recorder instanceof HttpClientMetricsRecorder) {
+				ChannelHandler handler = recorder instanceof ContextAwareHttpClientMetricsRecorder ?
+						new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) recorder, uriTagValue) :
+						new HttpClientMetricsHandler((HttpClientMetricsRecorder) recorder, uriTagValue);
+				p.addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.HttpMetricsHandler, handler);
 			}
 		}
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.LastHttpContent;
+import reactor.netty.channel.ChannelOperations;
+import reactor.util.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+/**
+ * @author Violeta Georgieva
+ * @since 1.0.8
+ */
+abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
+
+	long dataReceived;
+
+	long dataSent;
+
+
+	long dataReceivedTime;
+
+	long dataSentTime;
+
+
+	final Function<String, String> uriTagValue;
+
+	protected AbstractHttpServerMetricsHandler(@Nullable Function<String, String> uriTagValue) {
+		this.uriTagValue = uriTagValue;
+	}
+
+	@Override
+	@SuppressWarnings("FutureReturnValueIgnored")
+	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+		if (msg instanceof HttpResponse) {
+			if (((HttpResponse) msg).status().equals(HttpResponseStatus.CONTINUE)) {
+				//"FutureReturnValueIgnored" this is deliberate
+				ctx.write(msg, promise);
+				return;
+			}
+
+			dataSentTime = System.nanoTime();
+		}
+
+		if (msg instanceof ByteBufHolder) {
+			dataSent += ((ByteBufHolder) msg).content().readableBytes();
+		}
+		else if (msg instanceof ByteBuf) {
+			dataSent += ((ByteBuf) msg).readableBytes();
+		}
+
+		if (msg instanceof LastHttpContent) {
+			promise.addListener(future -> {
+				ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+				if (channelOps instanceof HttpServerOperations) {
+					HttpServerOperations ops = (HttpServerOperations) channelOps;
+					recordWrite(ops, uriTagValue == null ? ops.path : uriTagValue.apply(ops.path),
+							ops.method().name(), ops.status().codeAsText().toString());
+				}
+
+				dataSent = 0;
+			});
+		}
+
+		//"FutureReturnValueIgnored" this is deliberate
+		ctx.write(msg, promise);
+	}
+
+	@Override
+	public void channelRead(ChannelHandlerContext ctx, Object msg) {
+		if (msg instanceof HttpRequest) {
+			dataReceivedTime = System.nanoTime();
+		}
+
+		if (msg instanceof ByteBufHolder) {
+			dataReceived += ((ByteBufHolder) msg).content().readableBytes();
+		}
+		else if (msg instanceof ByteBuf) {
+			dataReceived += ((ByteBuf) msg).readableBytes();
+		}
+
+		if (msg instanceof LastHttpContent) {
+			ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+			if (channelOps instanceof HttpServerOperations) {
+				HttpServerOperations ops = (HttpServerOperations) channelOps;
+				recordRead(ops, uriTagValue == null ? ops.path : uriTagValue.apply(ops.path), ops.method().name());
+			}
+
+			dataReceived = 0;
+		}
+
+		ctx.fireChannelRead(msg);
+	}
+
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+		ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+		if (channelOps instanceof HttpServerOperations) {
+			HttpServerOperations ops = (HttpServerOperations) channelOps;
+			// Always take the remote address from the operations in order to consider proxy information
+			recordException(ops, uriTagValue == null ? ops.path : uriTagValue.apply(ops.path));
+		}
+
+		ctx.fireExceptionCaught(cause);
+	}
+
+	protected abstract HttpServerMetricsRecorder recorder();
+
+	protected void recordException(HttpServerOperations ops, String path) {
+		// Always take the remote address from the operations in order to consider proxy information
+		recorder().incrementErrorsCount(ops.remoteAddress(), path);
+	}
+
+	protected void recordRead(HttpServerOperations ops, String path, String method) {
+		recorder().recordDataReceivedTime(path, method, Duration.ofNanos(System.nanoTime() - dataReceivedTime));
+
+		// Always take the remote address from the operations in order to consider proxy information
+		recorder().recordDataReceived(ops.remoteAddress(), path, dataReceived);
+	}
+
+	protected void recordWrite(HttpServerOperations ops, String path, String method, String status) {
+		Duration dataSentTimeDuration = Duration.ofNanos(System.nanoTime() - dataSentTime);
+		recorder().recordDataSentTime(path, method, status, dataSentTimeDuration);
+
+		if (dataReceivedTime != 0) {
+			recorder().recordResponseTime(path, method, status, Duration.ofNanos(System.nanoTime() - dataReceivedTime));
+		}
+		else {
+			recorder().recordResponseTime(path, method, status, dataSentTimeDuration);
+		}
+
+		// Always take the remote address from the operations in order to consider proxy information
+		recorder().recordDataSent(ops.remoteAddress(), path, dataSent);
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import reactor.util.annotation.Nullable;
+import reactor.util.context.ContextView;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+/**
+ * @author Violeta Georgieva
+ * @since 1.0.8
+ */
+final class ContextAwareHttpServerMetricsHandler extends AbstractHttpServerMetricsHandler {
+
+	final ContextAwareHttpServerMetricsRecorder recorder;
+
+	ContextAwareHttpServerMetricsHandler(ContextAwareHttpServerMetricsRecorder recorder,
+			@Nullable Function<String, String> uriTagValue) {
+		super(uriTagValue);
+		this.recorder = recorder;
+	}
+
+	@Override
+	protected ContextAwareHttpServerMetricsRecorder recorder() {
+		return recorder;
+	}
+
+	@Override
+	protected void recordException(HttpServerOperations ops, String path) {
+		// Always take the remote address from the operations in order to consider proxy information
+		recorder().incrementErrorsCount(ops.currentContext(), ops.remoteAddress(), path);
+	}
+
+	@Override
+	protected void recordRead(HttpServerOperations ops, String path, String method) {
+		ContextView contextView = ops.currentContext();
+		recorder().recordDataReceivedTime(contextView, path, method,
+				Duration.ofNanos(System.nanoTime() - dataReceivedTime));
+
+		// Always take the remote address from the operations in order to consider proxy information
+		recorder().recordDataReceived(contextView, ops.remoteAddress(), path, dataReceived);
+	}
+
+	@Override
+	protected void recordWrite(HttpServerOperations ops, String path, String method, String status) {
+		ContextView contextView = ops.currentContext();
+		Duration dataSentTimeDuration = Duration.ofNanos(System.nanoTime() - dataSentTime);
+		recorder().recordDataSentTime(contextView, path, method, status, dataSentTimeDuration);
+
+		if (dataReceivedTime != 0) {
+			recorder().recordResponseTime(contextView, path, method, status,
+					Duration.ofNanos(System.nanoTime() - dataReceivedTime));
+		}
+		else {
+			recorder().recordResponseTime(contextView, path, method, status, dataSentTimeDuration);
+		}
+
+		// Always take the remote address from the operations in order to consider proxy information
+		recorder().recordDataSent(contextView, ops.remoteAddress(), path, dataSent);
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsRecorder.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import reactor.netty.http.ContextAwareHttpMetricsRecorder;
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+
+import java.time.Duration;
+
+/**
+ * {@link ContextView} aware class for collecting metrics on HTTP server level
+ *
+ * @author Violeta Georgieva
+ * @since 1.0.8
+ */
+public abstract class ContextAwareHttpServerMetricsRecorder extends ContextAwareHttpMetricsRecorder implements HttpServerMetricsRecorder {
+
+	/**
+	 * Records the time that is spent in consuming incoming data
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux
+	 * @param uri The requested URI
+	 * @param method The HTTP method
+	 * @param time The time in nanoseconds that is spent in consuming incoming data
+	 */
+	public abstract void recordDataReceivedTime(ContextView contextView, String uri, String method, Duration time);
+
+	/**
+	 * Records the time that is spent in sending outgoing data
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux
+	 * @param uri The requested URI
+	 * @param method The HTTP method
+	 * @param status The HTTP status
+	 * @param time The time in nanoseconds that is spent in sending outgoing data
+	 */
+	public abstract void recordDataSentTime(ContextView contextView, String uri, String method, String status, Duration time);
+
+	/**
+	 * Records the total time for the request/response
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux
+	 * @param uri The requested URI
+	 * @param method The HTTP method
+	 * @param status The HTTP status
+	 * @param time The total time in nanoseconds for the request/response
+	 */
+	public abstract void recordResponseTime(ContextView contextView, String uri, String method, String status, Duration time);
+
+	@Override
+	public void recordDataReceivedTime(String uri, String method, Duration time) {
+		recordDataReceivedTime(Context.empty(), uri, method, time);
+	}
+
+	@Override
+	public void recordDataSentTime(String uri, String method, String status, Duration time) {
+		recordDataSentTime(Context.empty(), uri, method, status, time);
+	}
+
+	@Override
+	public void recordResponseTime(String uri, String method, String status, Duration time) {
+		recordResponseTime(Context.empty(), uri, method, status, time);
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -508,11 +508,13 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		}
 
 		if (metricsRecorder != null) {
-			ChannelMetricsRecorder channelMetricsRecorder = metricsRecorder.get();
-			if (channelMetricsRecorder instanceof HttpServerMetricsRecorder) {
-				p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.HttpMetricsHandler,
-				           new HttpServerMetricsHandler((HttpServerMetricsRecorder) channelMetricsRecorder, uriTagValue));
-				if (channelMetricsRecorder instanceof MicrometerHttpServerMetricsRecorder) {
+			ChannelMetricsRecorder recorder = metricsRecorder.get();
+			if (recorder instanceof HttpServerMetricsRecorder) {
+				ChannelHandler handler = recorder instanceof ContextAwareHttpServerMetricsRecorder ?
+						new ContextAwareHttpServerMetricsHandler((ContextAwareHttpServerMetricsRecorder) recorder, uriTagValue) :
+						new HttpServerMetricsHandler((HttpServerMetricsRecorder) recorder, uriTagValue);
+				p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.HttpMetricsHandler, handler);
+				if (recorder instanceof MicrometerHttpServerMetricsRecorder) {
 					// MicrometerHttpServerMetricsRecorder does not implement metrics on protocol level
 					// ChannelMetricsHandler will be removed from the pipeline
 					p.remove(NettyPipeline.ChannelMetricsHandler);
@@ -556,11 +558,13 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		}
 
 		if (metricsRecorder != null) {
-			ChannelMetricsRecorder channelMetricsRecorder = metricsRecorder.get();
-			if (channelMetricsRecorder instanceof HttpServerMetricsRecorder) {
-				p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.HttpMetricsHandler,
-				           new HttpServerMetricsHandler((HttpServerMetricsRecorder) channelMetricsRecorder, uriTagValue));
-				if (channelMetricsRecorder instanceof MicrometerHttpServerMetricsRecorder) {
+			ChannelMetricsRecorder recorder = metricsRecorder.get();
+			if (recorder instanceof HttpServerMetricsRecorder) {
+				ChannelHandler handler = recorder instanceof ContextAwareHttpServerMetricsRecorder ?
+						new ContextAwareHttpServerMetricsHandler((ContextAwareHttpServerMetricsRecorder) recorder, uriTagValue) :
+						new HttpServerMetricsHandler((HttpServerMetricsRecorder) recorder, uriTagValue);
+				p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.HttpMetricsHandler, handler);
+				if (recorder instanceof MicrometerHttpServerMetricsRecorder) {
 					// MicrometerHttpServerMetricsRecorder does not implement metrics on protocol level
 					// ChannelMetricsHandler will be removed from the pipeline
 					p.remove(NettyPipeline.ChannelMetricsHandler);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMetricsHandler.java
@@ -15,140 +15,24 @@
  */
 package reactor.netty.http.server;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufHolder;
-import io.netty.channel.ChannelDuplexHandler;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPromise;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.LastHttpContent;
-import reactor.netty.channel.ChannelOperations;
 import reactor.util.annotation.Nullable;
 
-import java.time.Duration;
 import java.util.function.Function;
 
 /**
  * @author Violeta Georgieva
  */
-final class HttpServerMetricsHandler extends ChannelDuplexHandler {
-
-	long dataReceived;
-
-	long dataSent;
-
-
-	long dataReceivedTime;
-
-	long dataSentTime;
-
+final class HttpServerMetricsHandler extends AbstractHttpServerMetricsHandler {
 
 	final HttpServerMetricsRecorder recorder;
-	final Function<String, String> uriTagValue;
 
 	HttpServerMetricsHandler(HttpServerMetricsRecorder recorder, @Nullable Function<String, String> uriTagValue) {
+		super(uriTagValue);
 		this.recorder = recorder;
-		this.uriTagValue = uriTagValue;
 	}
 
 	@Override
-	@SuppressWarnings("FutureReturnValueIgnored")
-	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-		if (msg instanceof HttpResponse) {
-			if (((HttpResponse) msg).status().equals(HttpResponseStatus.CONTINUE)) {
-				//"FutureReturnValueIgnored" this is deliberate
-				ctx.write(msg, promise);
-				return;
-			}
-
-			dataSentTime = System.nanoTime();
-		}
-
-		if (msg instanceof ByteBufHolder) {
-			dataSent += ((ByteBufHolder) msg).content().readableBytes();
-		}
-		else if (msg instanceof ByteBuf) {
-			dataSent += ((ByteBuf) msg).readableBytes();
-		}
-
-		if (msg instanceof LastHttpContent) {
-			promise.addListener(future -> {
-				ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
-				if (channelOps instanceof HttpServerOperations) {
-					HttpServerOperations ops = (HttpServerOperations) channelOps;
-					String path = uriTagValue == null ? ops.path : uriTagValue.apply(ops.path);
-					String method = ops.method().name();
-					String status = ops.status().codeAsText().toString();
-					recorder.recordDataSentTime(
-							path, method, status,
-							Duration.ofNanos(System.nanoTime() - dataSentTime));
-
-					if (dataReceivedTime != 0) {
-						recorder.recordResponseTime(
-								path, method, status,
-								Duration.ofNanos(System.nanoTime() - dataReceivedTime));
-					}
-					else {
-						recorder.recordResponseTime(
-								path, method, status,
-								Duration.ofNanos(System.nanoTime() - dataSentTime));
-					}
-
-					// Always take the remote address from the operations in order to consider proxy information
-					recorder.recordDataSent(ops.remoteAddress(), path, dataSent);
-
-					dataSent = 0;
-				}
-			});
-		}
-
-		//"FutureReturnValueIgnored" this is deliberate
-		ctx.write(msg, promise);
-	}
-
-	@Override
-	public void channelRead(ChannelHandlerContext ctx, Object msg) {
-		if (msg instanceof HttpRequest) {
-			dataReceivedTime = System.nanoTime();
-		}
-
-		if (msg instanceof ByteBufHolder) {
-			dataReceived += ((ByteBufHolder) msg).content().readableBytes();
-		}
-		else if (msg instanceof ByteBuf) {
-			dataReceived += ((ByteBuf) msg).readableBytes();
-		}
-
-		if (msg instanceof LastHttpContent) {
-			ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
-			if (channelOps instanceof HttpServerOperations) {
-				HttpServerOperations ops = (HttpServerOperations) channelOps;
-				String path = uriTagValue == null ? ops.path : uriTagValue.apply(ops.path);
-				String method = ops.method().name();
-				recorder.recordDataReceivedTime(path, method, Duration.ofNanos(System.nanoTime() - dataReceivedTime));
-
-				// Always take the remote address from the operations in order to consider proxy information
-				recorder.recordDataReceived(ops.remoteAddress(), path, dataReceived);
-			}
-
-			dataReceived = 0;
-		}
-
-		ctx.fireChannelRead(msg);
-	}
-
-	@Override
-	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-		ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
-		if (channelOps instanceof HttpServerOperations) {
-			HttpServerOperations ops = (HttpServerOperations) channelOps;
-			// Always take the remote address from the operations in order to consider proxy information
-			recorder.incrementErrorsCount(ops.remoteAddress(),
-					uriTagValue == null ? ops.path : uriTagValue.apply(ops.path));
-		}
-
-		ctx.fireExceptionCaught(cause);
+	protected HttpServerMetricsRecorder recorder() {
+		return recorder;
 	}
 }


### PR DESCRIPTION
New abstract classes are exposed so that the custom metrics recorder
can access the ContextView associated with the Mono/Flux
- ContextAwareChannelMetricsRecorder
- ContextAwareHttpClientMetricsRecorder
- ContextAwareHttpServerMetricsRecorder

Fixes #1628