### PR TITLE
Add API HttpServerRequest#receiveForm()

### DIFF
--- a/docs/asciidoc/http-server.adoc
+++ b/docs/asciidoc/http-server.adoc
@@ -215,6 +215,56 @@ include::{examplesdir}/read/headers/Application.java[lines=18..40]
 ----
 ====
 
+=== Reading Post Form or Multipart Data
+
+When you receive data from the connected clients, you might want to access `POST` `form` (`application/x-www-form-urlencoded`) or
+`multipart` (`multipart/form-data`) data. You can obtain this data by using
+{javadoc}/reactor/netty/http/server/HttpServerRequest.html[`HttpServerRequest`].
+
+====
+[source,java,indent=0]
+.{examplesdir}/multipart/Application.java
+----
+include::{examplesdir}/multipart/Application.java[lines=18..36]
+----
+<1> Receives `POST` form/multipart data.
+====
+
+When you need to change the default settings, you can configure the `HttpServer` or you can provide a configuration per request:
+
+====
+[source,java,indent=0]
+.{examplesdir}/multipart/custom/Application.java
+----
+include::{examplesdir}/multipart/custom/Application.java[lines=18..37]
+----
+<1> Configuration on the `HttpServer` that specifies that the data is stored on disk only.
+<2> Configuration per request that specifies that if the data size exceed the specified size, the data is stored on the disk.
+====
+
+The following listing shows the available configurations:
+
+[width="100%",options="header"]
+|=======
+| Configuration name | Description
+| `baseDirectory` | Configures the directory where to store the data on the disk. Default to system temp directory.
+| `charset` | Configures the `Charset` for the data. Default to `StandardCharsets#UTF_8`.
+| `deleteOnExit` | Configures whether the temporary files should be deleted with the JVM. Default to `true`.
+| `maxInMemorySize` | Configures the maximum in-memory size per data i.e. the data is written
+on disk if the size is greater than `maxInMemorySize`, else it is in memory.
+If set to `-1` the entire contents is stored in memory. If set to `0` the entire contents is stored on disk.
+Default to `16kb`.
+| `maxSize` | Configures the maximum size per data. When the limit is reached, an exception is raised.
+If set to `-1` this means no limitation. Default to `-1` - unlimited.
+| `scheduler` | Configures the scheduler to be used for offloading disk operations in the decoding phase.
+Default to `Schedulers#boundedElastic()`
+| `streaming` | When set to `true`, the data is streamed directly from the parsed input buffer stream,
+which means it is not stored either in memory or file. When `false`, parts are backed by in-memory and/or file storage.
+Default to `false`.
+*NOTE* that with streaming enabled, the provided data might not be in a complete state i.e. `HttpData#isCompleted()`
+has to be checked. Also note that enabling this property effectively ignores `maxInMemorySize`, `baseDirectory`, and `scheduler`.
+|=======
+
 ==== Obtaining the Remote (Client) Address
 
 In addition to the metadata that you can obtain from the request, you can also receive the

--- a/docs/asciidoc/http-server.adoc
+++ b/docs/asciidoc/http-server.adoc
@@ -249,7 +249,6 @@ The following listing shows the available configurations:
 | Configuration name | Description
 | `baseDirectory` | Configures the directory where to store the data on the disk. Default to system temp directory.
 | `charset` | Configures the `Charset` for the data. Default to `StandardCharsets#UTF_8`.
-| `deleteOnExit` | Configures whether the temporary files should be deleted with the JVM. Default to `true`.
 | `maxInMemorySize` | Configures the maximum in-memory size per data i.e. the data is written
 on disk if the size is greater than `maxInMemorySize`, else it is in memory.
 If set to `-1` the entire contents is stored in memory. If set to `0` the entire contents is stored on disk.

--- a/docs/asciidoc/http-server.adoc
+++ b/docs/asciidoc/http-server.adoc
@@ -247,7 +247,7 @@ The following listing shows the available configurations:
 [width="100%",options="header"]
 |=======
 | Configuration name | Description
-| `baseDirectory` | Configures the directory where to store the data on the disk. Default to system temp directory.
+| `baseDirectory` | Configures the directory where to store the data on the disk. Default to generated temp directory.
 | `charset` | Configures the `Charset` for the data. Default to `StandardCharsets#UTF_8`.
 | `maxInMemorySize` | Configures the maximum in-memory size per data i.e. the data is written
 on disk if the size is greater than `maxInMemorySize`, else it is in memory.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/multipart/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/multipart/Application.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.server.multipart;
+
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+public class Application {
+
+	public static void main(String[] args) {
+		DisposableServer server =
+				HttpServer.create()
+				          .route(routes ->
+				              routes.post("/multipart", (request, response) -> response.sendString(
+				                      request.receiveForm() //<1>
+				                             .flatMap(data -> Mono.just('[' + data.getName() + ']')))))
+				          .bindNow();
+
+		server.onDispose()
+		      .block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/multipart/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/multipart/custom/Application.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.server.multipart.custom;
+
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+public class Application {
+
+	public static void main(String[] args) {
+		DisposableServer server =
+				HttpServer.create()
+				          .httpFormDecoder(builder -> builder.maxInMemorySize(0))                  //<1>
+				          .route(routes ->
+				              routes.post("/multipart", (request, response) -> response.sendString(
+				                      request.receiveForm(builder -> builder.maxInMemorySize(256)) //<2>
+				                             .flatMap(data -> Mono.just('[' + data.getName() + ']')))))
+				          .bindNow();
+
+		server.onDispose()
+		      .block();
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
@@ -52,6 +52,7 @@ final class Http2StreamBridgeServerHandler extends ChannelDuplexHandler implemen
 	final BiPredicate<HttpServerRequest, HttpServerResponse>      compress;
 	final ServerCookieDecoder                                     cookieDecoder;
 	final ServerCookieEncoder                                     cookieEncoder;
+	final HttpServerFormDecoderProvider                           formDecoderProvider;
 	final BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> forwardedHeaderHandler;
 	final ConnectionObserver                                      listener;
 	final BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>>
@@ -65,12 +66,14 @@ final class Http2StreamBridgeServerHandler extends ChannelDuplexHandler implemen
 			@Nullable BiPredicate<HttpServerRequest, HttpServerResponse> compress,
 			ServerCookieDecoder decoder,
 			ServerCookieEncoder encoder,
+			HttpServerFormDecoderProvider formDecoderProvider,
 			@Nullable BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> forwardedHeaderHandler,
 			ConnectionObserver listener,
 			@Nullable BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>> mapHandle) {
 		this.compress = compress;
 		this.cookieDecoder = decoder;
 		this.cookieEncoder = encoder;
+		this.formDecoderProvider = formDecoderProvider;
 		this.forwardedHeaderHandler = forwardedHeaderHandler;
 		this.listener = listener;
 		this.mapHandle = mapHandle;
@@ -109,6 +112,7 @@ final class Http2StreamBridgeServerHandler extends ChannelDuplexHandler implemen
 						                    forwardedHeaderHandler),
 						cookieDecoder,
 						cookieEncoder,
+						formDecoderProvider,
 						mapHandle,
 						secured);
 			}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -445,6 +445,29 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	}
 
 	/**
+	 * Apply HTTP form decoder configuration.
+	 * The configuration is used when {@link HttpServerRequest#receiveForm()} is invoked.
+	 * When a specific configuration per request is needed {@link HttpServerRequest#receiveForm(Consumer)}
+	 * should be used.
+	 *
+	 * @param formDecoderBuilder {@link HttpServerFormDecoderProvider.Builder} for HTTP form decoder configuration
+	 * @return a new {@link HttpServer}
+	 * @since 1.0.11
+	 */
+	public final HttpServer httpFormDecoder(Consumer<HttpServerFormDecoderProvider.Builder> formDecoderBuilder) {
+		Objects.requireNonNull(formDecoderBuilder, "formDecoderBuilder");
+		HttpServerFormDecoderProvider.Build builder = new HttpServerFormDecoderProvider.Build();
+		formDecoderBuilder.accept(builder);
+		HttpServerFormDecoderProvider formDecoderProvider = builder.build();
+		if (formDecoderProvider.equals(configuration().formDecoderProvider)) {
+			return this;
+		}
+		HttpServer dup = duplicate();
+		dup.configuration().formDecoderProvider = formDecoderProvider;
+		return dup;
+	}
+
+	/**
 	 * Configure the {@link io.netty.handler.codec.http.HttpServerCodec}'s request decoding options.
 	 *
 	 * @param requestDecoderOptions a function to mutate the provided Http request decoder options

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
@@ -82,7 +82,7 @@ public final class HttpServerFormDecoderProvider {
 		 * Default to {@link DefaultHttpDataFactory#MAXSIZE} - unlimited.
 		 * <p>Note: If set to {@code -1} this means no limitation.
 		 *
-		 * @param maxSize the maximum in-memory size
+		 * @param maxSize the maximum size allowed for an individual attribute/fileUpload
 		 * @return {@code this}
 		 */
 		Builder maxSize(long maxSize);
@@ -146,18 +146,18 @@ public final class HttpServerFormDecoderProvider {
 	}
 
 	/**
-	 * Returns the configured maximum in-memory size per {@link Attribute}/{@link FileUpload}.
+	 * Returns the configured maximum size after which an {@link Attribute}/{@link FileUpload} starts being stored on disk rather than in memory.
 	 *
-	 * @return the configured maximum in-memory size per {@link Attribute}/{@link FileUpload}
+	 * @return the configured maximum size after which an {@link Attribute}/{@link FileUpload} starts being stored on disk rather than in memory
 	 */
 	public long maxInMemorySize() {
 		return maxInMemorySize;
 	}
 
 	/**
-	 * Returns the configured maximum size per {@link Attribute}/{@link FileUpload}.
+	 * Returns the configured maximum allowed size of individual {@link Attribute}/{@link FileUpload}.
 	 *
-	 * @return the configured maximum size per {@link Attribute}/{@link FileUpload}
+	 * @return the configured maximum allowed size of individual {@link Attribute}/{@link FileUpload}
 	 */
 	public long maxSize() {
 		return maxSize;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
@@ -345,8 +345,8 @@ public final class HttpServerFormDecoderProvider {
 		public void destroy() {
 			super.destroy();
 			InterfaceHttpData partial = currentPartialHttpData();
-			if (partial instanceof HttpData) {
-				((HttpData) partial).delete();
+			if (partial != null) {
+				partial.release();
 			}
 		}
 	}
@@ -407,8 +407,8 @@ public final class HttpServerFormDecoderProvider {
 		public void destroy() {
 			super.destroy();
 			InterfaceHttpData partial = currentPartialHttpData();
-			if (partial instanceof HttpData) {
-				((HttpData) partial).delete();
+			if (partial != null) {
+				partial.release();
 			}
 		}
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
@@ -327,10 +327,7 @@ public final class HttpServerFormDecoderProvider {
 			if (!onlyCompleted) {
 				InterfaceHttpData partial = currentPartialHttpData();
 				if (partial instanceof HttpData) {
-					List<HttpData> all = new ArrayList<>(currentCompletedHttpData.size() + 1);
-					all.addAll(currentCompletedHttpData);
-					all.add((HttpData) partial);
-					return all;
+					currentCompletedHttpData.add(((HttpData) partial).retainedDuplicate());
 				}
 			}
 
@@ -387,10 +384,7 @@ public final class HttpServerFormDecoderProvider {
 			if (!onlyCompleted) {
 				InterfaceHttpData partial = currentPartialHttpData();
 				if (partial instanceof HttpData) {
-					List<HttpData> all = new ArrayList<>(currentCompletedHttpData.size() + 1);
-					all.addAll(currentCompletedHttpData);
-					all.add((HttpData) partial);
-					return all;
+					currentCompletedHttpData.add(((HttpData) partial).retainedDuplicate());
 				}
 			}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.multipart.Attribute;
+import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory;
+import io.netty.handler.codec.http.multipart.FileUpload;
+import io.netty.handler.codec.http.multipart.HttpData;
+import io.netty.handler.codec.http.multipart.HttpDataFactory;
+import io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder;
+import io.netty.handler.codec.http.multipart.HttpPostStandardRequestDecoder;
+import io.netty.handler.codec.http.multipart.InterfaceHttpData;
+import io.netty.handler.codec.http.multipart.InterfaceHttpPostRequestDecoder;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.annotation.Nullable;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A configuration builder to fine tune the HTTP form decoder.
+ *
+ * @author Violeta Georgieva
+ * @since 1.0.11
+ */
+public final class HttpServerFormDecoderProvider {
+
+	public interface Builder {
+
+		/**
+		 * Sets the directory where to store disk {@link Attribute}/{@link FileUpload}. Default to system temp directory.
+		 *
+		 * @param baseDirectory directory where to store disk {@link Attribute}/{@link FileUpload}
+		 * @return {@code this}
+		 */
+		Builder baseDirectory(Path baseDirectory);
+
+		/**
+		 * Set the {@link Charset} for {@link Attribute}/{@link FileUpload}. Default to {@link StandardCharsets#UTF_8}.
+		 *
+		 * @param charset the charset for {@link Attribute}/{@link FileUpload}
+		 * @return {@code this}
+		 */
+		Builder charset(Charset charset);
+
+		/**
+		 * Specifies whether the temporary files should be deleted with the JVM. Default to {@code true}.
+		 *
+		 * @param deleteOnExit if true the temporary files should be deleted with the JVM, false - otherwise
+		 * @return {@code this}
+		 */
+		Builder deleteOnExit(boolean deleteOnExit);
+
+		/**
+		 * Sets the maximum in-memory size per {@link Attribute}/{@link FileUpload} i.e. the data is written
+		 * on disk if the size is greater than {@code maxInMemorySize}, else it is in memory.
+		 * Default to {@link DefaultHttpDataFactory#MINSIZE}.
+		 * <p>Note:
+		 * <ul>
+		 *     <li>If set to {@code -1} the entire contents is stored in memory</li>
+		 *     <li>If set to {@code 0} the entire contents is stored on disk</li>
+		 * </ul>
+		 *
+		 * @param maxInMemorySize the maximum in-memory size
+		 * @return {@code this}
+		 */
+		Builder maxInMemorySize(long maxInMemorySize);
+
+		/**
+		 * Set the maximum size per {@link Attribute}/{@link FileUpload}. When the limit is reached, an exception is raised.
+		 * Default to {@link DefaultHttpDataFactory#MAXSIZE} - unlimited.
+		 * <p>Note: If set to {@code -1} this means no limitation.
+		 *
+		 * @param maxSize the maximum in-memory size
+		 * @return {@code this}
+		 */
+		Builder maxSize(long maxSize);
+
+		/**
+		 * Sets the scheduler to be used for offloading disk operations in the decoding phase.
+		 * Default to {@link Schedulers#boundedElastic()}
+		 *
+		 * @param scheduler the scheduler to be used for offloading disk operations in the decoding phase
+		 * @return {@code this}
+		 */
+		Builder scheduler(Scheduler scheduler);
+
+		/**
+		 * When set to {@code true}, the data is streamed directly from the parsed input buffer stream,
+		 * which means it is not stored either in memory or file.
+		 * When {@code false}, parts are backed by in-memory and/or file storage. Default to {@code false}.
+		 * <p><strong>NOTE</strong> that with streaming enabled, the provided {@link Attribute}/{@link FileUpload}
+		 * might not be in a complete state i.e. {@link HttpData#isCompleted()} has to be checked.
+		 * <p>Also note that enabling this property effectively ignores
+		 * {@link #maxInMemorySize(long)},
+		 * {@link #baseDirectory(Path)}, and
+		 * {@link #scheduler(Scheduler)}.
+		 */
+		Builder streaming(boolean enable);
+	}
+
+	final Path baseDirectory;
+	final Charset charset;
+	final boolean deleteOnExit;
+	final long maxInMemorySize;
+	final long maxSize;
+	final Scheduler scheduler;
+	final boolean streaming;
+
+	HttpServerFormDecoderProvider(Build build) {
+		this.baseDirectory = build.baseDirectory;
+		this.charset = build.charset;
+		this.deleteOnExit = build.deleteOnExit;
+		this.maxInMemorySize = !build.streaming ? build.maxInMemorySize : -1;
+		this.maxSize = build.maxSize;
+		this.scheduler = build.scheduler;
+		this.streaming = build.streaming;
+	}
+
+	/**
+	 * Returns the configured directory where to store disk {@link Attribute}/{@link FileUpload}.
+	 *
+	 * @return the configured directory where to store disk {@link Attribute}/{@link FileUpload}
+	 */
+	@Nullable
+	public Path baseDirectory() {
+		return baseDirectory;
+	}
+
+	/**
+	 * Returns the configured charset for {@link Attribute}/{@link FileUpload}.
+	 *
+	 * @return the configured charset for {@link Attribute}/{@link FileUpload}
+	 */
+	public Charset charset() {
+		return charset;
+	}
+
+	/**
+	 * Returns whether the temporary files should be deleted with the JVM.
+	 *
+	 * @return whether the temporary files should be deleted with the JVM
+	 */
+	public boolean deleteOnExit() {
+		return deleteOnExit;
+	}
+
+	/**
+	 * Returns the configured maximum in-memory size per {@link Attribute}/{@link FileUpload}.
+	 *
+	 * @return the configured maximum in-memory size per {@link Attribute}/{@link FileUpload}
+	 */
+	public long maxInMemorySize() {
+		return maxInMemorySize;
+	}
+
+	/**
+	 * Returns the configured maximum size per {@link Attribute}/{@link FileUpload}.
+	 *
+	 * @return the configured maximum size per {@link Attribute}/{@link FileUpload}
+	 */
+	public long maxSize() {
+		return maxSize;
+	}
+
+	/**
+	 * Returns the configured scheduler to be used for offloading disk operations in the decoding phase.
+	 *
+	 * @return the configured scheduler to be used for offloading disk operations in the decoding phase
+	 */
+	public Scheduler scheduler() {
+		return scheduler;
+	}
+
+	/**
+	 * Returns whether the streaming mode is enabled.
+	 *
+	 * @return whether the streaming mode is enabled
+	 */
+	public boolean streaming() {
+		return streaming;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof HttpServerFormDecoderProvider)) {
+			return false;
+		}
+		HttpServerFormDecoderProvider that = (HttpServerFormDecoderProvider) o;
+		return deleteOnExit == that.deleteOnExit &&
+				maxInMemorySize == that.maxInMemorySize &&
+				maxSize == that.maxSize &&
+				streaming == that.streaming &&
+				Objects.equals(baseDirectory, that.baseDirectory) &&
+				charset.equals(that.charset) &&
+				scheduler.equals(that.scheduler);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(baseDirectory, charset, deleteOnExit, maxInMemorySize, maxSize, scheduler, streaming);
+	}
+
+	ReactorNettyHttpPostRequestDecoder newHttpPostRequestDecoder(HttpRequest request, boolean isMultipart) {
+		DefaultHttpDataFactory factory = maxInMemorySize > 0 ?
+				new DefaultHttpDataFactory(maxInMemorySize, charset) :
+				new DefaultHttpDataFactory(maxInMemorySize == 0, charset);
+		factory.setMaxLimit(maxSize);
+		factory.setDeleteOnExit(deleteOnExit);
+		if (baseDirectory != null) {
+			factory.setBaseDir(baseDirectory.toFile().getAbsolutePath());
+		}
+		return isMultipart ?
+				new ReactorNettyHttpPostMultipartRequestDecoder(factory, request) :
+				new ReactorNettyHttpPostStandardRequestDecoder(factory, request);
+	}
+
+	static final HttpServerFormDecoderProvider DEFAULT_FORM_DECODER_SPEC = new HttpServerFormDecoderProvider.Build().build();
+
+	interface ReactorNettyHttpPostRequestDecoder extends InterfaceHttpPostRequestDecoder {
+
+		void cleanCurrentHttpData(boolean onlyCompleted);
+
+		List<HttpData> currentCompletedHttpData();
+
+		List<HttpData> currentHttpData();
+	}
+
+	static final class Build implements Builder {
+
+		static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+		static final boolean DEFAULT_DELETE_ON_EXIT = true;
+		static final long DEFAULT_MAX_IN_MEMORY_SIZE = DefaultHttpDataFactory.MINSIZE;
+		static final long DEFAULT_MAX_SIZE = DefaultHttpDataFactory.MAXSIZE;
+		static final Scheduler DEFAULT_SCHEDULER = Schedulers.boundedElastic();
+		static final boolean DEFAULT_STREAMING = false;
+
+		Path baseDirectory;
+		Charset charset = DEFAULT_CHARSET;
+		boolean deleteOnExit = DEFAULT_DELETE_ON_EXIT;
+		long maxInMemorySize = DEFAULT_MAX_IN_MEMORY_SIZE;
+		long maxSize = DEFAULT_MAX_SIZE;
+		Scheduler scheduler = DEFAULT_SCHEDULER;
+		boolean streaming = DEFAULT_STREAMING;
+
+		@Override
+		public Builder baseDirectory(Path baseDirectory) {
+			this.baseDirectory = Objects.requireNonNull(baseDirectory, "baseDirectory");
+			return this;
+		}
+
+		@Override
+		public Builder charset(Charset charset) {
+			this.charset = Objects.requireNonNull(charset, "charset");
+			return this;
+		}
+
+		@Override
+		public Builder deleteOnExit(boolean deleteOnExit) {
+			this.deleteOnExit = deleteOnExit;
+			return this;
+		}
+
+		@Override
+		public Builder maxInMemorySize(long maxInMemorySize) {
+			if (maxInMemorySize < -1) {
+				throw new IllegalArgumentException("Maximum in-memory size must be greater or equal to -1");
+			}
+			this.maxInMemorySize = maxInMemorySize;
+			return this;
+		}
+
+		@Override
+		public Builder maxSize(long maxSize) {
+			if (maxSize < -1) {
+				throw new IllegalArgumentException("Maximum size must be be greater or equal to -1");
+			}
+			this.maxSize = maxSize;
+			return this;
+		}
+
+		@Override
+		public Builder scheduler(Scheduler scheduler) {
+			this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
+			return this;
+		}
+
+		@Override
+		public Builder streaming(boolean enable) {
+			this.streaming = enable;
+			return this;
+		}
+
+		HttpServerFormDecoderProvider build() {
+			return new HttpServerFormDecoderProvider(this);
+		}
+	}
+
+	static final class ReactorNettyHttpPostMultipartRequestDecoder extends HttpPostMultipartRequestDecoder
+			implements ReactorNettyHttpPostRequestDecoder {
+
+		/**
+		 * Current {@link HttpData} from the body (only the completed {@link HttpData}).
+		 */
+		final List<HttpData> currentCompletedHttpData = new ArrayList<>();
+
+		ReactorNettyHttpPostMultipartRequestDecoder(HttpDataFactory factory, HttpRequest request) {
+			super(factory, request);
+		}
+
+		@Override
+		protected void addHttpData(InterfaceHttpData data) {
+			if (data instanceof HttpData) {
+				currentCompletedHttpData.add((HttpData) data);
+			}
+		}
+
+		@Override
+		public void cleanCurrentHttpData(boolean cleanAll) {
+			for (HttpData data : currentCompletedHttpData) {
+				removeHttpDataFromClean(data);
+				data.release();
+			}
+			currentCompletedHttpData.clear();
+
+			if (cleanAll) {
+				InterfaceHttpData partial = currentPartialHttpData();
+				if (partial instanceof HttpData) {
+					((HttpData) partial).delete();
+				}
+			}
+		}
+
+		@Override
+		public List<HttpData> currentCompletedHttpData() {
+			return currentCompletedHttpData;
+		}
+
+		@Override
+		public List<HttpData> currentHttpData() {
+			InterfaceHttpData partial = currentPartialHttpData();
+			if (partial instanceof HttpData) {
+				List<HttpData> all = new ArrayList<>(currentCompletedHttpData.size() + 1);
+				all.addAll(currentCompletedHttpData);
+				all.add((HttpData) partial);
+				return all;
+			}
+			return currentCompletedHttpData;
+		}
+	}
+
+	static final class ReactorNettyHttpPostStandardRequestDecoder extends HttpPostStandardRequestDecoder
+			implements ReactorNettyHttpPostRequestDecoder {
+
+		/**
+		 * Current {@link HttpData} from the body (only the completed {@link HttpData}).
+		 */
+		final List<HttpData> currentCompletedHttpData = new ArrayList<>();
+
+		ReactorNettyHttpPostStandardRequestDecoder(HttpDataFactory factory, HttpRequest request) {
+			super(factory, request);
+		}
+
+		@Override
+		protected void addHttpData(InterfaceHttpData data) {
+			if (data instanceof HttpData) {
+				currentCompletedHttpData.add((HttpData) data);
+			}
+		}
+
+		@Override
+		public void cleanCurrentHttpData(boolean onlyCompleted) {
+			for (HttpData data : currentCompletedHttpData) {
+				removeHttpDataFromClean(data);
+				data.release();
+			}
+			currentCompletedHttpData.clear();
+
+			if (!onlyCompleted) {
+				InterfaceHttpData partial = currentPartialHttpData();
+				if (partial != null) {
+					currentPartialHttpData().release();
+				}
+			}
+		}
+
+		@Override
+		public List<HttpData> currentCompletedHttpData() {
+			return currentCompletedHttpData;
+		}
+
+		@Override
+		public List<HttpData> currentHttpData() {
+			InterfaceHttpData partial = currentPartialHttpData();
+			if (partial instanceof HttpData) {
+				List<HttpData> all = new ArrayList<>(currentCompletedHttpData.size() + 1);
+				all.addAll(currentCompletedHttpData);
+				all.add((HttpData) partial);
+				return all;
+			}
+			return currentCompletedHttpData;
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
@@ -63,14 +63,6 @@ public final class HttpServerFormDecoderProvider {
 		Builder charset(Charset charset);
 
 		/**
-		 * Specifies whether the temporary files should be deleted with the JVM. Default to {@code true}.
-		 *
-		 * @param deleteOnExit if true the temporary files should be deleted with the JVM, false - otherwise
-		 * @return {@code this}
-		 */
-		Builder deleteOnExit(boolean deleteOnExit);
-
-		/**
 		 * Sets the maximum in-memory size per {@link Attribute}/{@link FileUpload} i.e. the data is written
 		 * on disk if the size is greater than {@code maxInMemorySize}, else it is in memory.
 		 * Default to {@link DefaultHttpDataFactory#MINSIZE}.
@@ -120,7 +112,6 @@ public final class HttpServerFormDecoderProvider {
 
 	final Path baseDirectory;
 	final Charset charset;
-	final boolean deleteOnExit;
 	final long maxInMemorySize;
 	final long maxSize;
 	final Scheduler scheduler;
@@ -129,7 +120,6 @@ public final class HttpServerFormDecoderProvider {
 	HttpServerFormDecoderProvider(Build build) {
 		this.baseDirectory = build.baseDirectory;
 		this.charset = build.charset;
-		this.deleteOnExit = build.deleteOnExit;
 		this.maxInMemorySize = !build.streaming ? build.maxInMemorySize : -1;
 		this.maxSize = build.maxSize;
 		this.scheduler = build.scheduler;
@@ -153,15 +143,6 @@ public final class HttpServerFormDecoderProvider {
 	 */
 	public Charset charset() {
 		return charset;
-	}
-
-	/**
-	 * Returns whether the temporary files should be deleted with the JVM.
-	 *
-	 * @return whether the temporary files should be deleted with the JVM
-	 */
-	public boolean deleteOnExit() {
-		return deleteOnExit;
 	}
 
 	/**
@@ -209,8 +190,7 @@ public final class HttpServerFormDecoderProvider {
 			return false;
 		}
 		HttpServerFormDecoderProvider that = (HttpServerFormDecoderProvider) o;
-		return deleteOnExit == that.deleteOnExit &&
-				maxInMemorySize == that.maxInMemorySize &&
+		return maxInMemorySize == that.maxInMemorySize &&
 				maxSize == that.maxSize &&
 				streaming == that.streaming &&
 				Objects.equals(baseDirectory, that.baseDirectory) &&
@@ -220,7 +200,7 @@ public final class HttpServerFormDecoderProvider {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(baseDirectory, charset, deleteOnExit, maxInMemorySize, maxSize, scheduler, streaming);
+		return Objects.hash(baseDirectory, charset, maxInMemorySize, maxSize, scheduler, streaming);
 	}
 
 	ReactorNettyHttpPostRequestDecoder newHttpPostRequestDecoder(HttpRequest request, boolean isMultipart) {
@@ -228,7 +208,6 @@ public final class HttpServerFormDecoderProvider {
 				new DefaultHttpDataFactory(maxInMemorySize, charset) :
 				new DefaultHttpDataFactory(maxInMemorySize == 0, charset);
 		factory.setMaxLimit(maxSize);
-		factory.setDeleteOnExit(deleteOnExit);
 		if (baseDirectory != null) {
 			factory.setBaseDir(baseDirectory.toFile().getAbsolutePath());
 		}
@@ -251,7 +230,6 @@ public final class HttpServerFormDecoderProvider {
 	static final class Build implements Builder {
 
 		static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
-		static final boolean DEFAULT_DELETE_ON_EXIT = true;
 		static final long DEFAULT_MAX_IN_MEMORY_SIZE = DefaultHttpDataFactory.MINSIZE;
 		static final long DEFAULT_MAX_SIZE = DefaultHttpDataFactory.MAXSIZE;
 		static final Scheduler DEFAULT_SCHEDULER = Schedulers.boundedElastic();
@@ -259,7 +237,6 @@ public final class HttpServerFormDecoderProvider {
 
 		Path baseDirectory;
 		Charset charset = DEFAULT_CHARSET;
-		boolean deleteOnExit = DEFAULT_DELETE_ON_EXIT;
 		long maxInMemorySize = DEFAULT_MAX_IN_MEMORY_SIZE;
 		long maxSize = DEFAULT_MAX_SIZE;
 		Scheduler scheduler = DEFAULT_SCHEDULER;
@@ -274,12 +251,6 @@ public final class HttpServerFormDecoderProvider {
 		@Override
 		public Builder charset(Charset charset) {
 			this.charset = Objects.requireNonNull(charset, "charset");
-			return this;
-		}
-
-		@Override
-		public Builder deleteOnExit(boolean deleteOnExit) {
-			this.deleteOnExit = deleteOnExit;
 			return this;
 		}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
@@ -369,6 +369,15 @@ public final class HttpServerFormDecoderProvider {
 			}
 			return currentCompletedHttpData;
 		}
+
+		@Override
+		public void destroy() {
+			super.destroy();
+			InterfaceHttpData partial = currentPartialHttpData();
+			if (partial instanceof HttpData) {
+				((HttpData) partial).delete();
+			}
+		}
 	}
 
 	static final class ReactorNettyHttpPostStandardRequestDecoder extends HttpPostStandardRequestDecoder
@@ -421,6 +430,15 @@ public final class HttpServerFormDecoderProvider {
 				return all;
 			}
 			return currentCompletedHttpData;
+		}
+
+		@Override
+		public void destroy() {
+			super.destroy();
+			InterfaceHttpData partial = currentPartialHttpData();
+			if (partial instanceof HttpData) {
+				((HttpData) partial).delete();
+			}
 		}
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
@@ -130,7 +130,7 @@ public final class HttpServerFormDecoderProvider {
 	 * Returns the configured directory where to store disk {@link Attribute}/{@link FileUpload}.
 	 *
 	 * @return the configured directory where to store disk {@link Attribute}/{@link FileUpload}
-	 * @see Builder#baseDirectory(Path) 
+	 * @see Builder#baseDirectory(Path)
 	 */
 	@Nullable
 	public Path baseDirectory() {
@@ -141,7 +141,7 @@ public final class HttpServerFormDecoderProvider {
 	 * Returns the configured charset for {@link Attribute}/{@link FileUpload}.
 	 *
 	 * @return the configured charset for {@link Attribute}/{@link FileUpload}
-	 * @see Builder#charset(Charset) 
+	 * @see Builder#charset(Charset)
 	 */
 	public Charset charset() {
 		return charset;
@@ -151,7 +151,7 @@ public final class HttpServerFormDecoderProvider {
 	 * Returns the configured maximum size after which an {@link Attribute}/{@link FileUpload} starts being stored on disk rather than in memory.
 	 *
 	 * @return the configured maximum size after which an {@link Attribute}/{@link FileUpload} starts being stored on disk rather than in memory
-	 * @see Builder#maxInMemorySize(long) 
+	 * @see Builder#maxInMemorySize(long)
 	 */
 	public long maxInMemorySize() {
 		return maxInMemorySize;
@@ -161,7 +161,7 @@ public final class HttpServerFormDecoderProvider {
 	 * Returns the configured maximum allowed size of individual {@link Attribute}/{@link FileUpload}.
 	 *
 	 * @return the configured maximum allowed size of individual {@link Attribute}/{@link FileUpload}
-	 * @see Builder#maxSize(long) 
+	 * @see Builder#maxSize(long)
 	 */
 	public long maxSize() {
 		return maxSize;
@@ -171,7 +171,7 @@ public final class HttpServerFormDecoderProvider {
 	 * Returns the configured scheduler to be used for offloading disk operations in the decoding phase.
 	 *
 	 * @return the configured scheduler to be used for offloading disk operations in the decoding phase
-	 * @see Builder#scheduler(Scheduler) 
+	 * @see Builder#scheduler(Scheduler)
 	 */
 	public Scheduler scheduler() {
 		return scheduler;
@@ -181,7 +181,7 @@ public final class HttpServerFormDecoderProvider {
 	 * Returns whether the streaming mode is enabled.
 	 *
 	 * @return whether the streaming mode is enabled
-	 * @see Builder#streaming(boolean) 
+	 * @see Builder#streaming(boolean)
 	 */
 	public boolean streaming() {
 		return streaming;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
@@ -222,9 +222,7 @@ public final class HttpServerFormDecoderProvider {
 
 		void cleanCurrentHttpData(boolean onlyCompleted);
 
-		List<HttpData> currentCompletedHttpData();
-
-		List<HttpData> currentHttpData();
+		List<HttpData> currentHttpData(boolean onlyCompleted);
 	}
 
 	static final class Build implements Builder {
@@ -309,14 +307,14 @@ public final class HttpServerFormDecoderProvider {
 		}
 
 		@Override
-		public void cleanCurrentHttpData(boolean cleanAll) {
+		public void cleanCurrentHttpData(boolean onlyCompleted) {
 			for (HttpData data : currentCompletedHttpData) {
 				removeHttpDataFromClean(data);
 				data.release();
 			}
 			currentCompletedHttpData.clear();
 
-			if (cleanAll) {
+			if (!onlyCompleted) {
 				InterfaceHttpData partial = currentPartialHttpData();
 				if (partial instanceof HttpData) {
 					((HttpData) partial).delete();
@@ -325,19 +323,17 @@ public final class HttpServerFormDecoderProvider {
 		}
 
 		@Override
-		public List<HttpData> currentCompletedHttpData() {
-			return currentCompletedHttpData;
-		}
-
-		@Override
-		public List<HttpData> currentHttpData() {
-			InterfaceHttpData partial = currentPartialHttpData();
-			if (partial instanceof HttpData) {
-				List<HttpData> all = new ArrayList<>(currentCompletedHttpData.size() + 1);
-				all.addAll(currentCompletedHttpData);
-				all.add((HttpData) partial);
-				return all;
+		public List<HttpData> currentHttpData(boolean onlyCompleted) {
+			if (!onlyCompleted) {
+				InterfaceHttpData partial = currentPartialHttpData();
+				if (partial instanceof HttpData) {
+					List<HttpData> all = new ArrayList<>(currentCompletedHttpData.size() + 1);
+					all.addAll(currentCompletedHttpData);
+					all.add((HttpData) partial);
+					return all;
+				}
 			}
+
 			return currentCompletedHttpData;
 		}
 
@@ -380,26 +376,24 @@ public final class HttpServerFormDecoderProvider {
 
 			if (!onlyCompleted) {
 				InterfaceHttpData partial = currentPartialHttpData();
-				if (partial != null) {
-					currentPartialHttpData().release();
+				if (partial instanceof HttpData) {
+					((HttpData) partial).delete();
 				}
 			}
 		}
 
 		@Override
-		public List<HttpData> currentCompletedHttpData() {
-			return currentCompletedHttpData;
-		}
-
-		@Override
-		public List<HttpData> currentHttpData() {
-			InterfaceHttpData partial = currentPartialHttpData();
-			if (partial instanceof HttpData) {
-				List<HttpData> all = new ArrayList<>(currentCompletedHttpData.size() + 1);
-				all.addAll(currentCompletedHttpData);
-				all.add((HttpData) partial);
-				return all;
+		public List<HttpData> currentHttpData(boolean onlyCompleted) {
+			if (!onlyCompleted) {
+				InterfaceHttpData partial = currentPartialHttpData();
+				if (partial instanceof HttpData) {
+					List<HttpData> all = new ArrayList<>(currentCompletedHttpData.size() + 1);
+					all.addAll(currentCompletedHttpData);
+					all.add((HttpData) partial);
+					return all;
+				}
 			}
+
 			return currentCompletedHttpData;
 		}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
@@ -130,6 +130,7 @@ public final class HttpServerFormDecoderProvider {
 	 * Returns the configured directory where to store disk {@link Attribute}/{@link FileUpload}.
 	 *
 	 * @return the configured directory where to store disk {@link Attribute}/{@link FileUpload}
+	 * @see Builder#baseDirectory(Path) 
 	 */
 	@Nullable
 	public Path baseDirectory() {
@@ -140,6 +141,7 @@ public final class HttpServerFormDecoderProvider {
 	 * Returns the configured charset for {@link Attribute}/{@link FileUpload}.
 	 *
 	 * @return the configured charset for {@link Attribute}/{@link FileUpload}
+	 * @see Builder#charset(Charset) 
 	 */
 	public Charset charset() {
 		return charset;
@@ -149,6 +151,7 @@ public final class HttpServerFormDecoderProvider {
 	 * Returns the configured maximum size after which an {@link Attribute}/{@link FileUpload} starts being stored on disk rather than in memory.
 	 *
 	 * @return the configured maximum size after which an {@link Attribute}/{@link FileUpload} starts being stored on disk rather than in memory
+	 * @see Builder#maxInMemorySize(long) 
 	 */
 	public long maxInMemorySize() {
 		return maxInMemorySize;
@@ -158,6 +161,7 @@ public final class HttpServerFormDecoderProvider {
 	 * Returns the configured maximum allowed size of individual {@link Attribute}/{@link FileUpload}.
 	 *
 	 * @return the configured maximum allowed size of individual {@link Attribute}/{@link FileUpload}
+	 * @see Builder#maxSize(long) 
 	 */
 	public long maxSize() {
 		return maxSize;
@@ -167,6 +171,7 @@ public final class HttpServerFormDecoderProvider {
 	 * Returns the configured scheduler to be used for offloading disk operations in the decoding phase.
 	 *
 	 * @return the configured scheduler to be used for offloading disk operations in the decoding phase
+	 * @see Builder#scheduler(Scheduler) 
 	 */
 	public Scheduler scheduler() {
 		return scheduler;
@@ -176,6 +181,7 @@ public final class HttpServerFormDecoderProvider {
 	 * Returns whether the streaming mode is enabled.
 	 *
 	 * @return whether the streaming mode is enabled
+	 * @see Builder#streaming(boolean) 
 	 */
 	public boolean streaming() {
 		return streaming;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
@@ -120,7 +120,7 @@ public final class HttpServerFormDecoderProvider {
 	final Scheduler scheduler;
 	final boolean streaming;
 
-	private volatile Mono<Path> defaultTempDirectory = createDefaultTemDirectory();
+	private volatile Mono<Path> defaultTempDirectory = createDefaultTempDirectory();
 
 	HttpServerFormDecoderProvider(Build build) {
 		this.baseDirectory = build.baseDirectory;
@@ -214,7 +214,7 @@ public final class HttpServerFormDecoderProvider {
 		return Objects.hash(baseDirectory, charset, maxInMemorySize, maxSize, scheduler, streaming);
 	}
 
-	Mono<Path> createDefaultTemDirectory() {
+	Mono<Path> createDefaultTempDirectory() {
 		return Mono.fromCallable(() -> Files.createTempDirectory(DEFAULT_TEMP_DIRECTORY_PREFIX))
 		           .cache();
 	}
@@ -223,7 +223,7 @@ public final class HttpServerFormDecoderProvider {
 		return defaultTempDirectory
 				.flatMap(dir -> {
 					if (!Files.exists(dir)) {
-						Mono<Path> newDirectory = createDefaultTemDirectory();
+						Mono<Path> newDirectory = createDefaultTempDirectory();
 						defaultTempDirectory = newDirectory;
 						return newDirectory;
 					}
@@ -243,14 +243,14 @@ public final class HttpServerFormDecoderProvider {
 			else {
 				directoryMono = Mono.just(baseDirectory);
 			}
-			return directoryMono.map(directory -> newHttpPostRequestDecoder(request, isMultipart, directory));
+			return directoryMono.map(directory -> createNewHttpPostRequestDecoder(request, isMultipart, directory));
 		}
 		else {
-			return Mono.just(newHttpPostRequestDecoder(request, isMultipart, null));
+			return Mono.just(createNewHttpPostRequestDecoder(request, isMultipart, null));
 		}
 	}
 
-	ReactorNettyHttpPostRequestDecoder newHttpPostRequestDecoder(HttpRequest request, boolean isMultipart,
+	ReactorNettyHttpPostRequestDecoder createNewHttpPostRequestDecoder(HttpRequest request, boolean isMultipart,
 			@Nullable Path baseDirectory) {
 		DefaultHttpDataFactory factory = maxInMemorySize > 0 ?
 				new DefaultHttpDataFactory(maxInMemorySize, charset) :

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -744,7 +744,6 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 					config.newHttpPostRequestDecoder(nettyRequest, isMultipart);
 
 			return receiveContent()
-					.filter(content -> content.content().readableBytes() > 0)
 					.doOnNext(content -> {
 						if (config.maxInMemorySize > -1) {
 							content.retain();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -53,6 +53,8 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
+import io.netty.handler.codec.http.multipart.HttpData;
+import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
 import io.netty.handler.codec.http2.HttpConversionUtil;
@@ -80,6 +82,7 @@ import reactor.util.context.Context;
 
 import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 import static reactor.netty.ReactorNetty.format;
+import static reactor.netty.http.server.HttpServerFormDecoderProvider.DEFAULT_FORM_DECODER_SPEC;
 import static reactor.netty.http.server.HttpServerState.REQUEST_DECODING_FAILED;
 
 /**
@@ -95,6 +98,7 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 	final ServerCookieDecoder cookieDecoder;
 	final ServerCookieEncoder cookieEncoder;
 	final ServerCookies cookieHolder;
+	final HttpServerFormDecoderProvider formDecoderProvider;
 	final BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>> mapHandle;
 	final HttpRequest nettyRequest;
 	final HttpResponse nettyResponse;
@@ -111,6 +115,7 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		this.cookieDecoder = replaced.cookieDecoder;
 		this.cookieEncoder = replaced.cookieEncoder;
 		this.cookieHolder = replaced.cookieHolder;
+		this.formDecoderProvider = replaced.formDecoderProvider;
 		this.mapHandle = replaced.mapHandle;
 		this.nettyRequest = replaced.nettyRequest;
 		this.nettyResponse = replaced.nettyResponse;
@@ -125,9 +130,11 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 			@Nullable ConnectionInfo connectionInfo,
 			ServerCookieDecoder decoder,
 			ServerCookieEncoder encoder,
+			HttpServerFormDecoderProvider formDecoderProvider,
 			@Nullable BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>> mapHandle,
 			boolean secured) {
-		this(c, listener, nettyRequest, compressionPredicate, connectionInfo, decoder, encoder, mapHandle, true, secured);
+		this(c, listener, nettyRequest, compressionPredicate, connectionInfo, decoder, encoder, formDecoderProvider,
+				mapHandle, true, secured);
 	}
 
 	HttpServerOperations(Connection c, ConnectionObserver listener, HttpRequest nettyRequest,
@@ -135,6 +142,7 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 			@Nullable ConnectionInfo connectionInfo,
 			ServerCookieDecoder decoder,
 			ServerCookieEncoder encoder,
+			HttpServerFormDecoderProvider formDecoderProvider,
 			@Nullable BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>> mapHandle,
 			boolean resolvePath,
 			boolean secured) {
@@ -144,6 +152,7 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		this.cookieDecoder = decoder;
 		this.cookieEncoder = encoder;
 		this.cookieHolder = ServerCookies.newServerRequestHolder(nettyRequest.headers(), decoder);
+		this.formDecoderProvider = formDecoderProvider;
 		this.mapHandle = mapHandle;
 		this.nettyRequest = nettyRequest;
 		this.nettyResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
@@ -275,8 +284,19 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 	}
 
 	@Override
+	public boolean isFormUrlencoded() {
+		String contentType = requestHeaders().get(HttpHeaderNames.CONTENT_TYPE);
+		return HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.contentEqualsIgnoreCase(contentType);
+	}
+
+	@Override
 	public boolean isKeepAlive() {
 		return HttpUtil.isKeepAlive(nettyRequest);
+	}
+
+	@Override
+	public boolean isMultipart() {
+		return HttpPostRequestDecoder.isMultipart(nettyRequest);
 	}
 
 	@Override
@@ -320,6 +340,20 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 	public HttpServerRequest paramsResolver(Function<? super String, Map<String, String>> paramsResolver) {
 		this.paramsResolver = paramsResolver;
 		return this;
+	}
+
+	@Override
+	public Flux<HttpData> receiveForm() {
+		return receiveFormInternal(formDecoderProvider);
+	}
+
+	@Override
+	public Flux<HttpData> receiveForm(Consumer<HttpServerFormDecoderProvider.Builder> formDecoderBuilder) {
+		Objects.requireNonNull(formDecoderBuilder, "formDecoderBuilder");
+		HttpServerFormDecoderProvider.Build builder = new HttpServerFormDecoderProvider.Build();
+		formDecoderBuilder.accept(builder);
+		HttpServerFormDecoderProvider config = builder.build();
+		return receiveFormInternal(config);
 	}
 
 	@Override
@@ -698,6 +732,42 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		return nettyResponse;
 	}
 
+	final Flux<HttpData> receiveFormInternal(HttpServerFormDecoderProvider config) {
+		boolean isMultipart = isMultipart();
+		if (!Objects.equals(method(), HttpMethod.POST) || !(isFormUrlencoded() || isMultipart)) {
+			return Flux.error(new IllegalStateException(
+					"Request is not POST or does not have Content-Type " +
+							"with value 'application/x-www-form-urlencoded' or 'multipart/form-data'"));
+		}
+		return Flux.defer(() -> {
+			HttpServerFormDecoderProvider.ReactorNettyHttpPostRequestDecoder decoder =
+					config.newHttpPostRequestDecoder(nettyRequest, isMultipart);
+
+			return receiveContent()
+					.filter(content -> content.content().readableBytes() > 0)
+					.doOnNext(content -> {
+						if (config.maxInMemorySize > -1) {
+							content.retain();
+						}
+					})
+					.concatMap(httpContent ->
+							config.maxInMemorySize == -1 ?
+									Flux.using(
+											() -> decoder.offer(httpContent),
+											d -> Flux.fromIterable(config.streaming ? decoder.currentHttpData() :
+													decoder.currentCompletedHttpData()),
+											d -> decoder.cleanCurrentHttpData(config.streaming)) :
+									Flux.usingWhen(
+											Mono.fromCallable(() -> decoder.offer(httpContent)).subscribeOn(config.scheduler),
+											d -> Flux.fromIterable(decoder.currentCompletedHttpData()),
+											d -> Mono.fromRunnable(() -> {
+												httpContent.release();
+												decoder.cleanCurrentHttpData(false);
+											})))
+					.doFinally(sig -> decoder.destroy());
+		});
+	}
+
 	final Mono<Void> withWebsocketSupport(String url,
 			WebsocketServerSpec websocketServerSpec,
 			BiFunction<? super WebsocketInbound, ? super WebsocketOutbound, ? extends Publisher<Void>> websocketHandler) {
@@ -781,7 +851,8 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 				@Nullable HttpRequest nettyRequest,
 				HttpResponse nettyResponse,
 				boolean secure) {
-			super(c, listener, nettyRequest, null, null, ServerCookieDecoder.STRICT, ServerCookieEncoder.STRICT, null, false, secure);
+			super(c, listener, nettyRequest, null, null, ServerCookieDecoder.STRICT, ServerCookieEncoder.STRICT,
+					DEFAULT_FORM_DECODER_SPEC, null, false, secure);
 			this.customResponse = nettyResponse;
 		}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRequest.java
@@ -22,6 +22,9 @@ import java.util.function.Function;
 
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.multipart.Attribute;
+import io.netty.handler.codec.http.multipart.FileUpload;
+import io.netty.handler.codec.http.multipart.HttpData;
 import reactor.core.publisher.Flux;
 import reactor.netty.Connection;
 import reactor.netty.NettyInbound;
@@ -73,6 +76,56 @@ public interface HttpServerRequest extends NettyInbound, HttpServerInfos {
 	default Flux<HttpContent> receiveContent() {
 		return receiveObject().ofType(HttpContent.class);
 	}
+
+	/**
+	 * Returns true if the request has {@code Content-Type} with value {@code application/x-www-form-urlencoded}.
+	 *
+	 * @return true if the request has {@code Content-Type} with value {@code application/x-www-form-urlencoded},
+	 * false - otherwise
+	 * @since 1.0.11
+	 */
+	boolean isFormUrlencoded();
+
+	/**
+	 * Returns true if the request has {@code Content-Type} with value {@code multipart/form-data}.
+	 *
+	 * @return true if the request has {@code Content-Type} with value {@code multipart/form-data},
+	 * false - otherwise
+	 * @since 1.0.11
+	 */
+	boolean isMultipart();
+
+	/**
+	 * When the request is {@code POST} and have {@code Content-Type} with value
+	 * {@code application/x-www-form-urlencoded} or {@code multipart/form-data},
+	 * returns a {@link Flux} of {@link HttpData} containing received {@link Attribute}/{@link FileUpload}.
+	 * When the request is not {@code POST} or does not have {@code Content-Type}
+	 * with value {@code application/x-www-form-urlencoded} or {@code multipart/form-data},
+	 * a {@link Flux#error(Throwable)} will be returned.
+	 * <p>Uses HTTP form decoder configuration specified on server level or the default one if nothing is configured.
+	 * <p>{@link HttpData#retain()} disables auto memory release on each {@link HttpData} published,
+	 * retaining in order to prevent premature recycling when {@link HttpData} is accumulated downstream.
+	 *
+	 * @return a {@link Flux} of {@link HttpData} containing received {@link Attribute}/{@link FileUpload}
+	 * @since 1.0.11
+	 */
+	Flux<HttpData> receiveForm();
+
+	/**
+	 * When the request is {@code POST} and have {@code Content-Type} with value
+	 * {@code application/x-www-form-urlencoded} or {@code multipart/form-data},
+	 * returns a {@link Flux} of {@link HttpData} containing received {@link Attribute}/{@link FileUpload}.
+	 * When the request is not {@code POST} or does not have {@code Content-Type}
+	 * with value {@code application/x-www-form-urlencoded} or {@code multipart/form-data},
+	 * a {@link Flux#error(Throwable)} will be returned.
+	 * <p>{@link HttpData#retain()} disables auto memory release on each {@link HttpData} published,
+	 * retaining in order to prevent premature recycling when {@link HttpData} is accumulated downstream.
+	 *
+	 * @param formDecoderBuilder {@link HttpServerFormDecoderProvider.Builder} for HTTP form decoder configuration
+	 * @return a {@link Flux} of {@link HttpData} containing received {@link Attribute}/{@link FileUpload}
+	 * @since 1.0.11
+	 */
+	Flux<HttpData> receiveForm(Consumer<HttpServerFormDecoderProvider.Builder> formDecoderBuilder);
 
 	/**
 	 * Returns the address of the host peer or {@code null} in case of Unix Domain Sockets.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -74,6 +74,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 	final BiPredicate<HttpServerRequest, HttpServerResponse>      compress;
 	final ServerCookieDecoder                                     cookieDecoder;
 	final ServerCookieEncoder                                     cookieEncoder;
+	HttpServerFormDecoderProvider                                 formDecoderProvider;
 	final BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> forwardedHeaderHandler;
 	final Duration                                                idleTimeout;
 	final ConnectionObserver                                      listener;
@@ -99,11 +100,13 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 			@Nullable BiPredicate<HttpServerRequest, HttpServerResponse> compress,
 			ServerCookieDecoder decoder,
 			ServerCookieEncoder encoder,
+			HttpServerFormDecoderProvider formDecoderProvider,
 			@Nullable BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> forwardedHeaderHandler,
 			@Nullable Duration idleTimeout,
 			ConnectionObserver listener,
 			@Nullable BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>> mapHandle) {
 		this.listener = listener;
+		this.formDecoderProvider = formDecoderProvider;
 		this.forwardedHeaderHandler = forwardedHeaderHandler;
 		this.compress = compress;
 		this.cookieEncoder = encoder;
@@ -200,6 +203,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 							                    forwardedHeaderHandler),
 							cookieDecoder,
 							cookieEncoder,
+							formDecoderProvider,
 							mapHandle,
 							secure);
 				}
@@ -386,6 +390,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 						                    forwardedHeaderHandler),
 						cookieDecoder,
 						cookieEncoder,
+						formDecoderProvider,
 						mapHandle,
 						secure);
 				ops.bind();

--- a/reactor-netty-http/src/test/java/reactor/netty/CustomBlockHoundIntegration.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/CustomBlockHoundIntegration.java
@@ -24,5 +24,7 @@ public class CustomBlockHoundIntegration implements BlockHoundIntegration {
 	public void applyTo(BlockHound.Builder builder) {
 		// Calls blocking SecureRandom.next
 		builder.allowBlockingCallsInside("java.nio.file.TempFileHelper", "createTempFile");
+
+		builder.allowBlockingCallsInside("reactor.core.scheduler.BoundedElasticScheduler$BoundedServices", "pick");
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerFormDecoderProviderTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerFormDecoderProviderTests.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.scheduler.Schedulers;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static reactor.netty.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_CHARSET;
+import static reactor.netty.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_DELETE_ON_EXIT;
+import static reactor.netty.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_MAX_IN_MEMORY_SIZE;
+import static reactor.netty.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_MAX_SIZE;
+import static reactor.netty.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_SCHEDULER;
+import static reactor.netty.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_STREAMING;
+
+/**
+ * @author Violeta Georgieva
+ * @since 1.0.11
+ */
+class HttpServerFormDecoderProviderTests {
+
+	private HttpServerFormDecoderProvider.Build builder;
+
+	@BeforeEach
+	void setUp() {
+		builder = new HttpServerFormDecoderProvider.Build();
+	}
+
+	@Test
+	void baseDirectory() {
+		checkDefaultBaseDirectory(builder);
+
+		Path path = Paths.get("/tmp");
+		builder.baseDirectory(path);
+
+		assertThat(builder.baseDirectory).as("base directory").isSameAs(path);
+
+		checkDefaultCharset(builder);
+		checkDefaultDeleteOnExit(builder);
+		checkDefaultMaxInMemorySize(builder);
+		checkDefaultMaxSize(builder);
+		checkDefaultScheduler(builder);
+		checkDefaultStreaming(builder);
+	}
+
+	@Test
+	void baseDirectoryBadValue() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> builder.baseDirectory(null));
+	}
+
+	@Test
+	void charset() {
+		checkDefaultCharset(builder);
+
+		builder.charset(Charset.defaultCharset());
+
+		assertThat(builder.charset).as("charset").isSameAs(Charset.defaultCharset());
+
+		checkDefaultBaseDirectory(builder);
+		checkDefaultDeleteOnExit(builder);
+		checkDefaultMaxInMemorySize(builder);
+		checkDefaultMaxSize(builder);
+		checkDefaultScheduler(builder);
+		checkDefaultStreaming(builder);
+	}
+
+	@Test
+	void charsetBadValue() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> builder.charset(null));
+	}
+
+	@Test
+	void deleteOnExit() {
+		checkDefaultDeleteOnExit(builder);
+
+		builder.deleteOnExit(false);
+
+		assertThat(builder.deleteOnExit).as("delete on exit").isFalse();
+
+		checkDefaultBaseDirectory(builder);
+		checkDefaultCharset(builder);
+		checkDefaultMaxInMemorySize(builder);
+		checkDefaultMaxSize(builder);
+		checkDefaultScheduler(builder);
+		checkDefaultStreaming(builder);
+	}
+
+	@Test
+	void maxInMemorySize() {
+		checkDefaultMaxInMemorySize(builder);
+
+		builder.maxInMemorySize(-1);
+
+		assertThat(builder.maxInMemorySize).as("max in-memory size").isEqualTo(-1);
+
+		checkDefaultBaseDirectory(builder);
+		checkDefaultCharset(builder);
+		checkDefaultDeleteOnExit(builder);
+		checkDefaultMaxSize(builder);
+		checkDefaultScheduler(builder);
+		checkDefaultStreaming(builder);
+	}
+
+	@Test
+	void maxInMemorySizeBadValue() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> builder.maxInMemorySize(-2))
+				.withMessage("Maximum in-memory size must be greater or equal to -1");
+	}
+
+	@Test
+	void maxSize() {
+		checkDefaultMaxSize(builder);
+
+		builder.maxSize(256);
+
+		assertThat(builder.maxSize).as("max size").isEqualTo(256);
+
+		checkDefaultBaseDirectory(builder);
+		checkDefaultCharset(builder);
+		checkDefaultDeleteOnExit(builder);
+		checkDefaultMaxInMemorySize(builder);
+		checkDefaultScheduler(builder);
+		checkDefaultStreaming(builder);
+	}
+
+	@Test
+	void maxSizeBadValue() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> builder.maxSize(-2))
+				.withMessage("Maximum size must be be greater or equal to -1");
+	}
+
+	@Test
+	void scheduler() {
+		checkDefaultScheduler(builder);
+
+		builder.scheduler(Schedulers.immediate());
+
+		assertThat(builder.scheduler).as("scheduler").isSameAs(Schedulers.immediate());
+
+		checkDefaultBaseDirectory(builder);
+		checkDefaultCharset(builder);
+		checkDefaultDeleteOnExit(builder);
+		checkDefaultMaxInMemorySize(builder);
+		checkDefaultMaxSize(builder);
+		checkDefaultStreaming(builder);
+	}
+
+	@Test
+	void schedulerBadValue() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> builder.scheduler(null));
+	}
+
+	@Test
+	void streaming() {
+		checkDefaultStreaming(builder);
+
+		builder.streaming(true);
+
+		assertThat(builder.streaming).as("streaming").isTrue();
+
+		checkDefaultBaseDirectory(builder);
+		checkDefaultCharset(builder);
+		checkDefaultDeleteOnExit(builder);
+		checkDefaultMaxInMemorySize(builder);
+		checkDefaultMaxSize(builder);
+		checkDefaultScheduler(builder);
+	}
+
+	private static void checkDefaultBaseDirectory(HttpServerFormDecoderProvider.Build builder) {
+		assertThat(builder.baseDirectory).as("default base directory").isNull();
+	}
+
+	private static void checkDefaultCharset(HttpServerFormDecoderProvider.Build builder) {
+		assertThat(builder.charset).as("default charset")
+				.isSameAs(DEFAULT_CHARSET)
+				.isSameAs(StandardCharsets.UTF_8);
+	}
+
+	private static void checkDefaultDeleteOnExit(HttpServerFormDecoderProvider.Build builder) {
+		assertThat(builder.deleteOnExit).as("default delete on exit")
+				.isEqualTo(DEFAULT_DELETE_ON_EXIT)
+				.isTrue();
+	}
+
+	private static void checkDefaultMaxInMemorySize(HttpServerFormDecoderProvider.Build builder) {
+		assertThat(builder.maxInMemorySize).as("default max in-memory size")
+				.isEqualTo(DEFAULT_MAX_IN_MEMORY_SIZE)
+				.isEqualTo(16 * 1024);
+	}
+
+	private static void checkDefaultMaxSize(HttpServerFormDecoderProvider.Build builder) {
+		assertThat(builder.maxSize).as("default max size")
+				.isEqualTo(DEFAULT_MAX_SIZE)
+				.isEqualTo(-1);
+	}
+
+	private static void checkDefaultScheduler(HttpServerFormDecoderProvider.Build builder) {
+		assertThat(builder.scheduler).as("default scheduler")
+				.isSameAs(DEFAULT_SCHEDULER)
+				.isSameAs(Schedulers.boundedElastic());
+	}
+
+	private static void checkDefaultStreaming(HttpServerFormDecoderProvider.Build builder) {
+		assertThat(builder.streaming).as("default streaming")
+				.isEqualTo(DEFAULT_STREAMING)
+				.isFalse();
+	}
+}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerFormDecoderProviderTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerFormDecoderProviderTests.java
@@ -27,7 +27,6 @@ import java.nio.file.Paths;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static reactor.netty.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_CHARSET;
-import static reactor.netty.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_DELETE_ON_EXIT;
 import static reactor.netty.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_MAX_IN_MEMORY_SIZE;
 import static reactor.netty.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_MAX_SIZE;
 import static reactor.netty.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_SCHEDULER;
@@ -56,7 +55,6 @@ class HttpServerFormDecoderProviderTests {
 		assertThat(builder.baseDirectory).as("base directory").isSameAs(path);
 
 		checkDefaultCharset(builder);
-		checkDefaultDeleteOnExit(builder);
 		checkDefaultMaxInMemorySize(builder);
 		checkDefaultMaxSize(builder);
 		checkDefaultScheduler(builder);
@@ -78,7 +76,6 @@ class HttpServerFormDecoderProviderTests {
 		assertThat(builder.charset).as("charset").isSameAs(Charset.defaultCharset());
 
 		checkDefaultBaseDirectory(builder);
-		checkDefaultDeleteOnExit(builder);
 		checkDefaultMaxInMemorySize(builder);
 		checkDefaultMaxSize(builder);
 		checkDefaultScheduler(builder);
@@ -92,22 +89,6 @@ class HttpServerFormDecoderProviderTests {
 	}
 
 	@Test
-	void deleteOnExit() {
-		checkDefaultDeleteOnExit(builder);
-
-		builder.deleteOnExit(false);
-
-		assertThat(builder.deleteOnExit).as("delete on exit").isFalse();
-
-		checkDefaultBaseDirectory(builder);
-		checkDefaultCharset(builder);
-		checkDefaultMaxInMemorySize(builder);
-		checkDefaultMaxSize(builder);
-		checkDefaultScheduler(builder);
-		checkDefaultStreaming(builder);
-	}
-
-	@Test
 	void maxInMemorySize() {
 		checkDefaultMaxInMemorySize(builder);
 
@@ -117,7 +98,6 @@ class HttpServerFormDecoderProviderTests {
 
 		checkDefaultBaseDirectory(builder);
 		checkDefaultCharset(builder);
-		checkDefaultDeleteOnExit(builder);
 		checkDefaultMaxSize(builder);
 		checkDefaultScheduler(builder);
 		checkDefaultStreaming(builder);
@@ -140,7 +120,6 @@ class HttpServerFormDecoderProviderTests {
 
 		checkDefaultBaseDirectory(builder);
 		checkDefaultCharset(builder);
-		checkDefaultDeleteOnExit(builder);
 		checkDefaultMaxInMemorySize(builder);
 		checkDefaultScheduler(builder);
 		checkDefaultStreaming(builder);
@@ -163,7 +142,6 @@ class HttpServerFormDecoderProviderTests {
 
 		checkDefaultBaseDirectory(builder);
 		checkDefaultCharset(builder);
-		checkDefaultDeleteOnExit(builder);
 		checkDefaultMaxInMemorySize(builder);
 		checkDefaultMaxSize(builder);
 		checkDefaultStreaming(builder);
@@ -185,7 +163,6 @@ class HttpServerFormDecoderProviderTests {
 
 		checkDefaultBaseDirectory(builder);
 		checkDefaultCharset(builder);
-		checkDefaultDeleteOnExit(builder);
 		checkDefaultMaxInMemorySize(builder);
 		checkDefaultMaxSize(builder);
 		checkDefaultScheduler(builder);
@@ -199,12 +176,6 @@ class HttpServerFormDecoderProviderTests {
 		assertThat(builder.charset).as("default charset")
 				.isSameAs(DEFAULT_CHARSET)
 				.isSameAs(StandardCharsets.UTF_8);
-	}
-
-	private static void checkDefaultDeleteOnExit(HttpServerFormDecoderProvider.Build builder) {
-		assertThat(builder.deleteOnExit).as("default delete on exit")
-				.isEqualTo(DEFAULT_DELETE_ON_EXIT)
-				.isTrue();
 	}
 
 	private static void checkDefaultMaxInMemorySize(HttpServerFormDecoderProvider.Build builder) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerPostFormTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerPostFormTests.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.multipart.HttpData;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.netty.BaseHttpTest;
+import reactor.netty.http.Http2SslContextSpec;
+import reactor.netty.http.HttpProtocol;
+import reactor.netty.http.client.HttpClient;
+import reactor.util.annotation.Nullable;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Violeta Georgieva
+ * @since 1.0.11
+ */
+class HttpServerPostFormTests extends BaseHttpTest {
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.METHOD)
+	@ParameterizedTest(name = "{displayName}({0}, {1})")
+	@MethodSource("data")
+	@interface ParameterizedPostFormTest {
+	}
+
+	static Object[][] data() throws Exception {
+		SelfSignedCertificate cert = new SelfSignedCertificate();
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(cert.certificate(), cert.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+						.configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+
+		HttpServer server = HttpServer.create().httpRequestDecoder(spec -> spec.h2cMaxContentLength(32 * 1024));
+
+		HttpServer h2Server = server.protocol(HttpProtocol.H2)
+				.secure(spec -> spec.sslContext(serverCtx));
+
+		HttpServer h2Http1Server = server.protocol(HttpProtocol.H2, HttpProtocol.HTTP11)
+				.secure(spec -> spec.sslContext(serverCtx));
+
+		HttpClient client = HttpClient.create();
+
+		HttpClient h2Client = client.protocol(HttpProtocol.H2)
+				.secure(spec -> spec.sslContext(clientCtx));
+
+		HttpClient h2Http1Client = client.protocol(HttpProtocol.H2, HttpProtocol.HTTP11)
+				.secure(spec -> spec.sslContext(clientCtx));
+
+		return new Object[][] {{server, client},
+				{server.protocol(HttpProtocol.H2C), client.protocol(HttpProtocol.H2C)},
+				{server.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11), client.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11)},
+				{h2Server, h2Client},
+				{h2Http1Server, h2Http1Client}};
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartInMemoryConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(-1), false, true, false,
+				"[test1 MemoryFileUpload true] [attr1 MemoryAttribute true] [test2 MemoryFileUpload true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartInMemoryConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(-1), true, true, false,
+				"[test1 MemoryFileUpload true] [attr1 MemoryAttribute true] [test2 MemoryFileUpload true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartMixedConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(256), false, true, false,
+				"[test1 MixedFileUpload true] [attr1 MixedAttribute true] [test2 MixedFileUpload true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartMixedConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(256), true, true, false,
+				"[test1 MixedFileUpload true] [attr1 MixedAttribute true] [test2 MixedFileUpload true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartOnDiskConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(0), false, true, false,
+				"[test1 DiskFileUpload true] [attr1 DiskAttribute true] [test2 DiskFileUpload true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartOnDiskConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(0), true, true, false,
+				"[test1 DiskFileUpload true] [attr1 DiskAttribute true] [test2 DiskFileUpload true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartStreamingConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.streaming(true), false, true, true, null);
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartStreamingConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.streaming(true), true, true, true, null);
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedInMemoryConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(-1), false, false, false,
+				"[test1 MemoryAttribute true] [attr1 MemoryAttribute true] [test2 MemoryAttribute true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedInMemoryConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(-1), true, false, false,
+				"[test1 MemoryAttribute true] [attr1 MemoryAttribute true] [test2 MemoryAttribute true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedMixedConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(256), false, false, false,
+				"[test1 MixedAttribute true] [attr1 MixedAttribute true] [test2 MixedAttribute true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedMixedConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(256), true, false, false,
+				"[test1 MixedAttribute true] [attr1 MixedAttribute true] [test2 MixedAttribute true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedOnDiskConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(0), false, false, false,
+				"[test1 DiskAttribute true] [attr1 DiskAttribute true] [test2 DiskAttribute true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedOnDiskConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(0), true, false, false,
+				"[test1 DiskAttribute true] [attr1 DiskAttribute true] [test2 DiskAttribute true] ");
+	}
+
+	private void doTestPostForm(HttpServer server, HttpClient client,
+			Consumer<HttpServerFormDecoderProvider.Builder> provider, boolean configOnServer,
+			boolean multipart, boolean streaming, @Nullable String expectedResponse) throws Exception {
+		AtomicReference<List<HttpData>> originalHttpData1 = new AtomicReference<>(new ArrayList<>());
+		AtomicReference<List<HttpData>> originalHttpData2 = new AtomicReference<>(new ArrayList<>());
+		AtomicReference<Map<String, CompositeByteBuf>> copiedHttpData = new AtomicReference<>(new HashMap<>());
+		server = (configOnServer ? server.httpFormDecoder(provider) : server)
+		        .handle((req, res) ->
+		            res.sendString((configOnServer ? req.receiveForm() : req.receiveForm(provider))
+		                    .flatMap(data -> {
+		                        if ("0".equals(req.path())) {
+		                            originalHttpData1.get().add(data);
+
+		                            if (streaming) {
+		                                CompositeByteBuf copy = copiedHttpData.get()
+		                                        .computeIfAbsent(data.getName(), k -> Unpooled.compositeBuffer());
+		                                try {
+		                                    // In case of streaming this is not a blocking call
+		                                    copy.writeBytes(data.get());
+		                                }
+		                                catch (IOException e) {
+		                                    return Mono.error(e);
+		                                }
+		                            }
+		                        }
+		                        else {
+		                            originalHttpData2.get().add(data);
+		                        }
+		                        return Mono.just('[' + data.getName() + ' ' +
+		                                data.getClass().getSimpleName() + ' ' +
+		                                data.isCompleted() + "] ");
+		                    })
+		                    .log()));
+
+		disposableServer = server.bindNow();
+
+		List<Tuple2<Integer, String>> responses;
+		Path file = Paths.get(getClass().getResource("/largeFile1.txt").toURI());
+		responses =
+				Flux.range(0, 2)
+				    .flatMap(i ->
+				            client.port(disposableServer.port()).post()
+				                  .uri("/" + i)
+				                  .sendForm((req, form) -> form.multipart(multipart)
+				                                               .file("test1", "largeFile1.txt", file.toFile(), null)
+				                                               .attr("attr1", "attr2")
+				                                               .file("test2", "largeFile1.txt", file.toFile(), null))
+				                  .responseSingle((r, buf) -> buf.asString().map(s -> Tuples.of(r.status().code(), s))))
+				    .collectList()
+				    .block(Duration.ofSeconds(30));
+
+		assertThat(responses).as("response").isNotNull();
+
+		for (Tuple2<Integer, String> response : responses) {
+			assertThat(response.getT1()).as("status code").isEqualTo(200);
+
+			if (expectedResponse != null) {
+				assertThat(response.getT2()).as("response body reflecting request").isEqualTo(expectedResponse);
+			}
+		}
+
+		assertThat(originalHttpData1.get()).allMatch(data -> data.refCnt() == 0);
+		assertThat(originalHttpData2.get()).allMatch(data -> data.refCnt() == 0);
+
+		if (streaming) {
+			assertThat(copiedHttpData.get()).hasSize(3);
+
+			byte[] fileBytes = Files.readAllBytes(file);
+			testContent(copiedHttpData.get().get("test1"), fileBytes);
+			testContent(copiedHttpData.get().get("test2"), fileBytes);
+
+			copiedHttpData.get().forEach((s, buffer) -> buffer.release());
+		}
+	}
+
+	private void testContent(CompositeByteBuf file, byte[] expectedBytes) {
+		byte[] fileBytes = new byte[file.readableBytes()];
+		file.readBytes(fileBytes);
+		assertThat(fileBytes).isEqualTo(expectedBytes);
+	}
+}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -127,6 +127,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static reactor.netty.http.server.HttpServerFormDecoderProvider.DEFAULT_FORM_DECODER_SPEC;
 
 /**
  * @author Stephane Maldini
@@ -1886,6 +1887,7 @@ class HttpServerTests extends BaseHttpTest {
 				null,
 				ServerCookieDecoder.STRICT,
 				ServerCookieEncoder.STRICT,
+				DEFAULT_FORM_DECODER_SPEC,
 				null,
 				false);
 		ops.status(status);

--- a/reactor-netty-http/src/test/resources/largeFile1.txt
+++ b/reactor-netty-http/src/test/resources/largeFile1.txt
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+


### PR DESCRIPTION
When the request is `POST` and have `Content-Type` with value
`application/x-www-form-urlencoded` or `multipart/form-data`,
the API returns a `Flux<HttpData>` containing received form/multipart data.

Fixes #3, #1351