### PR TITLE
Ensure HTTP/2 pool owner is taken from the connection and not from the stream

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
@@ -107,7 +107,7 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 			  .invalidate()
 			  .subscribe(null, null, () -> {
 			      if (log.isDebugEnabled()) {
-			          logPoolState(channel, da.pool, "Channel removed from the pool");
+			          logPoolState(channel, da.pool, "Channel removed from the http2 pool");
 			      }
 			  });
 		}
@@ -121,7 +121,7 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 	}
 
 	static void registerClose(Channel channel) {
-		ConnectionObserver owner = channel.attr(OWNER).get();
+		ConnectionObserver owner = channel.parent().attr(OWNER).get();
 		channel.closeFuture()
 		       .addListener(f -> {
 		           Channel parent = channel.parent();
@@ -132,7 +132,7 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 		           }
 
 		           if (localEndpoint.numActiveStreams() == 0) {
-		               channel.attr(OWNER).set(null);
+		               channel.parent().attr(OWNER).set(null);
 		               invalidate(owner, parent);
 		           }
 		       });


### PR DESCRIPTION
HTTP/2 pool owner is stored in the connection and not in the individual stream.