### PR TITLE
Integrated with Micrometer Docs Generator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ ext {
 
 	//Metrics
 	micrometerVersion = '2.0.0-M2' //optional baseline
+	micrometerDocsVersion = '1.0.0-M1' //optional baseline
 
 	braveVersion = '5.13.7'
 

--- a/docs/asciidoc/alloc-metrics.adoc
+++ b/docs/asciidoc/alloc-metrics.adoc
@@ -3,14 +3,24 @@
 [width="100%",options="header"]
 |=======
 | metric name | type | description
-| reactor.netty.bytebuf.allocator.used.heap.memory | Gauge | The number of bytes reserved by heap buffer allocator
-| reactor.netty.bytebuf.allocator.used.direct.memory | Gauge | The number of bytes reserved by direct buffer allocator
-| reactor.netty.bytebuf.allocator.used.heap.arenas | Gauge | The number of heap arenas (when `PooledByteBufAllocator`)
-| reactor.netty.bytebuf.allocator.used.direct.arenas | Gauge | The number of direct arenas (when `PooledByteBufAllocator`)
-| reactor.netty.bytebuf.allocator.used.threadlocal.caches | Gauge | The number of thread local caches (when `PooledByteBufAllocator`)
-| reactor.netty.bytebuf.allocator.used.small.cache.size | Gauge | The size of the small cache (when `PooledByteBufAllocator`)
-| reactor.netty.bytebuf.allocator.used.normal.cache.size | Gauge | The size of the normal cache (when `PooledByteBufAllocator`)
-| reactor.netty.bytebuf.allocator.used.chunk.size | Gauge | The chunk size for an arena (when `PooledByteBufAllocator`)
-| reactor.netty.bytebuf.allocator.active.heap.buffers | Gauge | The actual bytes consumed by in-use heap buffers (when `PooledByteBufAllocator`)
-| reactor.netty.bytebuf.allocator.active.direct.buffers | Gauge | The actual bytes consumed by in-use direct buffers (when `PooledByteBufAllocator`)
+| reactor.netty.bytebuf.allocator.used.heap.memory | Gauge | The number of bytes reserved by heap buffer allocator.
+See <<observability-metrics-used-heap-memory>>
+| reactor.netty.bytebuf.allocator.used.direct.memory | Gauge | The number of bytes reserved by direct buffer allocator.
+See <<observability-metrics-used-direct-memory>>
+| reactor.netty.bytebuf.allocator.used.heap.arenas | Gauge | The number of heap arenas (when `PooledByteBufAllocator`).
+See <<observability-metrics-heap-arenas>>
+| reactor.netty.bytebuf.allocator.used.direct.arenas | Gauge | The number of direct arenas (when `PooledByteBufAllocator`).
+See <<observability-metrics-direct-arenas>>
+| reactor.netty.bytebuf.allocator.used.threadlocal.caches | Gauge | The number of thread local caches (when `PooledByteBufAllocator`).
+See <<observability-metrics-thread-local-caches>>
+| reactor.netty.bytebuf.allocator.used.small.cache.size | Gauge | The size of the small cache (when `PooledByteBufAllocator`).
+See <<observability-metrics-small-cache-size>>
+| reactor.netty.bytebuf.allocator.used.normal.cache.size | Gauge | The size of the normal cache (when `PooledByteBufAllocator`).
+See <<observability-metrics-normal-cache-size>>
+| reactor.netty.bytebuf.allocator.used.chunk.size | Gauge | The chunk size for an arena (when `PooledByteBufAllocator`).
+See <<observability-metrics-chunk-size>>
+| reactor.netty.bytebuf.allocator.active.heap.buffers | Gauge | The actual bytes consumed by in-use heap buffers (when `PooledByteBufAllocator`).
+See <<observability-metrics-active-heap-memory>>
+| reactor.netty.bytebuf.allocator.active.direct.buffers | Gauge | The actual bytes consumed by in-use direct buffers (when `PooledByteBufAllocator`).
+See <<observability-metrics-active-direct-memory>>
 |=======

--- a/docs/asciidoc/conn-provider-metrics.adoc
+++ b/docs/asciidoc/conn-provider-metrics.adoc
@@ -3,10 +3,16 @@ Pooled `ConnectionProvider` metrics
 [width="100%",options="header"]
 |=======
 | metric name | type | description
-| reactor.netty.connection.provider.total.connections | Gauge | The number of all connections, active or idle
-| reactor.netty.connection.provider.active.connections | Gauge | The number of the connections that have been successfully acquired and are in active use
-| reactor.netty.connection.provider.max.connections | Gauge | The maximum number of active connections that are allowed
-| reactor.netty.connection.provider.idle.connections | Gauge | The number of the idle connections
-| reactor.netty.connection.provider.pending.connections | Gauge | The number of requests that are waiting for a connection
-| reactor.netty.connection.provider.max.pending.connections | Gauge | The maximum number of requests that will be queued while waiting for a ready connection
+| reactor.netty.connection.provider.total.connections | Gauge | The number of all connections, active or idle.
+See <<observability-metrics-total-connections>>
+| reactor.netty.connection.provider.active.connections | Gauge | The number of the connections that have been successfully acquired and are in active use.
+See <<observability-metrics-active-connections>>
+| reactor.netty.connection.provider.max.connections | Gauge | The maximum number of active connections that are allowed.
+See <<observability-metrics-max-connections>>
+| reactor.netty.connection.provider.idle.connections | Gauge | The number of the idle connections.
+See <<observability-metrics-idle-connections>>
+| reactor.netty.connection.provider.pending.connections | Gauge | The number of requests that are waiting for a connection.
+See <<observability-metrics-pending-connections>>
+| reactor.netty.connection.provider.max.pending.connections | Gauge | The maximum number of requests that will be queued while waiting for a ready connection.
+See <<observability-metrics-max-pending-connections>>
 |=======

--- a/docs/asciidoc/eventloop-metrics.adoc
+++ b/docs/asciidoc/eventloop-metrics.adoc
@@ -3,5 +3,6 @@
 [width="100%",options="header"]
 |=======
 | metric name | type | description
-| reactor.netty.eventloop.pending.tasks | Gauge | The number of tasks that are pending for processing on an event loop
+| reactor.netty.eventloop.pending.tasks | Gauge | The number of tasks that are pending for processing on an event loop.
+See <<observability-metrics-pending-tasks>>
 |=======

--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -364,14 +364,19 @@ The following table provides information for the HTTP client metrics:
 [width="100%",options="header"]
 |=======
 | metric name | type | description
-| reactor.netty.http.client.data.received | DistributionSummary | Amount of the data received, in bytes
-| reactor.netty.http.client.data.sent | DistributionSummary | Amount of the data sent, in bytes
-| reactor.netty.http.client.errors | Counter | Number of errors that occurred
+| reactor.netty.http.client.data.received | DistributionSummary | Amount of the data received, in bytes.
+See <<observability-metrics-data-received>>
+| reactor.netty.http.client.data.sent | DistributionSummary | Amount of the data sent, in bytes.
+See <<observability-metrics-data-sent>>
+| reactor.netty.http.client.errors | Counter | Number of errors that occurred.
+See <<observability-metrics-errors-count>>
 | reactor.netty.http.client.tls.handshake.time | Timer | Time spent for TLS handshake
 | reactor.netty.http.client.connect.time | Timer | Time spent for connecting to the remote address
 | reactor.netty.http.client.address.resolver | Timer | Time spent for resolving the address
-| reactor.netty.http.client.data.received.time | Timer | Time spent in consuming incoming data
-| reactor.netty.http.client.data.sent.time | Timer | Time spent in sending outgoing data
+| reactor.netty.http.client.data.received.time | Timer | Time spent in consuming incoming data.
+See <<observability-metrics-http-client-data-received-time>>
+| reactor.netty.http.client.data.sent.time | Timer | Time spent in sending outgoing data.
+See <<observability-metrics-http-client-data-sent-time>>
 | reactor.netty.http.client.response.time | Timer | Total time for the request/response
 |=======
 
@@ -384,8 +389,10 @@ The following table provides information for the HTTP client metrics when it is 
 [width="100%",options="header"]
 |=======
 | metric name | type | description
-| reactor.netty.connection.provider.active.streams | Gauge | The number of the active HTTP/2 streams
-| reactor.netty.connection.provider.pending.streams | Gauge | The number of requests that are waiting for opening HTTP/2 stream
+| reactor.netty.connection.provider.active.streams | Gauge | The number of the active HTTP/2 streams.
+See <<observability-metrics-active-streams>>
+| reactor.netty.connection.provider.pending.streams | Gauge | The number of requests that are waiting for opening HTTP/2 stream.
+See <<observability-metrics-pending-streams>>
 |=======
 
 include::alloc-metrics.adoc[]

--- a/docs/asciidoc/http-server.adoc
+++ b/docs/asciidoc/http-server.adoc
@@ -560,13 +560,20 @@ The following table provides information for the HTTP server metrics:
 [width="100%",options="header"]
 |=======
 | metric name | type | description
-| reactor.netty.http.server.connections.active | Gauge | The number of http connections currently processing requests
-| reactor.netty.http.server.connections.total | Gauge | The number of all opened connections
-| reactor.netty.http.server.data.received | DistributionSummary | Amount of the data received, in bytes
-| reactor.netty.http.server.data.sent | DistributionSummary | Amount of the data sent, in bytes
-| reactor.netty.http.server.errors | Counter | Number of errors that occurred
-| reactor.netty.http.server.data.received.time | Timer | Time spent in consuming incoming data
-| reactor.netty.http.server.data.sent.time | Timer | Time spent in sending outgoing data
+| reactor.netty.http.server.connections.active | Gauge | The number of http connections currently processing requests.
+See <<observability-metrics-connections-active>>
+| reactor.netty.http.server.connections.total | Gauge | The number of all opened connections.
+See <<observability-metrics-connections-total>>
+| reactor.netty.http.server.data.received | DistributionSummary | Amount of the data received, in bytes.
+See <<observability-metrics-data-received>>
+| reactor.netty.http.server.data.sent | DistributionSummary | Amount of the data sent, in bytes.
+See <<observability-metrics-data-sent>>
+| reactor.netty.http.server.errors | Counter | Number of errors that occurred.
+See <<observability-metrics-errors-count>>
+| reactor.netty.http.server.data.received.time | Timer | Time spent in consuming incoming data.
+See <<observability-metrics-http-server-data-received-time>>
+| reactor.netty.http.server.data.sent.time | Timer | Time spent in sending outgoing data.
+See <<observability-metrics-http-server-data-sent-time>>
 | reactor.netty.http.server.response.time | Timer | Total time for the request/response
 |=======
 

--- a/docs/asciidoc/index.asciidoc
+++ b/docs/asciidoc/index.asciidoc
@@ -62,3 +62,10 @@ https://github.com/reactor/reactor-netty/edit/main/docs/asciidoc/faq.adoc[Sugges
 to "<<faq>>"
 endif::[]
 
+[appendix]
+include::observability.adoc[leveloffset=1]
+ifeval::["{backend}" == "html5"]
+https://github.com/reactor/reactor-netty/edit/main/docs/asciidoc/observability.adoc[Suggest Edit^, title="Suggest an edit to the above section via github", role="fa fa-edit"]
+to "<<faq>>"
+endif::[]
+

--- a/docs/asciidoc/observability.adoc
+++ b/docs/asciidoc/observability.adoc
@@ -1,0 +1,9 @@
+:root-target: ./../../build/
+
+= Observability
+
+== Observability metadata
+
+include::{root-target}_metrics.adoc[]
+
+include::{root-target}_spans.adoc[]

--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -277,9 +277,12 @@ The following table provides information for the TCP client metrics:
 [width="100%",options="header"]
 |=======
 | metric name | type | description
-| reactor.netty.tcp.client.data.received | DistributionSummary | Amount of the data received, in bytes
-| reactor.netty.tcp.client.data.sent | DistributionSummary | Amount of the data sent, in bytes
-| reactor.netty.tcp.client.errors | Counter | Number of errors that occurred
+| reactor.netty.tcp.client.data.received | DistributionSummary | Amount of the data received, in bytes.
+See <<observability-metrics-data-received>>
+| reactor.netty.tcp.client.data.sent | DistributionSummary | Amount of the data sent, in bytes.
+See <<observability-metrics-data-sent>>
+| reactor.netty.tcp.client.errors | Counter | Number of errors that occurred.
+See <<observability-metrics-errors-count>>
 | reactor.netty.tcp.client.tls.handshake.time | Timer | Time spent for TLS handshake
 | reactor.netty.tcp.client.connect.time | Timer | Time spent for connecting to the remote address
 | reactor.netty.tcp.client.address.resolver | Timer | Time spent for resolving the address

--- a/docs/asciidoc/tcp-server.adoc
+++ b/docs/asciidoc/tcp-server.adoc
@@ -253,10 +253,14 @@ The following table provides information for the TCP server metrics:
 [width="100%",options="header"]
 |=======
 | metric name | type | description
-| reactor.netty.tcp.server.connections.total | Gauge | The number of all opened connections
-| reactor.netty.tcp.server.data.received | DistributionSummary | Amount of the data received, in bytes
-| reactor.netty.tcp.server.data.sent | DistributionSummary | Amount of the data sent, in bytes
-| reactor.netty.tcp.server.errors | Counter | Number of errors that occurred
+| reactor.netty.tcp.server.connections.total | Gauge | The number of all opened connections.
+See <<observability-metrics-connections-total>>
+| reactor.netty.tcp.server.data.received | DistributionSummary | Amount of the data received, in bytes.
+See <<observability-metrics-data-received>>
+| reactor.netty.tcp.server.data.sent | DistributionSummary | Amount of the data sent, in bytes.
+See <<observability-metrics-data-sent>>
+| reactor.netty.tcp.server.errors | Counter | Number of errors that occurred.
+See <<observability-metrics-errors-count>>
 | reactor.netty.tcp.server.tls.handshake.time | Timer | Time spent for TLS handshake
 |=======
 

--- a/docs/asciidoc/udp-client.adoc
+++ b/docs/asciidoc/udp-client.adoc
@@ -208,9 +208,12 @@ The following table provides information for the UDP client metrics:
 [width="100%",options="header"]
 |=======
 | metric name | type | description
-| reactor.netty.udp.client.data.received | DistributionSummary | Amount of the data received, in bytes
-| reactor.netty.udp.client.data.sent | DistributionSummary | Amount of the data sent, in bytes
-| reactor.netty.udp.client.errors | Counter | Number of errors that occurred
+| reactor.netty.udp.client.data.received | DistributionSummary | Amount of the data received, in bytes.
+See <<observability-metrics-data-received>>
+| reactor.netty.udp.client.data.sent | DistributionSummary | Amount of the data sent, in bytes.
+See <<observability-metrics-data-sent>>
+| reactor.netty.udp.client.errors | Counter | Number of errors that occurred.
+See <<observability-metrics-errors-count>>
 | reactor.netty.udp.client.connect.time | Timer | Time spent for connecting to the remote address
 | reactor.netty.udp.client.address.resolver | Timer | Time spent for resolving the address
 |=======

--- a/docs/asciidoc/udp-server.adoc
+++ b/docs/asciidoc/udp-server.adoc
@@ -202,9 +202,12 @@ The following table provides information for the UDP server metrics:
 [width="100%",options="header"]
 |=======
 | metric name | type | description
-| reactor.netty.udp.server.data.received | DistributionSummary | Amount of the data received, in bytes
-| reactor.netty.udp.server.data.sent | DistributionSummary | Amount of the data sent, in bytes
-| reactor.netty.udp.server.errors | Counter | Number of errors that occurred
+| reactor.netty.udp.server.data.received | DistributionSummary | Amount of the data received, in bytes.
+See <<observability-metrics-data-received>>
+| reactor.netty.udp.server.data.sent | DistributionSummary | Amount of the data sent, in bytes.
+See <<observability-metrics-data-sent>>
+| reactor.netty.udp.server.errors | Counter | Number of errors that occurred.
+See <<observability-metrics-errors-count>>
 |=======
 
 These additional metrics are also available:

--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -26,6 +26,7 @@ asciidoctorj {
 }
 
 asciidoctor {
+	dependsOn "generateObservabilityDocs"
 	sourceDir "$rootDir/docs/asciidoc/"
 	sources {
 		include "index.asciidoc"
@@ -69,4 +70,28 @@ task docsZip(type: Zip, dependsOn: [asciidoctor, asciidoctorPdf]) {
 		}
 	}
 	from(asciidoctor) { into("docs/") }
+}
+
+configurations {
+	adoc
+}
+
+dependencies {
+	adoc "io.micrometer:micrometer-docs-generator-spans:$micrometerDocsVersion"
+	adoc "io.micrometer:micrometer-docs-generator-metrics:$micrometerDocsVersion"
+}
+
+task generateObservabilityDocs(dependsOn: ["generateObservabilityMetricsDocs", "generateObservabilitySpansDocs"]) {
+}
+
+task generateObservabilityMetricsDocs(type: JavaExec) {
+	mainClass = "io.micrometer.docs.metrics.DocsFromSources"
+	classpath configurations.adoc
+	args project.rootDir.getAbsolutePath(), ".*", project.rootProject.buildDir.getAbsolutePath()
+}
+
+task generateObservabilitySpansDocs(type: JavaExec) {
+	mainClass = "io.micrometer.docs.spans.DocsFromSources"
+	classpath configurations.adoc
+	args project.rootDir.getAbsolutePath(), ".*", project.rootProject.buildDir.getAbsolutePath()
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMeters.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMeters.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.channel;
+
+import io.micrometer.api.instrument.Meter;
+import io.micrometer.api.instrument.docs.DocumentedMeter;
+import io.micrometer.api.instrument.docs.TagKey;
+
+/**
+ * Channel meters.
+ *
+ * @author Marcin Grzejszczak
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+public enum ChannelMeters implements DocumentedMeter {
+
+	/**
+	 * The number of all opened connections on the server.
+	 */
+	CONNECTIONS_TOTAL {
+		@Override
+		public String getName() {
+			return "%s";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ConnectionsTotalMeterTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * Amount of the data received, in bytes.
+	 */
+	DATA_RECEIVED {
+		@Override
+		public String getBaseUnit() {
+			return "bytes";
+		}
+
+		@Override
+		public String getName() {
+			return "%s";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ChannelMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.DISTRIBUTION_SUMMARY;
+		}
+	},
+
+	/**
+	 * Amount of the data sent, in bytes.
+	 */
+	DATA_SENT {
+		@Override
+		public String getBaseUnit() {
+			return "bytes";
+		}
+
+		@Override
+		public String getName() {
+			return "%s";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ChannelMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.DISTRIBUTION_SUMMARY;
+		}
+	},
+
+	/**
+	 * Number of errors that occurred.
+	 */
+	ERRORS_COUNT {
+		@Override
+		public String getName() {
+			return "%s";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ChannelMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.COUNTER;
+		}
+	};
+
+	public enum ChannelMetersTags implements TagKey {
+
+		/**
+		 * Remote address.
+		 */
+		REMOTE_ADDRESS {
+			@Override
+			public String getKey() {
+				return "remote.address";
+			}
+		},
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String getKey() {
+				return "uri";
+			}
+		}
+	}
+
+	public enum ConnectionsTotalMeterTags implements TagKey {
+
+		/**
+		 * Local address.
+		 */
+		LOCAL_ADDRESS {
+			@Override
+			public String getKey() {
+				return "local.address";
+			}
+		},
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String getKey() {
+				return "uri";
+			}
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProviderMeters.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProviderMeters.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.resources;
+
+import io.micrometer.api.instrument.Meter;
+import io.micrometer.api.instrument.docs.DocumentedMeter;
+import io.micrometer.api.instrument.docs.TagKey;
+
+/**
+ * {@link ConnectionProvider} meters.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum ConnectionProviderMeters implements DocumentedMeter {
+
+	/**
+	 * The number of the connections in the connection pool that have been successfully acquired and are in active use.
+	 */
+	ACTIVE_CONNECTIONS {
+		@Override
+		public String getName() {
+			return "reactor.netty.connection.provider.active.connections";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ConnectionProviderMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The number of the idle connections in the connection pool.
+	 */
+	IDLE_CONNECTIONS {
+		@Override
+		public String getName() {
+			return "reactor.netty.connection.provider.idle.connections";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ConnectionProviderMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The maximum number of active connections that are allowed in the connection pool.
+	 */
+	MAX_CONNECTIONS {
+		@Override
+		public String getName() {
+			return "reactor.netty.connection.provider.max.connections";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ConnectionProviderMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The maximum number of requests that will be queued while waiting for a ready connection from the connection pool.
+	 */
+	MAX_PENDING_CONNECTIONS {
+		@Override
+		public String getName() {
+			return "reactor.netty.connection.provider.max.pending.connections";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ConnectionProviderMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The number of the request, that are pending acquire a connection from the connection pool.
+	 */
+	PENDING_CONNECTIONS {
+		@Override
+		public String getName() {
+			return "reactor.netty.connection.provider.pending.connections";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ConnectionProviderMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The number of all connections in the connection pool, active or idle.
+	 */
+	TOTAL_CONNECTIONS {
+		@Override
+		public String getName() {
+			return "reactor.netty.connection.provider.total.connections";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ConnectionProviderMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	};
+
+	enum ConnectionProviderMetersTags implements TagKey {
+
+		/**
+		 * ID.
+		 */
+		ID {
+			@Override
+			public String getKey() {
+				return "id";
+			}
+		},
+
+		/**
+		 * NAME.
+		 */
+		NAME {
+			@Override
+			public String getKey() {
+				return "name";
+			}
+		},
+
+		/**
+		 * Remote address.
+		 */
+		REMOTE_ADDRESS {
+			@Override
+			public String getKey() {
+				return "remote.address";
+			}
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/MicrometerPooledConnectionProviderMeterRegistrar.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/MicrometerPooledConnectionProviderMeterRegistrar.java
@@ -18,20 +18,20 @@ package reactor.netty.resources;
 import java.net.SocketAddress;
 
 import io.micrometer.api.instrument.Gauge;
+import io.micrometer.api.instrument.Tags;
 import reactor.netty.Metrics;
 import reactor.pool.InstrumentedPool;
 
-import static reactor.netty.Metrics.ACTIVE_CONNECTIONS;
-import static reactor.netty.Metrics.CONNECTION_PROVIDER_PREFIX;
-import static reactor.netty.Metrics.ID;
-import static reactor.netty.Metrics.IDLE_CONNECTIONS;
-import static reactor.netty.Metrics.MAX_CONNECTIONS;
-import static reactor.netty.Metrics.MAX_PENDING_CONNECTIONS;
-import static reactor.netty.Metrics.PENDING_CONNECTIONS;
-import static reactor.netty.Metrics.NAME;
 import static reactor.netty.Metrics.REGISTRY;
-import static reactor.netty.Metrics.REMOTE_ADDRESS;
-import static reactor.netty.Metrics.TOTAL_CONNECTIONS;
+import static reactor.netty.resources.ConnectionProviderMeters.ACTIVE_CONNECTIONS;
+import static reactor.netty.resources.ConnectionProviderMeters.ConnectionProviderMetersTags.ID;
+import static reactor.netty.resources.ConnectionProviderMeters.ConnectionProviderMetersTags.NAME;
+import static reactor.netty.resources.ConnectionProviderMeters.ConnectionProviderMetersTags.REMOTE_ADDRESS;
+import static reactor.netty.resources.ConnectionProviderMeters.IDLE_CONNECTIONS;
+import static reactor.netty.resources.ConnectionProviderMeters.MAX_CONNECTIONS;
+import static reactor.netty.resources.ConnectionProviderMeters.MAX_PENDING_CONNECTIONS;
+import static reactor.netty.resources.ConnectionProviderMeters.PENDING_CONNECTIONS;
+import static reactor.netty.resources.ConnectionProviderMeters.TOTAL_CONNECTIONS;
 
 /**
  * Default implementation of {@link reactor.netty.resources.ConnectionProvider.MeterRegistrar}.
@@ -44,15 +44,6 @@ import static reactor.netty.Metrics.TOTAL_CONNECTIONS;
  * @since 0.9
  */
 final class MicrometerPooledConnectionProviderMeterRegistrar {
-	static final String ACTIVE_CONNECTIONS_DESCRIPTION =
-			"The number of the connections that have been successfully acquired and are in active use";
-	static final String IDLE_CONNECTIONS_DESCRIPTION = "The number of the idle connections";
-	static final String MAX_CONNECTIONS_DESCRIPTIONS = "The maximum number of active connections that are allowed";
-	static final String MAX_PENDING_CONNECTIONS_DESCRIPTIONS =
-			"The maximum number of requests that will be queued while waiting for a ready connection";
-	static final String PENDING_CONNECTIONS_DESCRIPTION =
-			"The number of the request, that are pending acquire a connection";
-	static final String TOTAL_CONNECTIONS_DESCRIPTION = "The number of all connections, active or idle.";
 
 	static final MicrometerPooledConnectionProviderMeterRegistrar INSTANCE = new MicrometerPooledConnectionProviderMeterRegistrar();
 
@@ -60,34 +51,28 @@ final class MicrometerPooledConnectionProviderMeterRegistrar {
 
 	void registerMetrics(String poolName, String id, SocketAddress remoteAddress, InstrumentedPool.PoolMetrics metrics) {
 		String addressAsString = Metrics.formatSocketAddress(remoteAddress);
-		String[] tags = new String[] {ID, id, REMOTE_ADDRESS, addressAsString, NAME, poolName};
-		Gauge.builder(CONNECTION_PROVIDER_PREFIX + TOTAL_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::allocatedSize)
-		     .description(TOTAL_CONNECTIONS_DESCRIPTION)
+		Tags tags = Tags.of(ID.getKey(), id, REMOTE_ADDRESS.getKey(), addressAsString, NAME.getKey(), poolName);
+		Gauge.builder(TOTAL_CONNECTIONS.getName(), metrics, InstrumentedPool.PoolMetrics::allocatedSize)
 		     .tags(tags)
 		     .register(REGISTRY);
 
-		Gauge.builder(CONNECTION_PROVIDER_PREFIX + ACTIVE_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::acquiredSize)
-		     .description(ACTIVE_CONNECTIONS_DESCRIPTION)
+		Gauge.builder(ACTIVE_CONNECTIONS.getName(), metrics, InstrumentedPool.PoolMetrics::acquiredSize)
 		     .tags(tags)
 		     .register(REGISTRY);
 
-		Gauge.builder(CONNECTION_PROVIDER_PREFIX + IDLE_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::idleSize)
-		     .description(IDLE_CONNECTIONS_DESCRIPTION)
+		Gauge.builder(IDLE_CONNECTIONS.getName(), metrics, InstrumentedPool.PoolMetrics::idleSize)
 		     .tags(tags)
 		     .register(REGISTRY);
 
-		Gauge.builder(CONNECTION_PROVIDER_PREFIX + PENDING_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::pendingAcquireSize)
-		     .description(PENDING_CONNECTIONS_DESCRIPTION)
+		Gauge.builder(PENDING_CONNECTIONS.getName(), metrics, InstrumentedPool.PoolMetrics::pendingAcquireSize)
 		     .tags(tags)
 		     .register(REGISTRY);
 
-		Gauge.builder(CONNECTION_PROVIDER_PREFIX + MAX_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::getMaxAllocatedSize)
-		     .description(MAX_CONNECTIONS_DESCRIPTIONS)
+		Gauge.builder(MAX_CONNECTIONS.getName(), metrics, InstrumentedPool.PoolMetrics::getMaxAllocatedSize)
 		     .tags(tags)
 		     .register(REGISTRY);
 
-		Gauge.builder(CONNECTION_PROVIDER_PREFIX + MAX_PENDING_CONNECTIONS, metrics, InstrumentedPool.PoolMetrics::getMaxPendingAcquireSize)
-		     .description(MAX_PENDING_CONNECTIONS_DESCRIPTIONS)
+		Gauge.builder(MAX_PENDING_CONNECTIONS.getName(), metrics, InstrumentedPool.PoolMetrics::getMaxPendingAcquireSize)
 		     .tags(tags)
 		     .register(REGISTRY);
 	}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMeters.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMeters.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.transport;
+
+import io.micrometer.api.instrument.Meter;
+import io.micrometer.api.instrument.docs.DocumentedMeter;
+import io.micrometer.api.instrument.docs.TagKey;
+
+/**
+ * {@link io.netty.buffer.ByteBufAllocator} meters.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum ByteBufAllocatorMeters implements DocumentedMeter {
+
+	/**
+	 * The actual bytes consumed by in-use buffers allocated from direct buffer pools.
+	 */
+	ACTIVE_DIRECT_MEMORY {
+		@Override
+		public String getName() {
+			return "reactor.netty.bytebuf.allocator.active.direct.memory";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ByteBufAllocatorMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The actual bytes consumed by in-use buffers allocated from heap buffer pools.
+	 */
+	ACTIVE_HEAP_MEMORY {
+		@Override
+		public String getName() {
+			return "reactor.netty.bytebuf.allocator.active.heap.memory";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ByteBufAllocatorMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The chunk size for an arena.
+	 */
+	CHUNK_SIZE {
+		@Override
+		public String getName() {
+			return "reactor.netty.bytebuf.allocator.chunk.size";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ByteBufAllocatorMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The number of direct arenas.
+	 */
+	DIRECT_ARENAS {
+		@Override
+		public String getName() {
+			return "reactor.netty.bytebuf.allocator.direct.arenas";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ByteBufAllocatorMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The number of heap arenas.
+	 */
+	HEAP_ARENAS {
+		@Override
+		public String getName() {
+			return "reactor.netty.bytebuf.allocator.heap.arenas";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ByteBufAllocatorMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The size of the normal cache.
+	 */
+	NORMAL_CACHE_SIZE {
+		@Override
+		public String getName() {
+			return "reactor.netty.bytebuf.allocator.normal.cache.size";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ByteBufAllocatorMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The size of the small cache.
+	 */
+	SMALL_CACHE_SIZE {
+		@Override
+		public String getName() {
+			return "reactor.netty.bytebuf.allocator.small.cache.size";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ByteBufAllocatorMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The number of thread local caches.
+	 */
+	THREAD_LOCAL_CACHES {
+		@Override
+		public String getName() {
+			return "reactor.netty.bytebuf.allocator.threadlocal.caches";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ByteBufAllocatorMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The number of bytes reserved by direct buffer allocator.
+	 */
+	USED_DIRECT_MEMORY {
+		@Override
+		public String getName() {
+			return "reactor.netty.bytebuf.allocator.used.direct.memory";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ByteBufAllocatorMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The number of bytes reserved by heap buffer allocator.
+	 */
+	USED_HEAP_MEMORY {
+		@Override
+		public String getName() {
+			return "reactor.netty.bytebuf.allocator.used.heap.memory";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ByteBufAllocatorMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	};
+
+	enum ByteBufAllocatorMetersTags implements TagKey {
+
+		/**
+		 * ID.
+		 */
+		ID {
+			@Override
+			public String getKey() {
+				return "id";
+			}
+		},
+
+		/**
+		 * TYPE.
+		 */
+		TYPE {
+			@Override
+			public String getKey() {
+				return "type";
+			}
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMetrics.java
@@ -16,6 +16,7 @@
 package reactor.netty.transport;
 
 import io.micrometer.api.instrument.Gauge;
+import io.micrometer.api.instrument.Tags;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufAllocatorMetric;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -25,36 +26,25 @@ import reactor.netty.internal.util.MapUtils;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static reactor.netty.Metrics.ACTIVE_DIRECT_MEMORY;
-import static reactor.netty.Metrics.ACTIVE_HEAP_MEMORY;
-import static reactor.netty.Metrics.BYTE_BUF_ALLOCATOR_PREFIX;
-import static reactor.netty.Metrics.CHUNK_SIZE;
-import static reactor.netty.Metrics.DIRECT_ARENAS;
-import static reactor.netty.Metrics.HEAP_ARENAS;
-import static reactor.netty.Metrics.ID;
-import static reactor.netty.Metrics.NORMAL_CACHE_SIZE;
 import static reactor.netty.Metrics.REGISTRY;
-import static reactor.netty.Metrics.SMALL_CACHE_SIZE;
-import static reactor.netty.Metrics.THREAD_LOCAL_CACHES;
-import static reactor.netty.Metrics.TYPE;
-import static reactor.netty.Metrics.USED_DIRECT_MEMORY;
-import static reactor.netty.Metrics.USED_HEAP_MEMORY;
+import static reactor.netty.transport.ByteBufAllocatorMeters.ACTIVE_DIRECT_MEMORY;
+import static reactor.netty.transport.ByteBufAllocatorMeters.ACTIVE_HEAP_MEMORY;
+import static reactor.netty.transport.ByteBufAllocatorMeters.ByteBufAllocatorMetersTags.ID;
+import static reactor.netty.transport.ByteBufAllocatorMeters.ByteBufAllocatorMetersTags.TYPE;
+import static reactor.netty.transport.ByteBufAllocatorMeters.CHUNK_SIZE;
+import static reactor.netty.transport.ByteBufAllocatorMeters.DIRECT_ARENAS;
+import static reactor.netty.transport.ByteBufAllocatorMeters.HEAP_ARENAS;
+import static reactor.netty.transport.ByteBufAllocatorMeters.NORMAL_CACHE_SIZE;
+import static reactor.netty.transport.ByteBufAllocatorMeters.SMALL_CACHE_SIZE;
+import static reactor.netty.transport.ByteBufAllocatorMeters.THREAD_LOCAL_CACHES;
+import static reactor.netty.transport.ByteBufAllocatorMeters.USED_DIRECT_MEMORY;
+import static reactor.netty.transport.ByteBufAllocatorMeters.USED_HEAP_MEMORY;
 
 /**
  * @author Violeta Georgieva
  * @since 0.9
  */
 final class ByteBufAllocatorMetrics {
-	static final String CHUNK_SIZE_DESCRIPTION = "The chunk size for an arena.";
-	static final String DIRECT_ARENAS_DESCRIPTION = "The number of direct arenas.";
-	static final String HEAP_ARENAS_DESCRIPTION = "The number of heap arenas.";
-	static final String NORMAL_CACHE_SIZE_DESCRIPTION = "The size of the normal cache.";
-	static final String SMALL_CACHE_SIZE_DESCRIPTION = "The size of the small cache.";
-	static final String THREAD_LOCAL_CACHES_DESCRIPTION = "The number of thread local caches.";
-	static final String USED_DIRECT_MEMORY_DESCRIPTION = "The number of bytes reserved by direct buffer allocator.";
-	static final String USED_HEAP_MEMORY_DESCRIPTION = "The number of bytes reserved by heap buffer allocator.";
-	static final String ACTIVE_DIRECT_MEMORY_DESCRIPTION = "The actual bytes consumed by in-use buffers allocated from heap buffer pools.";
-	static final String ACTIVE_HEAP_MEMORY_DESCRIPTION = "The actual bytes consumed by in-use buffers allocated from direct buffer pools.";
 
 	static final ByteBufAllocatorMetrics INSTANCE = new ByteBufAllocatorMetrics();
 
@@ -65,15 +55,13 @@ final class ByteBufAllocatorMetrics {
 
 	void registerMetrics(String allocType, ByteBufAllocatorMetric metrics, ByteBufAllocator alloc) {
 		MapUtils.computeIfAbsent(cache, metrics.hashCode() + "", key -> {
-			String[] tags = new String[] {ID, key, TYPE, allocType};
+			Tags tags = Tags.of(ID.getKey(), key, TYPE.getKey(), allocType);
 
-			Gauge.builder(BYTE_BUF_ALLOCATOR_PREFIX + USED_HEAP_MEMORY, metrics, ByteBufAllocatorMetric::usedHeapMemory)
-			     .description(USED_HEAP_MEMORY_DESCRIPTION)
+			Gauge.builder(USED_HEAP_MEMORY.getName(), metrics, ByteBufAllocatorMetric::usedHeapMemory)
 			     .tags(tags)
 			     .register(REGISTRY);
 
-			Gauge.builder(BYTE_BUF_ALLOCATOR_PREFIX + USED_DIRECT_MEMORY, metrics, ByteBufAllocatorMetric::usedDirectMemory)
-			     .description(USED_DIRECT_MEMORY_DESCRIPTION)
+			Gauge.builder(USED_DIRECT_MEMORY.getName(), metrics, ByteBufAllocatorMetric::usedDirectMemory)
 			     .tags(tags)
 			     .register(REGISTRY);
 
@@ -81,43 +69,35 @@ final class ByteBufAllocatorMetrics {
 				PooledByteBufAllocatorMetric pooledMetrics = (PooledByteBufAllocatorMetric) metrics;
 				PooledByteBufAllocator pooledAlloc = (PooledByteBufAllocator) alloc;
 
-				Gauge.builder(BYTE_BUF_ALLOCATOR_PREFIX + HEAP_ARENAS, pooledMetrics, PooledByteBufAllocatorMetric::numHeapArenas)
-				     .description(HEAP_ARENAS_DESCRIPTION)
+				Gauge.builder(HEAP_ARENAS.getName(), pooledMetrics, PooledByteBufAllocatorMetric::numHeapArenas)
 				     .tags(tags)
 				     .register(REGISTRY);
 
-				Gauge.builder(BYTE_BUF_ALLOCATOR_PREFIX + DIRECT_ARENAS, pooledMetrics, PooledByteBufAllocatorMetric::numDirectArenas)
-				     .description(DIRECT_ARENAS_DESCRIPTION)
+				Gauge.builder(DIRECT_ARENAS.getName(), pooledMetrics, PooledByteBufAllocatorMetric::numDirectArenas)
 				     .tags(tags)
 				     .register(REGISTRY);
 
-				Gauge.builder(BYTE_BUF_ALLOCATOR_PREFIX + THREAD_LOCAL_CACHES, pooledMetrics, PooledByteBufAllocatorMetric::numThreadLocalCaches)
-				     .description(THREAD_LOCAL_CACHES_DESCRIPTION)
+				Gauge.builder(THREAD_LOCAL_CACHES.getName(), pooledMetrics, PooledByteBufAllocatorMetric::numThreadLocalCaches)
 				     .tags(tags)
 				     .register(REGISTRY);
 
-				Gauge.builder(BYTE_BUF_ALLOCATOR_PREFIX + SMALL_CACHE_SIZE, pooledMetrics, PooledByteBufAllocatorMetric::smallCacheSize)
-				     .description(SMALL_CACHE_SIZE_DESCRIPTION)
+				Gauge.builder(SMALL_CACHE_SIZE.getName(), pooledMetrics, PooledByteBufAllocatorMetric::smallCacheSize)
 				     .tags(tags)
 				     .register(REGISTRY);
 
-				Gauge.builder(BYTE_BUF_ALLOCATOR_PREFIX + NORMAL_CACHE_SIZE, pooledMetrics, PooledByteBufAllocatorMetric::normalCacheSize)
-				     .description(NORMAL_CACHE_SIZE_DESCRIPTION)
+				Gauge.builder(NORMAL_CACHE_SIZE.getName(), pooledMetrics, PooledByteBufAllocatorMetric::normalCacheSize)
 				     .tags(tags)
 				     .register(REGISTRY);
 
-				Gauge.builder(BYTE_BUF_ALLOCATOR_PREFIX + CHUNK_SIZE, pooledMetrics, PooledByteBufAllocatorMetric::chunkSize)
-				     .description(CHUNK_SIZE_DESCRIPTION)
+				Gauge.builder(CHUNK_SIZE.getName(), pooledMetrics, PooledByteBufAllocatorMetric::chunkSize)
 				     .tags(tags)
 				     .register(REGISTRY);
 
-				Gauge.builder(BYTE_BUF_ALLOCATOR_PREFIX + ACTIVE_HEAP_MEMORY, pooledAlloc, PooledByteBufAllocator::pinnedHeapMemory)
-				     .description(ACTIVE_HEAP_MEMORY_DESCRIPTION)
+				Gauge.builder(ACTIVE_HEAP_MEMORY.getName(), pooledAlloc, PooledByteBufAllocator::pinnedHeapMemory)
 				     .tags(tags)
 				     .register(REGISTRY);
 
-				Gauge.builder(BYTE_BUF_ALLOCATOR_PREFIX + ACTIVE_DIRECT_MEMORY, pooledAlloc, PooledByteBufAllocator::pinnedDirectMemory)
-				     .description(ACTIVE_DIRECT_MEMORY_DESCRIPTION)
+				Gauge.builder(ACTIVE_DIRECT_MEMORY.getName(), pooledAlloc, PooledByteBufAllocator::pinnedDirectMemory)
 				     .tags(tags)
 				     .register(REGISTRY);
 			}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/EventLoopMeters.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/EventLoopMeters.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.transport;
+
+import io.micrometer.api.instrument.Meter;
+import io.micrometer.api.instrument.docs.DocumentedMeter;
+import io.micrometer.api.instrument.docs.TagKey;
+
+/**
+ * {@link io.netty.channel.EventLoop} meters.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum EventLoopMeters implements DocumentedMeter {
+
+	/**
+	 * Event loop pending scheduled tasks.
+	 */
+	PENDING_TASKS {
+		@Override
+		public String getName() {
+			return "reactor.netty.eventloop.pending.tasks";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return EventLoopMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	};
+
+	enum EventLoopMetersTags implements TagKey {
+		/**
+		 * NAME.
+		 */
+		NAME {
+			@Override
+			public String getKey() {
+				return "name";
+			}
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerEventLoopMeterRegistrar.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerEventLoopMeterRegistrar.java
@@ -23,9 +23,9 @@ import reactor.netty.internal.util.MapUtils;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static reactor.netty.Metrics.EVENT_LOOP_PREFIX;
-import static reactor.netty.Metrics.NAME;
-import static reactor.netty.Metrics.PENDING_TASKS;
+import static reactor.netty.transport.EventLoopMeters.PENDING_TASKS;
+import static reactor.netty.transport.EventLoopMeters.EventLoopMetersTags.NAME;
+
 import static reactor.netty.Metrics.REGISTRY;
 
 /**
@@ -34,10 +34,10 @@ import static reactor.netty.Metrics.REGISTRY;
  * Every gauge uses thread name as tag.
  *
  * @author Pierre De Rop
+ * @author Violeta Georgieva
  * @since 1.0.14
  */
 final class MicrometerEventLoopMeterRegistrar {
-	static final String PENDING_TASKS_DESCRIPTION = "Event loop pending scheduled tasks.";
 
 	final static MicrometerEventLoopMeterRegistrar INSTANCE = new MicrometerEventLoopMeterRegistrar();
 
@@ -50,13 +50,11 @@ final class MicrometerEventLoopMeterRegistrar {
 			SingleThreadEventExecutor singleThreadEventExecutor = (SingleThreadEventExecutor) eventLoop;
 			String executorName = singleThreadEventExecutor.threadProperties().name();
 			MapUtils.computeIfAbsent(cache, executorName, key -> {
-				Gauge.builder(EVENT_LOOP_PREFIX + PENDING_TASKS, singleThreadEventExecutor::pendingTasks)
-				     .description(PENDING_TASKS_DESCRIPTION)
-				     .tag(NAME, executorName)
+				Gauge.builder(PENDING_TASKS.getName(), singleThreadEventExecutor::pendingTasks)
+				     .tag(NAME.getKey(), executorName)
 				     .register(REGISTRY);
 				return eventLoop;
 			});
 		}
 	}
-
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/MicrometerHttpMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/MicrometerHttpMetricsRecorder.java
@@ -19,6 +19,7 @@ import io.micrometer.api.instrument.Counter;
 import io.micrometer.api.instrument.DistributionSummary;
 import io.micrometer.api.instrument.Timer;
 import reactor.netty.Metrics;
+import reactor.netty.channel.ChannelMeters;
 import reactor.netty.channel.MeterKey;
 import reactor.netty.channel.MicrometerChannelMetricsRecorder;
 import reactor.netty.internal.util.MapUtils;
@@ -31,8 +32,8 @@ import static reactor.netty.Metrics.DATA_RECEIVED;
 import static reactor.netty.Metrics.DATA_SENT;
 import static reactor.netty.Metrics.ERRORS;
 import static reactor.netty.Metrics.REGISTRY;
-import static reactor.netty.Metrics.REMOTE_ADDRESS;
-import static reactor.netty.Metrics.URI;
+import static reactor.netty.channel.ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS;
+import static reactor.netty.channel.ChannelMeters.ChannelMetersTags.URI;
 
 /**
  * An {@link HttpMetricsRecorder} implementation for integration with Micrometer.
@@ -41,8 +42,6 @@ import static reactor.netty.Metrics.URI;
  * @since 0.9
  */
 public class MicrometerHttpMetricsRecorder extends MicrometerChannelMetricsRecorder implements HttpMetricsRecorder {
-	protected static final String DATA_RECEIVED_TIME_DESCRIPTION = "Time spent in consuming incoming data";
-	protected static final String DATA_SENT_TIME_DESCRIPTION = "Time spent in sending outgoing data";
 	protected static final String RESPONSE_TIME_DESCRIPTION = "Total time for the request/response";
 
 	protected final ConcurrentMap<MeterKey, Timer> dataReceivedTimeCache = new ConcurrentHashMap<>();
@@ -67,9 +66,8 @@ public class MicrometerHttpMetricsRecorder extends MicrometerChannelMetricsRecor
 		MeterKey meterKey = new MeterKey(uri, address, null, null);
 		DistributionSummary dataReceived = MapUtils.computeIfAbsent(dataReceivedCache, meterKey,
 				key -> filter(DistributionSummary.builder(name() + DATA_RECEIVED)
-				                                 .baseUnit(BYTES_UNIT)
-				                                 .description(DATA_RECEIVED_DESCRIPTION)
-				                                 .tags(REMOTE_ADDRESS, address, URI, uri)
+				                                 .baseUnit(ChannelMeters.DATA_RECEIVED.getBaseUnit())
+				                                 .tags(REMOTE_ADDRESS.getKey(), address, URI.getKey(), uri)
 				                                 .register(REGISTRY)));
 		if (dataReceived != null) {
 			dataReceived.record(bytes);
@@ -82,9 +80,8 @@ public class MicrometerHttpMetricsRecorder extends MicrometerChannelMetricsRecor
 		MeterKey meterKey = new MeterKey(uri, address, null, null);
 		DistributionSummary dataSent = MapUtils.computeIfAbsent(dataSentCache, meterKey,
 				key -> filter(DistributionSummary.builder(name() + DATA_SENT)
-				                                 .baseUnit(BYTES_UNIT)
-				                                 .description(DATA_SENT_DESCRIPTION)
-				                                 .tags(REMOTE_ADDRESS, address, URI, uri)
+				                                 .baseUnit(ChannelMeters.DATA_SENT.getBaseUnit())
+				                                 .tags(REMOTE_ADDRESS.getKey(), address, URI.getKey(), uri)
 				                                 .register(REGISTRY)));
 		if (dataSent != null) {
 			dataSent.record(bytes);
@@ -97,8 +94,7 @@ public class MicrometerHttpMetricsRecorder extends MicrometerChannelMetricsRecor
 		MeterKey meterKey = new MeterKey(uri, address, null, null);
 		Counter errors = MapUtils.computeIfAbsent(errorsCache, meterKey,
 				key -> filter(Counter.builder(name() + ERRORS)
-				                     .description(ERRORS_DESCRIPTION)
-				                     .tags(REMOTE_ADDRESS, address, URI, uri)
+				                     .tags(REMOTE_ADDRESS.getKey(), address, URI.getKey(), uri)
 				                     .register(REGISTRY)));
 		if (errors != null) {
 			errors.increment();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProviderMeters.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProviderMeters.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.client;
+
+import io.micrometer.api.instrument.Meter;
+import io.micrometer.api.instrument.docs.DocumentedMeter;
+import io.micrometer.api.instrument.docs.TagKey;
+
+/**
+ * HTTP/2 {@link reactor.netty.resources.ConnectionProvider} meters.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum Http2ConnectionProviderMeters implements DocumentedMeter {
+
+	/**
+	 * The number of the active HTTP/2 streams.
+	 */
+	ACTIVE_STREAMS {
+		@Override
+		public String getName() {
+			return "reactor.netty.connection.provider.active.streams";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return Http2ConnectionProviderMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The number of requests that are waiting for opening HTTP/2 stream.
+	 */
+	PENDING_STREAMS {
+		@Override
+		public String getName() {
+			return "reactor.netty.connection.provider.pending.streams";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return Http2ConnectionProviderMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	};
+
+	enum Http2ConnectionProviderMetersTags implements TagKey {
+
+		/**
+		 * ID.
+		 */
+		ID {
+			@Override
+			public String getKey() {
+				return "id";
+			}
+		},
+
+		/**
+		 * NAME.
+		 */
+		NAME {
+			@Override
+			public String getKey() {
+				return "name";
+			}
+		},
+
+		/**
+		 * Remote address.
+		 */
+		REMOTE_ADDRESS {
+			@Override
+			public String getKey() {
+				return "remote.address";
+			}
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMeters.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMeters.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.client;
+
+import io.micrometer.api.instrument.Meter;
+import io.micrometer.api.instrument.docs.DocumentedMeter;
+import io.micrometer.api.instrument.docs.TagKey;
+
+/**
+ * {@link HttpClient} meters.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum HttpClientMeters implements DocumentedMeter {
+
+	/**
+	 * Time spent in consuming incoming data on the client.
+	 */
+	HTTP_CLIENT_DATA_RECEIVED_TIME {
+		@Override
+		public String getName() {
+			return "reactor.netty.http.client.data.received.time";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return DataReceivedTimeTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.TIMER;
+		}
+	},
+
+	/**
+	 * Time spent in sending outgoing data from the client.
+	 */
+	HTTP_CLIENT_DATA_SENT_TIME {
+		@Override
+		public String getName() {
+			return "reactor.netty.http.client.data.sent.time";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return DataSentTimeTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.TIMER;
+		}
+	};
+
+	enum DataReceivedTimeTags implements TagKey {
+
+		/**
+		 * METHOD.
+		 */
+		METHOD {
+			@Override
+			public String getKey() {
+				return "method";
+			}
+		},
+
+		/**
+		 * Remote address.
+		 */
+		REMOTE_ADDRESS {
+			@Override
+			public String getKey() {
+				return "remote.address";
+			}
+		},
+
+		/**
+		 * STATUS.
+		 */
+		STATUS {
+			@Override
+			public String getKey() {
+				return "status";
+			}
+		},
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String getKey() {
+				return "uri";
+			}
+		}
+	}
+
+	enum DataSentTimeTags implements TagKey {
+
+		/**
+		 * METHOD.
+		 */
+		METHOD {
+			@Override
+			public String getKey() {
+				return "method";
+			}
+		},
+
+		/**
+		 * Remote address.
+		 */
+		REMOTE_ADDRESS {
+			@Override
+			public String getKey() {
+				return "remote.address";
+			}
+		},
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String getKey() {
+				return "uri";
+			}
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttp2ConnectionProviderMeterRegistrar.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttp2ConnectionProviderMeterRegistrar.java
@@ -16,23 +16,20 @@
 package reactor.netty.http.client;
 
 import io.micrometer.api.instrument.Gauge;
+import io.micrometer.api.instrument.Tags;
 import reactor.netty.Metrics;
 import reactor.netty.internal.shaded.reactor.pool.InstrumentedPool;
 
 import java.net.SocketAddress;
 
-import static reactor.netty.Metrics.ACTIVE_STREAMS;
-import static reactor.netty.Metrics.CONNECTION_PROVIDER_PREFIX;
-import static reactor.netty.Metrics.ID;
-import static reactor.netty.Metrics.NAME;
-import static reactor.netty.Metrics.PENDING_STREAMS;
 import static reactor.netty.Metrics.REGISTRY;
-import static reactor.netty.Metrics.REMOTE_ADDRESS;
+import static reactor.netty.http.client.Http2ConnectionProviderMeters.ACTIVE_STREAMS;
+import static reactor.netty.http.client.Http2ConnectionProviderMeters.Http2ConnectionProviderMetersTags.ID;
+import static reactor.netty.http.client.Http2ConnectionProviderMeters.Http2ConnectionProviderMetersTags.NAME;
+import static reactor.netty.http.client.Http2ConnectionProviderMeters.Http2ConnectionProviderMetersTags.REMOTE_ADDRESS;
+import static reactor.netty.http.client.Http2ConnectionProviderMeters.PENDING_STREAMS;
 
 final class MicrometerHttp2ConnectionProviderMeterRegistrar {
-	static final String ACTIVE_STREAMS_DESCRIPTION = "The number of the active HTTP/2 streams";
-	static final String PENDING_STREAMS_DESCRIPTION =
-			"The number of requests that are waiting for opening HTTP/2 stream";
 
 	static final MicrometerHttp2ConnectionProviderMeterRegistrar INSTANCE =
 			new MicrometerHttp2ConnectionProviderMeterRegistrar();
@@ -42,15 +39,13 @@ final class MicrometerHttp2ConnectionProviderMeterRegistrar {
 
 	void registerMetrics(String poolName, String id, SocketAddress remoteAddress, InstrumentedPool.PoolMetrics metrics) {
 		String addressAsString = Metrics.formatSocketAddress(remoteAddress);
-		String[] tags = new String[]{ID, id, REMOTE_ADDRESS, addressAsString, NAME, poolName};
+		Tags tags = Tags.of(ID.getKey(), id, REMOTE_ADDRESS.getKey(), addressAsString, NAME.getKey(), poolName);
 
-		Gauge.builder(CONNECTION_PROVIDER_PREFIX + ACTIVE_STREAMS, metrics, InstrumentedPool.PoolMetrics::acquiredSize)
-		     .description(ACTIVE_STREAMS_DESCRIPTION)
+		Gauge.builder(ACTIVE_STREAMS.getName(), metrics, InstrumentedPool.PoolMetrics::acquiredSize)
 		     .tags(tags)
 		     .register(REGISTRY);
 
-		Gauge.builder(CONNECTION_PROVIDER_PREFIX + PENDING_STREAMS, metrics, InstrumentedPool.PoolMetrics::pendingAcquireSize)
-		     .description(PENDING_STREAMS_DESCRIPTION)
+		Gauge.builder(PENDING_STREAMS.getName(), metrics, InstrumentedPool.PoolMetrics::pendingAcquireSize)
 		     .tags(tags)
 		     .register(REGISTRY);
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
@@ -52,8 +52,10 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 		MeterKey meterKey = new MeterKey(uri, address, method, status);
 		Timer dataReceivedTime = MapUtils.computeIfAbsent(dataReceivedTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_RECEIVED_TIME)
-				                   .description(DATA_RECEIVED_TIME_DESCRIPTION)
-				                   .tags(REMOTE_ADDRESS, address, URI, uri, METHOD, method, STATUS, status)
+				                   .tags(HttpClientMeters.DataReceivedTimeTags.REMOTE_ADDRESS.getKey(), address,
+				                         HttpClientMeters.DataReceivedTimeTags.URI.getKey(), uri,
+				                         HttpClientMeters.DataReceivedTimeTags.METHOD.getKey(), method,
+				                         HttpClientMeters.DataReceivedTimeTags.STATUS.getKey(), status)
 				                   .register(REGISTRY)));
 		if (dataReceivedTime != null) {
 			dataReceivedTime.record(time);
@@ -66,8 +68,9 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 		MeterKey meterKey = new MeterKey(uri, address, method, null);
 		Timer dataSentTime = MapUtils.computeIfAbsent(dataSentTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_SENT_TIME)
-				                   .description(DATA_SENT_TIME_DESCRIPTION)
-				                   .tags(REMOTE_ADDRESS, address, URI, uri, METHOD, method)
+				                   .tags(HttpClientMeters.DataSentTimeTags.REMOTE_ADDRESS.getKey(), address,
+				                         HttpClientMeters.DataSentTimeTags.URI.getKey(), uri,
+				                         HttpClientMeters.DataSentTimeTags.METHOD.getKey(), method)
 				                   .register(REGISTRY)));
 		if (dataSentTime != null) {
 			dataSentTime.record(time);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMeters.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMeters.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.micrometer.api.instrument.Meter;
+import io.micrometer.api.instrument.docs.DocumentedMeter;
+import io.micrometer.api.instrument.docs.TagKey;
+import reactor.netty.channel.ChannelMeters;
+
+/**
+ * {@link HttpServer} meters.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum HttpServerMeters implements DocumentedMeter {
+
+	/**
+	 * The number of http connections, on the server, currently processing requests.
+	 */
+	CONNECTIONS_ACTIVE {
+		@Override
+		public String getName() {
+			return "reactor.netty.http.server.connections.active";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ConnectionsActiveTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * Amount of the data received, in bytes.
+	 */
+	HTTP_SERVER_DATA_RECEIVED {
+		@Override
+		public String getBaseUnit() {
+			return "bytes";
+		}
+
+		@Override
+		public String getName() {
+			return "%s";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return HttpServerMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.DISTRIBUTION_SUMMARY;
+		}
+	},
+
+	/**
+	 * Time spent in consuming incoming data on the server.
+	 */
+	HTTP_SERVER_DATA_RECEIVED_TIME {
+		@Override
+		public String getName() {
+			return "reactor.netty.http.server.data.received.time";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return DataReceivedTimeTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.TIMER;
+		}
+	},
+
+	/**
+	 * Amount of the data sent, in bytes.
+	 */
+	HTTP_SERVER_DATA_SENT {
+		@Override
+		public String getBaseUnit() {
+			return "bytes";
+		}
+
+		@Override
+		public String getName() {
+			return "%s";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return HttpServerMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.DISTRIBUTION_SUMMARY;
+		}
+	},
+
+	/**
+	 * Time spent in sending outgoing data from the server.
+	 */
+	HTTP_SERVER_DATA_SENT_TIME {
+		@Override
+		public String getName() {
+			return "reactor.netty.http.server.data.sent.time";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return DataSentTimeTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.TIMER;
+		}
+	},
+
+	/**
+	 * Number of errors that occurred.
+	 */
+	HTTP_SERVER_ERRORS_COUNT {
+		@Override
+		public String getName() {
+			return "%s";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return HttpServerMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.COUNTER;
+		}
+	};
+
+	enum ConnectionsActiveTags implements TagKey {
+
+		/**
+		 * Local address.
+		 */
+		LOCAL_ADDRESS {
+			@Override
+			public String getKey() {
+				return "local.address";
+			}
+		},
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String getKey() {
+				return "uri";
+			}
+		}
+	}
+
+	enum DataReceivedTimeTags implements TagKey {
+
+		/**
+		 * METHOD.
+		 */
+		METHOD {
+			@Override
+			public String getKey() {
+				return "method";
+			}
+		},
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String getKey() {
+				return "uri";
+			}
+		}
+	}
+
+	enum DataSentTimeTags implements TagKey {
+
+		/**
+		 * METHOD.
+		 */
+		METHOD {
+			@Override
+			public String getKey() {
+				return "method";
+			}
+		},
+
+		/**
+		 * STATUS.
+		 */
+		STATUS {
+			@Override
+			public String getKey() {
+				return "status";
+			}
+		},
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String getKey() {
+				return "uri";
+			}
+		}
+	}
+
+	public enum HttpServerMetersTags implements TagKey {
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String getKey() {
+				return "uri";
+			}
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsRecorder.java
@@ -19,6 +19,7 @@ import io.micrometer.api.instrument.Counter;
 import io.micrometer.api.instrument.DistributionSummary;
 import io.micrometer.api.instrument.Gauge;
 import io.micrometer.api.instrument.Timer;
+import reactor.netty.channel.ChannelMeters;
 import reactor.netty.channel.MeterKey;
 import reactor.netty.http.MicrometerHttpMetricsRecorder;
 import reactor.netty.internal.util.MapUtils;
@@ -29,19 +30,18 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.LongAdder;
 
-import static reactor.netty.Metrics.CONNECTIONS_ACTIVE;
 import static reactor.netty.Metrics.DATA_RECEIVED;
 import static reactor.netty.Metrics.DATA_RECEIVED_TIME;
 import static reactor.netty.Metrics.DATA_SENT;
 import static reactor.netty.Metrics.DATA_SENT_TIME;
 import static reactor.netty.Metrics.ERRORS;
 import static reactor.netty.Metrics.HTTP_SERVER_PREFIX;
-import static reactor.netty.Metrics.LOCAL_ADDRESS;
 import static reactor.netty.Metrics.METHOD;
 import static reactor.netty.Metrics.REGISTRY;
 import static reactor.netty.Metrics.RESPONSE_TIME;
 import static reactor.netty.Metrics.STATUS;
 import static reactor.netty.Metrics.URI;
+import static reactor.netty.http.server.HttpServerMeters.CONNECTIONS_ACTIVE;
 
 /**
  * @author Violeta Georgieva
@@ -51,7 +51,6 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 
 	final static MicrometerHttpServerMetricsRecorder INSTANCE = new MicrometerHttpServerMetricsRecorder();
 	private final static String PROTOCOL_VALUE_HTTP = "http";
-	private final static String ACTIVE_CONNECTIONS_DESCRIPTION = "The number of http connections currently processing requests";
 	private final LongAdder activeConnectionsAdder = new LongAdder();
 	private final ConcurrentMap<String, LongAdder> activeConnectionsCache = new ConcurrentHashMap<>();
 	private final ConcurrentMap<String, DistributionSummary> dataReceivedCache = new ConcurrentHashMap<>();
@@ -67,8 +66,8 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 		MeterKey meterKey = new MeterKey(uri, null, method, null);
 		Timer dataReceivedTime = MapUtils.computeIfAbsent(dataReceivedTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_RECEIVED_TIME)
-				                   .description(DATA_RECEIVED_TIME_DESCRIPTION)
-				                   .tags(URI, uri, METHOD, method)
+				                   .tags(HttpServerMeters.DataReceivedTimeTags.URI.getKey(), uri,
+				                         HttpServerMeters.DataReceivedTimeTags.METHOD.getKey(), method)
 				                   .register(REGISTRY)));
 		if (dataReceivedTime != null) {
 			dataReceivedTime.record(time);
@@ -80,8 +79,9 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 		MeterKey meterKey = new MeterKey(uri, null, method, status);
 		Timer dataSentTime = MapUtils.computeIfAbsent(dataSentTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_SENT_TIME)
-				                   .description(DATA_SENT_TIME_DESCRIPTION)
-				                   .tags(URI, uri, METHOD, method, STATUS, status)
+				                   .tags(HttpServerMeters.DataSentTimeTags.URI.getKey(), uri,
+				                         HttpServerMeters.DataSentTimeTags.METHOD.getKey(), method,
+				                         HttpServerMeters.DataSentTimeTags.STATUS.getKey(), status)
 				                   .register(REGISTRY)));
 		if (dataSentTime != null) {
 			dataSentTime.record(time);
@@ -105,8 +105,8 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 	public void recordDataReceived(SocketAddress remoteAddress, String uri, long bytes) {
 		DistributionSummary dataReceived = MapUtils.computeIfAbsent(dataReceivedCache, uri,
 				key -> filter(DistributionSummary.builder(name() + DATA_RECEIVED)
-				                                 .baseUnit(BYTES_UNIT)
-				                                 .description(DATA_RECEIVED_DESCRIPTION).tags(URI, uri)
+				                                 .baseUnit(HttpServerMeters.HTTP_SERVER_DATA_RECEIVED.getBaseUnit())
+				                                 .tags(HttpServerMeters.HttpServerMetersTags.URI.getKey(), uri)
 				                                 .register(REGISTRY)));
 		if (dataReceived != null) {
 			dataReceived.record(bytes);
@@ -117,9 +117,8 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 	public void recordDataSent(SocketAddress remoteAddress, String uri, long bytes) {
 		DistributionSummary dataSent = MapUtils.computeIfAbsent(dataSentCache, uri,
 				key -> filter(DistributionSummary.builder(name() + DATA_SENT)
-				                                 .baseUnit(BYTES_UNIT)
-				                                 .description(DATA_SENT_DESCRIPTION)
-				                                 .tags(URI, uri)
+				                                 .baseUnit(HttpServerMeters.HTTP_SERVER_DATA_SENT.getBaseUnit())
+				                                 .tags(HttpServerMeters.HttpServerMetersTags.URI.getKey(), uri)
 				                                 .register(REGISTRY)));
 		if (dataSent != null) {
 			dataSent.record(bytes);
@@ -130,8 +129,7 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 	public void incrementErrorsCount(SocketAddress remoteAddress, String uri) {
 		Counter errors = MapUtils.computeIfAbsent(errorsCache, uri,
 				key -> filter(Counter.builder(name() + ERRORS)
-				                     .description(ERRORS_DESCRIPTION)
-				                     .tags(URI, uri)
+				                     .tags(HttpServerMeters.HttpServerMetersTags.URI.getKey(), uri)
 				                     .register(REGISTRY)));
 		if (errors != null) {
 			errors.increment();
@@ -188,11 +186,11 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 		String address = reactor.netty.Metrics.formatSocketAddress(localAddress);
 		return MapUtils.computeIfAbsent(activeConnectionsCache, address,
 				key -> {
-					Gauge gauge = filter(Gauge.builder(reactor.netty.Metrics.HTTP_SERVER_PREFIX + CONNECTIONS_ACTIVE,
-							activeConnectionsAdder, LongAdder::longValue)
-							.tags(URI, PROTOCOL_VALUE_HTTP, LOCAL_ADDRESS, address)
-							.description(ACTIVE_CONNECTIONS_DESCRIPTION)
-							.register(REGISTRY));
+					Gauge gauge = filter(
+							Gauge.builder(CONNECTIONS_ACTIVE.getName(), activeConnectionsAdder, LongAdder::longValue)
+							     .tags(HttpServerMeters.ConnectionsActiveTags.URI.getKey(), PROTOCOL_VALUE_HTTP,
+							           HttpServerMeters.ConnectionsActiveTags.LOCAL_ADDRESS.getKey(), address)
+							     .register(REGISTRY));
 					return gauge != null ? activeConnectionsAdder : null;
 				});
 	}


### PR DESCRIPTION
Use DocumentedMeter for describing Reactor Netty metrics
and add gradle task for generating documentation for these metrics.

Related to #1952

Co-authored-by: Marcin Grzejszczak <mgrzejszczak@vmware.com>