### PR TITLE
[chores] reactor-netty-core module: recompute copyright notice range from git history

### DIFF
--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/jarFileTest/java/reactor/netty/AbstractJarFileTest.java
+++ b/reactor-netty-core/src/jarFileTest/java/reactor/netty/AbstractJarFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/jarFileTest/java/reactor/netty/JarFileShadingTest.java
+++ b/reactor-netty-core/src/jarFileTest/java/reactor/netty/JarFileShadingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/ChannelBindException.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ChannelBindException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/ChannelOperationsId.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ChannelOperationsId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/ChannelPipelineConfigurer.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ChannelPipelineConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/ConnectionObserver.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ConnectionObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/DisposableChannel.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/DisposableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/DisposableServer.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/DisposableServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/AbstractChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/AbstractChannelMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MeterKey.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MeterKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSend.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSendMany.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSendMany.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionPoolMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionPoolMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoop.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopIOUring.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopIOUring.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopKQueue.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopKQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNIO.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNativeDetector.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNativeDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultPooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultPooledConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DelegatingConnectionPoolMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DelegatingConnectionPoolMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/MicrometerPooledConnectionProviderMeterRegistrar.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/MicrometerPooledConnectionProviderMeterRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/NewConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/NewConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/AbstractProtocolSslContextSpec.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/AbstractProtocolSslContextSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/DefaultSslContextSpec.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/DefaultSslContextSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientBootstrap.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConnect.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientSecure.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientSecure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServerBind.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServerBind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServerConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpSslContextSpec.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpSslContextSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/AddressResolverGroupMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/AddressResolverGroupMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/AddressUtils.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/AddressUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransportConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConnector.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/logging/AdvancedByteBufFormat.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/logging/AdvancedByteBufFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/logging/ReactorNettyLoggingHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/logging/ReactorNettyLoggingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/package-info.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConnect.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServerBind.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServerBind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServerConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/BlockHoundIntegrationTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/BlockHoundIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ByteBufFluxTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ByteBufFluxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ByteBufMonoTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ByteBufMonoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ChannelBindExceptionTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ChannelBindExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ChannelOperationsIdTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ChannelOperationsIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ConnectionIdleTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ConnectionIdleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ConnectionObserverContextTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ConnectionObserverContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/ConnectionTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/CustomBlockHoundIntegration.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/CustomBlockHoundIntegration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/FutureMonoTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/FutureMonoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/NettyOutboundTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/NettyOutboundTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/channel/MonoSendManyTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/channel/MonoSendManyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultLoopResourcesTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultLoopResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/NewConnectionProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/NewConnectionProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/PooledConnectionProviderCustomMetricsTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/PooledConnectionProviderCustomMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/BlockingConnectionTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/BlockingConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpMetricsTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpMetricsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpResourcesTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpSecureMetricsTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpSecureMetricsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/AddressUtilsTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/AddressUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportResolverHooksTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportResolverHooksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ProxyProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ProxyProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ServerTransportTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ServerTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/TransportTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/TransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/logging/AdvancedByteBufFormatTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/logging/AdvancedByteBufFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/logging/ReactorNettyLoggingHandlerTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/logging/ReactorNettyLoggingHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/udp/UdpClientTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/udp/UdpClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/udp/UdpMetricsTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/udp/UdpMetricsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/udp/UdpResourcesTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/udp/UdpResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
+++ b/reactor-netty-core/src/test/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+# Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
See reactor/reactor#682