### PR TITLE
#1872: Implement additional metrics from reactor-pool

### DIFF
--- a/docs/asciidoc/conn-provider-metrics.adoc
+++ b/docs/asciidoc/conn-provider-metrics.adoc
@@ -5,6 +5,8 @@ Pooled `ConnectionProvider` metrics
 | metric name | type | description
 | reactor.netty.connection.provider.total.connections | Gauge | The number of all connections, active or idle
 | reactor.netty.connection.provider.active.connections | Gauge | The number of the connections that have been successfully acquired and are in active use
+| reactor.netty.connection.provider.max.connections | Gauge | The maximum number of connections that can be acquired
 | reactor.netty.connection.provider.idle.connections | Gauge | The number of the idle connections
 | reactor.netty.connection.provider.pending.connections | Gauge | The number of requests that are waiting for a connection
+| reactor.netty.connection.provider.max.pending.connections | Gauge | The maximum number of requests that are waiting for a connection
 |=======

--- a/docs/asciidoc/conn-provider-metrics.adoc
+++ b/docs/asciidoc/conn-provider-metrics.adoc
@@ -5,8 +5,8 @@ Pooled `ConnectionProvider` metrics
 | metric name | type | description
 | reactor.netty.connection.provider.total.connections | Gauge | The number of all connections, active or idle
 | reactor.netty.connection.provider.active.connections | Gauge | The number of the connections that have been successfully acquired and are in active use
-| reactor.netty.connection.provider.max.connections | Gauge | The maximum number of connections that can be acquired
+| reactor.netty.connection.provider.max.connections | Gauge | The maximum number of active connections that are allowed
 | reactor.netty.connection.provider.idle.connections | Gauge | The number of the idle connections
 | reactor.netty.connection.provider.pending.connections | Gauge | The number of requests that are waiting for a connection
-| reactor.netty.connection.provider.max.pending.connections | Gauge | The maximum number of requests that are waiting for a connection
+| reactor.netty.connection.provider.max.pending.connections | Gauge | The maximum number of requests that will be queued while waiting for a ready connection
 |=======

--- a/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
@@ -142,6 +142,11 @@ public class Metrics {
 	public static final String ACTIVE_CONNECTIONS = ".active.connections";
 
 	/**
+	 * The maximum number of connections that can be acquired
+	 */
+	public static final String MAX_CONNECTIONS = ".max.connections";
+
+	/**
 	 * The number of the idle connections
 	 */
 	public static final String IDLE_CONNECTIONS = ".idle.connections";
@@ -150,6 +155,11 @@ public class Metrics {
 	 * The number of requests that are waiting for a connection
 	 */
 	public static final String PENDING_CONNECTIONS = ".pending.connections";
+
+	/**
+	 * The maximum number of requests that are waiting for a connection
+	 */
+	public static final String MAX_PENDING_CONNECTIONS = ".max.pending.connections";
 
 
 	// ByteBufAllocator Metrics

--- a/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
@@ -142,7 +142,7 @@ public class Metrics {
 	public static final String ACTIVE_CONNECTIONS = ".active.connections";
 
 	/**
-	 * The maximum number of connections that can be acquired
+	 * The maximum number of active connections that are allowed
 	 */
 	public static final String MAX_CONNECTIONS = ".max.connections";
 
@@ -157,7 +157,7 @@ public class Metrics {
 	public static final String PENDING_CONNECTIONS = ".pending.connections";
 
 	/**
-	 * The maximum number of requests that are waiting for a connection
+	 * The maximum number of requests that will be queued while waiting for a ready connection
 	 */
 	public static final String MAX_PENDING_CONNECTIONS = ".max.pending.connections";
 

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionPoolMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionPoolMetrics.java
@@ -54,4 +54,21 @@ public interface ConnectionPoolMetrics {
 	 */
 	int pendingAcquireSize();
 
+	/**
+	 * Get the maximum number of live resources this Pool will allow.
+	 * A Pool might be unbounded, in which case this method returns Integer.MAX_VALUE.
+	 * @return the maximum number of live resources that can be allocated by this Pool
+	 */
+	int maxAllocatedSize();
+
+	/**
+	 * Get the maximum number of Pool.acquire() this Pool can queue in a pending state
+	 * when no available resource is immediately handy (and the Pool cannot allocate more
+	 * resources).
+	 * A Pool pending queue might be unbounded, in which case this method returns
+	 * Integer.MAX_VALUE.
+	 * @return the maximum number of pending acquire that can be enqueued by this Pool
+	 */
+	int maxPendingAcquireSize();
+
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionPoolMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionPoolMetrics.java
@@ -56,18 +56,22 @@ public interface ConnectionPoolMetrics {
 
 	/**
 	 * Get the maximum number of live resources this Pool will allow.
-	 * A Pool might be unbounded, in which case this method returns Integer.MAX_VALUE.
+	 * <p>
+	 * A Pool might be unbounded, in which case this method returns {@code Integer.MAX_VALUE}.
 	 * @return the maximum number of live resources that can be allocated by this Pool
+	 * @since 1.0.14
 	 */
 	int maxAllocatedSize();
 
 	/**
-	 * Get the maximum number of Pool.acquire() this Pool can queue in a pending state
+	 * Get the maximum number of {@code Pool.acquire()} this Pool can queue in a pending state
 	 * when no available resource is immediately handy (and the Pool cannot allocate more
 	 * resources).
+	 * <p>
 	 * A Pool pending queue might be unbounded, in which case this method returns
-	 * Integer.MAX_VALUE.
+	 * {@code Integer.MAX_VALUE}.
 	 * @return the maximum number of pending acquire that can be enqueued by this Pool
+	 * @since 1.0.14
 	 */
 	int maxPendingAcquireSize();
 

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DelegatingConnectionPoolMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DelegatingConnectionPoolMetrics.java
@@ -44,4 +44,14 @@ final class DelegatingConnectionPoolMetrics implements ConnectionPoolMetrics {
 	public int pendingAcquireSize() {
 		return delegate.pendingAcquireSize();
 	}
+
+	@Override
+	public int maxAllocatedSize() {
+		return delegate.getMaxAllocatedSize();
+	}
+
+	@Override
+	public int maxPendingAcquireSize() {
+		return delegate.getMaxPendingAcquireSize();
+	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/MicrometerPooledConnectionProviderMeterRegistrar.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/MicrometerPooledConnectionProviderMeterRegistrar.java
@@ -25,6 +25,8 @@ import static reactor.netty.Metrics.ACTIVE_CONNECTIONS;
 import static reactor.netty.Metrics.CONNECTION_PROVIDER_PREFIX;
 import static reactor.netty.Metrics.ID;
 import static reactor.netty.Metrics.IDLE_CONNECTIONS;
+import static reactor.netty.Metrics.MAX_CONNECTIONS;
+import static reactor.netty.Metrics.MAX_PENDING_CONNECTIONS;
 import static reactor.netty.Metrics.PENDING_CONNECTIONS;
 import static reactor.netty.Metrics.NAME;
 import static reactor.netty.Metrics.REGISTRY;
@@ -69,5 +71,15 @@ final class MicrometerPooledConnectionProviderMeterRegistrar {
 		     .description("The number of the request, that are pending acquire a connection")
 		     .tags(tags)
 		     .register(REGISTRY);
+
+		Gauge.builder(CONNECTION_PROVIDER_PREFIX + MAX_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::getMaxAllocatedSize)
+				.description("The maximum number of connections that can be acquired")
+				.tags(tags)
+				.register(REGISTRY);
+
+		Gauge.builder(CONNECTION_PROVIDER_PREFIX + MAX_PENDING_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::getMaxPendingAcquireSize)
+				.description("The maximum number of requests that are waiting for a connection")
+				.tags(tags)
+				.register(REGISTRY);
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/MicrometerPooledConnectionProviderMeterRegistrar.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/MicrometerPooledConnectionProviderMeterRegistrar.java
@@ -73,12 +73,12 @@ final class MicrometerPooledConnectionProviderMeterRegistrar {
 		     .register(REGISTRY);
 
 		Gauge.builder(CONNECTION_PROVIDER_PREFIX + MAX_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::getMaxAllocatedSize)
-				.description("The maximum number of connections that can be acquired")
+				.description("The maximum number of active connections that are allowed")
 				.tags(tags)
 				.register(REGISTRY);
 
 		Gauge.builder(CONNECTION_PROVIDER_PREFIX + MAX_PENDING_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::getMaxPendingAcquireSize)
-				.description("The maximum number of requests that are waiting for a connection")
+				.description("The maximum number of requests that will be queued while waiting for a ready connection")
 				.tags(tags)
 				.register(REGISTRY);
 	}


### PR DESCRIPTION
Please review this PR, which adds two methods in the ConnectionPoolMetrics interface:

The added methods (maxAllocatedSize, and maxPendingAcquireSize) simply expose the delegated methods from the original InstrumentedPool.PoolMetrics. This will most likely resolve the #1872 issue.

