### PR TITLE
Add an example for long-living TCP client connection

### DIFF
--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -86,6 +86,23 @@ include::{examplesdir}/send/Application.java[lines=18..35]
 <1> Sends `hello` string to the endpoint.
 ====
 
+When you need more control over the writing process, as an alternative for I/O handler you may use
+{javadoc}/reactor/netty/Connection.html#outbound--[`Connection#outbound`]. As opposed to I/O handler
+where the connection is closed when the provided `Publisher` finishes (in case of finite `Publisher`),
+when using {javadoc}/reactor/netty/Connection.html#outbound--[`Connection#outbound`], you have to invoke explicitly
+`Connection#dispose` in order to close the connection.
+
+====
+[source,java,indent=0]
+.{examplesdir}/send/connection/Application.java
+----
+include::{examplesdir}/send/connection/Application.java[lines=18..44]
+----
+<1> Sends `hello 1` string to the endpoint.
+<2> Sends `hello 2` string to the endpoint.
+<3> Closes the connection once the message is sent to the endpoint.
+====
+
 == Consuming Data
 
 To receive data from a given endpoint, you must attach an I/O handler.
@@ -99,6 +116,21 @@ to be able to read data. The following example shows how to do so:
 include::{examplesdir}/read/Application.java[lines=18..34]
 ----
 <1> Receives data from a given endpoint
+====
+
+When you need more control over the reading process, as an alternative for I/O handler you may use
+{javadoc}/reactor/netty/Connection.html#inbound--[`Connection#inbound`]. As opposed to I/O handler
+where the connection is closed when the provided `Publisher` finishes (in case of finite `Publisher`),
+when using {javadoc}/reactor/netty/Connection.html#inbound--[`Connection#inbound`], you have to invoke explicitly
+`Connection#dispose` in order to close the connection.
+
+====
+[source,java,indent=0]
+.{examplesdir}/read/connection/Application.java
+----
+include::{examplesdir}/read/connection/Application.java[lines=18..38]
+----
+<1> Receives data from a given endpoint.
 ====
 
 == Lifecycle Callbacks

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/read/connection/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/read/connection/Application.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.tcp.client.read.connection;
+
+import reactor.netty.Connection;
+import reactor.netty.tcp.TcpClient;
+
+public class Application {
+
+	public static void main(String[] args) {
+		Connection connection =
+				TcpClient.create()
+				         .host("example.com")
+				         .port(80)
+				         .connectNow();
+
+		connection.inbound()
+		          .receive() //<1>
+		          .then()
+		          .subscribe();
+
+		connection.onDispose()
+		          .block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/send/connection/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/send/connection/Application.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.tcp.client.send.connection;
+
+import reactor.core.publisher.Mono;
+import reactor.netty.Connection;
+import reactor.netty.tcp.TcpClient;
+
+public class Application {
+
+	public static void main(String[] args) {
+		Connection connection =
+				TcpClient.create()
+				         .host("example.com")
+				         .port(80)
+				         .connectNow();
+
+		connection.outbound()
+		          .sendString(Mono.just("hello 1")) //<1>
+		          .then()
+		          .subscribe();
+
+		connection.outbound()
+		          .sendString(Mono.just("hello 2")) //<2>
+		          .then()
+		          .subscribe(null, null, connection::dispose); //<3>
+
+		connection.onDispose()
+		          .block();
+	}
+}


### PR DESCRIPTION
Example with `Connection#outbound` and `Connection#inbound` as an alternative of I/O handler.

Fixes #532