### PR TITLE
Handlers added on channel init must stay until channel close

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultPooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultPooledConnectionProvider.java
@@ -537,12 +537,12 @@ final class DefaultPooledConnectionProvider extends PooledConnectionProvider<Def
 
 				this.pooledConnection = pooledConnection;
 
-				pooledConnection.bind();
-
 				ch.attr(OWNER).compareAndSet(null, new PendingConnectionObserver(sink.currentContext()));
 				ch.pipeline().remove(this);
 				ch.pipeline()
 				  .addFirst(config.channelInitializer(pooledConnection, remoteAddress, false));
+
+				pooledConnection.bind();
 			}
 
 			@Override


### PR DESCRIPTION
When a handler is added to the pipeline (`Connection#addHandler`) with `doOnChannelInit` callback
it must stay until channel close. This means that in case the `Connection` is `PooledConnection`,
the `PooledConnection` must be bound after channel init invocation.
Every handler added with `Connection#addHandler` is removed on `onTerminate` event.
In case of `PooledConnection`, `onTerminate` event is channel released to the pool,
this leads to a handler removed from the pipeline on channel release to the pool,
which is not expected for a handler added with `doOnChannelInit` callback.

This is related to https://github.com/spring-cloud/spring-cloud-sleuth/issues/1690#issuecomment-854416606
The handlers for Reactor Netty <-> Brave integration are added with with `doOnChannelInit` callback