### PR TITLE
Update Reactor Netty version to 1.1.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 reactorPoolVersion=0.2.8-SNAPSHOT
-version=1.0.17-SNAPSHOT
-reactorNettyQuicVersion=0.0.6-SNAPSHOT
+version=1.1.0-SNAPSHOT
+reactorNettyQuicVersion=0.1.0-SNAPSHOT
 reactorCoreVersion=3.4.16-SNAPSHOT
 reactorAddonsVersion=3.4.7-SNAPSHOT
 compatibleVersion=1.0.16
-bomVersion=2020.0.16
+bomVersion=2022.0.0


### PR DESCRIPTION
Reactor Netty QUIC version to 0.1.0-SNAPSHOT
Reactor BOM to 2022.0.0