### PR TITLE
Simplify the pre-screen for ConcurrentHashMap#computeIfAbsent

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.noop.NoopMeter;
+import reactor.netty.internal.util.MapUtils;
 import reactor.util.annotation.Nullable;
 
 import java.net.SocketAddress;
@@ -76,8 +77,7 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 	@Override
 	public void recordDataReceived(SocketAddress remoteAddress, long bytes) {
 		String address = reactor.netty.Metrics.formatSocketAddress(remoteAddress);
-		DistributionSummary ds = dataReceivedCache.get(address);
-		ds = ds != null ? ds : dataReceivedCache.computeIfAbsent(address,
+		DistributionSummary ds = MapUtils.computeIfAbsent(dataReceivedCache, address,
 				key -> filter(DistributionSummary.builder(name + DATA_RECEIVED)
 				                                 .baseUnit(BYTES_UNIT)
 				                                 .description(DATA_RECEIVED_DESCRIPTION)
@@ -91,8 +91,7 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 	@Override
 	public void recordDataSent(SocketAddress remoteAddress, long bytes) {
 		String address = reactor.netty.Metrics.formatSocketAddress(remoteAddress);
-		DistributionSummary ds = dataSentCache.get(address);
-		ds = ds != null ? ds : dataSentCache.computeIfAbsent(address,
+		DistributionSummary ds = MapUtils.computeIfAbsent(dataSentCache, address,
 				key -> filter(DistributionSummary.builder(name + DATA_SENT)
 				                                 .baseUnit(BYTES_UNIT)
 				                                 .description(DATA_SENT_DESCRIPTION)
@@ -106,8 +105,7 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 	@Override
 	public void incrementErrorsCount(SocketAddress remoteAddress) {
 		String address = reactor.netty.Metrics.formatSocketAddress(remoteAddress);
-		Counter c = errorsCache.get(address);
-		c = c != null ? c : errorsCache.computeIfAbsent(address,
+		Counter c = MapUtils.computeIfAbsent(errorsCache, address,
 				key -> filter(Counter.builder(name + ERRORS)
 				                     .description(ERRORS_DESCRIPTION)
 				                     .tags(URI, protocol, REMOTE_ADDRESS, address)
@@ -121,8 +119,7 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 	public void recordTlsHandshakeTime(SocketAddress remoteAddress, Duration time, String status) {
 		String address = reactor.netty.Metrics.formatSocketAddress(remoteAddress);
 		MeterKey meterKey = new MeterKey(null, address, null, status);
-		Timer timer = tlsHandshakeTimeCache.get(meterKey);
-		timer = timer != null ? timer : tlsHandshakeTimeCache.computeIfAbsent(meterKey,
+		Timer timer = MapUtils.computeIfAbsent(tlsHandshakeTimeCache, meterKey,
 				key -> filter(Timer.builder(name + TLS_HANDSHAKE_TIME)
 				                   .description(TLS_HANDSHAKE_TIME_DESCRIPTION)
 				                   .tags(REMOTE_ADDRESS, address, STATUS, status)
@@ -136,8 +133,7 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 	public void recordConnectTime(SocketAddress remoteAddress, Duration time, String status) {
 		String address = reactor.netty.Metrics.formatSocketAddress(remoteAddress);
 		MeterKey meterKey = new MeterKey(null, address, null, status);
-		Timer timer = connectTimeCache.get(meterKey);
-		timer = timer != null ? timer : connectTimeCache.computeIfAbsent(meterKey,
+		Timer timer = MapUtils.computeIfAbsent(connectTimeCache, meterKey,
 				key -> filter(Timer.builder(name + CONNECT_TIME)
 				                   .description(CONNECT_TIME_DESCRIPTION)
 				                   .tags(REMOTE_ADDRESS, address, STATUS, status)
@@ -151,8 +147,7 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 	public void recordResolveAddressTime(SocketAddress remoteAddress, Duration time, String status) {
 		String address = reactor.netty.Metrics.formatSocketAddress(remoteAddress);
 		MeterKey meterKey = new MeterKey(null, address, null, status);
-		Timer timer = addressResolverTimeCache.get(meterKey);
-		timer = timer != null ? timer : addressResolverTimeCache.computeIfAbsent(meterKey,
+		Timer timer = MapUtils.computeIfAbsent(addressResolverTimeCache, meterKey,
 				key -> filter(Timer.builder(name + ADDRESS_RESOLVER)
 				                   .description(ADDRESS_RESOLVER_TIME_DESCRIPTION)
 				                   .tags(REMOTE_ADDRESS, address, STATUS, status)

--- a/reactor-netty-core/src/main/java/reactor/netty/internal/util/MapUtils.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/internal/util/MapUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.internal.util;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * It's a temporary workaround for Java 8 specific performance issue JDK-8161372
+ * and this class should be removed once the Java 8 support is dropped.
+ * <p><strong>Note:</strong> This utility class is for internal use only. It can be removed at any time.
+ *
+ * @author zimatars
+ */
+public class MapUtils {
+
+	/**
+	 * ConcurrentHashMap.computeIfAbsent(k,v) locks bin when k present.
+	 * Add pre-screen before locking inside computeIfAbsent.
+	 * <p><strong>Note:</strong> This utility is not for a general purpose usage.
+	 * Carefully consider the removal operations from the map.
+	 * If you have many remove operations that are critical, do not use this pre-screening.
+	 *
+	 * @param map the ConcurrentHashMap instance
+	 * @param key key with which the specified value is to be associated
+	 * @param mappingFunction the function to compute a value
+	 * @return the current (existing or computed) value associated with
+	 *         the specified key, or null if the computed value is null
+	 */
+	public static <K, V> V computeIfAbsent(Map<K, V> map, K key, Function<K, V> mappingFunction) {
+		V value = map.get(key);
+		return value != null ? value : map.computeIfAbsent(key, mappingFunction);
+	}
+
+	private MapUtils() {
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/internal/util/MapUtils.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/internal/util/MapUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -27,6 +27,7 @@ import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
 import reactor.netty.ReactorNetty;
 import reactor.netty.transport.TransportConfig;
+import reactor.netty.internal.util.MapUtils;
 import reactor.pool.AllocationStrategy;
 import reactor.pool.InstrumentedPool;
 import reactor.pool.Pool;
@@ -115,8 +116,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 			SocketAddress remoteAddress = Objects.requireNonNull(remote.get(), "Remote Address supplier returned null");
 			PoolKey holder = new PoolKey(remoteAddress, config.channelHash());
 			PoolFactory<T> poolFactory = poolFactory(remoteAddress);
-			InstrumentedPool<T> pool = channelPools.get(holder);
-			pool = pool != null ? pool : channelPools.computeIfAbsent(holder, poolKey -> {
+			InstrumentedPool<T> pool = MapUtils.computeIfAbsent(channelPools, holder, poolKey -> {
 				if (log.isDebugEnabled()) {
 					log.debug("Creating a new [{}] client pool [{}] for [{}]", name, poolFactory, remoteAddress);
 				}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/AddressResolverGroupMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/AddressResolverGroupMetrics.java
@@ -21,6 +21,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import reactor.netty.channel.ChannelMetricsRecorder;
+import reactor.netty.internal.util.MapUtils;
 
 import java.net.SocketAddress;
 import java.time.Duration;
@@ -42,9 +43,7 @@ final class AddressResolverGroupMetrics<T extends SocketAddress> extends Address
 
 	static AddressResolverGroupMetrics<?> getOrCreate(
 			AddressResolverGroup<?> resolverGroup, ChannelMetricsRecorder recorder) {
-		int hash = Objects.hash(resolverGroup, recorder);
-		AddressResolverGroupMetrics<?> resolverGroupMetrics = cache.get(hash);
-		return resolverGroupMetrics != null ? resolverGroupMetrics : cache.computeIfAbsent(hash,
+		return MapUtils.computeIfAbsent(cache, Objects.hash(resolverGroup, recorder),
 				key -> new AddressResolverGroupMetrics<>(resolverGroup, recorder));
 	}
 

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMetrics.java
@@ -18,6 +18,7 @@ package reactor.netty.transport;
 import io.micrometer.core.instrument.Gauge;
 import io.netty.buffer.ByteBufAllocatorMetric;
 import io.netty.buffer.PooledByteBufAllocatorMetric;
+import reactor.netty.internal.util.MapUtils;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -57,12 +58,7 @@ final class ByteBufAllocatorMetrics {
 	}
 
 	void registerMetrics(String allocType, ByteBufAllocatorMetric metrics) {
-		String hash = metrics.hashCode() + "";
-		ByteBufAllocatorMetric cachedMetrics = cache.get(hash);
-		if (cachedMetrics != null) {
-			return;
-		}
-		cache.computeIfAbsent(hash, key -> {
+		MapUtils.computeIfAbsent(cache, metrics.hashCode() + "", key -> {
 			String[] tags = new String[] {ID, key, TYPE, allocType};
 
 			Gauge.builder(BYTE_BUF_ALLOCATOR_PREFIX + USED_HEAP_MEMORY, metrics, ByteBufAllocatorMetric::usedHeapMemory)

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
@@ -37,6 +37,7 @@ import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
 import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.resources.LoopResources;
+import reactor.netty.internal.util.MapUtils;
 import reactor.util.annotation.Nullable;
 
 /**
@@ -235,9 +236,7 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 			NameResolverProvider nameResolverProvider,
 			LoopResources loopResources,
 			boolean preferNative) {
-		int hash = Objects.hash(nameResolverProvider, loopResources, preferNative);
-		DnsAddressResolverGroup resolverGroup = RESOLVERS_CACHE.get(hash);
-		return resolverGroup != null ? resolverGroup : RESOLVERS_CACHE.computeIfAbsent(hash,
+		return MapUtils.computeIfAbsent(RESOLVERS_CACHE, Objects.hash(nameResolverProvider, loopResources, preferNative),
 				key -> nameResolverProvider.newNameResolverGroup(loopResources, preferNative));
 	}
 

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerEventLoopMeterRegistrar.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerEventLoopMeterRegistrar.java
@@ -18,6 +18,7 @@ package reactor.netty.transport;
 import io.micrometer.core.instrument.Gauge;
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
+import reactor.netty.internal.util.MapUtils;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -48,11 +49,7 @@ final class MicrometerEventLoopMeterRegistrar {
 		if (eventLoop instanceof SingleThreadEventExecutor) {
 			SingleThreadEventExecutor singleThreadEventExecutor = (SingleThreadEventExecutor) eventLoop;
 			String executorName = singleThreadEventExecutor.threadProperties().name();
-			EventLoop executor = cache.get(executorName);
-			if (executor != null) {
-				return;
-			}
-			cache.computeIfAbsent(executorName, key -> {
+			MapUtils.computeIfAbsent(cache, executorName, key -> {
 				Gauge.builder(EVENT_LOOP_PREFIX + PENDING_TASKS, singleThreadEventExecutor::pendingTasks)
 				     .description(PENDING_TASKS_DESCRIPTION)
 				     .tag(NAME, executorName)

--- a/reactor-netty-http/src/main/java/reactor/netty/http/MicrometerHttpMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/MicrometerHttpMetricsRecorder.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.Timer;
 import reactor.netty.Metrics;
 import reactor.netty.channel.MeterKey;
 import reactor.netty.channel.MicrometerChannelMetricsRecorder;
+import reactor.netty.internal.util.MapUtils;
 
 import java.net.SocketAddress;
 import java.util.concurrent.ConcurrentHashMap;
@@ -64,8 +65,7 @@ public class MicrometerHttpMetricsRecorder extends MicrometerChannelMetricsRecor
 	public void recordDataReceived(SocketAddress remoteAddress, String uri, long bytes) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
 		MeterKey meterKey = new MeterKey(uri, address, null, null);
-		DistributionSummary dataReceived = dataReceivedCache.get(meterKey);
-		dataReceived = dataReceived != null ? dataReceived : dataReceivedCache.computeIfAbsent(meterKey,
+		DistributionSummary dataReceived = MapUtils.computeIfAbsent(dataReceivedCache, meterKey,
 				key -> filter(DistributionSummary.builder(name() + DATA_RECEIVED)
 				                                 .baseUnit(BYTES_UNIT)
 				                                 .description(DATA_RECEIVED_DESCRIPTION)
@@ -80,8 +80,7 @@ public class MicrometerHttpMetricsRecorder extends MicrometerChannelMetricsRecor
 	public void recordDataSent(SocketAddress remoteAddress, String uri, long bytes) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
 		MeterKey meterKey = new MeterKey(uri, address, null, null);
-		DistributionSummary dataSent = dataSentCache.get(meterKey);
-		dataSent = dataSent != null ? dataSent : dataSentCache.computeIfAbsent(meterKey,
+		DistributionSummary dataSent = MapUtils.computeIfAbsent(dataSentCache, meterKey,
 				key -> filter(DistributionSummary.builder(name() + DATA_SENT)
 				                                 .baseUnit(BYTES_UNIT)
 				                                 .description(DATA_SENT_DESCRIPTION)
@@ -96,8 +95,7 @@ public class MicrometerHttpMetricsRecorder extends MicrometerChannelMetricsRecor
 	public void incrementErrorsCount(SocketAddress remoteAddress, String uri) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
 		MeterKey meterKey = new MeterKey(uri, address, null, null);
-		Counter errors = errorsCache.get(meterKey);
-		errors = errors != null ? errors : errorsCache.computeIfAbsent(meterKey,
+		Counter errors = MapUtils.computeIfAbsent(errorsCache, meterKey,
 				key -> filter(Counter.builder(name() + ERRORS)
 				                     .description(ERRORS_DESCRIPTION)
 				                     .tags(REMOTE_ADDRESS, address, URI, uri)

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.Timer;
 import reactor.netty.Metrics;
 import reactor.netty.channel.MeterKey;
 import reactor.netty.http.MicrometerHttpMetricsRecorder;
+import reactor.netty.internal.util.MapUtils;
 
 import java.net.SocketAddress;
 import java.time.Duration;
@@ -49,8 +50,7 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 	public void recordDataReceivedTime(SocketAddress remoteAddress, String uri, String method, String status, Duration time) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
 		MeterKey meterKey = new MeterKey(uri, address, method, status);
-		Timer dataReceivedTime = dataReceivedTimeCache.get(meterKey);
-		dataReceivedTime = dataReceivedTime != null ? dataReceivedTime : dataReceivedTimeCache.computeIfAbsent(meterKey,
+		Timer dataReceivedTime = MapUtils.computeIfAbsent(dataReceivedTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_RECEIVED_TIME)
 				                   .description(DATA_RECEIVED_TIME_DESCRIPTION)
 				                   .tags(REMOTE_ADDRESS, address, URI, uri, METHOD, method, STATUS, status)
@@ -64,8 +64,7 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 	public void recordDataSentTime(SocketAddress remoteAddress, String uri, String method, Duration time) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
 		MeterKey meterKey = new MeterKey(uri, address, method, null);
-		Timer dataSentTime = dataSentTimeCache.get(meterKey);
-		dataSentTime = dataSentTime != null ? dataSentTime : dataSentTimeCache.computeIfAbsent(meterKey,
+		Timer dataSentTime = MapUtils.computeIfAbsent(dataSentTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_SENT_TIME)
 				                   .description(DATA_SENT_TIME_DESCRIPTION)
 				                   .tags(REMOTE_ADDRESS, address, URI, uri, METHOD, method)
@@ -79,8 +78,7 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 	public void recordResponseTime(SocketAddress remoteAddress, String uri, String method, String status, Duration time) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
 		MeterKey meterKey = new MeterKey(uri, address, method, status);
-		Timer responseTime = responseTimeCache.get(meterKey);
-		responseTime = responseTime != null ? responseTime : responseTimeCache.computeIfAbsent(meterKey,
+		Timer responseTime = MapUtils.computeIfAbsent(responseTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + RESPONSE_TIME)
 				                   .description(RESPONSE_TIME_DESCRIPTION)
 				                   .tags(REMOTE_ADDRESS, address, URI, uri, METHOD, method, STATUS, status)

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsRecorder.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Timer;
 import reactor.netty.channel.MeterKey;
 import reactor.netty.http.MicrometerHttpMetricsRecorder;
+import reactor.netty.internal.util.MapUtils;
 
 import java.net.SocketAddress;
 import java.time.Duration;
@@ -51,8 +52,7 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 	@Override
 	public void recordDataReceivedTime(String uri, String method, Duration time) {
 		MeterKey meterKey = new MeterKey(uri, null, method, null);
-		Timer dataReceivedTime = dataReceivedTimeCache.get(meterKey);
-		dataReceivedTime = dataReceivedTime != null ? dataReceivedTime : dataReceivedTimeCache.computeIfAbsent(meterKey,
+		Timer dataReceivedTime = MapUtils.computeIfAbsent(dataReceivedTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_RECEIVED_TIME)
 				                   .description(DATA_RECEIVED_TIME_DESCRIPTION)
 				                   .tags(URI, uri, METHOD, method)
@@ -65,8 +65,7 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 	@Override
 	public void recordDataSentTime(String uri, String method, String status, Duration time) {
 		MeterKey meterKey = new MeterKey(uri, null, method, status);
-		Timer dataSentTime = dataSentTimeCache.get(meterKey);
-		dataSentTime = dataSentTime != null ? dataSentTime : dataSentTimeCache.computeIfAbsent(meterKey,
+		Timer dataSentTime = MapUtils.computeIfAbsent(dataSentTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_SENT_TIME)
 				                   .description(DATA_SENT_TIME_DESCRIPTION)
 				                   .tags(URI, uri, METHOD, method, STATUS, status)
@@ -79,8 +78,7 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 	@Override
 	public void recordResponseTime(String uri, String method, String status, Duration time) {
 		MeterKey meterKey = new MeterKey(uri, null, method, status);
-		Timer responseTime = responseTimeCache.get(meterKey);
-		responseTime = responseTime != null ? responseTime : responseTimeCache.computeIfAbsent(meterKey,
+		Timer responseTime = MapUtils.computeIfAbsent(responseTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + RESPONSE_TIME)
 				                   .description(RESPONSE_TIME_DESCRIPTION)
 				                   .tags(URI, uri, METHOD, method, STATUS, status)
@@ -93,8 +91,7 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 	@Override
 	public void recordDataReceived(SocketAddress remoteAddress, String uri, long bytes) {
 		MeterKey meterKey = new MeterKey(uri, null, null, null);
-		DistributionSummary dataReceived = dataReceivedCache.get(meterKey);
-		dataReceived = dataReceived != null ? dataReceived : dataReceivedCache.computeIfAbsent(meterKey,
+		DistributionSummary dataReceived = MapUtils.computeIfAbsent(dataReceivedCache, meterKey,
 				key -> filter(DistributionSummary.builder(name() + DATA_RECEIVED)
 				                                 .baseUnit(BYTES_UNIT)
 				                                 .description(DATA_RECEIVED_DESCRIPTION).tags(URI, uri)
@@ -107,8 +104,7 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 	@Override
 	public void recordDataSent(SocketAddress remoteAddress, String uri, long bytes) {
 		MeterKey meterKey = new MeterKey(uri, null, null, null);
-		DistributionSummary dataSent = dataSentCache.get(meterKey);
-		dataSent = dataSent != null ? dataSent : dataSentCache.computeIfAbsent(meterKey,
+		DistributionSummary dataSent = MapUtils.computeIfAbsent(dataSentCache, meterKey,
 				key -> filter(DistributionSummary.builder(name() + DATA_SENT)
 				                                 .baseUnit(BYTES_UNIT)
 				                                 .description(DATA_SENT_DESCRIPTION)
@@ -122,8 +118,7 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 	@Override
 	public void incrementErrorsCount(SocketAddress remoteAddress, String uri) {
 		MeterKey meterKey = new MeterKey(uri, null, null, null);
-		Counter errors = errorsCache.get(meterKey);
-		errors = errors != null ? errors : errorsCache.computeIfAbsent(meterKey,
+		Counter errors = MapUtils.computeIfAbsent(errorsCache, meterKey,
 				key -> filter(Counter.builder(name() + ERRORS)
 				                     .description(ERRORS_DESCRIPTION)
 				                     .tags(URI, uri)


### PR DESCRIPTION
Simplify the pre-screen for ConcurrentHashMap#computeIfAbsent, and provide MapUtils as a temporary workaround for Java 8 specific performance issue [JDK-8161372](https://bugs.openjdk.java.net/browse/JDK-8161372).
Related to PR #1930 #1950 