### PR TITLE
Additional read operation needs to be scheduled on writing LastHttpContent

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
@@ -156,6 +156,7 @@ final class Http2StreamBridgeServerHandler extends ChannelDuplexHandler implemen
 			if (msg instanceof LastHttpContent) {
 				pendingResponse = false;
 				f.addListener(this);
+				ctx.read();
 			}
 		}
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/BaseHttpTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/BaseHttpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package reactor.netty;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.provider.Arguments;
+import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.server.HttpServer;
 import reactor.netty.resources.ConnectionProvider;
@@ -23,6 +25,7 @@ import reactor.util.annotation.Nullable;
 
 import java.net.SocketAddress;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
  * Provides utility methods for {@link HttpServer} and {@link HttpClient} creation.
@@ -124,5 +127,22 @@ public class BaseHttpTest {
 		return HttpClient.newConnection()
 		                 .port(port)
 		                 .wiretap(true);
+	}
+
+	protected static Stream<Arguments> h2CompatibleCombinations() {
+		return Stream.of(
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2}, new HttpProtocol[]{HttpProtocol.H2}),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2}, new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2}),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11})
+		);
+	}
+
+	protected static Stream<Arguments> h2cCompatibleCombinations() {
+		return Stream.of(
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C}, new HttpProtocol[]{HttpProtocol.H2C}),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C}),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11})
+		);
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Flux;
@@ -63,7 +62,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -484,25 +482,6 @@ class DefaultPooledConnectionProviderTest extends BaseHttpTest {
 			provider.disposeLater()
 			        .block(Duration.ofSeconds(5));
 		}
-	}
-
-	@SuppressWarnings("UnusedMethod")
-	private static Stream<Arguments> h2CompatibleCombinations() {
-		return Stream.of(
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2}, new HttpProtocol[]{HttpProtocol.H2}),
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2}, new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}),
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2}),
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11})
-		);
-	}
-
-	@SuppressWarnings("UnusedMethod")
-	private static Stream<Arguments> h2cCompatibleCombinations() {
-		return Stream.of(
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C}, new HttpProtocol[]{HttpProtocol.H2C}),
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C}),
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11})
-		);
 	}
 
 	static final class TestPromise extends DefaultChannelPromise {


### PR DESCRIPTION
This fix handles the use case when everything is received on the server and the response is delayed,
then additional read operation needs to be scheduled on writing `LastHttpContent`.
Extend the test to handle all compatible `H2` and `H2C` combinations.

Additional fix for #1978