### PR TITLE
Share the name resolver when the NameResolverProvider and the default LoopResources are the same

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
@@ -346,12 +346,13 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 		T dup = super.runOn(loopResources, preferNative);
 		CONF conf = dup.configuration();
 		if (conf.nameResolverProvider != null) {
-			conf.resolver = conf.nameResolverProvider.newNameResolverGroup(conf.loopResources(), conf.preferNative);
+			conf.resolver = ClientTransportConfig.getOrCreateResolver(
+					conf.nameResolverProvider, conf.loopResources(), conf.preferNative);
 		}
 		else if (conf.resolver == null) {
 			conf.nameResolverProvider = ClientTransportConfig.DEFAULT_NAME_RESOLVER_PROVIDER;
-			conf.resolver = ClientTransportConfig.DEFAULT_NAME_RESOLVER_PROVIDER
-					.newNameResolverGroup(conf.loopResources(), conf.preferNative);
+			conf.resolver = ClientTransportConfig.getOrCreateResolver(
+					ClientTransportConfig.DEFAULT_NAME_RESOLVER_PROVIDER, conf.loopResources(), conf.preferNative);
 		}
 		return dup;
 	}


### PR DESCRIPTION
Every name resolver keeps an opened channel that is used for the name resolution.
The name resolver should be shared when the `NameResolverProvider` and
the default `LoopResources` are the same, thus the opened channels will be kept to a minimum.

This is related to the Gitter discussion
https://gitter.im/reactor/reactor-netty?at=60ddeafb258ebf6d92fc9c50