### PR TITLE
Issue-887: Add option to enable proxy from system properties

### DIFF
--- a/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -624,6 +624,17 @@ public abstract class HttpClient {
 	}
 
 	/**
+	 * Set up proxy from java system properties.
+	 * Supports http, https, socks4, socks5 proxies.
+	 * List of supported system properties https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html
+     *
+	 * @return a new {@link HttpClient}
+	 */
+	public final HttpClient proxyWithSystemProperties() {
+		return new HttpClientProxyWithSystemProperties(this, System.getProperties());
+	}
+
+	/**
 	 * Enable or Disable Keep-Alive support for the outgoing request.
 	 *
 	 * @param keepAlive true if keepAlive should be enabled (default: true)

--- a/src/main/java/reactor/netty/http/client/HttpClientProxyWithSystemProperties.java
+++ b/src/main/java/reactor/netty/http/client/HttpClientProxyWithSystemProperties.java
@@ -1,0 +1,120 @@
+package reactor.netty.http.client;
+
+import reactor.netty.tcp.ProxyProvider;
+import reactor.netty.tcp.TcpClient;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.Properties;
+
+final class HttpClientProxyWithSystemProperties extends HttpClientOperator {
+
+    final static class ProxySettings {
+        static final String HTTP_PROXY_HOST = "http.proxyHost";
+        static final String HTTP_PROXY_PORT = "http.proxyPort";
+        static final String HTTPS_PROXY_HOST = "https.proxyHost";
+        static final String HTTPS_PROXY_PORT = "https.proxyPort";
+        static final String HTTP_NON_PROXY_HOSTS = "http.nonProxyHosts";
+
+        static final String SOCKS_PROXY_HOST = "socksProxyHost";
+        static final String SOCKS_PROXY_PORT = "socksProxyPort";
+        static final String SOCKS_VERSION = "socksProxyVersion";
+        static final String SOCKS_VERSION_5 = "5";
+        static final String SOCKS_USERNAME = "java.net.socks.username";
+        static final String SOCKS_PASSWORD = "java.net.socks.password";
+        public static final String DEFAULT_NON_PROXY_HOSTS = "localhost|127.*|[::1]";
+
+
+        @Nonnull final ProxyProvider.Proxy type;
+        @Nonnull final String hostname;
+        final int port;
+        @Nullable final String nonProxyHosts;
+        @Nullable final String username;
+        @Nullable final String password;
+
+        public ProxySettings(@Nonnull ProxyProvider.Proxy type, @Nonnull String hostname, int port,
+                             @Nullable String nonProxyHosts, @Nullable String username, @Nullable String password) {
+            this.type = type;
+            this.hostname = hostname;
+            this.port = port;
+            this.nonProxyHosts = nonProxyHosts;
+            this.username = username;
+            this.password = password;
+        }
+
+        @Nullable static ProxySettings from(Properties properties) {
+            Objects.requireNonNull(properties, "properties");
+
+            if (properties.containsKey(HTTP_PROXY_HOST) || properties.containsKey(HTTPS_PROXY_HOST)) {
+                return httpProxyFrom(properties);
+            }
+            if (properties.containsKey(SOCKS_PROXY_HOST)) {
+                return socksProxyFrom(properties);
+            }
+
+            return null;
+        }
+
+        static ProxySettings httpProxyFrom(Properties properties) {
+            String hostname = properties.getProperty(HTTPS_PROXY_HOST);
+            if (hostname == null) {
+                hostname = properties.getProperty(HTTP_PROXY_HOST);
+            }
+            int port = properties.containsKey(HTTPS_PROXY_HOST) ? 443 : 80;
+            if (properties.containsKey(HTTPS_PROXY_PORT)) {
+                port = Integer.parseInt(properties.getProperty(HTTPS_PROXY_PORT));
+            } else if (properties.containsKey(HTTP_PROXY_PORT)) {
+                port = Integer.parseInt(properties.getProperty(HTTP_PROXY_PORT));
+            }
+            String nonProxyHosts = properties.getProperty(HTTP_NON_PROXY_HOSTS, DEFAULT_NON_PROXY_HOSTS);
+
+            return new ProxySettings(ProxyProvider.Proxy.HTTP, hostname, port, nonProxyHosts, null, null);
+        }
+
+        static ProxySettings socksProxyFrom(Properties properties) {
+            String hostname = properties.getProperty(SOCKS_PROXY_HOST);
+            ProxyProvider.Proxy type = ProxyProvider.Proxy.SOCKS5;
+            if (properties.containsKey(SOCKS_VERSION)) {
+                type = SOCKS_VERSION_5.equals(properties.getProperty(SOCKS_VERSION))
+                        ? ProxyProvider.Proxy.SOCKS5
+                        : ProxyProvider.Proxy.SOCKS4;
+            }
+            int port = Integer.parseInt(properties.getProperty(SOCKS_PROXY_PORT, "1080"));
+
+            String username = properties.getProperty(SOCKS_USERNAME);
+            String password = properties.getProperty(SOCKS_PASSWORD);
+
+            return new ProxySettings(type, hostname, port, null, username, password);
+        }
+    }
+
+    final ProxySettings settings;
+
+    HttpClientProxyWithSystemProperties(HttpClient source, Properties properties) {
+        super(source);
+        this.settings = ProxySettings.from(properties);
+    }
+
+    @Override
+    protected TcpClient tcpConfiguration() {
+        TcpClient client = source.tcpConfiguration();
+        if (settings == null) return client;
+
+        return client.proxy(p -> {
+            ProxyProvider.Builder proxy = p.type(settings.type)
+                    .host(settings.hostname)
+                    .port(settings.port);
+
+            if (settings.nonProxyHosts != null)  {
+                proxy.nonProxyHosts(settings.nonProxyHosts);
+            }
+            if (settings.username != null) {
+                proxy.username(settings.username);
+            }
+            if (settings.password != null) {
+                proxy.password(u -> settings.password);
+            }
+        });
+    }
+}

--- a/src/test/java/reactor/netty/http/client/HttpClientProxyWithSystemPropertiesTest.java
+++ b/src/test/java/reactor/netty/http/client/HttpClientProxyWithSystemPropertiesTest.java
@@ -1,0 +1,259 @@
+package reactor.netty.http.client;
+
+import org.junit.Test;
+import reactor.netty.http.client.HttpClientProxyWithSystemProperties.ProxySettings;
+import reactor.netty.tcp.ProxyProvider;
+import reactor.netty.tcp.TcpClient;
+
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+
+public class HttpClientProxyWithSystemPropertiesTest {
+
+    @Test
+    public void nullProxySettingsIfNoHostnameDefined() {
+        Properties properties = new Properties();
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNull(settings);
+    }
+
+    @Test
+    public void proxySettingsIsNotNullWhenHttpHostSet() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.HTTP_PROXY_HOST, "host");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals(ProxyProvider.Proxy.HTTP, settings.type);
+        assertEquals("host", settings.hostname);
+    }
+
+    @Test
+    public void port80SetByDefaultForHttpProxy() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.HTTP_PROXY_HOST, "host");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals(80, settings.port);
+    }
+
+    @Test
+    public void parseHttpPortFromSystemProperties() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.HTTP_PROXY_HOST, "host");
+        properties.setProperty(ProxySettings.HTTP_PROXY_PORT, "8080");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals(8080, settings.port);
+    }
+
+    @Test
+    public void proxySettingsIsNotNullWhenHttpSHostSet() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.HTTPS_PROXY_HOST, "host");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals(ProxyProvider.Proxy.HTTP, settings.type);
+        assertEquals("host", settings.hostname);
+    }
+
+    @Test
+    public void port443SetByDefaultForHttpProxy() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.HTTPS_PROXY_HOST, "host");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals(443, settings.port);
+    }
+
+    @Test
+    public void parseHttpsPortFromSystemProperties() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.HTTPS_PROXY_HOST, "host");
+        properties.setProperty(ProxySettings.HTTP_PROXY_PORT, "8443");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals(8443, settings.port);
+    }
+
+    @Test
+    public void defaultNonHttpHostsSetForHttpProxy() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.HTTP_PROXY_HOST, "host");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals(ProxySettings.DEFAULT_NON_PROXY_HOSTS, settings.nonProxyHosts);
+    }
+
+    @Test
+    public void defaultNonHttpHostsSetForHttpsProxy() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.HTTPS_PROXY_HOST, "host");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals(ProxySettings.DEFAULT_NON_PROXY_HOSTS, settings.nonProxyHosts);
+    }
+
+    @Test
+    public void customNonProxyHostsSetForHttpProxy() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.HTTP_PROXY_HOST, "host");
+        properties.setProperty(ProxySettings.HTTP_NON_PROXY_HOSTS, "non-host");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals("non-host", settings.nonProxyHosts);
+    }
+
+    @Test
+    public void customNonProxyHostsSetForHttpsProxy() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.HTTPS_PROXY_HOST, "host");
+        properties.setProperty(ProxySettings.HTTP_NON_PROXY_HOSTS, "non-host");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals("non-host", settings.nonProxyHosts);
+    }
+
+    @Test
+    public void socksProxy5SetWhenSocksSystemPropertySet() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.SOCKS_PROXY_HOST, "host");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals("host", settings.hostname);
+        assertEquals(ProxyProvider.Proxy.SOCKS5, settings.type);
+    }
+
+    @Test
+    public void overrideSocksVersionWithCustomProperty() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.SOCKS_PROXY_HOST, "host");
+        properties.setProperty(ProxySettings.SOCKS_VERSION, "4");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals(ProxyProvider.Proxy.SOCKS4, settings.type);
+    }
+
+    @Test
+    public void overrideSocksPortWithCustomProperty() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.SOCKS_PROXY_HOST, "host");
+        properties.setProperty(ProxySettings.SOCKS_PROXY_PORT, "2080");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals(2080, settings.port);
+    }
+
+    @Test
+    public void setUserPasswordInSockProxy() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.SOCKS_PROXY_HOST, "host");
+        properties.setProperty(ProxySettings.SOCKS_USERNAME, "user");
+        properties.setProperty(ProxySettings.SOCKS_PASSWORD, "pwd");
+
+        ProxySettings settings = ProxySettings.from(properties);
+
+        assertNotNull(settings);
+        assertEquals("user", settings.username);
+        assertEquals("pwd", settings.password);
+    }
+
+    @Test
+    public void createClientWithoutProxy() {
+        Properties properties = new Properties();
+        HttpClient client = new HttpClientProxyWithSystemProperties(HttpClient.create(), properties);
+
+        TcpClient tcpClient = client.tcpConfiguration();
+
+        assertNotNull(tcpClient);
+        assertFalse(tcpClient.hasProxy());
+    }
+
+    @Test
+    public void createClientWithHttpProxy() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.HTTP_PROXY_HOST, "host");
+        HttpClient client = new HttpClientProxyWithSystemProperties(HttpClient.create(), properties);
+
+        TcpClient tcpClient = client.tcpConfiguration();
+
+        assertNotNull(tcpClient);
+        assertTrue(tcpClient.hasProxy());
+        assertEquals(ProxyProvider.Proxy.HTTP, tcpClient.proxyProvider().getType());
+    }
+
+    @Test
+    public void createClientWithHttpsProxy() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.HTTPS_PROXY_HOST, "host");
+        HttpClient client = new HttpClientProxyWithSystemProperties(HttpClient.create(), properties);
+
+        TcpClient tcpClient = client.tcpConfiguration();
+
+        assertNotNull(tcpClient);
+        assertTrue(tcpClient.hasProxy());
+        assertEquals(ProxyProvider.Proxy.HTTP, tcpClient.proxyProvider().getType());
+    }
+
+    @Test
+    public void createClientWithSock5Proxy() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.SOCKS_PROXY_HOST, "host");
+        HttpClient client = new HttpClientProxyWithSystemProperties(HttpClient.create(), properties);
+
+        TcpClient tcpClient = client.tcpConfiguration();
+
+        assertNotNull(tcpClient);
+        assertTrue(tcpClient.hasProxy());
+        assertEquals(ProxyProvider.Proxy.SOCKS5, tcpClient.proxyProvider().getType());
+    }
+
+    @Test
+    public void createClientWithSock4Proxy() {
+        Properties properties = new Properties();
+        properties.setProperty(ProxySettings.SOCKS_PROXY_HOST, "host");
+        properties.setProperty(ProxySettings.SOCKS_VERSION, "4");
+        HttpClient client = new HttpClientProxyWithSystemProperties(HttpClient.create(), properties);
+
+        TcpClient tcpClient = client.tcpConfiguration();
+
+        assertNotNull(tcpClient);
+        assertTrue(tcpClient.hasProxy());
+        assertEquals(ProxyProvider.Proxy.SOCKS4, tcpClient.proxyProvider().getType());
+    }
+
+    @Test
+    public void createClientWithSystemProxySettings() {
+        HttpClient client = HttpClient.create()
+                .proxyWithSystemProperties();
+
+        assertNotNull(client);
+    }
+}


### PR DESCRIPTION
Original issue https://github.com/reactor/reactor-netty/issues/887

This PR is to add an option to configure proxy in http client from system properties, the idea is based on the idea from this comment and below https://github.com/reactor/reactor-netty/issues/887#issuecomment-652806830

Java networking properties taken from this doc https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html