### PR TITLE
config dns bind address in NameResolverSpec

### DIFF
--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -472,6 +472,7 @@ Default: {nettyjavadoc}/io/netty/resolver/DefaultHostsFileEntriesResolver.html[`
 Default: -1 (to determine the value from the OS on Unix or use a value of 1 otherwise).
 | `queryTimeout` | Sets the timeout of each DNS query performed by this resolver (resolution: milliseconds). Default: 5000.
 | `resolvedAddressTypes` | The list of the protocol families of the resolved address.
+| `bindAddressSupplier` | The supplier of the local address to bind to.
 | `roundRobinSelection` | Enables an
 {nettyjavadoc}/io/netty/resolver/AddressResolverGroup.html[`AddressResolverGroup`] of
 {nettyjavadoc}/io/netty/resolver/dns/DnsNameResolver.html[`DnsNameResolver`] that supports random selection

--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -374,6 +374,7 @@ Default: {nettyjavadoc}/io/netty/resolver/DefaultHostsFileEntriesResolver.html[`
  Default: -1 (to determine the value from the OS on Unix or use a value of 1 otherwise).
 | `queryTimeout` | Sets the timeout of each DNS query performed by this resolver (resolution: milliseconds). Default: 5000.
 | `resolvedAddressTypes` | The list of the protocol families of the resolved address.
+| `bindAddressSupplier` | The supplier of the local address to bind to.
 | `roundRobinSelection` | Enables an
  {nettyjavadoc}/io/netty/resolver/AddressResolverGroup.html[`AddressResolverGroup`] of
  {nettyjavadoc}/io/netty/resolver/dns/DnsNameResolver.html[`DnsNameResolver`] that supports random selection

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
@@ -180,7 +180,7 @@ public final class NameResolverProvider {
 		NameResolverSpec resolvedAddressTypes(ResolvedAddressTypes resolvedAddressTypes);
 
 		/**
-		 * Set a new local address supplier that the address to bind to.
+		 * Set a new local address supplier that supply the address to bind to.
 		 * By default, the host is configured for any local address, and the system picks up an ephemeral port.
 		 *
 		 * @param bindAddressSupplier A supplier of local address to bind to.
@@ -400,9 +400,10 @@ public final class NameResolverProvider {
 	}
 
 	/**
-	 * Returns the supplier of local address to bind to or null.
+	 * Returns the configured supplier of local address to bind to or null.
 	 *
-	 * @return the supplier of local address to bind to or null
+	 * @return the configured supplier of local address to bind to or null
+	 * @since 1.0.14
 	 */
 	@Nullable
 	public Supplier<? extends SocketAddress> bindAddressSupplier() {

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
@@ -33,6 +33,7 @@ import io.netty.util.concurrent.Future;
 import reactor.netty.resources.LoopResources;
 import reactor.util.annotation.Nullable;
 
+import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -176,6 +177,13 @@ public final class NameResolverProvider {
 		 * @return {@code this}
 		 */
 		NameResolverSpec resolvedAddressTypes(ResolvedAddressTypes resolvedAddressTypes);
+
+		/**
+		 * Configure the address that will be used to bind too. If `null` the default will be used.
+		 * @param localAddress the bind address
+		 * @return {@code this}
+		 */
+		NameResolverSpec localAddress(SocketAddress localAddress);
 
 		/**
 		 * Enables an {@link AddressResolverGroup} of {@link DnsNameResolver}s that supports random selection
@@ -461,6 +469,7 @@ public final class NameResolverProvider {
 				.maxPayloadSize(maxPayloadSize)
 				.maxQueriesPerResolve(maxQueriesPerResolve)
 				.ndots(ndots)
+				.localAddress(localAddress)
 				.queryTimeoutMillis(queryTimeout.toMillis())
 				.eventLoop(group.next())
 				.channelFactory(() -> loop.onChannel(DatagramChannel.class, group))
@@ -497,6 +506,7 @@ public final class NameResolverProvider {
 	final ResolvedAddressTypes resolvedAddressTypes;
 	final boolean roundRobinSelection;
 	final Iterable<String> searchDomains;
+	final SocketAddress localAddress;
 
 	NameResolverProvider(Build build) {
 		this.cacheMaxTimeToLive = build.cacheMaxTimeToLive;
@@ -514,6 +524,7 @@ public final class NameResolverProvider {
 		this.preferNative = build.preferNative;
 		this.queryTimeout = build.queryTimeout;
 		this.resolvedAddressTypes = build.resolvedAddressTypes;
+		this.localAddress = build.localAddress;
 		this.roundRobinSelection = build.roundRobinSelection;
 		this.searchDomains = build.searchDomains;
 	}
@@ -545,6 +556,7 @@ public final class NameResolverProvider {
 		ResolvedAddressTypes resolvedAddressTypes;
 		boolean roundRobinSelection;
 		Iterable<String> searchDomains;
+		SocketAddress localAddress;
 
 		@Override
 		public NameResolverSpec cacheMaxTimeToLive(Duration cacheMaxTimeToLive) {
@@ -624,6 +636,12 @@ public final class NameResolverProvider {
 		@Override
 		public NameResolverSpec resolvedAddressTypes(ResolvedAddressTypes resolvedAddressTypes) {
 			this.resolvedAddressTypes = Objects.requireNonNull(resolvedAddressTypes);
+			return this;
+		}
+
+		@Override
+		public NameResolverSpec localAddress(SocketAddress localAddress) {
+			this.localAddress = Objects.requireNonNull(localAddress);
 			return this;
 		}
 

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
@@ -499,6 +499,8 @@ public final class NameResolverProvider {
 			builder.resolvedAddressTypes(resolvedAddressTypes);
 		}
 		if (bindAddressSupplier != null) {
+			// There is no check for bindAddressSupplier.get() == null
+			// This is deliberate, when null value is provided Netty will use the default behaviour
 			builder.localAddress(bindAddressSupplier.get());
 		}
 		if (searchDomains != null) {
@@ -659,6 +661,7 @@ public final class NameResolverProvider {
 
 		@Override
 		public NameResolverSpec bindAddressSupplier(Supplier<? extends SocketAddress> bindAddressSupplier)	{
+			// If the default behaviour for bindAddress is the desired behaviour, one can provide a Supplier that returns null
 			Objects.requireNonNull(bindAddressSupplier, "bindAddressSupplier");
 			this.bindAddressSupplier = bindAddressSupplier;
 			return this;

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
@@ -181,7 +181,9 @@ public final class NameResolverProvider {
 
 		/**
 		 * Set a new local address that will be used to bind.
-		 * By default, the host is configured for any local address, and the system picks up an ephemeral port.		 * @param localAddress the bind address
+		 * By default, the host is configured for any local address, and the system picks up an ephemeral port.
+		 *
+		 * @param bindAddressSupplier A supplier of the address to bind to.
 		 * @return {@code this}
 		 * @since 1.0.14
 		 */

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
@@ -26,9 +26,12 @@ import org.junit.jupiter.api.condition.OS;
 import reactor.netty.resources.LoopResources;
 import reactor.netty.tcp.TcpResources;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -219,6 +222,20 @@ class NameResolverProviderTest {
 	void resolvedAddressTypesBadValues() {
 		assertThatExceptionOfType(NullPointerException.class)
 				.isThrownBy(() -> builder.resolvedAddressTypes(null));
+	}
+
+	@Test
+	void bindAddressSupplier() {
+		assertThat(builder.build().bindAddressSupplier()).isNull();
+		Supplier<SocketAddress> addressSupplier = () -> new InetSocketAddress("localhost", 9527);
+		builder.bindAddressSupplier(addressSupplier);
+		assertThat(builder.build().bindAddressSupplier()).isEqualTo(addressSupplier);
+	}
+
+	@Test
+	void bindAddressSupplierBadValues() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> builder.bindAddressSupplier(null));
 	}
 
 	@Test


### PR DESCRIPTION
Allow to config dns bind address in NameResolverSpec

FIx [1920](https://github.com/reactor/reactor-netty/issues/1920)