### PR TITLE
Polish test logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -269,9 +269,7 @@ subprojects {
 			exceptionFormat "full"
 			maxGranularity 3
 		}
-	}
 
-	test {
 		onOutput { descriptor, event ->
 			def evMsg = event.message
 			if (evMsg.contains("ResourceLeakDetector")) {


### PR DESCRIPTION
This PR polishes test logging by:
 - applying the `testLogging` config on ALL tasks of type `Test` rather than
 just the base `test` task
 - excluding log lines that simply reflect Netty's configuration when attempting
 to highlight `ResourceLeakDetector` errors