### PR TITLE
Upgrade to Gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ description = 'Reactive Streams Netty driver'
 
 apply from: "gradle/releaser.gradle"
 
+repositories { //needed at root for nohttp-checkstyle
+	mavenCentral()
+}
+
 ext {
 	if (project.hasProperty('versionBranch') && version.toString().endsWith("-SNAPSHOT")) {
 		versionBranch = versionBranch.replaceAll("\"", "").trim()

--- a/build.gradle
+++ b/build.gradle
@@ -173,8 +173,8 @@ subprojects {
 
 	jacocoTestReport {
 		reports {
-			xml.enabled = true
-			html.enabled = true
+			xml.required = true
+			html.required = true
 		}
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,8 @@ buildscript {
 
 plugins {
 	id "com.diffplug.spotless" version "6.0.0"
-	id 'org.asciidoctor.convert' version '2.4.0'
+	id 'org.asciidoctor.jvm.convert' version '3.3.2' apply false
+	id 'org.asciidoctor.jvm.pdf' version '3.3.2' apply false
 	id 'com.google.osdetector' version '1.7.0'
 	id 'org.gradle.test-retry' version '1.3.1'
 	id 'io.spring.nohttp' version '0.0.10'
@@ -114,8 +115,14 @@ ext {
 	mockitoVersion = '4.0.0'
 	blockHoundVersion = '1.0.6.RELEASE'
 
-	javadocLinks = ["https://docs.oracle.com/javase/7/docs/api/",
-					"https://docs.oracle.com/javaee/6/api/",
+
+	jdk = JavaVersion.current().majorVersion
+	jdkJavadoc = "https://docs.oracle.com/javase/${jdk}/docs/api/"
+	if (JavaVersion.current().isJava11Compatible()) {
+		jdkJavadoc = "https://docs.oracle.com/en/java/javase/${jdk}/docs/api/"
+	}
+	println "JDK Javadoc link for this build is ${jdkJavadoc}"
+	javadocLinks = [jdkJavadoc,
 					"https://fasterxml.github.io/jackson-databind/javadoc/2.5/",
 					"https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/",
 					"https://projectreactor.io/docs/core/release/api/",

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,7 @@ buildscript {
 		maven { url "https://repo.spring.io/plugins-release" }
 	}
 	dependencies {
-		classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7',
-			'org.jfrog.buildinfo:build-info-extractor-gradle:4.24.21' //applied in individual submodules
+		classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.24.21' //applied in individual submodules
 	}
 }
 
@@ -157,10 +156,9 @@ spotless {
 subprojects {
 	group = 'io.projectreactor.netty'
 
-	apply plugin: 'java'
+	apply plugin: 'java-library'
 	apply plugin: 'jacoco'
 	apply plugin: 'checkstyle'
-	apply plugin: 'propdeps'
 	apply plugin: 'org.gradle.test-retry'
 	apply from: "${rootDir}/gradle/setup.gradle"
 	apply from: "${rootDir}/gradle/javadoc.gradle"

--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -13,12 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-apply plugin: 'org.asciidoctor.convert'
+apply plugin: 'org.asciidoctor.jvm.convert'
+apply plugin: 'org.asciidoctor.jvm.pdf'
 
-// put asciidoctor dependencies/extensions to 'asciidoctor' configuration instead of buildscript classpath
-dependencies {
-	asciidoctor 'org.asciidoctor:asciidoctorj-pdf:1.5.3'
-	asciidoctor 'org.jruby:jruby-complete:9.2.13.0'
+// This configuration applies both to the asciidoctor & asciidoctorPdf tasks
+asciidoctorj {
+	options = [doctype: 'book']
+	attributes 'allow-uri-read': '',
+			'attribute-missing': 'warn',
+			'project-version': "${project.version}",
+			'reactorReleaseTrain': "${bomVersion}"
 }
 
 asciidoctor {
@@ -26,6 +30,7 @@ asciidoctor {
 	sources {
 		include "index.asciidoc"
 	}
+	baseDirFollowsSourceDir()
 	resources {
 		from(sourceDir) {
 			include 'images/**'
@@ -33,32 +38,35 @@ asciidoctor {
 		}
 	}
 	outputDir file("$buildDir/asciidoc")
-	backends = ['html5', 'pdf']
 	logDocuments = true
-	options = [
-			doctype: 'book'
-	]
-	attributes 'allow-uri-read': '',
-			reactorReleaseTrain: "$bomVersion",
-			imagesdir: "images/",
-			stylesdir: "stylesheets/",
+	attributes stylesdir: "stylesheets/",
 			stylesheet: 'reactor.css',
 			'source-highlighter': 'highlightjs',
 			'highlightjsdir': "./highlight",
 			'highlightjs-theme': 'railscasts'
 }
 
-task docsZip(type: Zip, dependsOn: asciidoctor) {
+asciidoctorPdf {
+	onlyIf { System.getenv()["GITHUB_ACTION"] != null || !rootProject.version.toString().endsWith("-SNAPSHOT") || rootProject.hasProperty("forcePdf") }
+	sourceDir "$rootDir/docs/asciidoc/"
+	sources {
+		include "index.asciidoc"
+	}
+	baseDirFollowsSourceDir()
+	outputDir file("$buildDir/asciidoc/pdf")
+	logDocuments = true
+	attributes 'source-highlighter': 'rouge'
+}
+
+task docsZip(type: Zip, dependsOn: [asciidoctor, asciidoctorPdf]) {
 	archiveBaseName.set("reactor-netty")
 	archiveClassifier.set("docs")
 	afterEvaluate() {
 		//we copy the pdf late, when a potential customVersion has been applied to rootProject
-		from("$buildDir/asciidoc/pdf/index.pdf") {
+		from(asciidoctorPdf) {
 			into("docs/")
 			rename("index.pdf", "reactor-netty-reference-guide-${rootProject.version}.pdf")
 		}
 	}
-	from("$buildDir/asciidoc/html5/index.html") { into("docs/") }
-	from("$buildDir/asciidoc/html5/images") { into("docs/images/") }
-	from("$buildDir/asciidoc/html5/highlight") { into("docs/highlight/") }
+	from(asciidoctor) { into("docs/") }
 }

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -129,17 +129,6 @@ publishing {
 				}
 
 				withXml {
-					//set optional true for compileOnly dependencies, which are not in there by default
-					asNode().dependencies[0].each { node ->
-						def group = node.groupId.text()
-						def artifact = node.artifactId.text()
-						def version = node.version.text()
-						def isOptional = project.configurations.optional.allDependencies.any { dep -> dep.group == group && dep.name == artifact }
-						if (isOptional) {
-							node.appendNode('optional', true)
-							println "$group:$artifact:$version has been marked as optional in generated pom"
-						}
-					}
 					//groovy magic incantation to sort dependencies alphabetically (scope/group/name..)
 					def sorted = asNode().dependencies[0].children().collect().sort { it.scope.text() + it.groupId.text() + it.artifactId.text() }
 					asNode().dependencies[0].children().with { deps ->

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -51,35 +51,38 @@ dependencies {
 	// JSR-305 annotations
 	compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
 
-	compile "io.netty:netty-handler:$nettyVersion"
-	compile "io.netty:netty-handler-proxy:$nettyVersion"
-	compile "io.netty:netty-resolver-dns:$nettyVersion"
+	api "io.netty:netty-handler:$nettyVersion"
+	api "io.netty:netty-handler-proxy:$nettyVersion"
+	api "io.netty:netty-resolver-dns:$nettyVersion"
 	if (!"$nettyVersion".endsWithAny("SNAPSHOT")) {
-		compile "io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
+		api "io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
 	}
 	else {
 		// MacOS binaries are not available for Netty SNAPSHOT version
-		compile "io.netty:netty-resolver-dns-native-macos:$nettyVersion"
+		api "io.netty:netty-resolver-dns-native-macos:$nettyVersion"
 	}
 	//transport resolution: typical build forces epoll but not kqueue transitively
 	//on the other hand, if we want to make transport-specific tests, we'll make all
 	// native optional at compile time and add correct native/nio to testRuntime
 	if (project.hasProperty("forceTransport")) {
 		//so that the main code compiles
-		optional "io.netty:netty-transport-native-epoll:$nettyVersion"
-		optional "io.netty:netty-transport-native-kqueue:$nettyVersion"
-		optional "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
+		compileOnly "io.netty:netty-transport-native-epoll:$nettyVersion"
+		compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
+		testImplementation "io.netty:netty-transport-native-epoll:$nettyVersion"
+		testImplementation "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 		//now we explicitly add correctly qualified native, or do nothing if we want to test NIO
 		if (forceTransport == "native") {
 			if (osdetector.os == "osx") {
-				testRuntime "io.netty:netty-transport-native-kqueue:$nettyVersion$os_suffix"
+				testImplementation "io.netty:netty-transport-native-kqueue:$nettyVersion$os_suffix"
 			}
 			else if (osdetector.os == "linux") {
-				testRuntime "io.netty:netty-transport-native-epoll:$nettyVersion$os_suffix"
+				testImplementation "io.netty:netty-transport-native-epoll:$nettyVersion$os_suffix"
 			}
 		}
 		else if (forceTransport == "io_uring" && osdetector.os == "linux") {
-			testRuntime "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion$os_suffix"
+			testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion$os_suffix"
 		}
 		else if (forceTransport != "nio") {
 			throw new InvalidUserDataException("invalid -PforceTranport option " + forceTransport + ", should be native|nio")
@@ -87,18 +90,20 @@ dependencies {
 	}
 	else {
 		//classic build to be distributed
-		compile "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
-		optional "io.netty:netty-transport-native-kqueue:$nettyVersion"
-		optional "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
+		api "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
+		compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
+		testImplementation "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 	}
 
 	//Metrics
-	optional "io.micrometer:micrometer-core:$micrometerVersion"
+	compileOnly "io.micrometer:micrometer-core:$micrometerVersion"
 
 	// Logging
-	optional "org.slf4j:slf4j-api:$slf4jVersion"
+	compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
 
-	compile "io.projectreactor:reactor-core:$reactorCoreVersion"
+	api "io.projectreactor:reactor-core:$reactorCoreVersion"
 	shaded("io.projectreactor.addons:reactor-pool:$reactorPoolVersion") {
 		exclude module: "reactor-core"
 	}
@@ -108,16 +113,17 @@ dependencies {
 	// JSR-305 annotations
 	testCompileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
 
-	testCompile "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
-	testCompile "io.projectreactor:reactor-test:$testAddonVersion"
-	testCompile "io.projectreactor.addons:reactor-extra:$reactorAddonsVersion"
-	testCompile "org.assertj:assertj-core:$assertJVersion"
-	testCompile "org.awaitility:awaitility:$awaitilityVersion"
-	testCompile "org.junit.jupiter:junit-jupiter-api:$junitVersion"
-	testCompile "org.junit.jupiter:junit-jupiter-params:$junitVersion"
-	testCompile "org.mockito:mockito-core:$mockitoVersion"
-	testCompile "ch.qos.logback:logback-classic:$logbackVersion"
-	testCompile "io.projectreactor.tools:blockhound-junit-platform:$blockHoundVersion"
+	testImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+	testImplementation "io.projectreactor:reactor-test:$testAddonVersion"
+	testImplementation "io.projectreactor.addons:reactor-extra:$reactorAddonsVersion"
+	testImplementation "org.assertj:assertj-core:$assertJVersion"
+	testImplementation "org.awaitility:awaitility:$awaitilityVersion"
+	testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
+	testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
+	testImplementation "org.mockito:mockito-core:$mockitoVersion"
+	testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+	testImplementation "io.projectreactor.tools:blockhound-junit-platform:$blockHoundVersion"
+	testImplementation "io.micrometer:micrometer-core:$micrometerVersion"
 
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
@@ -125,11 +131,11 @@ dependencies {
 
 	for (dependency in project.configurations.shaded.dependencies) {
 		compileOnly(dependency)
-		testCompile(dependency)
+		testImplementation(dependency)
 	}
 
-	jarFileTestCompile "org.assertj:assertj-core:$assertJVersion"
-	jarFileTestCompile "org.junit.jupiter:junit-jupiter-api:$junitVersion"
+	jarFileTestImplementation "org.assertj:assertj-core:$assertJVersion"
+	jarFileTestImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
 	jarFileTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 }
 
@@ -210,7 +216,7 @@ shadowJar {
 					.toSet()
 
 			// Exclude every compile-scoped dependency (including the transitive ones)
-			for (id in project.configurations.compile.resolvedConfiguration.resolvedArtifacts*.moduleVersion*.id) {
+			for (id in project.configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts*.moduleVersion*.id) {
 				def module = "${id.group}:${id.name}".toString()
 				if (!shadedDependencies.contains(module)) {
 					project.configurations.shaded.exclude(group: id.group, module: id.name)

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -259,7 +259,7 @@ task shadedJarTest(type: Test) {
 
 	Set<? super File> mainOutputs = [
 			project.sourceSets.main.output.resourcesDir,
-			project.sourceSets.main.java.outputDir,
+			project.sourceSets.main.java.classesDirectory,
 	]
 
 	classpath = shadowJar.outputs.files

--- a/reactor-netty-examples/build.gradle
+++ b/reactor-netty-examples/build.gradle
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 dependencies {
-	compile project(':reactor-netty-http')
+	api project(':reactor-netty-http')
 
-	compile "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+	api "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+
+	api "io.micrometer:micrometer-core:$micrometerVersion"
+
+	api "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
 
 	runtimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 	runtimeOnly "io.netty:netty-tcnative-boringssl-static:$boringSslVersion$os_suffix"

--- a/reactor-netty-http-brave/build.gradle
+++ b/reactor-netty-http-brave/build.gradle
@@ -31,9 +31,9 @@ ext {
 }
 
 dependencies {
-	compile project(':reactor-netty-http')
+	api project(':reactor-netty-http')
 
-	compile "io.zipkin.brave:brave-instrumentation-http:$braveVersion"
+	api "io.zipkin.brave:brave-instrumentation-http:$braveVersion"
 
 	// JSR-305 annotations
 	compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
@@ -41,7 +41,7 @@ dependencies {
 	// JSR-305 annotations
 	testCompileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
 
-	testCompile "io.zipkin.brave:brave-instrumentation-http-tests:$braveVersion"
+	testImplementation "io.zipkin.brave:brave-instrumentation-http-tests:$braveVersion"
 
 	testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junitVersion"
 	testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -53,38 +53,38 @@ configurations {
 }
 
 dependencies {
-	compile project(path: ':reactor-netty-core', configuration: 'shadow')
+	api project(path: ':reactor-netty-core', configuration: 'shadow')
 
 	// JSR-305 annotations
 	compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
 
-	compile "io.netty:netty-codec-http:$nettyVersion"
-	compile "io.netty:netty-codec-http2:$nettyVersion"
-	compile "io.netty:netty-resolver-dns:$nettyVersion"
+	api "io.netty:netty-codec-http:$nettyVersion"
+	api "io.netty:netty-codec-http2:$nettyVersion"
+	api "io.netty:netty-resolver-dns:$nettyVersion"
 	// MacOS binaries are not available for Netty SNAPSHOT version
 	if (!"$nettyVersion".endsWithAny("SNAPSHOT")) {
-		compile "io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
+		api "io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
 	}
-	optional "io.netty:netty-codec-haproxy:$nettyVersion"
+	compileOnly "io.netty:netty-codec-haproxy:$nettyVersion"
 	//transport resolution: typical build forces epoll but not kqueue transitively
 	//on the other hand, if we want to make transport-specific tests, we'll make all
 	// native optional at compile time and add correct native/nio to testRuntime
 	if (project.hasProperty("forceTransport")) {
 		//so that the main code compiles
-		optional "io.netty:netty-transport-native-epoll:$nettyVersion"
-		optional "io.netty:netty-transport-native-kqueue:$nettyVersion"
-		optional "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
+		compileOnly "io.netty:netty-transport-native-epoll:$nettyVersion"
+		compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 		//now we explicitly add correctly qualified native, or do nothing if we want to test NIO
 		if (forceTransport == "native") {
 			if (osdetector.os == "osx") {
-				testRuntime "io.netty:netty-transport-native-kqueue:$nettyVersion$os_suffix"
+				testRuntimeOnly "io.netty:netty-transport-native-kqueue:$nettyVersion$os_suffix"
 			}
 			else if (osdetector.os == "linux") {
-				testRuntime "io.netty:netty-transport-native-epoll:$nettyVersion$os_suffix"
+				testRuntimeOnly "io.netty:netty-transport-native-epoll:$nettyVersion$os_suffix"
 			}
 		}
 		else if (forceTransport == "io_uring" && osdetector.os == "linux") {
-			testRuntime "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion$os_suffix"
+			testRuntimeOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion$os_suffix"
 		}
 		else if (forceTransport != "nio") {
 			throw new InvalidUserDataException("invalid -PforceTranport option " + forceTransport + ", should be native|nio")
@@ -92,20 +92,20 @@ dependencies {
 	}
 	else {
 		//classic build to be distributed
-		compile "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
-		optional "io.netty:netty-transport-native-kqueue:$nettyVersion"
-		optional "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
+		api "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
+		compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 	}
 
 	//Metrics
-	optional "io.micrometer:micrometer-core:$micrometerVersion"
+	compileOnly "io.micrometer:micrometer-core:$micrometerVersion"
 
 	// Logging
-	optional "org.slf4j:slf4j-api:$slf4jVersion"
+	compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
 
-	compile "io.projectreactor:reactor-core:$reactorCoreVersion"
+	api "io.projectreactor:reactor-core:$reactorCoreVersion"
 
-	testCompile(testFixtures(project(':reactor-netty-core'))) {
+	testImplementation(testFixtures(project(':reactor-netty-core'))) {
 		exclude module: "reactor-netty-core"
 	}
 
@@ -114,14 +114,15 @@ dependencies {
 	// JSR-305 annotations
 	testCompileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
 
-	testCompile "org.mockito:mockito-core:$mockitoVersion"
-	testCompile "io.specto:hoverfly-java-junit5:$hoverflyJavaVersion"
-	testCompile "org.apache.tomcat.embed:tomcat-embed-core:$tomcatVersion"
-	testCompile "io.projectreactor:reactor-test:$testAddonVersion"
-	testCompile "org.assertj:assertj-core:$assertJVersion"
-	testCompile "org.junit.jupiter:junit-jupiter-api:$junitVersion"
-	testCompile "org.junit.jupiter:junit-jupiter-params:$junitVersion"
-	testCompile "io.projectreactor.tools:blockhound-junit-platform:$blockHoundVersion"
+	testImplementation "org.mockito:mockito-core:$mockitoVersion"
+	testImplementation "io.specto:hoverfly-java-junit5:$hoverflyJavaVersion"
+	testImplementation "org.apache.tomcat.embed:tomcat-embed-core:$tomcatVersion"
+	testImplementation "io.projectreactor:reactor-test:$testAddonVersion"
+	testImplementation "org.assertj:assertj-core:$assertJVersion"
+	testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
+	testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
+	testImplementation "io.projectreactor.tools:blockhound-junit-platform:$blockHoundVersion"
+	testImplementation "io.micrometer:micrometer-core:$micrometerVersion"
 
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
@@ -130,12 +131,13 @@ dependencies {
 
 	// Needed for proxy testing
 	testRuntimeOnly "io.netty:netty-handler-proxy:$nettyVersion"
+	testRuntimeOnly "io.netty:netty-codec-haproxy:$nettyVersion"
 	// Needed for HTTP/2 testing
 	testRuntimeOnly "io.netty:netty-tcnative-boringssl-static:$boringSslVersion$os_suffix"
 
 	// noMicrometerTest sourceSet (must not include Micrometer)
-	noMicrometerTestCompile "org.assertj:assertj-core:$assertJVersion"
-	noMicrometerTestCompile "org.junit.jupiter:junit-jupiter-api:$junitVersion"
+	noMicrometerTestImplementation "org.assertj:assertj-core:$assertJVersion"
+	noMicrometerTestImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
 	noMicrometerTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 	noMicrometerTestRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 }

--- a/reactor-netty-incubator-quic/build.gradle
+++ b/reactor-netty-incubator-quic/build.gradle
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-apply plugin: 'java-library'
 apply plugin: 'io.spring.javadoc'
 apply plugin: 'biz.aQute.bnd.builder'
 

--- a/reactor-netty/build.gradle
+++ b/reactor-netty/build.gradle
@@ -17,12 +17,16 @@ apply plugin: 'io.spring.javadoc-aggregate'
 apply from: "${rootDir}/gradle/asciidoc.gradle"
 
 dependencies {
-	compile project(':reactor-netty-core')
-	compile project(':reactor-netty-http')
+	api project(':reactor-netty-core')
+	api project(':reactor-netty-http')
 
 	// JSR-305 annotations
 	compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
 
+	compileOnly "io.micrometer:micrometer-core:$micrometerVersion"
+	compileOnly "io.netty:netty-codec-haproxy:$nettyVersion"
+	compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
+	compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 	compileOnly "io.projectreactor.addons:reactor-pool:$reactorPoolVersion"
 }
 


### PR DESCRIPTION
This PR is separated on several commits in order to make the review process easier.
These commits are done in one and the same PR as otherwise the build cannot pass and all of them address the migration to Gradle 7.

1. Update Gradle to 7.2.
2. Remove the optional dependencies in the generated pom.xml.
  - There is no version of `org.springframework.build.gradle:propdeps-plugin` for Gradle 7.
The plugin is removed and Reactor Netty does not list anymore the optional dependencies in the generated pom.xml.
  - All modules are now `java-library`.
  - All dependencies with `compile` are moved to `api`, those with `optional` - `compileOnly`, `testCompile` - `testImplementation` and `testRuntime` - `testRuntimeOnly`.
3. Remove the usage of the Gradle deprecated functionality.
4. Update Asciidoctor to 3.3.2. This version is compatible with Gradle 7.
5. `nohttp-checkstyle` specify repository on root level.

Fixes #1875 