### PR TITLE
Run spotless/japicmp as a preliminary job in ci

### DIFF
--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -4,8 +4,36 @@ on:
   pull_request: {}
 permissions: read-all
 jobs:
-  build:
+    preliminary:
+        name: preliminary sanity checks
+        runs-on: ubuntu-20.04
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0 #needed by spotless
+            - uses: actions/setup-java@v2
+              with:
+                  distribution: 'temurin'
+                  java-version: 8
+            - name: spotless (license header)
+              if: always()
+              run: ./gradlew clean spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
+            - name: api compatibility
+              if: always()
+              run: ./gradlew clean japicmp
+            - name: how to fix
+              if: failure()
+                # the foreground (38;5) color code 022 is green
+              run: |
+                  echo "Tips for fixing errors in preliminary job:"
+                  echo -e "\033[38;5;255;48;5;022m ✅ License headers of touched java files can be automatically fixed by running:\033[0m\n\033[38;5;208;48;5;022m./gradlew spotlessApply\033[0m"
+                  echo ""
+                  echo -e "\033[38;5;255;48;5;202m ⚠️ JApiCmp failures should be considered carefully and discussed with maintainers in the PR\033[0m"
+                  echo "If there are failures, the detail should be available in the logs of the api compatibility step above"
+                  exit -1
 
+  build:
+    needs: preliminary
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -16,18 +44,13 @@ jobs:
           # excludes native on Windows (there's none)
           - os: windows-2019
             transport: native
-
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: '8'
-      - name: Check License
-        run: ./gradlew clean spotlessCheck -PspotlessFrom='origin/${{ github.base_ref }}'
       - name: Build with Gradle
-        run: ./gradlew clean check --no-daemon -PforceTransport=${{ matrix.transport }}
+        run: ./gradlew clean check --no-daemon -x spotlessCheck -PforceTransport=${{ matrix.transport }}

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -4,33 +4,33 @@ on:
   pull_request: {}
 permissions: read-all
 jobs:
-    preliminary:
-        name: preliminary sanity checks
-        runs-on: ubuntu-20.04
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                  fetch-depth: 0 #needed by spotless
-            - uses: actions/setup-java@v2
-              with:
-                  distribution: 'temurin'
-                  java-version: 8
-            - name: spotless (license header)
-              if: always()
-              run: ./gradlew clean spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
-            - name: api compatibility
-              if: always()
-              run: ./gradlew clean japicmp
-            - name: how to fix
-              if: failure()
-                # the foreground (38;5) color code 022 is green
-              run: |
-                  echo "Tips for fixing errors in preliminary job:"
-                  echo -e "\033[38;5;255;48;5;022m ✅ License headers of touched java files can be automatically fixed by running:\033[0m\n\033[38;5;208;48;5;022m./gradlew spotlessApply\033[0m"
-                  echo ""
-                  echo -e "\033[38;5;255;48;5;202m ⚠️ JApiCmp failures should be considered carefully and discussed with maintainers in the PR\033[0m"
-                  echo "If there are failures, the detail should be available in the logs of the api compatibility step above"
-                  exit -1
+  preliminary:
+    name: preliminary sanity checks
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 #needed by spotless
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 8
+      - name: spotless (license header)
+        if: always()
+        run: ./gradlew clean spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
+      - name: api compatibility
+        if: always()
+        run: ./gradlew clean japicmp
+      - name: how to fix
+        if: failure()
+        # the foreground (38;5) color code 022 is green
+        run: |
+          echo "Tips for fixing errors in preliminary job:"
+          echo -e "\033[38;5;255;48;5;022m ✅ License headers of touched java files can be automatically fixed by running:\033[0m\n\033[38;5;208;48;5;022m./gradlew spotlessApply\033[0m"
+          echo ""
+          echo -e "\033[38;5;255;48;5;202m ⚠️ JApiCmp failures should be considered carefully and discussed with maintainers in the PR\033[0m"
+          echo "If there are failures, the detail should be available in the logs of the api compatibility step above"
+          exit -1
 
   build:
     needs: preliminary

--- a/reactor-netty-http-brave/build.gradle
+++ b/reactor-netty-http-brave/build.gradle
@@ -88,4 +88,7 @@ task japicmp(type: JapicmpTask) {
 	onlyIf { "$compatibleVersion" != "SKIP" }
 }
 
+tasks.japicmp.dependsOn(downloadBaseline)
+tasks.check.dependsOn(japicmp)
+
 description = "Brave instrumentation for Reactor Netty HTTP"


### PR DESCRIPTION
This commit changes the `check_transport.yml` workflow so that it runs a
first job to check spotless and japicmp. The test matrix, which run longer,
depend on that first job succeeding.

We output a few tips to fix spotless failures and to indicate japicmp
failures need to be discussed with the maintainers, as pointers intended
for contributors.