### PR TITLE
[build] Switch from `adopt` to `temurin` as used java distribution

### DIFF
--- a/.github/workflows/check_netty_snapshots.yml
+++ b/.github/workflows/check_netty_snapshots.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
       - name: Build with Gradle
         run: ./gradlew clean check --no-daemon -PforceTransport=${{ matrix.transport }} -PforceNettyVersion='4.1.73.Final-SNAPSHOT'

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
       - name: Check License
         run: ./gradlew clean spotlessCheck -PspotlessFrom='origin/${{ github.base_ref }}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: setup java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
       - name: interpret version
         id: version
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
       - name: deploy
         env:
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
       - name: deploy
         env:
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
       - name: deploy
         env:


### PR DESCRIPTION
According to
https://github.com/actions/setup-java#supported-distributions

```
NOTE: Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore.
It is highly recommended to migrate workflows from adopt to temurin to keep receiving
software and security updates. See more details in the Good-bye AdoptOpenJDK post.
```