### PR TITLE
Introduce functionality for mutating the ConnectionProvider configuration

### DIFF
--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -193,6 +193,12 @@ task japicmp(type: JapicmpTask) {
 	txtOutputFile = file("${project.buildDir}/reports/japi.txt")
 	ignoreMissingClasses = true
 	includeSynthetic = true
+	methodExcludes = [
+			// New methods with default implementation
+			// reactor.netty.resources
+			"reactor.netty.resources.ConnectionProvider#mutate()",
+			"reactor.netty.resources.ConnectionProvider#name()"
+	]
 	onlyIf { "$compatibleVersion" != "SKIP" }
 }
 

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -232,6 +232,28 @@ public interface ConnectionProvider extends Disposable {
 	}
 
 	/**
+	 * Returns a builder to mutate properties of this {@link ConnectionProvider}
+	 *
+	 * @return a builder to mutate properties of this {@link ConnectionProvider}
+	 * @since 1.0.14
+	 */
+	@Nullable
+	default Builder mutate() {
+		return null;
+	}
+
+	/**
+	 * Returns {@link ConnectionProvider} name used for metrics
+	 *
+	 * @return {@link ConnectionProvider} name used for metrics
+	 * @since 1.0.14
+	 */
+	@Nullable
+	default String name() {
+		return null;
+	}
+
+	/**
 	 * Build a {@link ConnectionProvider} to cache and reuse a fixed maximum number of
 	 * {@link Connection}. Further connections will be pending acquisition depending on
 	 * pendingAcquireTime. The maximum number of connections is for the connections in a single
@@ -258,6 +280,15 @@ public interface ConnectionProvider extends Disposable {
 		private Builder(String name) {
 			super();
 			name(name);
+		}
+
+		Builder(Builder copy) {
+			super(copy);
+			this.name = copy.name;
+			this.inactivePoolDisposeInterval = copy.inactivePoolDisposeInterval;
+			this.poolInactivity = copy.poolInactivity;
+			this.disposeTimeout = copy.disposeTimeout;
+			copy.confPerRemoteHost.forEach((address, spec) -> this.confPerRemoteHost.put(address, new ConnectionPoolSpec<>(spec)));
 		}
 
 		/**
@@ -367,6 +398,18 @@ public interface ConnectionProvider extends Disposable {
 			if (DEFAULT_POOL_MAX_LIFE_TIME > -1) {
 				maxLifeTime(Duration.ofMillis(DEFAULT_POOL_MAX_LIFE_TIME));
 			}
+		}
+
+		ConnectionPoolSpec(ConnectionPoolSpec<SPEC> copy) {
+			this.evictionInterval = copy.evictionInterval;
+			this.maxConnections = copy.maxConnections;
+			this.pendingAcquireMaxCount = copy.pendingAcquireMaxCount;
+			this.pendingAcquireTimeout = copy.pendingAcquireTimeout;
+			this.maxIdleTime = copy.maxIdleTime;
+			this.maxLifeTime = copy.maxLifeTime;
+			this.metricsEnabled = copy.metricsEnabled;
+			this.leasingStrategy = copy.leasingStrategy;
+			this.registrar = copy.registrar;
 		}
 
 		/**

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -73,6 +73,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 
 	final ConcurrentMap<PoolKey, InstrumentedPool<T>> channelPools = new ConcurrentHashMap<>();
 
+	final Builder builder;
 	final String name;
 	final Duration inactivePoolDisposeInterval;
 	final Duration poolInactivity;
@@ -84,6 +85,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 
 	// Used only for testing purposes
 	PooledConnectionProvider(Builder builder, @Nullable Clock clock) {
+		this.builder = builder;
 		this.name = builder.name;
 		this.inactivePoolDisposeInterval = builder.inactivePoolDisposeInterval;
 		this.poolInactivity = builder.poolInactivity;
@@ -193,6 +195,16 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 	@Override
 	public int maxConnections() {
 		return defaultPoolFactory.maxConnections;
+	}
+
+	@Override
+	public Builder mutate() {
+		return new Builder(builder);
+	}
+
+	@Override
+	public String name() {
+		return name;
 	}
 
 	protected abstract CoreSubscriber<PooledRef<T>> createDisposableAcquire(

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpResources.java
@@ -235,6 +235,16 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 	}
 
 	@Override
+	public Builder mutate() {
+		return defaultProvider.mutate();
+	}
+
+	@Override
+	public String name() {
+		return defaultProvider.name();
+	}
+
+	@Override
 	public <CHANNEL extends Channel> CHANNEL onChannel(Class<CHANNEL> channelType, EventLoopGroup group) {
 		requireNonNull(channelType, "channelType");
 		requireNonNull(group, "group");

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/ConnectionProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/ConnectionProviderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.resources;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConnectionProviderTest {
+
+	static final String TEST_STRING = "";
+	static final Supplier<ConnectionProvider.MeterRegistrar> TEST_SUPPLIER = () -> (a, b, c, d) -> {};
+
+	@Test
+	void testBuilderCopyConstructor() throws IllegalAccessException {
+		ConnectionProvider.Builder original = ConnectionProvider.builder("testBuilderCopyConstructor");
+		init(original, original.getClass().getDeclaredFields());
+		init(original, original.getClass().getSuperclass().getDeclaredFields());
+		ConnectionProvider.Builder copy = new ConnectionProvider.Builder(original);
+		assertThat(copy).usingRecursiveComparison().isEqualTo(original);
+	}
+
+	static void init(ConnectionProvider.Builder builder, Field[] fields) throws IllegalAccessException {
+		for (Field field : fields) {
+			int modifier = field.getModifiers();
+			if (!(Modifier.isStatic(modifier) || Modifier.isVolatile(modifier))) {
+				modifyField(builder, field);
+			}
+		}
+	}
+
+	static void modifyField(ConnectionProvider.Builder builder, Field field) throws IllegalAccessException {
+		field.setAccessible(true);
+		Class<?> clazz = field.getType();
+		if (String.class == clazz) {
+			field.set(builder, TEST_STRING);
+		}
+		else if (Duration.class == clazz) {
+			field.set(builder, Duration.ZERO);
+		}
+		else if (Map.class == clazz) {
+			field.set(builder, Collections.EMPTY_MAP);
+		}
+		else if (Supplier.class == clazz) {
+			field.set(builder, TEST_SUPPLIER);
+		}
+		else if (boolean.class == clazz) {
+			field.setBoolean(builder, true);
+		}
+		else if (int.class == clazz) {
+			field.setInt(builder, 1);
+		}
+		else {
+			throw new IllegalArgumentException("Unknown field type " + clazz);
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
@@ -74,9 +74,24 @@ import static reactor.netty.http.client.HttpClientState.UPGRADE_SUCCESSFUL;
 final class Http2ConnectionProvider extends PooledConnectionProvider<Connection> {
 	final ConnectionProvider parent;
 
-	Http2ConnectionProvider(ConnectionProvider parent, Builder builder) {
-		super(builder);
+	Http2ConnectionProvider(ConnectionProvider parent) {
+		super(initConfiguration(parent));
 		this.parent = parent;
+	}
+
+	static Builder initConfiguration(ConnectionProvider parent) {
+		String name = parent.name() == null ? CONNECTION_PROVIDER_NAME : CONNECTION_PROVIDER_NAME + NAME_SEPARATOR + parent.name();
+		Builder builder = parent.mutate();
+		if (builder != null) {
+			return builder.name(name);
+		}
+		else {
+			// this is the case when there is no pool
+			// only one connection is created and used for all requests
+			return ConnectionProvider.builder(name)
+			                         .maxConnections(parent.maxConnections())
+			                         .pendingAcquireMaxCount(-1);
+		}
 	}
 
 	@Override
@@ -137,6 +152,9 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 		           }
 		       });
 	}
+
+	static final String CONNECTION_PROVIDER_NAME = "http2";
+	static final String NAME_SEPARATOR = ".";
 
 	static final Logger log = Loggers.getLogger(Http2ConnectionProvider.class);
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
@@ -83,7 +83,7 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 		String name = parent.name() == null ? CONNECTION_PROVIDER_NAME : CONNECTION_PROVIDER_NAME + NAME_SEPARATOR + parent.name();
 		Builder builder = parent.mutate();
 		if (builder != null) {
-			return builder.name(name);
+			return builder.name(name).pendingAcquireMaxCount(-1);
 		}
 		else {
 			// this is the case when there is no pool

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Resources.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Resources.java
@@ -54,16 +54,7 @@ final class Http2Resources extends TcpResources {
 	}
 
 	static ConnectionProvider newConnectionProvider(ConnectionProvider parent) {
-		Builder builder =
-				ConnectionProvider.builder("http2")
-				                  .maxConnections(parent.maxConnections())
-				                  .pendingAcquireMaxCount(-1);
-		if (parent.maxConnectionsPerHost() != null) {
-			parent.maxConnectionsPerHost()
-			      .forEach((address, maxConn) -> builder.forRemoteHost(address, spec -> spec.maxConnections(maxConn)));
-		}
-
-		return new Http2ConnectionProvider(parent, builder);
+		return new Http2ConnectionProvider(parent);
 	}
 
 	static final AtomicReference<Http2Resources> http2Resources;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpConnectionProvider.java
@@ -69,16 +69,7 @@ final class HttpConnectionProvider implements ConnectionProvider {
 	static ConnectionProvider getOrCreate(ConnectionProvider http1ConnectionProvider) {
 		ConnectionProvider provider = h2ConnectionProvider.get();
 		if (provider == null) {
-			Builder builder =
-					ConnectionProvider.builder("http2")
-					                  .maxConnections(http1ConnectionProvider.maxConnections())
-					                  .pendingAcquireMaxCount(-1);
-			if (http1ConnectionProvider.maxConnectionsPerHost() != null) {
-				http1ConnectionProvider.maxConnectionsPerHost()
-				                       .forEach((address, maxConn) -> builder.forRemoteHost(address, spec -> spec.maxConnections(maxConn)));
-			}
-			h2ConnectionProvider.compareAndSet(null,
-					new Http2ConnectionProvider(http1ConnectionProvider, builder));
+			h2ConnectionProvider.compareAndSet(null, new Http2ConnectionProvider(http1ConnectionProvider));
 			provider = getOrCreate(http1ConnectionProvider);
 		}
 		return provider;


### PR DESCRIPTION
HTTP/2 connection pool inherits the configuration from its parent pool.
HTTP/2 connection pool name is a combination of `http2` and the parent pool's name.

Fixes #1800