### PR TITLE
Additional read operation is needed when websocket handshake

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketClientOperations.java
@@ -114,6 +114,8 @@ final class WebsocketClientOperations extends HttpClientOperations
 			if (notRedirected(response)) {
 				try {
 					handshaker.finishHandshake(channel(), response);
+					// This change is needed after the Netty change https://github.com/netty/netty/pull/11966
+					ctx.read();
 					listener().onStateChange(this, HttpClientState.RESPONSE_RECEIVED);
 				}
 				catch (Exception e) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
@@ -120,6 +120,8 @@ final class WebsocketServerOperations extends HttpServerOperations
 			          .addListener(f -> {
 			              if (replaced.rebind(this)) {
 			                  markPersistent(false);
+			                  // This change is needed after the Netty change https://github.com/netty/netty/pull/11966
+			                  channel.read();
 			              }
 			              else {
 			                  log.debug(format(channel, "Cannot bind WebsocketServerOperations after the handshake."));


### PR DESCRIPTION
Additional read operations are needed on the server and the client when websocket handshake
is performed, this is a result of behaviour change in Netty https://github.com/netty/netty/pull/11966