### PR TITLE
ByteBufAllocatorMetrics register metrics only when Micrometer is in the classpath

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -40,6 +40,7 @@ import reactor.pool.decorators.InstrumentedPoolDecorators;
 import reactor.pool.introspection.SamplingAllocationStrategy;
 import reactor.util.Logger;
 import reactor.util.Loggers;
+import reactor.util.Metrics;
 import reactor.util.annotation.Nullable;
 
 import java.net.InetAddress;
@@ -120,7 +121,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 						poolFactory.registrar.get().registerMetrics(name, id, remoteAddress,
 								new DelegatingConnectionPoolMetrics(newPool.metrics()));
 					}
-					else {
+					else if (Metrics.isInstrumentationAvailable()) {
 						// work directly with the pool otherwise a weak reference is needed to ConnectionPoolMetrics
 						// we don't want to keep another map with weak references
 						MicrometerPooledConnectionProviderMeterRegistrar.INSTANCE

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
@@ -42,6 +42,7 @@ import reactor.netty.channel.ChannelOperations;
 import reactor.netty.resources.LoopResources;
 import reactor.util.Logger;
 import reactor.util.Loggers;
+import reactor.util.Metrics;
 import reactor.util.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
@@ -374,12 +375,14 @@ public abstract class TransportConfig {
 			if (config.metricsRecorder != null) {
 				ChannelOperations.addMetricsHandler(channel, config.metricsRecorder, remoteAddress, onServer);
 
-				ByteBufAllocator alloc = channel.alloc();
-				if (alloc instanceof PooledByteBufAllocator) {
-					ByteBufAllocatorMetrics.INSTANCE.registerMetrics("pooled", ((PooledByteBufAllocator) alloc).metric());
-				}
-				else if (alloc instanceof UnpooledByteBufAllocator) {
-					ByteBufAllocatorMetrics.INSTANCE.registerMetrics("unpooled", ((UnpooledByteBufAllocator) alloc).metric());
+				if (Metrics.isInstrumentationAvailable()) {
+					ByteBufAllocator alloc = channel.alloc();
+					if (alloc instanceof PooledByteBufAllocator) {
+						ByteBufAllocatorMetrics.INSTANCE.registerMetrics("pooled", ((PooledByteBufAllocator) alloc).metric());
+					}
+					else if (alloc instanceof UnpooledByteBufAllocator) {
+						ByteBufAllocatorMetrics.INSTANCE.registerMetrics("unpooled", ((UnpooledByteBufAllocator) alloc).metric());
+					}
 				}
 			}
 


### PR DESCRIPTION
MicrometerPooledConnectionProviderMeterRegistrar register metrics only when Micrometer is in the classpath

Fixes #1847