### PR TITLE
Expose an API for obtaining all cookies with one and the same name

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/Cookies.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/Cookies.java
@@ -34,9 +34,10 @@ import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 
 /**
  * Store cookies for the http channel.
+ *
  * @since 0.6
  */
-public final class Cookies {
+public class Cookies {
 
 	/**
 	 * Return a new cookies holder from client response headers.
@@ -53,7 +54,11 @@ public final class Cookies {
 	 *
 	 * @param headers server request headers
 	 * @return a new cookies holder from server request headers
+	 * @deprecated as of 1.0.8.
+	 * Prefer {@link reactor.netty.http.server.ServerCookies#newServerRequestHolder(HttpHeaders, ServerCookieDecoder)}.
+	 * This method will be removed in version 1.2.0.
 	 */
+	@Deprecated
 	public static Cookies newServerRequestHolder(HttpHeaders headers, ServerCookieDecoder decoder) {
 		return new Cookies(headers, HttpHeaderNames.COOKIE, false, decoder);
 	}
@@ -68,14 +73,14 @@ public final class Cookies {
 	final boolean       isClientChannel;
 	final CookieDecoder decoder;
 
-	Map<CharSequence, Set<Cookie>> cachedCookies;
+	protected Map<CharSequence, Set<Cookie>> cachedCookies;
 
 	volatile     int                                state;
 	static final AtomicIntegerFieldUpdater<Cookies> STATE =
 			AtomicIntegerFieldUpdater.newUpdater(Cookies.class, "state");
 
-	private Cookies(HttpHeaders nettyHeaders, CharSequence cookiesHeaderName, boolean isClientChannel,
-					CookieDecoder decoder) {
+	protected Cookies(HttpHeaders nettyHeaders, CharSequence cookiesHeaderName, boolean isClientChannel,
+			CookieDecoder decoder) {
 		this.nettyHeaders = Objects.requireNonNull(nettyHeaders, "nettyHeaders");
 		this.cookiesHeaderName = cookiesHeaderName;
 		this.isClientChannel = isClientChannel;
@@ -85,17 +90,19 @@ public final class Cookies {
 
 	/**
 	 * Wait for the cookies to become available, cache them and subsequently return the cached map of cookies.
+	 *
+	 * @return the cached map of cookies
 	 */
 	public Map<CharSequence, Set<Cookie>> getCachedCookies() {
-		if (!STATE.compareAndSet(this, NOT_READ, READING)) {
+		if (!markReadingCookies()) {
 			for (;;) {
-				if (state == READ) {
+				if (hasReadCookies()) {
 					return cachedCookies;
 				}
 			}
 		}
 
-		List<String> allCookieHeaders = nettyHeaders.getAll(cookiesHeaderName);
+		List<String> allCookieHeaders = allCookieHeaders();
 		Map<String, Set<Cookie>> cookies = new HashMap<>();
 		for (String aCookieHeader : allCookieHeaders) {
 			Set<Cookie> decode;
@@ -104,27 +111,35 @@ public final class Cookies {
 				if (c == null) {
 					continue;
 				}
-				Set<Cookie> existingCookiesOfName = cookies.get(c.name());
-				if (null == existingCookiesOfName) {
-					existingCookiesOfName = new HashSet<>();
-					cookies.put(c.name(), existingCookiesOfName);
-				}
+				Set<Cookie> existingCookiesOfName = cookies.computeIfAbsent(c.name(), k -> new HashSet<>());
 				existingCookiesOfName.add(c);
 			}
 			else {
 				decode = ((ServerCookieDecoder) decoder).decode(aCookieHeader);
 				for (Cookie cookie : decode) {
-					Set<Cookie> existingCookiesOfName = cookies.get(cookie.name());
-					if (null == existingCookiesOfName) {
-						existingCookiesOfName = new HashSet<>();
-						cookies.put(cookie.name(), existingCookiesOfName);
-					}
+					Set<Cookie> existingCookiesOfName = cookies.computeIfAbsent(cookie.name(), k -> new HashSet<>());
 					existingCookiesOfName.add(cookie);
 				}
 			}
 		}
 		cachedCookies = Collections.unmodifiableMap(cookies);
-		state = READ;
+		markReadCookies();
 		return cachedCookies;
+	}
+
+	protected List<String> allCookieHeaders() {
+		return nettyHeaders.getAll(cookiesHeaderName);
+	}
+
+	protected final boolean hasReadCookies() {
+		return state == READ;
+	}
+
+	protected final boolean markReadCookies() {
+		return STATE.compareAndSet(this, READING, READ);
+	}
+
+	protected final boolean markReadingCookies() {
+		return STATE.compareAndSet(this, NOT_READ, READING);
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerInfos.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerInfos.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.netty.handler.codec.http.cookie.Cookie;
+import reactor.netty.http.HttpInfos;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An Http Reactive Channel with several accessors related to HTTP flow: headers, params,
+ * URI, method, websocket...
+ *
+ * @author Violeta Georgieva
+ * @since 1.0.8
+ */
+public interface HttpServerInfos extends HttpInfos {
+
+	/**
+	 * Returns resolved HTTP cookies. As opposed to {@link #cookies()}, this
+	 * returns all cookies, even if they have the same name.
+	 *
+	 * @return Resolved HTTP cookies
+	 */
+	Map<CharSequence, List<Cookie>> allCookies();
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -73,7 +73,6 @@ import reactor.netty.NettyOutbound;
 import reactor.netty.NettyPipeline;
 import reactor.netty.channel.AbortedException;
 import reactor.netty.channel.ChannelOperations;
-import reactor.netty.http.Cookies;
 import reactor.netty.http.HttpOperations;
 import reactor.netty.http.websocket.WebsocketInbound;
 import reactor.netty.http.websocket.WebsocketOutbound;
@@ -95,8 +94,8 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		implements HttpServerRequest, HttpServerResponse {
 
 	final HttpResponse nettyResponse;
-	final HttpHeaders  responseHeaders;
-	final Cookies     cookieHolder;
+	final HttpHeaders responseHeaders;
+	final ServerCookies cookieHolder;
 	final HttpRequest nettyRequest;
 	final String path;
 	final ConnectionInfo connectionInfo;
@@ -160,7 +159,7 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		this.responseHeaders = nettyResponse.headers();
 		this.responseHeaders.set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
 		this.compressionPredicate = compressionPredicate;
-		this.cookieHolder = Cookies.newServerRequestHolder(requestHeaders(), decoder);
+		this.cookieHolder = ServerCookies.newServerRequestHolder(requestHeaders(), decoder);
 		this.connectionInfo = connectionInfo;
 		this.cookieEncoder = encoder;
 		this.cookieDecoder = decoder;
@@ -250,6 +249,14 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 	public Map<CharSequence, Set<Cookie>> cookies() {
 		if (cookieHolder != null) {
 			return cookieHolder.getCachedCookies();
+		}
+		throw new IllegalStateException("request not parsed");
+	}
+
+	@Override
+	public Map<CharSequence, List<Cookie>> allCookies() {
+		if (cookieHolder != null) {
+			return cookieHolder.getAllCachedCookies();
 		}
 		throw new IllegalStateException("request not parsed");
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRequest.java
@@ -26,7 +26,6 @@ import io.netty.handler.codec.http.HttpHeaders;
 import reactor.core.publisher.Flux;
 import reactor.netty.Connection;
 import reactor.netty.NettyInbound;
-import reactor.netty.http.HttpInfos;
 import reactor.util.annotation.Nullable;
 
 /**
@@ -36,7 +35,7 @@ import reactor.util.annotation.Nullable;
  * @author Stephane Maldini
  * @since 0.5
  */
-public interface HttpServerRequest extends NettyInbound, HttpInfos {
+public interface HttpServerRequest extends NettyInbound, HttpServerInfos {
 
 	@Override
 	HttpServerRequest withConnection(Consumer<? super Connection> withConnection);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerResponse.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerResponse.java
@@ -25,7 +25,6 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.NettyOutbound;
-import reactor.netty.http.HttpInfos;
 import reactor.netty.http.websocket.WebsocketInbound;
 import reactor.netty.http.websocket.WebsocketOutbound;
 
@@ -37,7 +36,7 @@ import reactor.netty.http.websocket.WebsocketOutbound;
  * @author Stephane Maldini
  * @since 0.5
  */
-public interface HttpServerResponse extends NettyOutbound, HttpInfos {
+public interface HttpServerResponse extends NettyOutbound, HttpServerInfos {
 
 	/**
 	 * Adds an outbound cookie

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ServerCookies.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ServerCookies.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
+import reactor.netty.http.Cookies;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * {@link Cookies} holder from server request headers.
+ *
+ * @author Violeta Georgieva
+ * @since 1.0.8
+ */
+public final class ServerCookies extends Cookies {
+
+	/**
+	 * Return a new cookies holder from server request headers.
+	 *
+	 * @param headers server request headers
+	 * @return a new cookies holder from server request headers
+	 */
+	public static ServerCookies newServerRequestHolder(HttpHeaders headers, ServerCookieDecoder decoder) {
+		return new ServerCookies(headers, HttpHeaderNames.COOKIE, false, decoder);
+	}
+
+	final ServerCookieDecoder serverCookieDecoder;
+
+	Map<CharSequence, List<Cookie>> allCachedCookies;
+
+	ServerCookies(HttpHeaders nettyHeaders, CharSequence cookiesHeaderName, boolean isClientChannel,
+			ServerCookieDecoder decoder) {
+		super(nettyHeaders, cookiesHeaderName, isClientChannel, decoder);
+		this.serverCookieDecoder = decoder;
+		allCachedCookies = Collections.emptyMap();
+	}
+
+	@Override
+	public Map<CharSequence, Set<Cookie>> getCachedCookies() {
+		getAllCachedCookies();
+		return cachedCookies;
+	}
+
+	/**
+	 * Wait for the cookies to become available, cache them and subsequently return the cached map of cookies.
+	 * As opposed to {@link #getCachedCookies()}, this returns all cookies, even if they have the same name.
+	 *
+	 * @return the cached map of cookies
+	 */
+	public Map<CharSequence, List<Cookie>> getAllCachedCookies() {
+		if (!markReadingCookies()) {
+			for (;;) {
+				if (hasReadCookies()) {
+					return allCachedCookies;
+				}
+			}
+		}
+
+		List<String> allCookieHeaders = allCookieHeaders();
+		Map<String, Set<Cookie>> cookies = new HashMap<>();
+		Map<String, List<Cookie>> allCookies = new HashMap<>();
+		for (String aCookieHeader : allCookieHeaders) {
+			List<Cookie> decode = serverCookieDecoder.decodeAll(aCookieHeader);
+			for (Cookie cookie : decode) {
+				Set<Cookie> existingCookiesOfNameSet = cookies.computeIfAbsent(cookie.name(), k -> new HashSet<>());
+				existingCookiesOfNameSet.add(cookie);
+				List<Cookie> existingCookiesOfNameList = allCookies.computeIfAbsent(cookie.name(), k -> new ArrayList<>());
+				existingCookiesOfNameList.add(cookie);
+			}
+		}
+		cachedCookies = Collections.unmodifiableMap(cookies);
+		allCachedCookies = Collections.unmodifiableMap(allCookies);
+		markReadCookies();
+		return allCachedCookies;
+	}
+}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpCookieHandlingTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpCookieHandlingTests.java
@@ -16,9 +16,12 @@
 package reactor.netty.http;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.cookie.ClientCookieDecoder;
 import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
 import io.netty.handler.codec.http.cookie.Cookie;
@@ -28,6 +31,8 @@ import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.netty.BaseHttpTest;
+import reactor.netty.http.server.HttpServerInfos;
+import reactor.netty.http.server.HttpServerRequest;
 import reactor.test.StepVerifier;
 
 /**
@@ -117,5 +122,41 @@ class HttpCookieHandlingTests extends BaseHttpTest {
 		            })
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(30));
+	}
+
+	@Test
+	void testServerCookiesDecodingMultipleCookiesSameName_Cookies() {
+		doTestServerCookiesDecodingMultipleCookiesSameName(HttpServerInfos::cookies, " value1");
+	}
+
+	@Test
+	void testServerCookiesDecodingMultipleCookiesSameName_AllCookies() {
+		doTestServerCookiesDecodingMultipleCookiesSameName(HttpServerInfos::allCookies, " value1 value2");
+	}
+
+	private void doTestServerCookiesDecodingMultipleCookiesSameName(
+			Function<HttpServerRequest, Map<CharSequence, ? extends Collection<Cookie>>> cookies,
+			String expectedResponse) {
+		disposableServer =
+				createServer()
+				        .handle((req, res) ->
+				                res.sendString(Mono.just(cookies.apply(req)
+				                                                .get("test")
+				                                                .stream()
+				                                                .map(Cookie::value)
+				                                                .reduce("", (a, b) -> a + " " + b))))
+				        .bindNow();
+
+		createClient(disposableServer.port())
+		        .headers(h -> h.add(HttpHeaderNames.COOKIE, "test=value1;test=value2"))
+		        .get()
+		        .uri("/")
+		        .responseContent()
+		        .aggregate()
+		        .asString()
+		        .as(StepVerifier::create)
+		        .expectNext(expectedResponse)
+		        .expectComplete()
+		        .verify(Duration.ofSeconds(5));
 	}
 }


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc6265#section-4.2.2

Although cookies are serialized linearly in the `Cookie` header,
servers SHOULD NOT rely upon the serialization order.  In particular,
if the `Cookie` header contains two cookies with the same name (e.g.,
that were set with different `Path` or `Domain` attributes), servers
SHOULD NOT rely upon the order in which these cookies appear in the
header.

Fixes #1641