### PR TITLE
Issue-1673: Use non language specific test conditions

### DIFF
--- a/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
@@ -15,6 +15,7 @@
  */
 package reactor.netty.resources;
 
+import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
@@ -150,9 +151,9 @@ class DefaultPooledConnectionProviderTest {
 
 			//fail a couple
 			StepVerifier.create(pool.acquire(config, observer, remoteAddress, config.resolverInternal()))
-			            .verifyErrorMatches(msg -> msg.getMessage().contains("Connection refused"));
+			            .verifyErrorMatches(msg -> msg.getCause() instanceof ConnectException);
 			StepVerifier.create(pool.acquire(config, observer, remoteAddress, config.resolverInternal()))
-			            .verifyErrorMatches(msg -> msg.getMessage().contains("Connection refused"));
+			            .verifyErrorMatches(msg -> msg.getCause() instanceof ConnectException);
 
 			//start the echo server
 			f1 = service.submit(echoServer);

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -1314,6 +1314,7 @@ class HttpClientTest extends BaseHttpTest {
 		                error.set(t);
 		                return t.getMessage() != null &&
 		                               (t.getMessage().contains("Connection reset by peer") ||
+				                                t.getMessage().contains("readAddress(..)") || // https://github.com/reactor/reactor-netty/issues/1673
 		                                        t.getMessage().contains("Connection prematurely closed BEFORE response"));
 		            })
 		            .verify(Duration.ofSeconds(30));


### PR DESCRIPTION
Original issue: #1673

This PR fixes the failed test cases on env language != en