### PR TITLE
Obtain the metrics resolver on the configuration step when the metrics are enabled

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
@@ -222,8 +222,7 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 	protected AddressResolverGroup<?> resolverInternal() {
 		AddressResolverGroup<?> resolverGroup = resolver != null ? resolver : defaultAddressResolverGroup();
 		if (metricsRecorder != null) {
-			return AddressResolverGroupMetrics.getOrCreate(resolverGroup,
-					Objects.requireNonNull(metricsRecorder.get(), "Metrics recorder supplier returned null"));
+			return AddressResolverGroupMetrics.getOrCreate(resolverGroup, metricsRecorder);
 		}
 		else {
 			return resolverGroup;

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
@@ -143,7 +143,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 			dup.configuration().metricsRecorder(() -> configuration().defaultMetricsRecorder());
 			return dup;
 		}
-		else if (configuration().metricsRecorderSupplier != null) {
+		else if (configuration().metricsRecorder != null) {
 			T dup = duplicate();
 			dup.configuration().metricsRecorder(null);
 			return dup;
@@ -171,7 +171,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 			dup.configuration().metricsRecorder(recorder);
 			return dup;
 		}
-		else if (configuration().metricsRecorderSupplier != null) {
+		else if (configuration().metricsRecorder != null) {
 			T dup = duplicate();
 			dup.configuration().metricsRecorder(null);
 			return dup;

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
@@ -158,7 +158,8 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	/**
 	 * Specifies whether the metrics are enabled on the {@link Transport}.
 	 * All generated metrics are provided to the specified recorder
-	 * which is only instantiated if metrics are being enabled.
+	 * which is only instantiated if metrics are being enabled (the instantiation is not lazy,
+	 * but happens immediately, while configuring the {@link Transport}).
 	 *
 	 * @param enable if true enables the metrics on the {@link Transport}.
 	 * @param recorder a supplier for the {@link ChannelMetricsRecorder}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
@@ -140,12 +140,12 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 						" to the class path first");
 			}
 			T dup = duplicate();
-			dup.configuration().metricsRecorder = () -> configuration().defaultMetricsRecorder();
+			dup.configuration().metricsRecorder(() -> configuration().defaultMetricsRecorder());
 			return dup;
 		}
-		else if (configuration().metricsRecorder != null) {
+		else if (configuration().metricsRecorderSupplier != null) {
 			T dup = duplicate();
-			dup.configuration().metricsRecorder = null;
+			dup.configuration().metricsRecorder(null);
 			return dup;
 		}
 		else {
@@ -167,12 +167,12 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	public T metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder) {
 		if (enable) {
 			T dup = duplicate();
-			dup.configuration().metricsRecorder = recorder;
+			dup.configuration().metricsRecorder(recorder);
 			return dup;
 		}
-		else if (configuration().metricsRecorder != null) {
+		else if (configuration().metricsRecorderSupplier != null) {
 			T dup = duplicate();
-			dup.configuration().metricsRecorder = null;
+			dup.configuration().metricsRecorder(null);
 			return dup;
 		}
 		else {

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
@@ -80,7 +80,7 @@ public abstract class TransportConfig {
 
 	public int channelHash() {
 		return Objects.hash(attrs, bindAddress != null ? bindAddress.get() : 0, channelGroup, doOnChannelInit,
-				loggingHandler, loopResources, metricsRecorder != null ? metricsRecorder.get() : 0, observer, options, preferNative);
+				loggingHandler, loopResources, metricsRecorder, observer, options, preferNative);
 	}
 
 	/**
@@ -169,7 +169,7 @@ public abstract class TransportConfig {
 	 */
 	@Nullable
 	public final Supplier<? extends ChannelMetricsRecorder> metricsRecorder() {
-		return this.metricsRecorder;
+		return this.metricsRecorderSupplier;
 	}
 
 	/**
@@ -193,7 +193,8 @@ public abstract class TransportConfig {
 	ChannelPipelineConfigurer                  doOnChannelInit;
 	LoggingHandler                             loggingHandler;
 	LoopResources                              loopResources;
-	Supplier<? extends ChannelMetricsRecorder> metricsRecorder;
+	ChannelMetricsRecorder                     metricsRecorder;
+	Supplier<? extends ChannelMetricsRecorder> metricsRecorderSupplier;
 	ConnectionObserver                         observer;
 	Map<ChannelOption<?>, ?>                   options;
 	boolean                                    preferNative;
@@ -232,6 +233,7 @@ public abstract class TransportConfig {
 		this.loggingHandler = parent.loggingHandler;
 		this.loopResources = parent.loopResources;
 		this.metricsRecorder = parent.metricsRecorder;
+		this.metricsRecorderSupplier = parent.metricsRecorderSupplier;
 		this.observer = parent.observer;
 		this.options = parent.options;
 		this.preferNative = parent.preferNative;
@@ -311,8 +313,13 @@ public abstract class TransportConfig {
 		this.loggingHandler = loggingHandler;
 	}
 
-	protected void metricsRecorder(@Nullable Supplier<? extends ChannelMetricsRecorder> metricsRecorder) {
-		this.metricsRecorder = metricsRecorder;
+	protected void metricsRecorder(@Nullable Supplier<? extends ChannelMetricsRecorder> metricsRecorderSupplier) {
+		this.metricsRecorderSupplier = metricsRecorderSupplier;
+		this.metricsRecorder = metricsRecorderSupplier != null ? metricsRecorderSupplier.get() : null;
+	}
+
+	protected ChannelMetricsRecorder metricsRecorderInternal() {
+		return metricsRecorder;
 	}
 
 	/**
@@ -363,10 +370,7 @@ public abstract class TransportConfig {
 			ChannelPipeline pipeline = channel.pipeline();
 
 			if (config.metricsRecorder != null) {
-				ChannelOperations.addMetricsHandler(channel,
-						requireNonNull(config.metricsRecorder.get(), "Metrics recorder supplier returned null"),
-						remoteAddress,
-						onServer);
+				ChannelOperations.addMetricsHandler(channel, config.metricsRecorder, remoteAddress, onServer);
 
 				ByteBufAllocator alloc = channel.alloc();
 				if (alloc instanceof PooledByteBufAllocator) {

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
@@ -169,7 +169,7 @@ public abstract class TransportConfig {
 	 */
 	@Nullable
 	public final Supplier<? extends ChannelMetricsRecorder> metricsRecorder() {
-		return this.metricsRecorderSupplier;
+		return this.metricsRecorder != null ? () -> this.metricsRecorder : null;
 	}
 
 	/**

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
@@ -194,7 +194,6 @@ public abstract class TransportConfig {
 	LoggingHandler                             loggingHandler;
 	LoopResources                              loopResources;
 	ChannelMetricsRecorder                     metricsRecorder;
-	Supplier<? extends ChannelMetricsRecorder> metricsRecorderSupplier;
 	ConnectionObserver                         observer;
 	Map<ChannelOption<?>, ?>                   options;
 	boolean                                    preferNative;
@@ -233,7 +232,6 @@ public abstract class TransportConfig {
 		this.loggingHandler = parent.loggingHandler;
 		this.loopResources = parent.loopResources;
 		this.metricsRecorder = parent.metricsRecorder;
-		this.metricsRecorderSupplier = parent.metricsRecorderSupplier;
 		this.observer = parent.observer;
 		this.options = parent.options;
 		this.preferNative = parent.preferNative;
@@ -313,8 +311,12 @@ public abstract class TransportConfig {
 		this.loggingHandler = loggingHandler;
 	}
 
+	/**
+	 * Obtains immediately the {@link ChannelMetricsRecorder} from the provided {@link Supplier}
+	 *
+	 * @param metricsRecorderSupplier a supplier for the {@link ChannelMetricsRecorder}
+	 */
 	protected void metricsRecorder(@Nullable Supplier<? extends ChannelMetricsRecorder> metricsRecorderSupplier) {
-		this.metricsRecorderSupplier = metricsRecorderSupplier;
 		this.metricsRecorder = metricsRecorderSupplier != null ? metricsRecorderSupplier.get() : null;
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1179,7 +1179,8 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	/**
 	 * Specifies whether the metrics are enabled on the {@link HttpClient}.
 	 * All generated metrics are provided to the specified recorder which is only
-	 * instantiated if metrics are being enabled.
+	 * instantiated if metrics are being enabled (the instantiation is not lazy,
+	 * but happens immediately, while configuring the {@link HttpClient}).
 	 * <p>{@code uriValue} function receives the actual uri and returns the uri value
 	 * that will be used when the metrics are propagated to the recorder.
 	 * For example instead of using the actual uri {@code "/users/1"} as uri value, templated uri

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -525,7 +525,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			boolean acceptGzip,
 			HttpResponseDecoderSpec decoder,
 			Http2Settings http2Settings,
-			@Nullable Supplier<? extends ChannelMetricsRecorder> metricsRecorder,
+			@Nullable ChannelMetricsRecorder metricsRecorder,
 			ConnectionObserver observer,
 			ChannelOperations.OnSetup opsFactory,
 			@Nullable Function<String, String> uriTagValue) {
@@ -566,11 +566,10 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		}
 
 		if (metricsRecorder != null) {
-			ChannelMetricsRecorder recorder = metricsRecorder.get();
-			if (recorder instanceof HttpClientMetricsRecorder) {
-				ChannelHandler handler = recorder instanceof ContextAwareHttpClientMetricsRecorder ?
-						new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) recorder, uriTagValue) :
-						new HttpClientMetricsHandler((HttpClientMetricsRecorder) recorder, uriTagValue);
+			if (metricsRecorder instanceof HttpClientMetricsRecorder) {
+				ChannelHandler handler = metricsRecorder instanceof ContextAwareHttpClientMetricsRecorder ?
+						new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) metricsRecorder, uriTagValue) :
+						new HttpClientMetricsHandler((HttpClientMetricsRecorder) metricsRecorder, uriTagValue);
 				p.addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.HttpMetricsHandler, handler);
 			}
 		}
@@ -580,7 +579,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 	static void configureHttp11Pipeline(ChannelPipeline p,
 			boolean acceptGzip,
 			HttpResponseDecoderSpec decoder,
-			@Nullable Supplier<? extends ChannelMetricsRecorder> metricsRecorder,
+			@Nullable ChannelMetricsRecorder metricsRecorder,
 			@Nullable Function<String, String> uriTagValue) {
 		p.addBefore(NettyPipeline.ReactiveBridge,
 				NettyPipeline.HttpCodec,
@@ -599,11 +598,10 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		}
 
 		if (metricsRecorder != null) {
-			ChannelMetricsRecorder recorder = metricsRecorder.get();
-			if (recorder instanceof HttpClientMetricsRecorder) {
-				ChannelHandler handler = recorder instanceof ContextAwareHttpClientMetricsRecorder ?
-						new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) recorder, uriTagValue) :
-						new HttpClientMetricsHandler((HttpClientMetricsRecorder) recorder, uriTagValue);
+			if (metricsRecorder instanceof HttpClientMetricsRecorder) {
+				ChannelHandler handler = metricsRecorder instanceof ContextAwareHttpClientMetricsRecorder ?
+						new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) metricsRecorder, uriTagValue) :
+						new HttpClientMetricsHandler((HttpClientMetricsRecorder) metricsRecorder, uriTagValue);
 				p.addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.HttpMetricsHandler, handler);
 			}
 		}
@@ -759,7 +757,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		final boolean                                    acceptGzip;
 		final HttpResponseDecoderSpec                    decoder;
 		final Http2Settings                              http2Settings;
-		final Supplier<? extends ChannelMetricsRecorder> metricsRecorder;
+		final ChannelMetricsRecorder                     metricsRecorder;
 		final ConnectionObserver                         observer;
 		final Function<String, String>                   uriTagValue;
 
@@ -803,7 +801,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		final boolean                                    acceptGzip;
 		final HttpResponseDecoderSpec                    decoder;
 		final Http2Settings                              http2Settings;
-		final Supplier<? extends ChannelMetricsRecorder> metricsRecorder;
+		final ChannelMetricsRecorder                     metricsRecorder;
 		final ChannelOperations.OnSetup                  opsFactory;
 		final int                                        protocols;
 		final SslProvider                                sslProvider;
@@ -813,7 +811,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			this.acceptGzip = config.acceptGzip;
 			this.decoder = config.decoder;
 			this.http2Settings = config.http2Settings();
-			this.metricsRecorder = config.metricsRecorder();
+			this.metricsRecorder = config.metricsRecorderInternal();
 			this.opsFactory = config.channelOperationsProvider();
 			this.protocols = config._protocols;
 			this.sslProvider = config.sslProvider;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -549,7 +549,8 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	/**
 	 * Specifies whether the metrics are enabled on the {@link HttpServer}.
 	 * All generated metrics are provided to the specified recorder which is only
-	 * instantiated if metrics are being enabled.
+	 * instantiated if metrics are being enabled (the instantiation is not lazy,
+	 * but happens immediately, while configuring the {@link HttpServer}).
 	 * <p>{@code uriValue} function receives the actual uri and returns the uri value
 	 * that will be used when the metrics are propagated to the recorder.
 	 * For example instead of using the actual uri {@code "/users/1"} as uri value, templated uri

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -467,7 +467,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 			Http2Settings http2Settings,
 			ConnectionObserver listener,
 			@Nullable BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>> mapHandle,
-			@Nullable Supplier<? extends ChannelMetricsRecorder> metricsRecorder,
+			@Nullable ChannelMetricsRecorder metricsRecorder,
 			int minCompressionSize,
 			ChannelOperations.OnSetup opsFactory,
 			@Nullable Function<String, String> uriTagValue,
@@ -508,13 +508,12 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		}
 
 		if (metricsRecorder != null) {
-			ChannelMetricsRecorder recorder = metricsRecorder.get();
-			if (recorder instanceof HttpServerMetricsRecorder) {
-				ChannelHandler handler = recorder instanceof ContextAwareHttpServerMetricsRecorder ?
-						new ContextAwareHttpServerMetricsHandler((ContextAwareHttpServerMetricsRecorder) recorder, uriTagValue) :
-						new HttpServerMetricsHandler((HttpServerMetricsRecorder) recorder, uriTagValue);
+			if (metricsRecorder instanceof HttpServerMetricsRecorder) {
+				ChannelHandler handler = metricsRecorder instanceof ContextAwareHttpServerMetricsRecorder ?
+						new ContextAwareHttpServerMetricsHandler((ContextAwareHttpServerMetricsRecorder) metricsRecorder, uriTagValue) :
+						new HttpServerMetricsHandler((HttpServerMetricsRecorder) metricsRecorder, uriTagValue);
 				p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.HttpMetricsHandler, handler);
-				if (recorder instanceof MicrometerHttpServerMetricsRecorder) {
+				if (metricsRecorder instanceof MicrometerHttpServerMetricsRecorder) {
 					// MicrometerHttpServerMetricsRecorder does not implement metrics on protocol level
 					// ChannelMetricsHandler will be removed from the pipeline
 					p.remove(NettyPipeline.ChannelMetricsHandler);
@@ -531,7 +530,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 			@Nullable BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> forwardedHeaderHandler,
 			ConnectionObserver listener,
 			@Nullable BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>> mapHandle,
-			@Nullable Supplier<? extends ChannelMetricsRecorder> metricsRecorder,
+			@Nullable ChannelMetricsRecorder metricsRecorder,
 			int minCompressionSize,
 			@Nullable Function<String, String> uriTagValue,
 			boolean accessLogEnabled,
@@ -558,13 +557,12 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		}
 
 		if (metricsRecorder != null) {
-			ChannelMetricsRecorder recorder = metricsRecorder.get();
-			if (recorder instanceof HttpServerMetricsRecorder) {
-				ChannelHandler handler = recorder instanceof ContextAwareHttpServerMetricsRecorder ?
-						new ContextAwareHttpServerMetricsHandler((ContextAwareHttpServerMetricsRecorder) recorder, uriTagValue) :
-						new HttpServerMetricsHandler((HttpServerMetricsRecorder) recorder, uriTagValue);
+			if (metricsRecorder instanceof HttpServerMetricsRecorder) {
+				ChannelHandler handler = metricsRecorder instanceof ContextAwareHttpServerMetricsRecorder ?
+						new ContextAwareHttpServerMetricsHandler((ContextAwareHttpServerMetricsRecorder) metricsRecorder, uriTagValue) :
+						new HttpServerMetricsHandler((HttpServerMetricsRecorder) metricsRecorder, uriTagValue);
 				p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.HttpMetricsHandler, handler);
-				if (recorder instanceof MicrometerHttpServerMetricsRecorder) {
+				if (metricsRecorder instanceof MicrometerHttpServerMetricsRecorder) {
 					// MicrometerHttpServerMetricsRecorder does not implement metrics on protocol level
 					// ChannelMetricsHandler will be removed from the pipeline
 					p.remove(NettyPipeline.ChannelMetricsHandler);
@@ -768,7 +766,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		final Duration                                                idleTimeout;
 		final ConnectionObserver                                      listener;
 		final BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>>      mapHandle;
-		final Supplier<? extends ChannelMetricsRecorder>              metricsRecorder;
+		final ChannelMetricsRecorder                                  metricsRecorder;
 		final int                                                     minCompressionSize;
 		final ChannelOperations.OnSetup                               opsFactory;
 		final Function<String, String>                                uriTagValue;
@@ -830,7 +828,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		final Http2Settings                                           http2Settings;
 		final Duration                                                idleTimeout;
 		final BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>>      mapHandle;
-		final Supplier<? extends ChannelMetricsRecorder>              metricsRecorder;
+		final ChannelMetricsRecorder                                  metricsRecorder;
 		final int                                                     minCompressionSize;
 		final ChannelOperations.OnSetup                               opsFactory;
 		final int                                                     protocols;
@@ -850,7 +848,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 			this.http2Settings = config.http2Settings();
 			this.idleTimeout = config.idleTimeout;
 			this.mapHandle = config.mapHandle;
-			this.metricsRecorder = config.metricsRecorder();
+			this.metricsRecorder = config.metricsRecorderInternal();
 			this.minCompressionSize = config.minCompressionSize;
 			this.opsFactory = config.channelOperationsProvider();
 			this.protocols = config._protocols;


### PR DESCRIPTION
This will guarantee the channel hash is calculated correctly as there are cases
when the metrics recorder supplier returns always different instances of the metrics recorder.

Fixes #1707