### PR TITLE
Http2 streams not closed if request data is not fully consumed

### DIFF
--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -2791,5 +2791,5 @@ class HttpServerTests extends BaseHttpTest {
 				.blockLast(Duration.ofSeconds(10));
 
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
-	}    
+	}
 }


### PR DESCRIPTION
Http2 streams close events are missed in case a full response is sent before having fully read the request.

Fixes #1978