### PR TITLE
Use the correct owner when invalidating the stream on close

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
@@ -135,8 +135,7 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 				localEndpoint.maxActiveStreams());
 	}
 
-	static void registerClose(Channel channel) {
-		ConnectionObserver owner = channel.parent().attr(OWNER).get();
+	static void registerClose(Channel channel, ConnectionObserver owner) {
 		channel.closeFuture()
 		       .addListener(f -> {
 		           Channel parent = channel.parent();
@@ -281,7 +280,7 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 				return;
 			}
 
-			HttpClientConfig.openStream(channel, obs, opsFactory, acceptGzip)
+			HttpClientConfig.openStream(channel, this, obs, opsFactory, acceptGzip)
 			                .addListener(this);
 		}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import io.netty.handler.codec.http2.Http2FrameCodec;
+import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
@@ -717,7 +718,8 @@ final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.
 
 		boolean canOpenStream() {
 			Http2FrameCodec frameCodec = connection.channel().pipeline().get(Http2FrameCodec.class);
-			if (frameCodec != null) {
+			Http2MultiplexHandler multiplexHandler = connection.channel().pipeline().get(Http2MultiplexHandler.class);
+			if (frameCodec != null && multiplexHandler != null) {
 				int maxActiveStreams = frameCodec.connection().local().maxActiveStreams();
 				int concurrency = this.concurrency;
 				return concurrency < maxActiveStreams;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2StreamBridgeClientHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2StreamBridgeClientHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,6 @@ final class Http2StreamBridgeClientHandler extends ChannelDuplexHandler {
 
 	@Override
 	public void channelActive(ChannelHandlerContext ctx) {
-		Http2ConnectionProvider.registerClose(ctx.channel());
 		ctx.read();
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,11 @@
 package reactor.netty.http.client;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelId;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
+import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
@@ -44,7 +46,8 @@ class Http2PoolTest {
 
 	@Test
 	void acquireInvalidate() {
-		EmbeddedChannel channel = new EmbeddedChannel(Http2FrameCodecBuilder.forClient().build());
+		EmbeddedChannel channel = new EmbeddedChannel(Http2FrameCodecBuilder.forClient().build(),
+				new Http2MultiplexHandler(new ChannelHandlerAdapter() {}));
 		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
 				PoolBuilder.from(Mono.just(Connection.from(channel)))
 				           .idleResourceReuseLruOrder()
@@ -82,7 +85,8 @@ class Http2PoolTest {
 
 	@Test
 	void acquireRelease() {
-		EmbeddedChannel channel = new EmbeddedChannel(Http2FrameCodecBuilder.forClient().build());
+		EmbeddedChannel channel = new EmbeddedChannel(Http2FrameCodecBuilder.forClient().build(),
+				new Http2MultiplexHandler(new ChannelHandlerAdapter() {}));
 		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
 				PoolBuilder.from(Mono.just(Connection.from(channel)))
 				           .idleResourceReuseLruOrder()


### PR DESCRIPTION
Both `Http2FrameCodec` and `Http2MultiplexHandler` has to be available
in the pipeline when checking whether max active streams limit has been reached.
In case of `H2C` upgrade these handlers are added only on a successful upgrade.

Fixes #1982