### PR TITLE
[polish] Update date range in copyright header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codequality/HEADER
+++ b/codequality/HEADER
@@ -1,4 +1,4 @@
-Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/codequality/checkstyle.xml
+++ b/codequality/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+  ~ Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -3,7 +3,7 @@ import java.time.ZonedDateTime
 import java.time.temporal.ChronoField
 
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/jarFileTest/java/reactor/netty/AbstractJarFileTest.java
+++ b/reactor-netty-core/src/jarFileTest/java/reactor/netty/AbstractJarFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/jarFileTest/java/reactor/netty/JarFileShadingTest.java
+++ b/reactor-netty-core/src/jarFileTest/java/reactor/netty/JarFileShadingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/ByteBufFlux.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ByteBufFlux.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/ByteBufMono.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ByteBufMono.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/ChannelBindException.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ChannelBindException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/ChannelOperationsId.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ChannelOperationsId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/ChannelPipelineConfigurer.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ChannelPipelineConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/Connection.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/ConnectionObserver.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ConnectionObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/DisposableChannel.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/DisposableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/DisposableServer.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/DisposableServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/FutureMono.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/FutureMono.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/NettyInbound.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/NettyInbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/NettyOutbound.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/NettyOutbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/AbortedException.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/AbortedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/AbstractChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/AbstractChannelMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/FluxReceive.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/FluxReceive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MeterKey.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MeterKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSend.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSendMany.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSendMany.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/package-info.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/package-info.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ColocatedEventLoopGroup.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ColocatedEventLoopGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionPoolMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionPoolMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoop.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopEpoll.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopEpoll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopIOUring.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopIOUring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopKQueue.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopKQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNIO.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNativeDetector.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNativeDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultPooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultPooledConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DelegatingConnectionPoolMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DelegatingConnectionPoolMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/LoopResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/LoopResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/MicrometerPooledConnectionProviderMeterRegistrar.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/MicrometerPooledConnectionProviderMeterRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/NewConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/NewConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/package-info.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/AbstractProtocolSslContextSpec.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/AbstractProtocolSslContextSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/DefaultSslContextSpec.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/DefaultSslContextSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientBootstrap.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConnect.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientSecure.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientSecure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServer.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServerBind.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServerBind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServerConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpSslContextSpec.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpSslContextSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/package-info.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/AddressResolverGroupMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/AddressResolverGroupMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/AddressUtils.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/AddressUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransportConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConnector.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/logging/AdvancedByteBufFormat.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/logging/AdvancedByteBufFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/logging/ReactorNettyLoggingHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/logging/ReactorNettyLoggingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/package-info.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClient.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConnect.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpConnection.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpInbound.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpInbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpOperations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpOutbound.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpOutbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServer.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServerBind.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServerBind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServerConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/package-info.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/BlockHoundIntegrationTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/BlockHoundIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ByteBufFluxTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ByteBufFluxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ByteBufMonoTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ByteBufMonoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ChannelBindExceptionTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ChannelBindExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ChannelOperationsIdTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ChannelOperationsIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ConnectionIdleTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ConnectionIdleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ConnectionObserverContextTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ConnectionObserverContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ConnectionTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/CustomBlockHoundIntegration.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/CustomBlockHoundIntegration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/FutureMonoTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/FutureMonoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/NettyOutboundTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/NettyOutboundTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/channel/MonoSendManyTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/channel/MonoSendManyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultLoopResourcesTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultLoopResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/NewConnectionProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/NewConnectionProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/PooledConnectionProviderCustomMetricsTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/PooledConnectionProviderCustomMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/BlockingConnectionTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/BlockingConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpClientTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpClientTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpMetricsTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpMetricsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpResourcesTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpSecureMetricsTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpSecureMetricsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/AddressUtilsTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/AddressUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportResolverHooksTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportResolverHooksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ProxyProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ProxyProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ServerTransportTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ServerTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/TransportTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/TransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/logging/AdvancedByteBufFormatTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/logging/AdvancedByteBufFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/logging/ReactorNettyLoggingHandlerTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/logging/ReactorNettyLoggingHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/udp/UdpClientTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/udp/UdpClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/udp/UdpMetricsTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/udp/UdpMetricsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/udp/UdpResourcesTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/udp/UdpResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/udp/UdpServerTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/udp/UdpServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
+++ b/reactor-netty-core/src/test/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+# Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/resources/logback.xml
+++ b/reactor-netty-core/src/test/resources/logback.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+  ~ Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/testFixtures/java/reactor/netty/SocketUtils.java
+++ b/reactor-netty-core/src/testFixtures/java/reactor/netty/SocketUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/build.gradle
+++ b/reactor-netty-examples/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/address/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/address/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/channeloptions/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/channeloptions/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/compression/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/compression/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/connect/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/connect/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/http2/H2Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/http2/H2Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/http2/H2CApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/http2/H2CApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/lifecycle/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/metrics/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/metrics/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/metrics/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/metrics/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/pool/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/pool/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/pool/config/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/pool/config/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/pool/metrics/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/pool/metrics/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/proxy/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/proxy/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/read/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/read/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/read/status/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/read/status/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/read/timeout/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/read/timeout/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/redirect/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/redirect/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/resolver/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/resolver/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/resolver/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/resolver/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/responsedecoder/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/responsedecoder/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/security/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/security/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/security/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/security/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/send/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/send/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/send/headers/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/send/headers/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/sni/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/sni/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/uds/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/uds/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/warmup/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/warmup/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/websocket/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/websocket/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/wiretap/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/wiretap/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/wiretap/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/accessLog/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/accessLog/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/accessLog/CustomFormatAndFilterAccessLogApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/accessLog/CustomFormatAndFilterAccessLogApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/accessLog/CustomLogAccessFormatApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/accessLog/CustomLogAccessFormatApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/accessLog/FilterLogAccessApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/accessLog/FilterLogAccessApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/address/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/address/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/channeloptions/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/channeloptions/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/clientaddress/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/clientaddress/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/clientaddress/CustomForwardedHeaderHandlerApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/clientaddress/CustomForwardedHeaderHandlerApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/compression/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/compression/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/create/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/create/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/http2/H2Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/http2/H2Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/http2/H2CApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/http2/H2CApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/lifecycle/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/metrics/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/metrics/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/metrics/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/metrics/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/read/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/read/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/read/headers/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/read/headers/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/requestdecoder/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/requestdecoder/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/routing/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/routing/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/security/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/security/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/send/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/send/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/send/headers/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/send/headers/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/sni/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/sni/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/sse/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/sse/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/staticresources/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/staticresources/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/uds/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/uds/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/warmup/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/warmup/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/wiretap/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/wiretap/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/wiretap/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/address/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/address/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/channeloptions/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/channeloptions/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/create/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/create/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/eventloop/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/eventloop/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/lifecycle/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/metrics/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/metrics/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/metrics/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/metrics/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/pool/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/pool/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/pool/config/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/pool/config/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/pool/metrics/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/pool/metrics/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/proxy/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/proxy/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/read/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/read/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/read/connection/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/read/connection/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/resolver/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/resolver/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/resolver/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/resolver/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/security/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/security/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/send/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/send/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/send/connection/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/send/connection/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/sni/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/sni/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/uds/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/uds/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/warmup/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/warmup/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/wiretap/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/wiretap/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/wiretap/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/address/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/address/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/channeloptions/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/channeloptions/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/create/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/create/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/eventloop/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/eventloop/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/lifecycle/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/metrics/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/metrics/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/metrics/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/metrics/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/read/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/read/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/security/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/security/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/send/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/send/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/sni/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/sni/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/uds/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/uds/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/warmup/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/warmup/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/wiretap/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/wiretap/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/wiretap/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/address/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/address/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/channeloptions/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/channeloptions/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/create/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/create/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/eventloop/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/eventloop/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/lifecycle/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/metrics/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/metrics/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/metrics/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/metrics/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/read/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/read/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/send/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/send/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/warmup/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/warmup/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/wiretap/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/wiretap/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/wiretap/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/address/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/address/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/channeloptions/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/channeloptions/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/create/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/create/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/eventloop/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/eventloop/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/lifecycle/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/metrics/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/metrics/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/metrics/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/metrics/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/read/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/read/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/send/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/send/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/warmup/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/warmup/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/wiretap/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/wiretap/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/wiretap/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/discard/DiscardClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/discard/DiscardClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/discard/DiscardServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/discard/DiscardServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/echo/EchoClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/echo/EchoClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/echo/EchoServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/echo/EchoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/resources/logback.xml
+++ b/reactor-netty-examples/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+  ~ Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/reactor-netty-http-brave/build.gradle
+++ b/reactor-netty-http-brave/build.gradle
@@ -1,7 +1,7 @@
 import me.champeau.gradle.japicmp.JapicmpTask
 
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/ReactorNettyHttpTracing.java
+++ b/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/ReactorNettyHttpTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/TracingChannelInboundHandler.java
+++ b/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/TracingChannelInboundHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/TracingChannelOutboundHandler.java
+++ b/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/TracingChannelOutboundHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/TracingChannelPipelineConfigurer.java
+++ b/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/TracingChannelPipelineConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/TracingHttpClientDecorator.java
+++ b/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/TracingHttpClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/TracingHttpServerDecorator.java
+++ b/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/TracingHttpServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/package-info.java
+++ b/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpClientDecoratorTest.java
+++ b/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpClientDecoratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpServerDecoratorTest.java
+++ b/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpServerDecoratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http-brave/src/test/resources/logback.xml
+++ b/reactor-netty-http-brave/src/test/resources/logback.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+  ~ Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/ContextAwareHttpMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/ContextAwareHttpMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/Cookies.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/Cookies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/Http11SslContextSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/Http11SslContextSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/Http2SettingsSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/Http2SettingsSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/Http2SslContextSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/Http2SslContextSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpDecoderSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpDecoderSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpInfos.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpInfos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpProtocol.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpResources.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/MicrometerHttpMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/MicrometerHttpMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/FailedHttpClientRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/FailedHttpClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Resources.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Resources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2StreamBridgeClientHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2StreamBridgeClientHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientForm.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFormEncoder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFormEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientInfos.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientInfos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientResponse.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSecure.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSecure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSecurityUtils.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSecurityUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientState.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientTcpConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientTcpConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpResponseDecoderSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpResponseDecoderSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpTrafficHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/PrematureCloseException.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/PrematureCloseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/RedirectClientException.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/RedirectClientException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/UriEndpoint.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/UriEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/UriEndpointFactory.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/UriEndpointFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketClientSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketClientSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketClientSpecImpl.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketClientSpecImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/package-info.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/package-info.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ConnectionInfo.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ConnectionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpServerRoutes.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpServerRoutes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HAProxyMessageDetector.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HAProxyMessageDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HAProxyMessageReader.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HAProxyMessageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpPredicate.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRequestDecoderSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRequestDecoderSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRouteHandlerMetadata.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRouteHandlerMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerBind.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerBind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerInfos.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerInfos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerResponse.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRoutes.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRoutes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerState.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerTcpConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerTcpConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/NonSslRedirectDetector.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/NonSslRedirectDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/NonSslRedirectHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/NonSslRedirectHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ProxyProtocolSupportType.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ProxyProtocolSupportType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ServerCookies.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ServerCookies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/SimpleCompressionHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/SimpleCompressionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerSpecImpl.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerSpecImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AbstractAccessLogArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AbstractAccessLogArgProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLog.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProviderH1.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProviderH1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProviderH2.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProviderH2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogFactory.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogHandlerFactory.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogHandlerH1.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogHandlerH1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogHandlerH2.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogHandlerH2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/BaseAccessLogHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/BaseAccessLogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/package-info.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/package-info.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/websocket/WebsocketInbound.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/websocket/WebsocketInbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/websocket/WebsocketOutbound.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/websocket/WebsocketOutbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/websocket/WebsocketSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/websocket/WebsocketSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/websocket/WebsocketSpecImpl.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/websocket/WebsocketSpecImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/websocket/package-info.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/websocket/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/BaseHttpTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/BaseHttpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/ByteBufFluxTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/ByteBufFluxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/CustomBlockHoundIntegration.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/CustomBlockHoundIntegration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/TomcatServer.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/TomcatServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/channel/ChannelOperationsHandlerTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/channel/ChannelOperationsHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/channel/FluxReceiveTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/channel/FluxReceiveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2SettingsSpecTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2SettingsSpecTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpCookieHandlingTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpCookieHandlingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpDecoderSpecTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpDecoderSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpErrorTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpErrorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpOperationsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpResourcesTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpResponseStatusCodesHandlingTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpResponseStatusCodesHandlingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpsMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpsMetricsHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/ConnectionPoolTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/ConnectionPoolTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientOperationsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientProxyTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientWithTomcatTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientWithTomcatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpResponseDecoderSpecTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpResponseDecoderSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/UriEndpointFactoryTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/UriEndpointFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/UrlExceptionTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/UrlExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/WebsocketClientOperationsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/WebsocketClientOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/WebsocketTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/WebsocketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/DefaultHttpServerRoutesTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/DefaultHttpServerRoutesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/Http2ConnectionInfoTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/Http2ConnectionInfoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpSendFileTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpSendFileTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpsSendFileTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpsSendFileTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/UriPathTemplateTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/UriPathTemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderH1Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderH1Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderH2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderH2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogHandlerFactoryTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogHandlerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogHandlerH1Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogHandlerH1Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogHandlerH2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogHandlerH2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/BaseAccessLogHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/BaseAccessLogHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/LoggingTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/LoggingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/resources/PooledConnectionProviderDefaultMetricsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/resources/PooledConnectionProviderDefaultMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/tcp/SslProviderTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/tcp/SslProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/transport/AddressResolverGroupMetricsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/transport/AddressResolverGroupMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/transport/ByteBufAllocatorMetricsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/transport/ByteBufAllocatorMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
+++ b/reactor-netty-http/src/test/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+# Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/resources/logback.xml
+++ b/reactor-netty-http/src/test/resources/logback.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+  ~ Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/resources/public/index.html
+++ b/reactor-netty-http/src/test/resources/public/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+  ~ Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/resources/public/test.css
+++ b/reactor-netty-http/src/test/resources/public/test.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/resources/public/test1.css
+++ b/reactor-netty-http/src/test/resources/public/test1.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/resources/public/test2.css
+++ b/reactor-netty-http/src/test/resources/public/test2.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/resources/public/test3.css
+++ b/reactor-netty-http/src/test/resources/public/test3.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/resources/public/test4.css
+++ b/reactor-netty-http/src/test/resources/public/test4.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/resources/public/test5.css
+++ b/reactor-netty-http/src/test/resources/public/test5.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty/build.gradle
+++ b/reactor-netty/build.gradle
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+* Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-Present VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The date range has been modified across the board to end at 2021.
For now start dates have been kept as is.

see reactor/reactor#682