### PR TITLE
Expose pending tasks of eventloops as metrics (#1398)

### DIFF
--- a/docs/asciidoc/eventloop-metrics.adoc
+++ b/docs/asciidoc/eventloop-metrics.adoc
@@ -1,0 +1,7 @@
+`EventLoop` metrics
+
+[width="100%",options="header"]
+|=======
+| metric name | type | description
+| reactor.netty.eventloop.pending.tasks | Gauge | The number of tasks that are pending for processing on an event loop
+|=======

--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -389,6 +389,8 @@ The following table provides information for the HTTP client metrics when it is 
 |=======
 
 include::alloc-metrics.adoc[]
+include::eventloop-metrics.adoc[]
+
 
 The following example enables that integration:
 

--- a/docs/asciidoc/http-server.adoc
+++ b/docs/asciidoc/http-server.adoc
@@ -571,6 +571,7 @@ The following table provides information for the HTTP server metrics:
 These additional metrics are also available:
 
 include::alloc-metrics.adoc[]
+include::eventloop-metrics.adoc[]
 
 The following example enables that integration:
 

--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -290,6 +290,7 @@ These additional metrics are also available:
 include::conn-provider-metrics.adoc[]
 
 include::alloc-metrics.adoc[]
+include::eventloop-metrics.adoc[]
 
 The following example enables that integration:
 

--- a/docs/asciidoc/tcp-server.adoc
+++ b/docs/asciidoc/tcp-server.adoc
@@ -262,6 +262,7 @@ The following table provides information for the TCP server metrics:
 These additional metrics are also available:
 
 include::alloc-metrics.adoc[]
+include::eventloop-metrics.adoc[]
 
 The following example enables that integration:
 

--- a/docs/asciidoc/udp-client.adoc
+++ b/docs/asciidoc/udp-client.adoc
@@ -218,6 +218,7 @@ The following table provides information for the UDP client metrics:
 These additional metrics are also available:
 
 include::alloc-metrics.adoc[]
+include::eventloop-metrics.adoc[]
 
 The following example enables that integration:
 

--- a/docs/asciidoc/udp-server.adoc
+++ b/docs/asciidoc/udp-server.adoc
@@ -210,6 +210,7 @@ The following table provides information for the UDP server metrics:
 These additional metrics are also available:
 
 include::alloc-metrics.adoc[]
+include::eventloop-metrics.adoc[]
 
 The following example enables that integration:
 

--- a/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
@@ -69,6 +69,12 @@ public class Metrics {
 	public static final String UDP_CLIENT_PREFIX = "reactor.netty.udp.client";
 
 	/**
+	 * Name prefix that will be used for Event Loop Group metrics
+	 * registered in Micrometer's global registry
+	 */
+	public static final String EVENT_LOOP_PREFIX = "reactor.netty.eventloop";
+
+	/**
 	 * Name prefix that will be used for the PooledConnectionProvider's metrics
 	 * registered in Micrometer's global registry
 	 */
@@ -212,6 +218,12 @@ public class Metrics {
 	 * The chunk size for an arena
 	 */
 	public static final String CHUNK_SIZE = ".chunk.size";
+
+	// EventLoop Metrics
+	/**
+	 * The number of tasks that are pending for processing on an event loop
+	 */
+	public static final String PENDING_TASKS = ".pending.tasks";
 
 
 	// Tags

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerEventLoopMeterRegistrar.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerEventLoopMeterRegistrar.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.transport;
+
+import io.micrometer.core.instrument.Gauge;
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.SingleThreadEventExecutor;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static reactor.netty.Metrics.EVENT_LOOP_PREFIX;
+import static reactor.netty.Metrics.NAME;
+import static reactor.netty.Metrics.PENDING_TASKS;
+import static reactor.netty.Metrics.REGISTRY;
+import static reactor.netty.Metrics.STATUS;
+
+/**
+ * Registers gauges for a given @{link {@link EventLoop}.
+ *
+ * Every gauge uses thread name and state as tags.
+ *
+ * @author Pierre De Rop
+ * @since 1.0.14
+ */
+public final class MicrometerEventLoopMeterRegistrar {
+
+	final static MicrometerEventLoopMeterRegistrar INSTANCE = new MicrometerEventLoopMeterRegistrar();
+
+	private final ConcurrentMap<String, EventLoop> cache = new ConcurrentHashMap<>();
+
+	private MicrometerEventLoopMeterRegistrar() {}
+
+	void registerMetrics(EventLoop eventLoop) {
+			if (eventLoop instanceof SingleThreadEventExecutor) {
+				SingleThreadEventExecutor singleThreadEventExecutor = (SingleThreadEventExecutor) eventLoop;
+
+				cache.computeIfAbsent(singleThreadEventExecutor.threadProperties().name(), key -> {
+					Gauge.builder(EVENT_LOOP_PREFIX + PENDING_TASKS, singleThreadEventExecutor::pendingTasks)
+							.description("Event loop pending scheduled tasks.")
+							.tag(NAME, singleThreadEventExecutor.threadProperties().name())
+							.tag(STATUS, singleThreadEventExecutor.threadProperties().state().name())
+							.register(REGISTRY);
+					return eventLoop;
+				});
+			}
+	}
+
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerEventLoopMeterRegistrar.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerEventLoopMeterRegistrar.java
@@ -28,9 +28,9 @@ import static reactor.netty.Metrics.PENDING_TASKS;
 import static reactor.netty.Metrics.REGISTRY;
 
 /**
- * Registers gauges for a given @{link {@link EventLoop}.
+ * Registers gauges for a given {@link EventLoop}.
  *
- * Every gauge uses thread name and state as tags.
+ * Every gauge uses thread name as tag.
  *
  * @author Pierre De Rop
  * @since 1.0.14
@@ -44,17 +44,17 @@ final class MicrometerEventLoopMeterRegistrar {
 	private MicrometerEventLoopMeterRegistrar() {}
 
 	void registerMetrics(EventLoop eventLoop) {
-			if (eventLoop instanceof SingleThreadEventExecutor) {
-				SingleThreadEventExecutor singleThreadEventExecutor = (SingleThreadEventExecutor) eventLoop;
-				String executorName = singleThreadEventExecutor.threadProperties().name();
-				cache.computeIfAbsent(executorName, key -> {
-					Gauge.builder(EVENT_LOOP_PREFIX + PENDING_TASKS, singleThreadEventExecutor::pendingTasks)
-							.description("Event loop pending scheduled tasks.")
-							.tag(NAME, executorName)
-							.register(REGISTRY);
-					return eventLoop;
-				});
-			}
+		if (eventLoop instanceof SingleThreadEventExecutor) {
+			SingleThreadEventExecutor singleThreadEventExecutor = (SingleThreadEventExecutor) eventLoop;
+			String executorName = singleThreadEventExecutor.threadProperties().name();
+			cache.computeIfAbsent(executorName, key -> {
+				Gauge.builder(EVENT_LOOP_PREFIX + PENDING_TASKS, singleThreadEventExecutor::pendingTasks)
+						.description("Event loop pending scheduled tasks.")
+						.tag(NAME, executorName)
+						.register(REGISTRY);
+				return eventLoop;
+			});
+		}
 	}
 
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerEventLoopMeterRegistrar.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerEventLoopMeterRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import static reactor.netty.Metrics.EVENT_LOOP_PREFIX;
 import static reactor.netty.Metrics.NAME;
 import static reactor.netty.Metrics.PENDING_TASKS;
 import static reactor.netty.Metrics.REGISTRY;
-import static reactor.netty.Metrics.STATUS;
 
 /**
  * Registers gauges for a given @{link {@link EventLoop}.
@@ -36,7 +35,7 @@ import static reactor.netty.Metrics.STATUS;
  * @author Pierre De Rop
  * @since 1.0.14
  */
-public final class MicrometerEventLoopMeterRegistrar {
+final class MicrometerEventLoopMeterRegistrar {
 
 	final static MicrometerEventLoopMeterRegistrar INSTANCE = new MicrometerEventLoopMeterRegistrar();
 
@@ -47,12 +46,11 @@ public final class MicrometerEventLoopMeterRegistrar {
 	void registerMetrics(EventLoop eventLoop) {
 			if (eventLoop instanceof SingleThreadEventExecutor) {
 				SingleThreadEventExecutor singleThreadEventExecutor = (SingleThreadEventExecutor) eventLoop;
-
-				cache.computeIfAbsent(singleThreadEventExecutor.threadProperties().name(), key -> {
+				String executorName = singleThreadEventExecutor.threadProperties().name();
+				cache.computeIfAbsent(executorName, key -> {
 					Gauge.builder(EVENT_LOOP_PREFIX + PENDING_TASKS, singleThreadEventExecutor::pendingTasks)
 							.description("Event loop pending scheduled tasks.")
-							.tag(NAME, singleThreadEventExecutor.threadProperties().name())
-							.tag(STATUS, singleThreadEventExecutor.threadProperties().state().name())
+							.tag(NAME, executorName)
 							.register(REGISTRY);
 					return eventLoop;
 				});

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
@@ -383,6 +383,8 @@ public abstract class TransportConfig {
 					else if (alloc instanceof UnpooledByteBufAllocator) {
 						ByteBufAllocatorMetrics.INSTANCE.registerMetrics("unpooled", ((UnpooledByteBufAllocator) alloc).metric());
 					}
+
+					MicrometerEventLoopMeterRegistrar.INSTANCE.registerMetrics(channel.eventLoop());
 				}
 			}
 

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/TransportEventLoopMetricsTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/TransportEventLoopMetricsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.transport;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.SingleThreadEventExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.netty.Connection;
+import reactor.netty.DisposableServer;
+import reactor.netty.tcp.TcpClient;
+import reactor.netty.tcp.TcpServer;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.netty.Metrics.EVENT_LOOP_PREFIX;
+import static reactor.netty.Metrics.NAME;
+import static reactor.netty.Metrics.PENDING_TASKS;
+import static reactor.netty.Metrics.STATUS;
+
+class TransportEventLoopMetricsTest {
+
+	private MeterRegistry registry;
+
+	@BeforeEach
+	void setUp() {
+		registry = new SimpleMeterRegistry();
+		Metrics.addRegistry(registry);
+	}
+
+	@AfterEach
+	void tearDown() {
+		Metrics.removeRegistry(registry);
+		registry.clear();
+		registry.close();
+	}
+
+	@Test
+	void testEventLoopMetrics() throws InterruptedException {
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		DisposableServer server = TcpServer.create()
+				.port(0)
+				.metrics(true)
+				.doOnConnection(c -> {
+					EventLoop eventLoop = c.channel().eventLoop();
+					IntStream.range(0, 10).forEach(i -> eventLoop.execute(() -> {}));
+					if (eventLoop instanceof SingleThreadEventExecutor) {
+						SingleThreadEventExecutor singleThreadEventExecutor = (SingleThreadEventExecutor) eventLoop;
+						String[] tags = new String[]{
+								NAME, singleThreadEventExecutor.threadProperties().name(),
+								STATUS, singleThreadEventExecutor.threadProperties().state().name()
+						};
+						assertThat(getGaugeValue(EVENT_LOOP_PREFIX + PENDING_TASKS, tags)).isEqualTo(10);
+						latch.countDown();
+					}
+				})
+				.wiretap(true)
+				.bindNow();
+
+		assertThat(server).isNotNull();
+
+		Connection client = TcpClient.create()
+				.port(server.port())
+				.wiretap(true)
+				.connectNow();
+
+		assertThat(client).isNotNull();
+		assertThat(latch.await(5, TimeUnit.SECONDS)).as("Did not find 10 pending tasks from meter").isTrue();
+
+		client.disposeNow();
+		server.disposeNow();
+	}
+
+	private double getGaugeValue(String name, String... tags) {
+		Gauge gauge = registry.find(name).tags(tags).gauge();
+		double result = -1;
+		if (gauge != null) {
+			result = gauge.value();
+		}
+		return result;
+	}
+
+}


### PR DESCRIPTION
this PR adds a metric for the pending tasks scheduled in netty event loops.

Fixes #1398