### PR TITLE
fix #1650 reactor.netty.internal is no longer exclude from MANIFEST

### DIFF
--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'biz.aQute.bnd.builder'
 
 ext {
 	bndOptions = [
-			"Export-Package" : "!reactor.netty.internal*,reactor.netty*;version=$osgiVersion;-noimport:=true",
+			"Export-Package" : "reactor.netty*;version=$osgiVersion;-noimport:=true",
 			"Import-Package": [
 					"!javax.annotation",
 					"io.netty.channel.kqueue;resolution:=optional;version=\"[4.1,5)\"",


### PR DESCRIPTION
The shadow jar is published under `reactor.netty.internal.shaded.reactor.pool` in reactor-netty-core and filtered in `Export-Package`.
To be used in reactor-netty-http it should not be filtered.

Fixes https://github.com/reactor/reactor-netty/issues/1650