### PR TITLE
Add testRuntimeOnly dependency to org.bouncycastle:bcpkix-jdk15on

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ ext {
 	junitPlatformLauncherVersion = '1.8.1'
 	mockitoVersion = '4.0.0'
 	blockHoundVersion = '1.0.6.RELEASE'
-
+	bouncycastleVersion = '1.69'
 
 	jdk = JavaVersion.current().majorVersion
 	jdkJavadoc = "https://docs.oracle.com/javase/${jdk}/docs/api/"

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -129,6 +129,13 @@ dependencies {
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 	testRuntimeOnly "org.slf4j:jcl-over-slf4j:$slf4jVersion"
 
+	if (JavaVersion.current() > JavaVersion.VERSION_14) {
+		// https://github.com/netty/netty/pull/11487
+		// https://github.com/netty/netty/issues/10317
+		// Necessary for generating SelfSignedCertificate on Java version >= 15
+		testRuntimeOnly "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
+	}
+
 	for (dependency in project.configurations.shaded.dependencies) {
 		compileOnly(dependency)
 		testImplementation(dependency)

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -135,6 +135,13 @@ dependencies {
 	// Needed for HTTP/2 testing
 	testRuntimeOnly "io.netty:netty-tcnative-boringssl-static:$boringSslVersion$os_suffix"
 
+	if (JavaVersion.current() > JavaVersion.VERSION_14) {
+		// https://github.com/netty/netty/pull/11487
+		// https://github.com/netty/netty/issues/10317
+		// Necessary for generating SelfSignedCertificate on Java version >= 15
+		testRuntimeOnly "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
+	}
+
 	// noMicrometerTest sourceSet (must not include Micrometer)
 	noMicrometerTestImplementation "org.assertj:assertj-core:$assertJVersion"
 	noMicrometerTestImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"

--- a/reactor-netty-incubator-quic/build.gradle
+++ b/reactor-netty-incubator-quic/build.gradle
@@ -48,6 +48,13 @@ dependencies {
 
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 	testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
+
+	if (JavaVersion.current() > JavaVersion.VERSION_14) {
+		// https://github.com/netty/netty/pull/11487
+		// https://github.com/netty/netty/issues/10317
+		// Necessary for generating SelfSignedCertificate on Java version >= 15
+		testRuntimeOnly "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
+	}
 }
 
 jar {


### PR DESCRIPTION
This is needed for generating `SelfSignedCertificate` on Java version >= 15