### PR TITLE
[build] Only qualifyVersionGha for reactor-netty module

### DIFF
--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -47,17 +47,17 @@ static def qualifyVersion(String v) {
 
 task qualifyVersionGha() {
 	doLast {
-		if (project.name != 'reactor-netty') {
-			return
-		}
 		def versionType = qualifyVersion("$version")
-
-		println "::set-output name=versionType::$versionType"
-		println "::set-output name=fullVersion::$version"
 		if (versionType == "BAD") {
 			println "::error ::Unable to parse $version to a VersionNumber with recognizable qualifier"
 			throw new TaskExecutionException(tasks.getByName("qualifyVersionGha"), new IllegalArgumentException("Unable to parse $version to a VersionNumber with recognizable qualifier"))
 		}
+
+		if (project.name != 'reactor-netty') {
+			return
+		}
+		println "::set-output name=versionType::$versionType"
+		println "::set-output name=fullVersion::$version"
 	}
 }
 


### PR DESCRIPTION
This commit changes the way the qualifyVersionGha task is applied,
ignoring most modules except the main one.

That way, even if we have incubating modules with a different version
number, only the main version number will be taken into account for
the release, and most notably the tagging step.
