### PR TITLE
Fix NPE when reporting metrics to Micrometer

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
@@ -85,7 +85,8 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelDuplexHandler {
 		}
 
 		if (msg instanceof LastHttpContent) {
-			promise.addListener(future -> recordWrite(ctx.channel().remoteAddress()));
+			SocketAddress address = ctx.channel().remoteAddress();
+			promise.addListener(future -> recordWrite(address));
 		}
 		//"FutureReturnValueIgnored" this is deliberate
 		ctx.write(msg, promise);


### PR DESCRIPTION
Obtain the remote address from the `ChannelHandlerContext` while in the `write` method and not in the callback.

Fixes #1766