### PR TITLE
[build] Hardening of GitHub actions

### DIFF
--- a/.github/workflows/check_netty_snapshots.yml
+++ b/.github/workflows/check_netty_snapshots.yml
@@ -3,7 +3,7 @@ name: Check Netty SNAPSHOTS
 on:
   schedule:
     - cron: "0 14 * * *"
-
+permissions: read-all
 jobs:
   build:
 

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -2,7 +2,7 @@ name: Check Matrix
 
 on:
   pull_request: {}
-
+permissions: read-all
 jobs:
   build:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,10 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
 
+    permissions:
+      # required for all workflows
+      security-events: write
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ on:
     branches: [ main ]
   schedule:
     - cron: '0 12 * * 6'
-
+permissions: read-all
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: # For branches, better to list them explicitly than regexp include
       - main
+permissions: read-all
 jobs:
   # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push
   # We specify the ubuntu version to minimize the chances we have to deal with a migration during a release
@@ -72,12 +73,6 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{secrets.SIGNING_PASSPHRASE}}
         run: |
           ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-milestone-local
-      - name: tag
-        run: |
-          git config --local user.name 'reactorbot'
-          git config --local user.email '32325210+reactorbot@users.noreply.github.com'
-          git tag -m "Release milestone ${{ needs.prepare.outputs.fullVersion }}" v${{ needs.prepare.outputs.fullVersion }} ${{ github.sha }}
-          git push --tags
 
   #sign the release artifacts and deploy them to Artifactory
   deployRelease:
@@ -102,6 +97,30 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{secrets.SONATYPE_PASSWORD}}
         run: |
           ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io  -Partifactory_publish_repoKey=libs-release-local publishMavenJavaPublicationToSonatypeRepository
+
+  tagMilestone:
+    name: Tag milestone
+    needs: [ prepare, deployMilestone ]
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: tag
+        run: |
+          git config --local user.name 'reactorbot'
+          git config --local user.email '32325210+reactorbot@users.noreply.github.com'
+          git tag -m "Release milestone ${{ needs.prepare.outputs.fullVersion }}" v${{ needs.prepare.outputs.fullVersion }} ${{ github.sha }}
+          git push --tags
+
+  tagRelease:
+    name: Tag release
+    needs: [ prepare, deployRelease ]
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
       - name: tag
         run: |
           git config --local user.name 'reactorbot'


### PR DESCRIPTION
This commit makes several modifications to our workflows to make them
more secure:

- explicitly have GITHUB_TOKEN read-only by default
- split tagging steps in their own jobs, limiting the scope of needed
write permission to these short-lived jobs