### PR TITLE
#1669  for discussion only

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpServerRoutes.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpServerRoutes.java
@@ -92,9 +92,9 @@ final class DefaultHttpServerRoutes implements HttpServerRoutes {
 		Objects.requireNonNull(handler, "handler");
 
 		if (condition instanceof HttpPredicate) {
+			HttpPredicate predicate = (HttpPredicate) condition;
 			HttpRouteHandler httpRouteHandler = new HttpRouteHandler(condition,
-					handler,
-					(HttpPredicate) condition, ((HttpPredicate) condition).uri, ((HttpPredicate) condition).method);
+					handler, predicate, predicate.uri, predicate.method);
 
 			handlers.add(httpRouteHandler);
 			initialOrderHandlers.add(httpRouteHandler);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpServerRoutes.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpServerRoutes.java
@@ -48,8 +48,6 @@ final class DefaultHttpServerRoutes implements HttpServerRoutes {
 
 	private Comparator<HttpRouteHandlerMetadata> comparator;
 
-	private List<Predicate<? super HttpServerRequest>> removedRoutes = new ArrayList<>();
-
 	@Override
 	public HttpServerRoutes directory(String uri, Path directory,
 			@Nullable Function<HttpServerResponse, HttpServerResponse> interceptor) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpServerRoutes.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpServerRoutes.java
@@ -197,23 +197,5 @@ final class DefaultHttpServerRoutes implements HttpServerRoutes {
 		public HttpMethod getMethod() {
 			return method;
 		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) {
-				return true;
-			}
-			if (o == null || getClass() != o.getClass()) {
-				return false;
-			}
-			HttpRouteHandler handler1 = (HttpRouteHandler) o;
-			return condition.equals(handler1.condition) && handler.equals(handler1.handler) && resolver
-					.equals(handler1.resolver) && path.equals(handler1.path);
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(condition, handler, resolver, path);
-		}
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpPredicate.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpPredicate.java
@@ -36,7 +36,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @author Stephane Maldini
  */
-public final class HttpPredicate
+final class HttpPredicate
 		implements Predicate<HttpServerRequest>, Function<Object, Map<String, String>> {
 
 	/**

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpPredicate.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpPredicate.java
@@ -36,7 +36,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @author Stephane Maldini
  */
-final class HttpPredicate
+public final class HttpPredicate
 		implements Predicate<HttpServerRequest>, Function<Object, Map<String, String>> {
 
 	/**

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRouteHandlerMetadata.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRouteHandlerMetadata.java
@@ -16,6 +16,7 @@
 
 package reactor.netty.http.server;
 
+import io.netty.handler.codec.http.HttpMethod;
 import reactor.util.annotation.Nullable;
 
 import java.util.Comparator;
@@ -36,4 +37,12 @@ public interface HttpRouteHandlerMetadata {
 	 */
 	@Nullable
 	String getPath();
+
+	/**
+	 * Get the http method this handler can handle
+	 *
+	 * @return the http method {@link HttpMethod}
+	 */
+	@Nullable
+	HttpMethod getMethod();
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRouteHandlerMetadata.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRouteHandlerMetadata.java
@@ -42,6 +42,7 @@ public interface HttpRouteHandlerMetadata {
 	 * Get the http method this handler can handle
 	 *
 	 * @return the http method {@link HttpMethod}
+	 * @since 1.0.10
 	 */
 	@Nullable
 	HttpMethod getMethod();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRouteHandlerMetadata.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRouteHandlerMetadata.java
@@ -42,7 +42,7 @@ public interface HttpRouteHandlerMetadata {
 	 * Get the http method this handler can handle
 	 *
 	 * @return the http method {@link HttpMethod}
-	 * @since 1.0.10
+	 * @since 1.0.11
 	 */
 	@Nullable
 	HttpMethod getMethod();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRoutes.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRoutes.java
@@ -258,7 +258,7 @@ public interface HttpServerRoutes extends
 	 *
 	 * @param condition a predicate given each http route handler {@link HttpRouteHandlerMetadata}
 	 * @return this {@link HttpServerRoutes}
-	 * @since 1.0.10
+	 * @since 1.0.11
 	 */
 	HttpServerRoutes removeIf(Predicate<? super HttpRouteHandlerMetadata> condition);
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRoutes.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRoutes.java
@@ -253,13 +253,13 @@ public interface HttpServerRoutes extends
 	}
 
 	/**
-	 * A generic route predicate that if matched not invoke already register I/O handler use
-	 * {@link HttpServerRoutes#route(Predicate, BiFunction)}.
+	 * A generic route predicate that if matched already register I/O handler use
+	 * {@link HttpServerRoutes#route(Predicate, BiFunction)} will be removed.
 	 *
-	 * @param condition a predicate given each inbound request
+	 * @param condition a predicate given each http route handler {@link HttpRouteHandlerMetadata}
 	 * @return this {@link HttpServerRoutes}
 	 */
-	HttpServerRoutes removeRoute(Predicate<? super HttpServerRequest> condition);
+	HttpServerRoutes removeIf(Predicate<? super HttpRouteHandlerMetadata> condition);
 
 	/**
 	 * A generic route predicate that if matched invoke the passed I/O handler.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRoutes.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRoutes.java
@@ -253,6 +253,15 @@ public interface HttpServerRoutes extends
 	}
 
 	/**
+	 * A generic route predicate that if matched not invoke already register I/O handler use
+	 * {@link HttpServerRoutes#route(Predicate, BiFunction)}.
+	 *
+	 * @param condition a predicate given each inbound request
+	 * @return this {@link HttpServerRoutes}
+	 */
+	HttpServerRoutes removeRoute(Predicate<? super HttpServerRequest> condition);
+
+	/**
 	 * A generic route predicate that if matched invoke the passed I/O handler.
 	 *
 	 * @param condition a predicate given each inbound request

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRoutes.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRoutes.java
@@ -258,6 +258,7 @@ public interface HttpServerRoutes extends
 	 *
 	 * @param condition a predicate given each http route handler {@link HttpRouteHandlerMetadata}
 	 * @return this {@link HttpServerRoutes}
+	 * @since 1.0.10
 	 */
 	HttpServerRoutes removeIf(Predicate<? super HttpRouteHandlerMetadata> condition);
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -2641,14 +2641,14 @@ class HttpServerTests extends BaseHttpTest {
 		}
 
 		HttpServerRoutes serverRoutes1 = serverRoutes.removeIf(metadata -> Objects.equals(metadata.getPath(), "/route1")
-				&& metadata.getMethod() == HttpMethod.GET);
+				&& metadata.getMethod().equals(HttpMethod.GET));
 
 		disposableServer = HttpServer.create().handle(serverRoutes1)
 				.bindNow();
 
 		StepVerifier.create(createClient(disposableServer.port()).get().uri("/route1")
 				.response())
-				.expectNextMatches(response -> response.status() == HttpResponseStatus.NOT_FOUND)
+				.expectNextMatches(response -> response.status().equals(HttpResponseStatus.NOT_FOUND))
 				.verifyComplete();
 
 		StepVerifier.create(createClient(disposableServer.port()).get().uri("/route2")


### PR DESCRIPTION
In current version,reactor netty hasn't really concept about ‘route’,we can't define route directly use code.In reactory netty,`HttpRouteHandler` is the route,when one request come in,we iterate `HttpRouteHandler` list to find one `HttpRouteHandler` can handle income request,if no `HttpRouteHandler` can handle request return http status code 404(mean no route). In the iterate process we use `Predicate<? super HttpServerRequest>` to match request one by one,when `Predicate<? super HttpServerRequest>` return true,it means there is one route for this request,so i think in reactory netty `Predicate<? super HttpServerRequest>` is  the "route".