### PR TITLE
New HTTP/2 connection pool implementation

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -1,0 +1,829 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.client;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.BiFunction;
+
+import io.netty.handler.codec.http2.Http2FrameCodec;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
+import reactor.core.Scannable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+import reactor.core.scheduler.Schedulers;
+import reactor.netty.Connection;
+import reactor.netty.ConnectionObserver;
+import reactor.netty.channel.ChannelOperations;
+import reactor.netty.internal.shaded.reactor.pool.InstrumentedPool;
+import reactor.netty.internal.shaded.reactor.pool.PoolAcquirePendingLimitException;
+import reactor.netty.internal.shaded.reactor.pool.PoolAcquireTimeoutException;
+import reactor.netty.internal.shaded.reactor.pool.PoolConfig;
+import reactor.netty.internal.shaded.reactor.pool.PoolShutdownException;
+import reactor.netty.internal.shaded.reactor.pool.PooledRef;
+import reactor.netty.internal.shaded.reactor.pool.PooledRefMetadata;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+import static reactor.netty.ReactorNetty.format;
+
+/**
+ * <p>This class is intended to be used only as {@code HTTP/2} connection pool. It doesn't have generic purpose.
+ * <p>
+ * The connection is removed from the pool when:
+ * <ul>
+ *     <li>The connection is closed.</li>
+ *     <li>The connection has reached its life time and there are no active streams.</li>
+ *     <li>The connection has no active streams.</li>
+ *     <li>When the client is in one of the two modes: 1) H2 and HTTP/1.1 or 2) H2C and HTTP/1.1,
+ *     and the negotiated protocol is HTTP/1.1.</li>
+ * </ul>
+ * <p>
+ * The connection is filtered out when:
+ * <ul>
+ *     <li>The connection has reached its life time and there are active streams. In this case, the connection stays
+ *     in the pool, but it is not used. Once there are no active streams, the connection is removed from the pool.</li>
+ *     <li>The connection has reached its max active streams configuration. In this case, the connection stays
+ *     in the pool, but it is not used. Once the number of the active streams is below max active streams configuration,
+ *     the connection can be used again.</li>
+ * </ul>
+ * <p>
+ * This pool always invalidate the {@link PooledRef}, there is no release functionality.
+ * <ul>
+ *     <li>{@link PoolMetrics#acquiredSize()} and {@link PoolMetrics#allocatedSize()} always return the number of
+ *     the active streams from all connections currently in the pool.</li>
+ *     <li>{@link PoolMetrics#idleSize()} always returns {@code 0}.</li>
+ * </ul>
+ * <p>
+ * Configurations that are not applicable
+ * <ul>
+ *     <li>{@link PoolConfig#destroyHandler()} - the destroy handler cannot be used as the destruction is more complex.</li>
+ *     <li>{@link PoolConfig#evictInBackgroundInterval()} and {@link PoolConfig#evictInBackgroundScheduler()} -
+ *     there are no idle resources in the pool. Once the connection does not have active streams, it
+ *     is returned to the parent pool.</li>
+ *     <li>{@link PoolConfig#evictionPredicate()} - the eviction predicate cannot be used as more complex
+ *     checks have to be done. Also the pool uses filtering for the connections (a connection might not be able
+ *     to be used but is required to stay in the pool).</li>
+ *     <li>{@link PoolConfig#metricsRecorder()} - no pool instrumentation.</li>
+ *     <li>{@link PoolConfig#releaseHandler()} - release functionality works as invalidate.</li>
+ *     <li>{@link PoolConfig#reuseIdleResourcesInLruOrder()} - FIFO is used when checking the connections.</li>
+ *     <li>FIFO is used when obtaining the pending borrowers</li>
+ *     <li>Warm up functionality is not supported</li>
+ * </ul>
+ * <p>This class is based on
+ * https://github.com/reactor/reactor-pool/blob/v0.2.7/src/main/java/reactor/pool/SimpleDequePool.java
+ *
+ * @author Violeta Georgieva
+ */
+final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMetrics {
+
+	static final Logger log = Loggers.getLogger(Http2Pool.class);
+
+	volatile int acquired;
+	static final AtomicIntegerFieldUpdater<Http2Pool> ACQUIRED =
+			AtomicIntegerFieldUpdater.newUpdater(Http2Pool.class, "acquired");
+
+	volatile ConcurrentLinkedQueue<Slot> connections;
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<Http2Pool, ConcurrentLinkedQueue> CONNECTIONS =
+			AtomicReferenceFieldUpdater.newUpdater(Http2Pool.class, ConcurrentLinkedQueue.class, "connections");
+
+	volatile ConcurrentLinkedDeque<Borrower> pending;
+	@SuppressWarnings("rawtypes")
+	static final AtomicReferenceFieldUpdater<Http2Pool, ConcurrentLinkedDeque> PENDING =
+			AtomicReferenceFieldUpdater.newUpdater(Http2Pool.class, ConcurrentLinkedDeque.class, "pending");
+
+	@SuppressWarnings("rawtypes")
+	static final ConcurrentLinkedDeque TERMINATED = new ConcurrentLinkedDeque();
+
+	volatile int wip;
+	static final AtomicIntegerFieldUpdater<Http2Pool> WIP =
+			AtomicIntegerFieldUpdater.newUpdater(Http2Pool.class, "wip");
+
+	final Clock clock;
+	final long maxLifeTime;
+	final PoolConfig<Connection> poolConfig;
+
+	long lastInteractionTimestamp;
+
+	Http2Pool(PoolConfig<Connection> poolConfig, long maxLifeTime) {
+		this.clock = poolConfig.clock();
+		this.connections = new ConcurrentLinkedQueue<>();
+		this.lastInteractionTimestamp = clock.millis();
+		this.maxLifeTime = maxLifeTime;
+		this.pending = new ConcurrentLinkedDeque<>();
+		this.poolConfig = poolConfig;
+
+		recordInteractionTimestamp();
+	}
+
+	@Override
+	public Mono<PooledRef<Connection>> acquire() {
+		return new BorrowerMono(this, Duration.ZERO);
+	}
+
+	@Override
+	public Mono<PooledRef<Connection>> acquire(Duration timeout) {
+		return new BorrowerMono(this, timeout);
+	}
+
+	@Override
+	public int acquiredSize() {
+		return acquired;
+	}
+
+	@Override
+	public int allocatedSize() {
+		return acquired;
+	}
+
+	@Override
+	public PoolConfig<Connection> config() {
+		return poolConfig;
+	}
+
+	@Override
+	public Mono<Void> disposeLater() {
+		return Mono.defer(() -> {
+			recordInteractionTimestamp();
+
+			@SuppressWarnings("unchecked")
+			ConcurrentLinkedDeque<Borrower> q = PENDING.getAndSet(this, TERMINATED);
+			if (q != TERMINATED) {
+				Borrower p;
+				while ((p = q.pollFirst()) != null) {
+					p.fail(new PoolShutdownException());
+				}
+
+				// the last stream on that connection will release the connection to the parent pool
+				// the structure should not contain connections with 0 streams as the last stream on that connection
+				// always removes the connection from this pool
+				CONNECTIONS.getAndSet(this, null);
+			}
+			return Mono.empty();
+		});
+	}
+
+	@Override
+	public int getMaxAllocatedSize() {
+		return Integer.MAX_VALUE;
+	}
+
+	@Override
+	public int getMaxPendingAcquireSize() {
+		return poolConfig.maxPending() < 0 ? Integer.MAX_VALUE : poolConfig.maxPending();
+	}
+
+	@Override
+	public int idleSize() {
+		return 0;
+	}
+
+	@Override
+	public boolean isDisposed() {
+		return PENDING.get(this) == TERMINATED || CONNECTIONS.get(this) == null;
+	}
+
+	@Override
+	public boolean isInactiveForMoreThan(Duration duration) {
+		return pendingAcquireSize() == 0 && allocatedSize() == 0
+				&& secondsSinceLastInteraction() >= duration.getSeconds();
+	}
+
+	@Override
+	public PoolMetrics metrics() {
+		return this;
+	}
+
+	@Override
+	public int pendingAcquireSize() {
+		return PENDING.get(this).size();
+	}
+
+	@Override
+	public long secondsSinceLastInteraction() {
+		long sinceMs = clock.millis() - lastInteractionTimestamp;
+		return sinceMs / 1000;
+	}
+
+	@Override
+	public Mono<Integer> warmup() {
+		return Mono.just(0);
+	}
+
+	void cancelAcquire(Borrower borrower) {
+		if (!isDisposed()) {
+			ConcurrentLinkedDeque<Borrower> q = pending;
+			q.remove(borrower);
+		}
+	}
+
+	Mono<Void> destroyPoolable(Http2PooledRef ref) {
+		Mono<Void> userProvidedDestroy;
+		try {
+			userProvidedDestroy = Mono.from(destroyHandler().apply(this, ref));
+		}
+		catch (Throwable destroyFunctionError) {
+			userProvidedDestroy = Mono.error(destroyFunctionError);
+		}
+		return userProvidedDestroy;
+	}
+
+	BiFunction<Http2Pool, Http2PooledRef, Publisher<Void>> destroyHandler() {
+		return (pool, pooledRef) -> {
+			pooledRef.slot.decrementConcurrency();
+			Connection connection = pooledRef.poolable();
+			Http2FrameCodec frameCodec = connection.channel().pipeline().get(Http2FrameCodec.class);
+			if (frameCodec != null) {
+				if (pooledRef.slot.concurrency() == 0 && pooledRef.slot.invalidate()) {
+					releaseConnection(connection);
+				}
+			}
+			else {
+				// no need to guard here with invalidate()
+				// #findConnection will never give a connection that does not have Http2FrameCodec
+				poolConfig.allocationStrategy().returnPermits(1);
+				removeSlot(pooledRef.slot);
+			}
+			return Mono.empty();
+		};
+	}
+
+	void doAcquire(Borrower borrower) {
+		if (isDisposed()) {
+			borrower.fail(new PoolShutdownException());
+			return;
+		}
+
+		pendingOffer(borrower);
+		drain();
+	}
+
+	void drain() {
+		if (WIP.getAndIncrement(this) == 0) {
+			drainLoop();
+		}
+	}
+
+	void drainLoop() {
+		recordInteractionTimestamp();
+		int maxPending = poolConfig.maxPending();
+
+		for (;;) {
+			@SuppressWarnings("unchecked")
+			ConcurrentLinkedQueue<Slot> resources = CONNECTIONS.get(this);
+			@SuppressWarnings("unchecked")
+			ConcurrentLinkedDeque<Borrower> borrowers = PENDING.get(this);
+			if (resources == null || borrowers == TERMINATED) {
+				return;
+			}
+
+			int borrowersCount = borrowers.size();
+
+			if (borrowersCount != 0) {
+				// find a connection that can be used for opening a new stream
+				Slot slot = findConnection(resources);
+				if (slot != null) {
+					Borrower borrower = borrowers.pollFirst();
+					if (borrower == null) {
+						resources.offer(slot);
+						continue;
+					}
+					if (isDisposed()) {
+						borrower.fail(new PoolShutdownException());
+						return;
+					}
+					if (slot.activate()) {
+						borrower.stopPendingCountdown();
+						ACQUIRED.incrementAndGet(this);
+						slot.incrementConcurrency();
+						// we are ready here, the connection can be used for opening another stream
+						slot.deactivate();
+						poolConfig.acquisitionScheduler().schedule(() -> borrower.deliver(new Http2PooledRef(slot)));
+					}
+					else {
+						borrowers.offerFirst(borrower);
+						continue;
+					}
+				}
+				else {
+					int permits = poolConfig.allocationStrategy().getPermits(1);
+					if (permits <= 0) {
+						if (maxPending >= 0) {
+							borrowersCount = borrowers.size();
+							int toCull = borrowersCount - maxPending;
+							for (int i = 0; i < toCull; i++) {
+								Borrower extraneous = borrowers.pollFirst();
+								if (extraneous != null) {
+									pendingAcquireLimitReached(extraneous, maxPending);
+								}
+							}
+						}
+					}
+					else {
+						Borrower borrower = borrowers.pollFirst();
+						if (borrower == null) {
+							continue;
+						}
+						if (isDisposed()) {
+							borrower.fail(new PoolShutdownException());
+							return;
+						}
+						borrower.stopPendingCountdown();
+						Mono<Connection> allocator = poolConfig.allocator();
+						Mono<Connection> primary =
+								allocator.doOnEach(sig -> {
+								             if (sig.isOnNext()) {
+								                 Connection newInstance = sig.get();
+								                 assert newInstance != null;
+								                 Slot newSlot = new Slot(this, newInstance);
+								                 newSlot.activate();
+								                 ACQUIRED.incrementAndGet(this);
+								                 newSlot.incrementConcurrency();
+								                 newSlot.deactivate();
+								                 borrower.deliver(new Http2PooledRef(newSlot));
+								             }
+								             else if (sig.isOnError()) {
+								                 Throwable error = sig.getThrowable();
+								                 assert error != null;
+								                 poolConfig.allocationStrategy().returnPermits(1);
+								                 borrower.fail(error);
+								             }
+								         })
+								         .contextWrite(borrower.currentContext());
+
+						if (permits == 1) {
+							primary.subscribe(alreadyPropagated -> {}, alreadyPropagatedOrLogged -> drain(), this::drain);
+						}
+						else {
+							int toWarmup = permits - 1;
+							if (log.isDebugEnabled()) {
+								log.debug("should warm up {} extra connections", toWarmup);
+							}
+
+							Flux<Void> warmupFlux =
+									Flux.range(1, toWarmup)
+									    .flatMap(i -> allocator.flatMap(poolable -> {
+									        if (log.isDebugEnabled()) {
+									            log.debug("warmed up extra connections {}/{}", i, toWarmup);
+									        }
+									        Slot newSlot = new Slot(this, poolable);
+									        if (!offerSlot(newSlot)) {
+									            poolConfig.allocationStrategy().returnPermits(1);
+									            releaseConnection(poolable);
+									            return Mono.<Void>empty();
+									        }
+									        return Mono.empty();
+									    })
+									    .onErrorResume(warmupError -> {
+									        if (log.isDebugEnabled()) {
+									            log.debug("failed to warm up extra connections {}/{}: {}", i, toWarmup, warmupError.toString());
+									        }
+									        poolConfig.allocationStrategy().returnPermits(1);
+									        return Mono.empty();
+									    }));
+
+							primary.onErrorResume(e -> Mono.empty())
+							       .thenMany(warmupFlux)
+							       .subscribe(aVoid -> {}, alreadyPropagatedOrLogged -> drain(), this::drain);
+						}
+					}
+				}
+			}
+
+			if (WIP.decrementAndGet(this) == 0) {
+				recordInteractionTimestamp();
+				break;
+			}
+		}
+	}
+
+	@Nullable
+	Slot findConnection(ConcurrentLinkedQueue<Slot> resources) {
+		int resourcesCount = resources.size();
+		while (resourcesCount > 0) {
+			// There are connections in the queue
+
+			resourcesCount--;
+
+			// get the connection
+			Slot slot = resources.poll();
+			if (slot == null) {
+				continue;
+			}
+
+			// check the connection is active
+			if (!slot.connection.channel().isActive()) {
+				if (slot.concurrency() > 0) {
+					if (log.isDebugEnabled()) {
+						log.debug(format(slot.connection.channel(), "Channel is closed, {} active streams"),
+								slot.concurrency());
+					}
+					resources.offer(slot);
+				}
+				else if (slot.isInvalidated()) {
+					if (log.isDebugEnabled()) {
+						log.debug(format(slot.connection.channel(), "Channel is closed, remove from pool"));
+					}
+					resources.remove(slot);
+				}
+				continue;
+			}
+
+			// check that the connection's max lifetime has not been reached
+			if (maxLifeTime != -1 && slot.lifeTime() >= maxLifeTime) {
+				if (slot.concurrency() > 0) {
+					if (log.isDebugEnabled()) {
+						log.debug(format(slot.connection.channel(), "Max life time is reached, {} active streams"),
+								slot.concurrency());
+					}
+					resources.offer(slot);
+				}
+				else if (slot.isInvalidated()) {
+					if (log.isDebugEnabled()) {
+						log.debug(format(slot.connection.channel(), "Max life time is reached, remove from pool"));
+					}
+					resources.remove(slot);
+				}
+				continue;
+			}
+
+			// check that the connection's max active streams has not been reached
+			if (!slot.canOpenStream()) {
+				resources.offer(slot);
+				if (log.isDebugEnabled()) {
+					log.debug(format(slot.connection.channel(), "Max active streams is reached"));
+				}
+				continue;
+			}
+
+			return slot;
+		}
+
+		return null;
+	}
+
+	void pendingAcquireLimitReached(Borrower borrower, int maxPending) {
+		if (maxPending == 0) {
+			borrower.fail(new PoolAcquirePendingLimitException(0,
+					"No pending allowed and pool has reached allocation limit"));
+		}
+		else {
+			borrower.fail(new PoolAcquirePendingLimitException(maxPending));
+		}
+	}
+
+	/**
+	 * @param borrower a new {@link Borrower} to add to the queue and later either serve or consider pending
+	 */
+	void pendingOffer(Borrower borrower) {
+		int maxPending = poolConfig.maxPending();
+		ConcurrentLinkedDeque<Borrower> pendingQueue = pending;
+		if (pendingQueue == TERMINATED) {
+			return;
+		}
+		pendingQueue.offerLast(borrower);
+		int postOffer = pendingQueue.size();
+
+		if (WIP.getAndIncrement(this) == 0) {
+			ConcurrentLinkedQueue<Slot> ir = connections;
+			if (maxPending >= 0 && postOffer > maxPending && ir.isEmpty() && poolConfig.allocationStrategy().estimatePermitCount() == 0) {
+				Borrower toCull = pendingQueue.pollLast();
+				if (toCull != null) {
+					pendingAcquireLimitReached(toCull, maxPending);
+				}
+
+				if (WIP.decrementAndGet(this) > 0) {
+					drainLoop();
+				}
+				return;
+			}
+
+			drainLoop();
+		}
+	}
+
+	void recordInteractionTimestamp() {
+		this.lastInteractionTimestamp = clock.millis();
+	}
+
+	static boolean offerSlot(Slot slot) {
+		@SuppressWarnings("unchecked")
+		ConcurrentLinkedQueue<Slot> q = CONNECTIONS.get(slot.pool);
+		return q != null && q.offer(slot);
+	}
+
+	static void releaseConnection(Connection connection) {
+		ChannelOperations<?, ?> ops = connection.as(ChannelOperations.class);
+		if (ops != null) {
+			ops.listener().onStateChange(ops, ConnectionObserver.State.DISCONNECTING);
+		}
+		else if (connection instanceof ConnectionObserver) {
+			((ConnectionObserver) connection).onStateChange(connection, ConnectionObserver.State.DISCONNECTING);
+		}
+		else {
+			connection.dispose();
+		}
+	}
+
+	static void removeSlot(Slot slot) {
+		@SuppressWarnings("unchecked")
+		ConcurrentLinkedQueue<Slot> q = CONNECTIONS.get(slot.pool);
+		if (q != null) {
+			q.remove(slot);
+		}
+	}
+
+	static final class Borrower extends AtomicBoolean implements Scannable, Subscription, Runnable {
+
+		static final Disposable TIMEOUT_DISPOSED = Disposables.disposed();
+
+		final Duration acquireTimeout;
+		final CoreSubscriber<? super Http2PooledRef> actual;
+		final Http2Pool pool;
+
+		Disposable timeoutTask;
+
+		Borrower(CoreSubscriber<? super Http2PooledRef> actual, Http2Pool pool, Duration acquireTimeout) {
+			this.acquireTimeout = acquireTimeout;
+			this.actual = actual;
+			this.pool = pool;
+			this.timeoutTask = TIMEOUT_DISPOSED;
+		}
+
+		@Override
+		public void cancel() {
+			stopPendingCountdown();
+			if (compareAndSet(false, true)) {
+				pool.cancelAcquire(this);
+			}
+		}
+
+		Context currentContext() {
+			return actual.currentContext();
+		}
+
+		@Override
+		public void request(long n) {
+			if (Operators.validate(n)) {
+				if (!acquireTimeout.isZero()) {
+					timeoutTask = Schedulers.parallel().schedule(this, acquireTimeout.toMillis(), TimeUnit.MILLISECONDS);
+				}
+				pool.doAcquire(this);
+			}
+		}
+
+		@Override
+		public void run() {
+			if (compareAndSet(false, true)) {
+				pool.cancelAcquire(Http2Pool.Borrower.this);
+				actual.onError(new PoolAcquireTimeoutException(acquireTimeout));
+			}
+		}
+
+		@Override
+		@Nullable
+		@SuppressWarnings("rawtypes")
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.CANCELLED) {
+				return get();
+			}
+			if (key == Attr.REQUESTED_FROM_DOWNSTREAM) {
+				return 1;
+			}
+			if (key == Attr.ACTUAL) {
+				return actual;
+			}
+
+			return null;
+		}
+
+		@Override
+		public String toString() {
+			return get() ? "Borrower(cancelled)" : "Borrower";
+		}
+
+		void deliver(Http2PooledRef poolSlot) {
+			stopPendingCountdown();
+			if (get()) {
+				//CANCELLED or timeout reached
+				poolSlot.invalidate().subscribe(aVoid -> {}, e -> Operators.onErrorDropped(e, Context.empty()));
+			}
+			else {
+				actual.onNext(poolSlot);
+				actual.onComplete();
+			}
+		}
+
+		void fail(Throwable error) {
+			stopPendingCountdown();
+			if (!get()) {
+				actual.onError(error);
+			}
+		}
+
+		void stopPendingCountdown() {
+			timeoutTask.dispose();
+		}
+	}
+
+	static final class BorrowerMono extends Mono<PooledRef<Connection>> {
+
+		final Duration acquireTimeout;
+		final Http2Pool parent;
+
+		BorrowerMono(Http2Pool pool, Duration acquireTimeout) {
+			this.acquireTimeout = acquireTimeout;
+			this.parent = pool;
+		}
+
+		@Override
+		public void subscribe(CoreSubscriber<? super PooledRef<Connection>> actual) {
+			Objects.requireNonNull(actual, "subscribing with null");
+			Borrower borrower = new Borrower(actual, parent, acquireTimeout);
+			actual.onSubscribe(borrower);
+		}
+	}
+
+	static final class Http2PooledRef extends AtomicBoolean implements PooledRef<Connection>, PooledRefMetadata {
+
+		final int acquireCount;
+		final Slot slot;
+
+		Http2PooledRef(Slot slot) {
+			this.acquireCount = 0;
+			this.slot = slot;
+		}
+
+		@Override
+		public int acquireCount() {
+			return 1;
+		}
+
+		@Override
+		public long allocationTimestamp() {
+			return 0;
+		}
+
+		@Override
+		public long idleTime() {
+			return 0;
+		}
+
+		@Override
+		public Mono<Void> invalidate() {
+			return Mono.defer(() -> {
+				if (compareAndSet(false, true)) {
+					ACQUIRED.decrementAndGet(slot.pool);
+					return slot.pool.destroyPoolable(this).doFinally(st -> slot.pool.drain());
+				}
+				else {
+					return Mono.empty();
+				}
+			});
+		}
+
+		@Override
+		public long lifeTime() {
+			return 0;
+		}
+
+		@Override
+		public PooledRefMetadata metadata() {
+			return this;
+		}
+
+		@Override
+		public Connection poolable() {
+			return slot.connection;
+		}
+
+		@Override
+		public Mono<Void> release() {
+			return invalidate();
+		}
+
+		@Override
+		public long releaseTimestamp() {
+			return 0;
+		}
+
+		@Override
+		public String toString() {
+			return "PooledRef{poolable=" + slot.connection + '}';
+		}
+	}
+
+	static final class Slot {
+
+		volatile int concurrency;
+		static final AtomicIntegerFieldUpdater<Slot> CONCURRENCY =
+				AtomicIntegerFieldUpdater.newUpdater(Slot.class, "concurrency");
+
+		volatile int state;
+		static final AtomicIntegerFieldUpdater<Slot> STATE = AtomicIntegerFieldUpdater.newUpdater(Slot.class, "state");
+
+		static final int STATE_DEACTIVATED = 0;
+		static final int STATE_ACTIVATED = 1;
+		static final int STATE_INVALIDATED = 2;
+
+		final Connection connection;
+		final long creationTimestamp;
+		final Http2Pool pool;
+
+		Slot(Http2Pool pool, Connection connection) {
+			this.connection = connection;
+			this.creationTimestamp = pool.clock.millis();
+			this.pool = pool;
+			this.state = STATE_DEACTIVATED;
+		}
+
+		boolean activate() {
+			if (STATE.compareAndSet(this, STATE_DEACTIVATED, STATE_ACTIVATED)) {
+				if (log.isDebugEnabled()) {
+					log.debug(format(connection.channel(), "Channel activated"));
+				}
+				return true;
+			}
+			return false;
+		}
+
+		boolean canOpenStream() {
+			Http2FrameCodec frameCodec = connection.channel().pipeline().get(Http2FrameCodec.class);
+			if (frameCodec != null) {
+				int maxActiveStreams = frameCodec.connection().local().maxActiveStreams();
+				int concurrency = this.concurrency;
+				return concurrency < maxActiveStreams;
+			}
+			return false;
+		}
+
+		int concurrency() {
+			return concurrency;
+		}
+
+		void deactivate() {
+			if (STATE.compareAndSet(this, STATE_ACTIVATED, STATE_DEACTIVATED)) {
+				if (log.isDebugEnabled()) {
+					log.debug(format(connection.channel(), "Channel deactivated"));
+				}
+				offerSlot(this);
+			}
+		}
+
+		void decrementConcurrency() {
+			CONCURRENCY.decrementAndGet(this);
+		}
+
+		void incrementConcurrency() {
+			CONCURRENCY.incrementAndGet(this);
+		}
+
+		boolean invalidate() {
+			if (STATE.compareAndSet(this, STATE_DEACTIVATED, STATE_INVALIDATED)) {
+				if (log.isDebugEnabled()) {
+					log.debug(format(connection.channel(), "Channel removed from pool"));
+				}
+				pool.poolConfig.allocationStrategy().returnPermits(1);
+				removeSlot(this);
+				return true;
+			}
+			return false;
+		}
+
+		boolean isInvalidated() {
+			return state == STATE_INVALIDATED;
+		}
+
+		long lifeTime() {
+			return pool.clock.millis() - creationTimestamp;
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -93,6 +93,7 @@ import static reactor.netty.ReactorNetty.format;
  *     <li>{@link PoolConfig#reuseIdleResourcesInLruOrder()} - FIFO is used when checking the connections.</li>
  *     <li>FIFO is used when obtaining the pending borrowers</li>
  *     <li>Warm up functionality is not supported</li>
+ *     <li>Setting minimum connections configuration is not supported</li>
  * </ul>
  * <p>This class is based on
  * https://github.com/reactor/reactor-pool/blob/v0.2.7/src/main/java/reactor/pool/SimpleDequePool.java
@@ -131,6 +132,9 @@ final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.
 	long lastInteractionTimestamp;
 
 	Http2Pool(PoolConfig<Connection> poolConfig, long maxLifeTime) {
+		if (poolConfig.allocationStrategy().getPermits(0) != 0) {
+			throw new IllegalArgumentException("No support for configuring minimum number of connections");
+		}
 		this.clock = poolConfig.clock();
 		this.connections = new ConcurrentLinkedQueue<>();
 		this.lastInteractionTimestamp = clock.millis();

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class Http2PoolTest {
 
@@ -452,6 +453,14 @@ class Http2PoolTest {
 				connection.dispose();
 			}
 		}
+	}
+
+	@Test
+	void minConnectionsConfigNotSupported() {
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.<Connection>empty()).sizeBetween(1, 2);
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> poolBuilder.build(config -> new Http2Pool(config, -1)));
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
@@ -1,0 +1,518 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.client;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelId;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.netty.Connection;
+import reactor.netty.internal.shaded.reactor.pool.InstrumentedPool;
+import reactor.netty.internal.shaded.reactor.pool.PoolAcquireTimeoutException;
+import reactor.netty.internal.shaded.reactor.pool.PoolBuilder;
+import reactor.netty.internal.shaded.reactor.pool.PoolConfig;
+import reactor.netty.internal.shaded.reactor.pool.PooledRef;
+import reactor.test.StepVerifier;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Http2PoolTest {
+
+	@Test
+	void acquireInvalidate() {
+		Channel channel = new EmbeddedChannel(Http2FrameCodecBuilder.forClient().build());
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.just(Connection.from(channel)))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1);
+		InstrumentedPool<Connection> http2Pool = poolBuilder.build(config -> new Http2Pool(config, -1));
+
+		try {
+			List<PooledRef<Connection>> acquired = new ArrayList<>();
+			http2Pool.acquire().subscribe(acquired::add);
+			http2Pool.acquire().subscribe(acquired::add);
+			http2Pool.acquire().subscribe(acquired::add);
+
+			assertThat(acquired).hasSize(3);
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(3);
+
+			for (PooledRef<Connection> slot : acquired) {
+				slot.invalidate().block(Duration.ofSeconds(1));
+			}
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(0);
+
+			for (PooledRef<Connection> slot : acquired) {
+				// second invalidate() should be ignored and ACQUIRED size should remain the same
+				slot.invalidate().block(Duration.ofSeconds(1));
+			}
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(0);
+		}
+		finally {
+			Connection.from(channel).dispose();
+		}
+	}
+
+	@Test
+	void acquireRelease() {
+		Channel channel = new EmbeddedChannel(Http2FrameCodecBuilder.forClient().build());
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.just(Connection.from(channel)))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1);
+		InstrumentedPool<Connection> http2Pool = poolBuilder.build(config -> new Http2Pool(config, -1));
+
+		try {
+			List<PooledRef<Connection>> acquired = new ArrayList<>();
+			http2Pool.acquire().subscribe(acquired::add);
+			http2Pool.acquire().subscribe(acquired::add);
+			http2Pool.acquire().subscribe(acquired::add);
+
+			assertThat(acquired).hasSize(3);
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(3);
+
+			for (PooledRef<Connection> slot : acquired) {
+				slot.release().block(Duration.ofSeconds(1));
+			}
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(0);
+
+			for (PooledRef<Connection> slot : acquired) {
+				// second release() should be ignored and ACQUIRED size should remain the same
+				slot.release().block(Duration.ofSeconds(1));
+			}
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(0);
+		}
+		finally {
+			Connection.from(channel).dispose();
+		}
+	}
+
+	@Test
+	void evictClosedConnection() throws Exception {
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> {
+				               Channel channel = new EmbeddedChannel(
+				                   new TestChannelId(),
+				                   Http2FrameCodecBuilder.forClient().build());
+				               return Connection.from(channel);
+				           }))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1);
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, -1));
+
+		Connection connection = null;
+		try {
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+
+			assertThat(acquired1).isNotNull();
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			connection = acquired1.poolable();
+			ChannelId id1 = connection.channel().id();
+			CountDownLatch latch = new CountDownLatch(1);
+			connection.onDispose(latch::countDown);
+			connection.dispose();
+
+			assertThat(latch.await(1, TimeUnit.SECONDS)).as("latch await").isTrue();
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			acquired1.invalidate().block();
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(0);
+			assertThat(http2Pool.connections.size()).isEqualTo(0);
+
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+
+			assertThat(acquired2).isNotNull();
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			connection = acquired2.poolable();
+			ChannelId id2 = connection.channel().id();
+
+			assertThat(id1).isNotEqualTo(id2);
+
+			acquired2.invalidate().block();
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(0);
+			assertThat(http2Pool.connections.size()).isEqualTo(0);
+		}
+		finally {
+			if (connection != null) {
+				connection.dispose();
+			}
+		}
+	}
+
+	@Test
+	void evictClosedConnectionMaxConnectionsNotReached() throws Exception {
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> {
+				               Channel channel = new EmbeddedChannel(
+				                   new TestChannelId(),
+				                   Http2FrameCodecBuilder.forClient().build());
+				               return Connection.from(channel);
+				           }))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 2);
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, -1));
+
+		Connection connection = null;
+		try {
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+
+			assertThat(acquired1).isNotNull();
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			connection = acquired1.poolable();
+			ChannelId id1 = connection.channel().id();
+			CountDownLatch latch = new CountDownLatch(1);
+			connection.onDispose(latch::countDown);
+			connection.dispose();
+
+			assertThat(latch.await(1, TimeUnit.SECONDS)).as("latch await").isTrue();
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+
+			assertThat(acquired2).isNotNull();
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(2);
+			assertThat(http2Pool.connections.size()).isEqualTo(2);
+
+			connection = acquired2.poolable();
+			ChannelId id2 = connection.channel().id();
+
+			assertThat(id1).isNotEqualTo(id2);
+
+			acquired1.invalidate().block();
+			acquired2.invalidate().block();
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(0);
+			assertThat(http2Pool.connections.size()).isEqualTo(0);
+		}
+		finally {
+			if (connection != null) {
+				connection.dispose();
+			}
+		}
+	}
+
+	@Test
+	void evictClosedConnectionMaxConnectionsReached() throws Exception {
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> {
+				               Channel channel = new EmbeddedChannel(
+				                   new TestChannelId(),
+				                   Http2FrameCodecBuilder.forClient().build());
+				               return Connection.from(channel);
+				           }))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1);
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, -1));
+
+		Connection connection = null;
+		try {
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+
+			assertThat(acquired1).isNotNull();
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			connection = acquired1.poolable();
+			CountDownLatch latch = new CountDownLatch(1);
+			connection.onDispose(latch::countDown);
+			connection.dispose();
+
+			assertThat(latch.await(1, TimeUnit.SECONDS)).as("latch await").isTrue();
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			http2Pool.acquire(Duration.ofMillis(10))
+			         .as(StepVerifier::create)
+			         .expectError(PoolAcquireTimeoutException.class)
+			         .verify(Duration.ofSeconds(1));
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			acquired1.invalidate().block();
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(0);
+			assertThat(http2Pool.connections.size()).isEqualTo(0);
+		}
+		finally {
+			if (connection != null) {
+				connection.dispose();
+			}
+		}
+	}
+
+	@Test
+	void maxLifeTime() throws Exception {
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> {
+				               Channel channel = new EmbeddedChannel(
+				                   new TestChannelId(),
+				                   Http2FrameCodecBuilder.forClient().build());
+				               return Connection.from(channel);
+				           }))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1);
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, 10));
+
+		Connection connection1 = null;
+		Connection connection2 = null;
+		try {
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+
+			assertThat(acquired1).isNotNull();
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			connection1 = acquired1.poolable();
+			ChannelId id1 = connection1.channel().id();
+
+			Thread.sleep(10);
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			acquired1.invalidate().block();
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(0);
+			assertThat(http2Pool.connections.size()).isEqualTo(0);
+
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+
+			assertThat(acquired2).isNotNull();
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			connection2 = acquired2.poolable();
+			ChannelId id2 = connection2.channel().id();
+
+			assertThat(id1).isNotEqualTo(id2);
+
+			acquired2.invalidate().block();
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(0);
+			assertThat(http2Pool.connections.size()).isEqualTo(0);
+		}
+		finally {
+			if (connection1 != null) {
+				connection1.dispose();
+			}
+			if (connection2 != null) {
+				connection2.dispose();
+			}
+		}
+	}
+
+	@Test
+	void maxLifeTimeMaxConnectionsNotReached() throws Exception {
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> {
+				               Channel channel = new EmbeddedChannel(
+				                   new TestChannelId(),
+				                   Http2FrameCodecBuilder.forClient().build());
+				               return Connection.from(channel);
+				           }))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 2);
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, 10));
+
+		Connection connection1 = null;
+		Connection connection2 = null;
+		try {
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+
+			assertThat(acquired1).isNotNull();
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			connection1 = acquired1.poolable();
+			ChannelId id1 = connection1.channel().id();
+
+			Thread.sleep(10);
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+
+			assertThat(acquired2).isNotNull();
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(2);
+			assertThat(http2Pool.connections.size()).isEqualTo(2);
+
+			connection2 = acquired2.poolable();
+			ChannelId id2 = connection2.channel().id();
+
+			assertThat(id1).isNotEqualTo(id2);
+
+			acquired1.invalidate().block();
+			acquired2.invalidate().block();
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(0);
+			assertThat(http2Pool.connections.size()).isEqualTo(0);
+		}
+		finally {
+			if (connection1 != null) {
+				connection1.dispose();
+			}
+			if (connection2 != null) {
+				connection2.dispose();
+			}
+		}
+	}
+
+	@Test
+	void maxLifeTimeMaxConnectionsReached() throws Exception {
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> {
+				               Channel channel = new EmbeddedChannel(
+				                   new TestChannelId(),
+				                   Http2FrameCodecBuilder.forClient().build());
+				               return Connection.from(channel);
+				           }))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1);
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, 10));
+
+		Connection connection = null;
+		try {
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+
+			assertThat(acquired1).isNotNull();
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			connection = acquired1.poolable();
+
+			Thread.sleep(10);
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			http2Pool.acquire(Duration.ofMillis(10))
+			         .as(StepVerifier::create)
+			         .expectError(PoolAcquireTimeoutException.class)
+			         .verify(Duration.ofSeconds(1));
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+			assertThat(http2Pool.connections.size()).isEqualTo(1);
+
+			acquired1.invalidate().block();
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(0);
+			assertThat(http2Pool.connections.size()).isEqualTo(0);
+		}
+		finally {
+			if (connection != null) {
+				connection.dispose();
+			}
+		}
+	}
+
+	@Test
+	void nonHttp2ConnectionEmittedOnce() {
+		Channel channel = new EmbeddedChannel();
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.just(Connection.from(channel)))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1);
+		InstrumentedPool<Connection> http2Pool = poolBuilder.build(config -> new Http2Pool(config, -1));
+
+		try {
+			PooledRef<Connection> acquired = http2Pool.acquire().block(Duration.ofSeconds(1));
+
+			assertThat(acquired).isNotNull();
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+
+			http2Pool.acquire(Duration.ofMillis(10))
+			         .as(StepVerifier::create)
+			         .expectError(PoolAcquireTimeoutException.class)
+			         .verify(Duration.ofSeconds(1));
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(1);
+
+			acquired.invalidate().block(Duration.ofSeconds(1));
+
+			assertThat(http2Pool.metrics().acquiredSize()).isEqualTo(0);
+		}
+		finally {
+			Connection.from(channel).dispose();
+		}
+	}
+
+	static final class TestChannelId implements ChannelId {
+
+		static final Random rndm = new Random();
+		final String id;
+
+		TestChannelId() {
+			byte[] array = new byte[8];
+			rndm.nextBytes(array);
+			this.id = new String(array, StandardCharsets.UTF_8);
+		}
+
+		@Override
+		public String asShortText() {
+			return id;
+		}
+
+		@Override
+		public String asLongText() {
+			return id;
+		}
+
+		@Override
+		public int compareTo(ChannelId o) {
+			if (this == o) {
+				return 0;
+			}
+			return this.asShortText().compareTo(o.asShortText());
+		}
+	}
+}

--- a/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
@@ -287,7 +287,6 @@ class DefaultPooledConnectionProviderTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testConnectionReturnedToParentPoolWhenNoActiveStreams() throws Exception {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =


### PR DESCRIPTION
The connection is removed from the pool when:
- The connection is closed.
- The connection has reached its life time and there are no active streams.
- The connection has no active streams.
- When the client is in one of the two modes: 1) `H2` and `HTTP/1.1` or 2) `H2C` and `HTTP/1.1`,
and the negotiated protocol is `HTTP/1.1`.

The connection is filtered out when:
- The connection has reached its life time and there are active streams. In this case, the connection stays
in the pool, but it is not used. Once there are no active streams, the connection is removed from the pool.
- The connection has reached its max active streams configuration. In this case, the connection stays
in the pool, but it is not used. Once the number of the active streams is below max active streams configuration,
the connection can be used again.

This pool always invalidate the `PooledRef`, there is no release functionality.
- `PoolMetrics#acquiredSize()` and `PoolMetrics#allocatedSize()` always return the number of
the active streams from all connections currently in the pool.
- `PoolMetrics#idleSize()` always returns `0`.

Fixes #1789, #1818, #1844