### PR TITLE
[doc] Separate connection pool documentation

### DIFF
--- a/docs/asciidoc/http-client-conn-provider.adoc
+++ b/docs/asciidoc/http-client-conn-provider.adoc
@@ -1,5 +1,5 @@
 == Connection Pool
-By default, Reactor Netty client uses a "`fixed`" connection pool with `500` as the maximum number of active channels
+By default, `HttpClient` uses a "`fixed`" connection pool with `500` as the maximum number of active channels
 and `1000` as the maximum number of further channel acquisition attempts allowed to be kept in a pending state
 (for the rest of the configurations check the system properties or the builder configurations below).
 This means that the implementation creates a new channel if someone tries to acquire a channel

--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -277,7 +277,7 @@ See <<tcp-client>> for more about `TCP` level configurations.
 
 include::wire-logger.adoc[]
 
-include::conn-provider.adoc[]
+include::http-client-conn-provider.adoc[]
 
 == SSL and TLS
 When you need SSL or TLS, you can apply the configuration shown in the next example.

--- a/docs/asciidoc/tcp-client-conn-provider.adoc
+++ b/docs/asciidoc/tcp-client-conn-provider.adoc
@@ -1,0 +1,85 @@
+== Connection Pool
+By default, `TcpClient` uses a "`fixed`" connection pool with `500` as the maximum number of active channels
+and `1000` as the maximum number of further channel acquisition attempts allowed to be kept in a pending state
+(for the rest of the configurations check the system properties or the builder configurations below).
+This means that the implementation creates a new channel if someone tries to acquire a channel
+as long as less than `500` have been created and are managed by the pool.
+When the maximum number of channels in the pool is reached, up to `1000` new attempts to
+acquire a channel are delayed (pending) until a channel is closed (and thus a slot is free and a new connection can be opened),
+and further attempts are declined with an error.
+
+NOTE: Connections used by the `TcpClient` are never returned to the pool, but closed. When a connection is closed, a slot is freed
+in the pool and thus a new connection can be opened when needed. This behaviour is specific only for `TcpClient`
+and is intentional because only the user/framework knows if the actual protocol is compatible with reusing connections.
+(opposed to `HttpClient` where the protocol is known and Reactor Netty can return the connection to the pool when this is possible)
+
+====
+[source,java,indent=0]
+../../../reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java
+----
+include::./../../reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java[lines=117..127]
+----
+====
+
+When you need to change the default settings, you can configure the `ConnectionProvider` as follows:
+
+====
+[source,java,indent=0]
+.{examplesdir}/pool/config/Application.java
+----
+include::{examplesdir}/pool/config/Application.java[lines=18..41]
+----
+<1> Configures the maximum time for the pending acquire operation to 60 seconds.
+====
+
+The following listing shows the available configurations:
+[width="100%",options="header"]
+|=======
+| Configuration name | Description
+| `disposeInactivePoolsInBackground` | When this option is enabled, connection pools are regularly checked in the background,
+and those that are empty and been inactive for a specified time become eligible for disposal. By default, this background
+disposal of inactive pools is disabled.
+| `disposeTimeout` | When `ConnectionProvider#dispose()` or `ConnectionProvider#disposeLater()` is called,
+trigger a graceful shutdown for the connection pools, with this grace period timeout.
+From there on, all calls for acquiring a connection will fail fast with an exception.
+However, for the provided `Duration`, pending acquires will get a chance to be served.
+Note: The rejection of new acquires and the grace timer start immediately,
+irrespective of subscription to the `Mono` returned by `ConnectionProvider#disposeLater()`.
+Subsequent calls return the same `Mono`, effectively getting notifications from the first graceful
+shutdown call and ignoring subsequently provided timeouts. By default, dispose timeout is not specified.
+| `maxConnections` | The maximum number of connections (per connection pool) before start pending. Default to
+2 * available number of processors (but with a minimum value of 16).
+| `metrics` | Enables/disables built-in integration with Micrometer. `ConnectionProvider.MeterRegistrar` can be provided
+for integration with another metrics system. By default, metrics are not enabled.
+| `pendingAcquireMaxCount` | The maximum number of extra attempts at acquiring a connection to keep in a pending queue.
+If -1 is specified, the pending queue does not have upper limit. Default to 2 * max connections.
+| `pendingAcquireTimeout` | The maximum time before which a pending acquire must complete, or a TimeoutException is
+thrown (resolution: ms). If -1 is specified, no such timeout is applied. Default: 45 seconds.
+|=======
+
+If you need to disable the connection pool, you can apply the following configuration:
+
+====
+[source,java,indent=0]
+.{examplesdir}/pool/Application.java
+----
+include::{examplesdir}/pool/Application.java[lines=18..35]
+----
+====
+
+=== Metrics
+The pooled `ConnectionProvider` supports built-in integration with https://micrometer.io/[`Micrometer`].
+It exposes all metrics with a prefix of `reactor.netty.connection.provider`.
+
+include::conn-provider-metrics.adoc[]
+
+The following example enables that integration:
+
+====
+[source,java,indent=0]
+.{examplesdir}/pool/metrics/Application.java
+----
+include::{examplesdir}/pool/metrics/Application.java[lines=18..45]
+----
+<1> Enables the built-in integration with Micrometer
+====

--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -231,7 +231,7 @@ include::{examplesdir}/eventloop/Application.java[lines=18..37]
 ----
 ====
 
-include::conn-provider.adoc[]
+include::tcp-client-conn-provider.adoc[]
 
 == SSL and TLS
 

--- a/reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,10 +127,14 @@ public final class ReactorNetty {
 	public static final String POOL_ACQUIRE_TIMEOUT = "reactor.netty.pool.acquireTimeout";
 	/**
 	 * Default max idle time, fallback - max idle time is not specified.
+	 * <p><strong>Note:</strong> This configuration is not applicable for {@link reactor.netty.tcp.TcpClient}.
+	 * A TCP connection is always closed and never returned to the pool.
 	 */
 	public static final String POOL_MAX_IDLE_TIME = "reactor.netty.pool.maxIdleTime";
 	/**
 	 * Default max life time, fallback - max life time is not specified.
+	 * <p><strong>Note:</strong> This configuration is not applicable for {@link reactor.netty.tcp.TcpClient}.
+	 * A TCP connection is always closed and never returned to the pool.
 	 */
 	public static final String POOL_MAX_LIFE_TIME = "reactor.netty.pool.maxLifeTime";
 	/**
@@ -139,6 +143,8 @@ public final class ReactorNetty {
 	 *     <li>fifo - The connection selection is first in, first out</li>
 	 *     <li>lifo - The connection selection is last in, first out</li>
 	 * </ul>
+	 * <p><strong>Note:</strong> This configuration is not applicable for {@link reactor.netty.tcp.TcpClient}.
+	 * A TCP connection is always closed and never returned to the pool.
 	 */
 	public static final String POOL_LEASING_STRATEGY = "reactor.netty.pool.leasingStrategy";
 	/**

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -464,6 +464,8 @@ public interface ConnectionProvider extends Disposable {
 		/**
 		 * Set the options to use for configuring {@link ConnectionProvider} max idle time (resolution: ms).
 		 * Default to {@link #DEFAULT_POOL_MAX_IDLE_TIME} if specified otherwise - no max idle time.
+		 * <p><strong>Note:</strong> This configuration is not applicable for {@link reactor.netty.tcp.TcpClient}.
+		 * A TCP connection is always closed and never returned to the pool.
 		 *
 		 * @param maxIdleTime the {@link Duration} after which the channel will be closed when idle (resolution: ms)
 		 * @return {@literal this}
@@ -477,6 +479,8 @@ public interface ConnectionProvider extends Disposable {
 		/**
 		 * Set the options to use for configuring {@link ConnectionProvider} max life time (resolution: ms).
 		 * Default to {@link #DEFAULT_POOL_MAX_LIFE_TIME} if specified otherwise - no max life time.
+		 * <p><strong>Note:</strong> This configuration is not applicable for {@link reactor.netty.tcp.TcpClient}.
+		 * A TCP connection is always closed and never returned to the pool.
 		 *
 		 * @param maxLifeTime the {@link Duration} after which the channel will be closed (resolution: ms)
 		 * @return {@literal this}
@@ -535,6 +539,8 @@ public interface ConnectionProvider extends Disposable {
 		 * Configure the pool so that if there are idle connections (i.e. pool is under-utilized),
 		 * the next acquire operation will get the <b>Most Recently Used</b> connection
 		 * (MRU, i.e. the connection that was released last among the current idle connections).
+		 * <p><strong>Note:</strong> This configuration is not applicable for {@link reactor.netty.tcp.TcpClient}.
+		 * A TCP connection is always closed and never returned to the pool.
 		 *
 		 * @return {@literal this}
 		 */
@@ -547,6 +553,8 @@ public interface ConnectionProvider extends Disposable {
 		 * Configure the pool so that if there are idle connections (i.e. pool is under-utilized),
 		 * the next acquire operation will get the <b>Least Recently Used</b> connection
 		 * (LRU, i.e. the connection that was released first among the current idle connections).
+		 * <p><strong>Note:</strong> This configuration is not applicable for {@link reactor.netty.tcp.TcpClient}.
+		 * A TCP connection is always closed and never returned to the pool.
 		 *
 		 * @return {@literal this}
 		 */
@@ -561,6 +569,8 @@ public interface ConnectionProvider extends Disposable {
 		 * that are applicable for removal.
 		 * Default to {@link #EVICT_IN_BACKGROUND_DISABLED} - the background eviction is disabled.
 		 * Providing an {@code evictionInterval} of {@link Duration#ZERO zero} means the background eviction is disabled.
+		 * <p><strong>Note:</strong> This configuration is not applicable for {@link reactor.netty.tcp.TcpClient}.
+		 * A TCP connection is always closed and never returned to the pool.
 		 *
 		 * @param evictionInterval specifies the interval to be used for checking the connection pool, (resolution: ns)
 		 * @return {@literal this}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/pool/config/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/pool/config/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,7 @@ public class Application {
 		ConnectionProvider provider =
 				ConnectionProvider.builder("fixed")
 				                  .maxConnections(50)
-				                  .maxIdleTime(Duration.ofSeconds(20))           //<1>
-				                  .maxLifeTime(Duration.ofSeconds(60))           //<2>
-				                  .pendingAcquireTimeout(Duration.ofSeconds(60)) //<3>
-				                  .evictInBackground(Duration.ofSeconds(120))    //<4>
+				                  .pendingAcquireTimeout(Duration.ofSeconds(60)) //<1>
 				                  .build();
 
 		Connection connection =


### PR DESCRIPTION
Connection pool documentation is separated for TCP and HTTP.
Some configurations related to HTTP are not applicable in TCP use case.
Clarify that in the TCP use case the connections are never returned to the pool.

Related to
https://github.com/reactor/reactor-netty/issues/1937#issuecomment-995568920
https://github.com/reactor/reactor-netty/issues/532#issuecomment-1018614618