### PR TITLE
Update reactor-netty-core timers to use the new Observation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,8 @@ ext {
 	}
 
 	//Metrics
-	micrometerVersion = '2.0.0-M2' //optional baseline
+	micrometerVersion = '2.0.0-SNAPSHOT' //optional baseline
+	micrometerTracingVersion = '1.0.0-SNAPSHOT' //optional baseline
 	micrometerDocsVersion = '1.0.0-M1' //optional baseline
 
 	braveVersion = '5.13.7'

--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -370,9 +370,12 @@ See <<observability-metrics-data-received>>
 See <<observability-metrics-data-sent>>
 | reactor.netty.http.client.errors | Counter | Number of errors that occurred.
 See <<observability-metrics-errors-count>>
-| reactor.netty.http.client.tls.handshake.time | Timer | Time spent for TLS handshake
-| reactor.netty.http.client.connect.time | Timer | Time spent for connecting to the remote address
-| reactor.netty.http.client.address.resolver | Timer | Time spent for resolving the address
+| reactor.netty.http.client.tls.handshake.time | Timer | Time spent for TLS handshake.
+See <<observability-metrics-tls-handshake-time>>
+| reactor.netty.http.client.connect.time | Timer | Time spent for connecting to the remote address.
+See <<observability-metrics-connect-time>>
+| reactor.netty.http.client.address.resolver | Timer | Time spent for resolving the address.
+See <<observability-metrics-hostname-resolution-time>>
 | reactor.netty.http.client.data.received.time | Timer | Time spent in consuming incoming data.
 See <<observability-metrics-http-client-data-received-time>>
 | reactor.netty.http.client.data.sent.time | Timer | Time spent in sending outgoing data.

--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -283,9 +283,12 @@ See <<observability-metrics-data-received>>
 See <<observability-metrics-data-sent>>
 | reactor.netty.tcp.client.errors | Counter | Number of errors that occurred.
 See <<observability-metrics-errors-count>>
-| reactor.netty.tcp.client.tls.handshake.time | Timer | Time spent for TLS handshake
-| reactor.netty.tcp.client.connect.time | Timer | Time spent for connecting to the remote address
-| reactor.netty.tcp.client.address.resolver | Timer | Time spent for resolving the address
+| reactor.netty.tcp.client.tls.handshake.time | Timer | Time spent for TLS handshake.
+See <<observability-metrics-tls-handshake-time>>
+| reactor.netty.tcp.client.connect.time | Timer | Time spent for connecting to the remote address.
+See <<observability-metrics-connect-time>>
+| reactor.netty.tcp.client.address.resolver | Timer | Time spent for resolving the address.
+See <<observability-metrics-hostname-resolution-time>>
 |=======
 
 These additional metrics are also available:

--- a/docs/asciidoc/tcp-server.adoc
+++ b/docs/asciidoc/tcp-server.adoc
@@ -261,7 +261,8 @@ See <<observability-metrics-data-received>>
 See <<observability-metrics-data-sent>>
 | reactor.netty.tcp.server.errors | Counter | Number of errors that occurred.
 See <<observability-metrics-errors-count>>
-| reactor.netty.tcp.server.tls.handshake.time | Timer | Time spent for TLS handshake
+| reactor.netty.tcp.server.tls.handshake.time | Timer | Time spent for TLS handshake.
+See <<observability-metrics-tls-handshake-time>>
 |=======
 
 These additional metrics are also available:

--- a/docs/asciidoc/udp-client.adoc
+++ b/docs/asciidoc/udp-client.adoc
@@ -214,8 +214,10 @@ See <<observability-metrics-data-received>>
 See <<observability-metrics-data-sent>>
 | reactor.netty.udp.client.errors | Counter | Number of errors that occurred.
 See <<observability-metrics-errors-count>>
-| reactor.netty.udp.client.connect.time | Timer | Time spent for connecting to the remote address
-| reactor.netty.udp.client.address.resolver | Timer | Time spent for resolving the address
+| reactor.netty.udp.client.connect.time | Timer | Time spent for connecting to the remote address.
+See <<observability-metrics-connect-time>>
+| reactor.netty.udp.client.address.resolver | Timer | Time spent for resolving the address.
+See <<observability-metrics-hostname-resolution-time>>
 |=======
 
 These additional metrics are also available:

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -104,6 +104,7 @@ dependencies {
 
 	//Metrics
 	compileOnly "io.micrometer:micrometer-api:$micrometerVersion"
+	compileOnly "io.micrometer:micrometer-tracing-api:$micrometerTracingVersion"
 
 	// Logging
 	compileOnly "org.slf4j:slf4j-api:$slf4jVersion"

--- a/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
@@ -29,6 +29,9 @@ import java.net.SocketAddress;
  */
 public class Metrics {
 	public static final MeterRegistry REGISTRY = io.micrometer.api.instrument.Metrics.globalRegistry;
+	static {
+		REGISTRY.withTimerObservationHandler();
+	}
 
 
 	// Names

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,9 +96,11 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 		if (remote == null) {
 			remote = ch.remoteAddress();
 		}
-		ChannelHandler handler = recorder instanceof ContextAwareChannelMetricsRecorder ?
-				new ContextAwareChannelMetricsHandler((ContextAwareChannelMetricsRecorder) recorder, remote, onServer) :
-				new ChannelMetricsHandler(recorder, remote, onServer);
+		ChannelHandler handler = recorder instanceof MicrometerChannelMetricsRecorder ?
+				new MicrometerChannelMetricsHandler((MicrometerChannelMetricsRecorder) recorder, remote, onServer) :
+				recorder instanceof ContextAwareChannelMetricsRecorder ?
+						new ContextAwareChannelMetricsHandler((ContextAwareChannelMetricsRecorder) recorder, remote, onServer) :
+						new ChannelMetricsHandler(recorder, remote, onServer);
 		ch.pipeline()
 		  .addFirst(NettyPipeline.ChannelMetricsHandler, handler);
 	}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
@@ -96,11 +96,16 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 		if (remote == null) {
 			remote = ch.remoteAddress();
 		}
-		ChannelHandler handler = recorder instanceof MicrometerChannelMetricsRecorder ?
-				new MicrometerChannelMetricsHandler((MicrometerChannelMetricsRecorder) recorder, remote, onServer) :
-				recorder instanceof ContextAwareChannelMetricsRecorder ?
-						new ContextAwareChannelMetricsHandler((ContextAwareChannelMetricsRecorder) recorder, remote, onServer) :
-						new ChannelMetricsHandler(recorder, remote, onServer);
+		ChannelHandler handler;
+		if (recorder instanceof MicrometerChannelMetricsRecorder) {
+			handler = new MicrometerChannelMetricsHandler((MicrometerChannelMetricsRecorder) recorder, remote, onServer);
+		}
+		else if (recorder instanceof ContextAwareChannelMetricsRecorder) {
+			handler = new ContextAwareChannelMetricsHandler((ContextAwareChannelMetricsRecorder) recorder, remote, onServer);
+		}
+		else {
+			handler = new ChannelMetricsHandler(recorder, remote, onServer);
+		}
 		ch.pipeline()
 		  .addFirst(NettyPipeline.ChannelMetricsHandler, handler);
 	}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ConnectObservations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ConnectObservations.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.channel;
+
+import io.micrometer.api.instrument.docs.DocumentedObservation;
+import io.micrometer.api.instrument.docs.TagKey;
+
+/**
+ * Connect observations.
+ *
+ * @author Marcin Grzejszczak
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum ConnectObservations implements DocumentedObservation {
+
+	/**
+	 * Connect metric.
+	 */
+	CONNECT_TIME {
+		@Override
+		public TagKey[] getHighCardinalityTagKeys() {
+			return ConnectTimeHighCardinalityTags.values();
+		}
+
+		@Override
+		public TagKey[] getLowCardinalityTagKeys() {
+			return ConnectTimeLowCardinalityTags.values();
+		}
+
+		@Override
+		public String getName() {
+			return "%s";
+		}
+	};
+
+	/**
+	 * Connect High Cardinality Tags.
+	 */
+	enum ConnectTimeHighCardinalityTags implements TagKey {
+
+		/**
+		 * Reactor Netty protocol (tcp/http etc.).
+		 */
+		REACTOR_NETTY_PROTOCOL {
+			@Override
+			public String getKey() {
+				return "reactor.netty.protocol";
+			}
+		},
+
+		/**
+		 * Reactor Netty status.
+		 */
+		REACTOR_NETTY_STATUS {
+			@Override
+			public String getKey() {
+				return "reactor.netty.status";
+			}
+		},
+
+		/**
+		 * Reactor Netty type (always client).
+		 */
+		REACTOR_NETTY_TYPE {
+			@Override
+			public String getKey() {
+				return "reactor.netty.type";
+			}
+		}
+	}
+
+	/**
+	 * Connect Low Cardinality Tags.
+	 */
+	enum ConnectTimeLowCardinalityTags implements TagKey {
+
+		/**
+		 * Remote address.
+		 */
+		REMOTE_ADDRESS {
+			@Override
+			public String getKey() {
+				return "remote.address";
+			}
+		},
+
+		/**
+		 * STATUS.
+		 */
+		STATUS {
+			@Override
+			public String getKey() {
+				return "status";
+			}
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ConnectSpans.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ConnectSpans.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.channel;
+
+import io.micrometer.api.instrument.docs.DocumentedObservation;
+import io.micrometer.api.instrument.docs.TagKey;
+import io.micrometer.tracing.docs.DocumentedSpan;
+
+/**
+ * Connect spans.
+ *
+ * @author Marcin Grzejszczak
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum ConnectSpans implements DocumentedSpan {
+
+	/**
+	 * Connect Span.
+	 */
+	CONNECT_SPAN {
+		@Override
+		public String getName() {
+			return "%s";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ConnectTimeHighCardinalityTags.values();
+		}
+
+		@Override
+		public DocumentedObservation overridesDefaultSpanFrom() {
+			return ConnectObservations.CONNECT_TIME;
+		}
+	};
+
+	enum ConnectTimeHighCardinalityTags implements TagKey {
+
+		/**
+		 * Reactor Netty protocol (tcp/http etc.).
+		 */
+		REACTOR_NETTY_PROTOCOL {
+			@Override
+			public String getKey() {
+				return "reactor.netty.protocol";
+			}
+		},
+
+		/**
+		 * Reactor Netty status.
+		 */
+		REACTOR_NETTY_STATUS {
+			@Override
+			public String getKey() {
+				return "reactor.netty.status";
+			}
+		},
+
+		/**
+		 * Reactor Netty type (always client).
+		 */
+		REACTOR_NETTY_TYPE {
+			@Override
+			public String getKey() {
+				return "reactor.netty.type";
+			}
+		},
+
+		/**
+		 * Remote address.
+		 */
+		REMOTE_ADDRESS {
+			@Override
+			public String getKey() {
+				return "remote.address";
+			}
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsHandler.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.channel;
+
+import io.micrometer.api.instrument.Tags;
+import io.micrometer.api.instrument.observation.Observation;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandler;
+import io.netty.channel.ChannelPromise;
+import reactor.netty.observability.ReactorNettyHandlerContext;
+import reactor.util.annotation.Nullable;
+
+import java.net.SocketAddress;
+
+import static reactor.netty.Metrics.CONNECT_TIME;
+import static reactor.netty.Metrics.ERROR;
+import static reactor.netty.Metrics.REGISTRY;
+import static reactor.netty.Metrics.SUCCESS;
+import static reactor.netty.Metrics.formatSocketAddress;
+import static reactor.netty.channel.ConnectObservations.ConnectTimeHighCardinalityTags.REACTOR_NETTY_PROTOCOL;
+import static reactor.netty.channel.ConnectObservations.ConnectTimeHighCardinalityTags.REACTOR_NETTY_STATUS;
+import static reactor.netty.channel.ConnectObservations.ConnectTimeHighCardinalityTags.REACTOR_NETTY_TYPE;
+import static reactor.netty.channel.ConnectObservations.ConnectTimeLowCardinalityTags.REMOTE_ADDRESS;
+import static reactor.netty.channel.ConnectObservations.ConnectTimeLowCardinalityTags.STATUS;
+
+/**
+ * {@link ChannelHandler} for collecting metrics on protocol level.
+ * This class is based on {@link ChannelMetricsHandler}, but it utilizes Micrometer's {@link Observation}.
+ *
+ * @author Marcin Grzejszczak
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+public final class MicrometerChannelMetricsHandler extends AbstractChannelMetricsHandler {
+
+	final MicrometerChannelMetricsRecorder recorder;
+
+	MicrometerChannelMetricsHandler(MicrometerChannelMetricsRecorder recorder, @Nullable SocketAddress remoteAddress, boolean onServer) {
+		super(remoteAddress, onServer);
+		this.recorder = recorder;
+	}
+
+	@Override
+	public ChannelHandler connectMetricsHandler() {
+		return new ConnectMetricsHandler(recorder);
+	}
+
+	@Override
+	public MicrometerChannelMetricsRecorder recorder() {
+		return recorder;
+	}
+
+	// ConnectMetricsHandler is Observation.Context and ChannelOutboundHandler in order to reduce allocations,
+	// this is invoked on every connection establishment
+	// This handler is not shared and as such it is different object per connection.
+	static final class ConnectMetricsHandler extends Observation.Context implements ReactorNettyHandlerContext, ChannelOutboundHandler {
+		static final String CONTEXTUAL_NAME = "connect";
+		static final String TYPE = "client";
+
+		final MicrometerChannelMetricsRecorder recorder;
+
+		// remote address and status are not known beforehand
+		String remoteAddress;
+		String status;
+
+		ConnectMetricsHandler(MicrometerChannelMetricsRecorder recorder) {
+			this.recorder = recorder;
+		}
+
+		@Override
+		@SuppressWarnings("FutureReturnValueIgnored")
+		public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
+			//"FutureReturnValueIgnored" this is deliberate
+			ctx.bind(localAddress, promise);
+		}
+
+		@Override
+		@SuppressWarnings("FutureReturnValueIgnored")
+		public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
+			//"FutureReturnValueIgnored" this is deliberate
+			ctx.close(promise);
+		}
+
+		@Override
+		public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress,
+				SocketAddress localAddress, ChannelPromise promise) throws Exception {
+			// TODO
+			// Cannot invoke the recorder any more:
+			// 1. The recorder is one instance only, it is invoked for all connection establishments that can happen
+			// 2. The recorder does not have knowledge about connection establishment lifecycle
+			//
+			// Move the implementation from the recorder here
+			//
+			// Important:
+			// Cannot cache the Timer anymore - need to test the performance
+			this.remoteAddress = formatSocketAddress(remoteAddress);
+			Observation observation = Observation.start(recorder.name() + CONNECT_TIME, this, REGISTRY);
+			ctx.connect(remoteAddress, localAddress, promise)
+			   .addListener(future -> {
+			       ctx.pipeline().remove(this);
+
+			       status = future.isSuccess() ? SUCCESS : ERROR;
+
+			       observation.stop();
+			});
+		}
+
+		@Override
+		@SuppressWarnings("FutureReturnValueIgnored")
+		public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
+			//"FutureReturnValueIgnored" this is deliberate
+			ctx.deregister(promise);
+		}
+
+		@Override
+		@SuppressWarnings("FutureReturnValueIgnored")
+		public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
+			//"FutureReturnValueIgnored" this is deliberate
+			ctx.disconnect(promise);
+		}
+
+		@Override
+		@SuppressWarnings("deprecation")
+		public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+			ctx.fireExceptionCaught(cause);
+		}
+
+		@Override
+		public void flush(ChannelHandlerContext ctx) {
+			ctx.flush();
+		}
+
+		@Override
+		public String getContextualName() {
+			return CONTEXTUAL_NAME;
+		}
+
+		@Override
+		public Tags getHighCardinalityTags() {
+			return Tags.of(REACTOR_NETTY_PROTOCOL.of(recorder.protocol()), REACTOR_NETTY_STATUS.of(status), REACTOR_NETTY_TYPE.of(TYPE));
+		}
+
+		@Override
+		public Tags getLowCardinalityTags() {
+			return Tags.of(REMOTE_ADDRESS.of(remoteAddress), STATUS.of(status));
+		}
+
+		@Override
+		public void handlerAdded(ChannelHandlerContext ctx) {
+			// noop
+		}
+
+		@Override
+		public void handlerRemoved(ChannelHandlerContext ctx) {
+			// noop
+		}
+
+		@Override
+		public void read(ChannelHandlerContext ctx) {
+			ctx.read();
+		}
+
+		@Override
+		@SuppressWarnings("FutureReturnValueIgnored")
+		public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+			//"FutureReturnValueIgnored" this is deliberate
+			ctx.write(msg, promise);
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
@@ -185,11 +185,11 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 		}
 	}
 
-	protected String name() {
+	public String name() {
 		return name;
 	}
 
-	protected String protocol() {
+	public String protocol() {
 		return protocol;
 	}
 

--- a/reactor-netty-core/src/main/java/reactor/netty/observability/ReactorNettyHandlerContext.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/observability/ReactorNettyHandlerContext.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.observability;
+
+/**
+ * Abstraction over all Reactor Netty contexts.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.1.0
+ */
+public interface ReactorNettyHandlerContext {
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/observability/ReactorNettyTracingObservationHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/observability/ReactorNettyTracingObservationHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.observability;
+
+import io.micrometer.api.instrument.Tag;
+import io.micrometer.api.instrument.observation.Observation;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
+
+import static reactor.netty.Metrics.REMOTE_ADDRESS;
+
+/**
+ * Abstraction over all Reactor Netty handlers.
+ *
+ * @author Marcin Grzejszczak
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+public final class ReactorNettyTracingObservationHandler extends DefaultTracingObservationHandler {
+
+	public ReactorNettyTracingObservationHandler(Tracer tracer) {
+		super(tracer);
+	}
+
+	@Override
+	public void tagSpan(Observation.Context context, Span span) {
+		for (Tag tag : context.getHighCardinalityTags()) {
+			span.tag(tag.getKey(), tag.getValue());
+		}
+		for (Tag tag : context.getLowCardinalityTags()) {
+			if (tag.getKey().equals(REMOTE_ADDRESS)) {
+				span.tag(tag.getKey(), tag.getValue());
+				break;
+			}
+		}
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public String getSpanName(Observation.Context context) {
+		String name = context.getContextualName();
+		return name != null ? name : super.getSpanName(context);
+	}
+
+	@Override
+	public boolean supportsContext(Observation.Context handlerContext) {
+		return handlerContext instanceof ReactorNettyHandlerContext;
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/MicrometerSslReadHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/MicrometerSslReadHandler.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.tcp;
+
+import io.micrometer.api.instrument.Tags;
+import io.micrometer.api.instrument.observation.Observation;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import reactor.netty.channel.MicrometerChannelMetricsRecorder;
+import reactor.netty.observability.ReactorNettyHandlerContext;
+
+import static reactor.netty.Metrics.ERROR;
+import static reactor.netty.Metrics.REGISTRY;
+import static reactor.netty.Metrics.SUCCESS;
+import static reactor.netty.Metrics.TLS_HANDSHAKE_TIME;
+import static reactor.netty.Metrics.formatSocketAddress;
+import static reactor.netty.tcp.TlsHandshakeObservations.TlsHandshakeTimeHighCardinalityTags.REACTOR_NETTY_PROTOCOL;
+import static reactor.netty.tcp.TlsHandshakeObservations.TlsHandshakeTimeHighCardinalityTags.REACTOR_NETTY_STATUS;
+import static reactor.netty.tcp.TlsHandshakeObservations.TlsHandshakeTimeHighCardinalityTags.REACTOR_NETTY_TYPE;
+import static reactor.netty.tcp.TlsHandshakeObservations.TlsHandshakeTimeLowCardinalityTags.REMOTE_ADDRESS;
+import static reactor.netty.tcp.TlsHandshakeObservations.TlsHandshakeTimeLowCardinalityTags.STATUS;
+
+/**
+ * @author Marcin Grzejszczak
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+// MicrometerSslReadHandler is Observation.Context and ChannelInboundHandler in order to reduce allocations,
+// this is invoked on every TLS negotiation
+// This handler is not shared and as such it is different object per connection.
+final class MicrometerSslReadHandler extends Observation.Context implements ReactorNettyHandlerContext, ChannelInboundHandler {
+	static final String CONTEXTUAL_NAME = "tls handshake";
+	static final String TYPE_CLIENT = "client";
+	static final String TYPE_SERVER = "server";
+
+	final MicrometerChannelMetricsRecorder recorder;
+	final String type;
+
+	boolean handshakeDone;
+
+	Observation observation;
+
+	// remote address and status are not known beforehand
+	String remoteAddress;
+	String status;
+
+	MicrometerSslReadHandler(MicrometerChannelMetricsRecorder recorder, boolean onServer) {
+		this.recorder = recorder;
+		this.type = onServer ? TYPE_SERVER : TYPE_CLIENT;
+	}
+
+	@Override
+	public void channelActive(ChannelHandlerContext ctx) {
+		observation = Observation.start(recorder.name() + TLS_HANDSHAKE_TIME, this, REGISTRY);
+		ctx.read(); //consume handshake
+	}
+
+	@Override
+	public void channelInactive(ChannelHandlerContext ctx) {
+		ctx.fireChannelInactive();
+	}
+
+	@Override
+	public void channelRead(ChannelHandlerContext ctx, Object msg) {
+		ctx.fireChannelRead(msg);
+	}
+
+	@Override
+	public void channelReadComplete(ChannelHandlerContext ctx) {
+		if (!handshakeDone) {
+			ctx.read(); /* continue consuming. */
+		}
+		ctx.fireChannelReadComplete();
+	}
+
+	@Override
+	public void channelRegistered(ChannelHandlerContext ctx) {
+		ctx.fireChannelRegistered();
+	}
+
+	@Override
+	public void channelUnregistered(ChannelHandlerContext ctx) {
+		ctx.fireChannelUnregistered();
+	}
+
+	@Override
+	public void channelWritabilityChanged(ChannelHandlerContext ctx) {
+		ctx.fireChannelWritabilityChanged();
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+		ctx.fireExceptionCaught(cause);
+	}
+
+	@Override
+	public String getContextualName() {
+		return CONTEXTUAL_NAME;
+	}
+
+	@Override
+	public Tags getHighCardinalityTags() {
+		return Tags.of(REACTOR_NETTY_PROTOCOL.of(recorder.protocol()), REACTOR_NETTY_STATUS.of(status), REACTOR_NETTY_TYPE.of(type));
+	}
+
+	@Override
+	public Tags getLowCardinalityTags() {
+		return Tags.of(REMOTE_ADDRESS.of(remoteAddress), STATUS.of(status));
+	}
+
+	@Override
+	public void handlerAdded(ChannelHandlerContext ctx) {
+		// noop
+	}
+
+	@Override
+	public void handlerRemoved(ChannelHandlerContext ctx) {
+		// noop
+	}
+
+	@Override
+	public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+		if (evt instanceof SslHandshakeCompletionEvent) {
+			handshakeDone = true;
+			if (ctx.pipeline().context(this) != null) {
+				ctx.pipeline().remove(this);
+			}
+			SslHandshakeCompletionEvent handshake = (SslHandshakeCompletionEvent) evt;
+			// TODO
+			// Cannot invoke the recorder any more:
+			// 1. The recorder is one instance only, it is invoked for all TLS negotiations that can happen
+			// 2. The recorder does not have knowledge about TLS negotiation lifecycle
+			//
+			// Move the implementation from the recorder here
+			//
+			// Important:
+			// Cannot cache the Timer anymore - need to test the performance
+			this.remoteAddress = formatSocketAddress(ctx.channel().remoteAddress());
+			if (handshake.isSuccess()) {
+				status = SUCCESS;
+				observation.stop();
+				ctx.fireChannelActive();
+			}
+			else {
+				status = ERROR;
+				observation.stop();
+				ctx.fireExceptionCaught(handshake.cause());
+			}
+		}
+		ctx.fireUserEventTriggered(evt);
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ final class SniProvider {
 		else {
 			pipeline.addFirst(NettyPipeline.SslHandler, newSniHandler());
 		}
-		SslProvider.addSslReadHandler(pipeline, sslDebug);
+		SslProvider.addSslReadHandler(pipeline, sslDebug, true);
 	}
 
 	final Map<String, SslProvider> confPerDomainName;

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ import reactor.netty.ReactorNetty;
 import reactor.netty.channel.AbstractChannelMetricsHandler;
 import reactor.netty.channel.ChannelMetricsRecorder;
 import reactor.netty.channel.ContextAwareChannelMetricsRecorder;
+import reactor.netty.channel.MicrometerChannelMetricsHandler;
 import reactor.netty.transport.logging.AdvancedByteBufFormat;
 import reactor.util.Logger;
 import reactor.util.Loggers;
@@ -559,7 +560,7 @@ public final class SslProvider {
 			pipeline.addFirst(NettyPipeline.SslHandler, sslHandler);
 		}
 
-		addSslReadHandler(pipeline, sslDebug);
+		addSslReadHandler(pipeline, sslDebug, remoteAddress == null);
 	}
 
 	@Override
@@ -589,15 +590,19 @@ public final class SslProvider {
 		return Objects.hash(builderHashCode);
 	}
 
-	static void addSslReadHandler(ChannelPipeline pipeline, boolean sslDebug) {
+	static void addSslReadHandler(ChannelPipeline pipeline, boolean sslDebug, boolean onServer) {
+		ChannelHandler handler = pipeline.get(NettyPipeline.ChannelMetricsHandler);
+		ChannelHandler sslReadHandler = handler instanceof MicrometerChannelMetricsHandler ?
+				new MicrometerSslReadHandler(((MicrometerChannelMetricsHandler) handler).recorder(), onServer) :
+				new SslReadHandler();
 		if (pipeline.get(NettyPipeline.LoggingHandler) != null) {
-			pipeline.addAfter(NettyPipeline.LoggingHandler, NettyPipeline.SslReader, new SslReadHandler());
+			pipeline.addAfter(NettyPipeline.LoggingHandler, NettyPipeline.SslReader, sslReadHandler);
 			if (sslDebug) {
 				pipeline.addBefore(NettyPipeline.SslHandler, NettyPipeline.SslLoggingHandler, LOGGING_HANDLER);
 			}
 		}
 		else {
-			pipeline.addAfter(NettyPipeline.SslHandler, NettyPipeline.SslReader, new SslReadHandler());
+			pipeline.addAfter(NettyPipeline.SslHandler, NettyPipeline.SslReader, sslReadHandler);
 		}
 	}
 
@@ -779,7 +784,7 @@ public final class SslProvider {
 		}
 	}
 
-	static final class SslReadHandler extends ChannelInboundHandlerAdapter {
+	static class SslReadHandler extends ChannelInboundHandlerAdapter {
 
 		boolean handshakeDone;
 

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TlsHandshakeObservations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TlsHandshakeObservations.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.tcp;
+
+import io.micrometer.api.instrument.docs.DocumentedObservation;
+import io.micrometer.api.instrument.docs.TagKey;
+
+/**
+ * TLS handshake observations.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum TlsHandshakeObservations implements DocumentedObservation {
+
+	/**
+	 * TLS handshake metric.
+	 */
+	TLS_HANDSHAKE_TIME {
+		@Override
+		public TagKey[] getHighCardinalityTagKeys() {
+			return TlsHandshakeTimeHighCardinalityTags.values();
+		}
+
+		@Override
+		public TagKey[] getLowCardinalityTagKeys() {
+			return TlsHandshakeTimeLowCardinalityTags.values();
+		}
+
+		@Override
+		public String getName() {
+			return "%s";
+		}
+	};
+
+	/**
+	 * TLS Handshake High Cardinality Tags.
+	 */
+	enum TlsHandshakeTimeHighCardinalityTags implements TagKey {
+
+		/**
+		 * Reactor Netty protocol (tcp/http etc.).
+		 */
+		REACTOR_NETTY_PROTOCOL {
+			@Override
+			public String getKey() {
+				return "reactor.netty.protocol";
+			}
+		},
+
+		/**
+		 * Reactor Netty status.
+		 */
+		REACTOR_NETTY_STATUS {
+			@Override
+			public String getKey() {
+				return "reactor.netty.status";
+			}
+		},
+
+		/**
+		 * Reactor Netty type (client/server).
+		 */
+		REACTOR_NETTY_TYPE {
+			@Override
+			public String getKey() {
+				return "reactor.netty.type";
+			}
+		}
+	}
+
+	/**
+	 * TLS Handshake Low Cardinality Tags.
+	 */
+	enum TlsHandshakeTimeLowCardinalityTags implements TagKey {
+
+		/**
+		 * Remote address.
+		 */
+		REMOTE_ADDRESS {
+			@Override
+			public String getKey() {
+				return "remote.address";
+			}
+		},
+
+		/**
+		 * STATUS.
+		 */
+		STATUS {
+			@Override
+			public String getKey() {
+				return "status";
+			}
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TlsHandshakeSpans.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TlsHandshakeSpans.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.tcp;
+
+import io.micrometer.api.instrument.docs.DocumentedObservation;
+import io.micrometer.api.instrument.docs.TagKey;
+import io.micrometer.tracing.docs.DocumentedSpan;
+
+/**
+ * TLS handshake spans.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum TlsHandshakeSpans implements DocumentedSpan {
+
+	/**
+	 * TLS Handshake Span.
+	 */
+	TLS_HANDSHAKE_SPAN {
+		@Override
+		public String getName() {
+			return "%s";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return TlsHandshakeTimeHighCardinalityTags.values();
+		}
+
+		@Override
+		public DocumentedObservation overridesDefaultSpanFrom() {
+			return TlsHandshakeObservations.TLS_HANDSHAKE_TIME;
+		}
+	};
+
+	enum TlsHandshakeTimeHighCardinalityTags implements TagKey {
+
+		/**
+		 * Reactor Netty protocol (tcp/http etc.).
+		 */
+		REACTOR_NETTY_PROTOCOL {
+			@Override
+			public String getKey() {
+				return "reactor.netty.protocol";
+			}
+		},
+
+		/**
+		 * Reactor Netty status.
+		 */
+		REACTOR_NETTY_STATUS {
+			@Override
+			public String getKey() {
+				return "reactor.netty.status";
+			}
+		},
+
+		/**
+		 * Reactor Netty type (client/server).
+		 */
+		REACTOR_NETTY_TYPE {
+			@Override
+			public String getKey() {
+				return "reactor.netty.type";
+			}
+		},
+
+		/**
+		 * Remote address.
+		 */
+		REMOTE_ADDRESS {
+			@Override
+			public String getKey() {
+				return "remote.address";
+			}
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/AddressResolverGroupMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/AddressResolverGroupMetrics.java
@@ -37,7 +37,7 @@ import static reactor.netty.Metrics.SUCCESS;
 /**
  * @author Violeta Georgieva
  */
-final class AddressResolverGroupMetrics<T extends SocketAddress> extends AddressResolverGroup<T> {
+class AddressResolverGroupMetrics<T extends SocketAddress> extends AddressResolverGroup<T> {
 
 	static final ConcurrentMap<Integer, AddressResolverGroupMetrics<?>> cache = new ConcurrentHashMap<>();
 
@@ -51,76 +51,84 @@ final class AddressResolverGroupMetrics<T extends SocketAddress> extends Address
 
 	final ChannelMetricsRecorder recorder;
 
-	private AddressResolverGroupMetrics(AddressResolverGroup<T> resolverGroup, ChannelMetricsRecorder recorder) {
+	AddressResolverGroupMetrics(AddressResolverGroup<T> resolverGroup, ChannelMetricsRecorder recorder) {
 		this.resolverGroup = resolverGroup;
 		this.recorder = recorder;
 	}
 
 	@Override
 	protected AddressResolver<T> newResolver(EventExecutor executor) {
-		AddressResolver<T> resolver = resolverGroup.getResolver(executor);
+		return new DelegatingAddressResolver<>(recorder, resolverGroup.getResolver(executor));
+	}
 
-		return new AddressResolver<T>() {
+	static class DelegatingAddressResolver<T extends SocketAddress> implements AddressResolver<T> {
 
-			@Override
-			public boolean isSupported(SocketAddress address) {
-				return resolver.isSupported(address);
-			}
+		final ChannelMetricsRecorder recorder;
+		final AddressResolver<T> resolver;
 
-			@Override
-			public boolean isResolved(SocketAddress address) {
-				return resolver.isResolved(address);
-			}
+		DelegatingAddressResolver(ChannelMetricsRecorder recorder, AddressResolver<T> resolver) {
+			this.recorder = recorder;
+			this.resolver = resolver;
+		}
 
-			@Override
-			public Future<T> resolve(SocketAddress address) {
-				return resolveInternal(address, () -> resolver.resolve(address));
-			}
+		@Override
+		public boolean isSupported(SocketAddress address) {
+			return resolver.isSupported(address);
+		}
 
-			@Override
-			public Future<T> resolve(SocketAddress address, Promise<T> promise) {
-				return resolveInternal(address, () -> resolver.resolve(address, promise));
-			}
+		@Override
+		public boolean isResolved(SocketAddress address) {
+			return resolver.isResolved(address);
+		}
 
-			@Override
-			public Future<List<T>> resolveAll(SocketAddress address) {
-				return resolveAllInternal(address, () -> resolver.resolveAll(address));
-			}
+		@Override
+		public Future<T> resolve(SocketAddress address) {
+			return resolveInternal(address, () -> resolver.resolve(address));
+		}
 
-			@Override
-			public Future<List<T>> resolveAll(SocketAddress address, Promise<List<T>> promise) {
-				return resolveAllInternal(address, () -> resolver.resolveAll(address, promise));
-			}
+		@Override
+		public Future<T> resolve(SocketAddress address, Promise<T> promise) {
+			return resolveInternal(address, () -> resolver.resolve(address, promise));
+		}
 
-			@Override
-			public void close() {
-				resolver.close();
-			}
+		@Override
+		public Future<List<T>> resolveAll(SocketAddress address) {
+			return resolveAllInternal(address, () -> resolver.resolveAll(address));
+		}
 
-			Future<T> resolveInternal(SocketAddress address, Supplier<Future<T>> resolver) {
-				long resolveTimeStart = System.nanoTime();
-				return resolver.get()
-				               .addListener(
-				                   future -> record(resolveTimeStart,
-				                                    future.isSuccess() ? SUCCESS : ERROR,
-				                                    address));
-			}
+		@Override
+		public Future<List<T>> resolveAll(SocketAddress address, Promise<List<T>> promise) {
+			return resolveAllInternal(address, () -> resolver.resolveAll(address, promise));
+		}
 
-			Future<List<T>> resolveAllInternal(SocketAddress address, Supplier<Future<List<T>>> resolver) {
-				long resolveTimeStart = System.nanoTime();
-				return resolver.get()
-				               .addListener(
-				                   future -> record(resolveTimeStart,
-				                                    future.isSuccess() ? SUCCESS : ERROR,
-				                                    address));
-			}
+		@Override
+		public void close() {
+			resolver.close();
+		}
 
-			void record(long resolveTimeStart, String status, SocketAddress remoteAddress) {
-				recorder.recordResolveAddressTime(
-						remoteAddress,
-						Duration.ofNanos(System.nanoTime() - resolveTimeStart),
-						status);
-			}
-		};
+		Future<T> resolveInternal(SocketAddress address, Supplier<Future<T>> resolver) {
+			long resolveTimeStart = System.nanoTime();
+			return resolver.get()
+			               .addListener(
+			                   future -> record(resolveTimeStart,
+			                                    future.isSuccess() ? SUCCESS : ERROR,
+			                                    address));
+		}
+
+		Future<List<T>> resolveAllInternal(SocketAddress address, Supplier<Future<List<T>>> resolver) {
+			long resolveTimeStart = System.nanoTime();
+			return resolver.get()
+			               .addListener(
+			                   future -> record(resolveTimeStart,
+			                                    future.isSuccess() ? SUCCESS : ERROR,
+			                                    address));
+		}
+
+		void record(long resolveTimeStart, String status, SocketAddress remoteAddress) {
+			recorder.recordResolveAddressTime(
+					remoteAddress,
+					Duration.ofNanos(System.nanoTime() - resolveTimeStart),
+					status);
+		}
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
@@ -35,6 +35,7 @@ import io.netty.resolver.dns.DnsAddressResolverGroup;
 import reactor.netty.ChannelPipelineConfigurer;
 import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
+import reactor.netty.channel.MicrometerChannelMetricsRecorder;
 import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.resources.LoopResources;
 import reactor.netty.internal.util.MapUtils;
@@ -223,7 +224,12 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 	protected AddressResolverGroup<?> resolverInternal() {
 		AddressResolverGroup<?> resolverGroup = resolver != null ? resolver : defaultAddressResolverGroup();
 		if (metricsRecorder != null) {
-			return AddressResolverGroupMetrics.getOrCreate(resolverGroup, metricsRecorder);
+			if (metricsRecorder instanceof MicrometerChannelMetricsRecorder) {
+				return MicrometerAddressResolverGroupMetrics.getOrCreate(resolverGroup, (MicrometerChannelMetricsRecorder) metricsRecorder);
+			}
+			else {
+				return AddressResolverGroupMetrics.getOrCreate(resolverGroup, metricsRecorder);
+			}
 		}
 		else {
 			return resolverGroup;

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/HostnameResolutionObservations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/HostnameResolutionObservations.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.transport;
+
+import io.micrometer.api.instrument.docs.DocumentedObservation;
+import io.micrometer.api.instrument.docs.TagKey;
+
+/**
+ * Hostname resolution observations.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum HostnameResolutionObservations implements DocumentedObservation {
+
+	/**
+	 * Hostname resolution metric.
+	 */
+	HOSTNAME_RESOLUTION_TIME {
+		@Override
+		public TagKey[] getHighCardinalityTagKeys() {
+			return HostnameResolutionTimeHighCardinalityTags.values();
+		}
+
+		@Override
+		public TagKey[] getLowCardinalityTagKeys() {
+			return HostnameResolutionTimeLowCardinalityTags.values();
+		}
+
+		@Override
+		public String getName() {
+			return "%s";
+		}
+	};
+
+	/**
+	 * Hostname Resolution High Cardinality Tags.
+	 */
+	enum HostnameResolutionTimeHighCardinalityTags implements TagKey {
+
+		/**
+		 * Reactor Netty protocol (tcp/http etc.).
+		 */
+		REACTOR_NETTY_PROTOCOL {
+			@Override
+			public String getKey() {
+				return "reactor.netty.protocol";
+			}
+		},
+
+		/**
+		 * Reactor Netty status.
+		 */
+		REACTOR_NETTY_STATUS {
+			@Override
+			public String getKey() {
+				return "reactor.netty.status";
+			}
+		},
+
+		/**
+		 * Reactor Netty type (always client).
+		 */
+		REACTOR_NETTY_TYPE {
+			@Override
+			public String getKey() {
+				return "reactor.netty.type";
+			}
+		}
+	}
+
+	/**
+	 * Hostname Resolution Low Cardinality Tags.
+	 */
+	enum HostnameResolutionTimeLowCardinalityTags implements TagKey {
+
+		/**
+		 * Remote address.
+		 */
+		REMOTE_ADDRESS {
+			@Override
+			public String getKey() {
+				return "remote.address";
+			}
+		},
+
+		/**
+		 * STATUS.
+		 */
+		STATUS {
+			@Override
+			public String getKey() {
+				return "status";
+			}
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/HostnameResolutionSpans.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/HostnameResolutionSpans.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.transport;
+
+import io.micrometer.api.instrument.docs.DocumentedObservation;
+import io.micrometer.api.instrument.docs.TagKey;
+import io.micrometer.tracing.docs.DocumentedSpan;
+
+/**
+ * Hostname resolution spans.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum HostnameResolutionSpans implements DocumentedSpan {
+
+	/**
+	 * Hostname Resolution Span.
+	 */
+	HOSTNAME_RESOLUTION_SPAN {
+		@Override
+		public String getName() {
+			return "%s";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return HostnameResolutionTimeHighCardinalityTags.values();
+		}
+
+		@Override
+		public DocumentedObservation overridesDefaultSpanFrom() {
+			return HostnameResolutionObservations.HOSTNAME_RESOLUTION_TIME;
+		}
+	};
+
+	enum HostnameResolutionTimeHighCardinalityTags implements TagKey {
+
+		/**
+		 * Reactor Netty protocol (tcp/http etc.).
+		 */
+		REACTOR_NETTY_PROTOCOL {
+			@Override
+			public String getKey() {
+				return "reactor.netty.protocol";
+			}
+		},
+
+		/**
+		 * Reactor Netty status.
+		 */
+		REACTOR_NETTY_STATUS {
+			@Override
+			public String getKey() {
+				return "reactor.netty.status";
+			}
+		},
+
+		/**
+		 * Reactor Netty type (always client).
+		 */
+		REACTOR_NETTY_TYPE {
+			@Override
+			public String getKey() {
+				return "reactor.netty.type";
+			}
+		},
+
+		/**
+		 * Remote address.
+		 */
+		REMOTE_ADDRESS {
+			@Override
+			public String getKey() {
+				return "remote.address";
+			}
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerAddressResolverGroupMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerAddressResolverGroupMetrics.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.transport;
+
+import io.micrometer.api.instrument.Tags;
+import io.micrometer.api.instrument.observation.Observation;
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+import reactor.netty.channel.MicrometerChannelMetricsRecorder;
+import reactor.netty.internal.util.MapUtils;
+import reactor.netty.observability.ReactorNettyHandlerContext;
+
+import java.net.SocketAddress;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+
+import static reactor.netty.Metrics.ADDRESS_RESOLVER;
+import static reactor.netty.Metrics.ERROR;
+import static reactor.netty.Metrics.REGISTRY;
+import static reactor.netty.Metrics.SUCCESS;
+import static reactor.netty.Metrics.formatSocketAddress;
+import static reactor.netty.transport.HostnameResolutionObservations.HostnameResolutionTimeHighCardinalityTags.REACTOR_NETTY_PROTOCOL;
+import static reactor.netty.transport.HostnameResolutionObservations.HostnameResolutionTimeHighCardinalityTags.REACTOR_NETTY_STATUS;
+import static reactor.netty.transport.HostnameResolutionObservations.HostnameResolutionTimeHighCardinalityTags.REACTOR_NETTY_TYPE;
+import static reactor.netty.transport.HostnameResolutionObservations.HostnameResolutionTimeLowCardinalityTags.REMOTE_ADDRESS;
+import static reactor.netty.transport.HostnameResolutionObservations.HostnameResolutionTimeLowCardinalityTags.STATUS;
+
+/**
+ * @author Marcin Grzejszczak
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+final class MicrometerAddressResolverGroupMetrics<T extends SocketAddress> extends AddressResolverGroupMetrics<T> {
+
+	static final ConcurrentMap<Integer, MicrometerAddressResolverGroupMetrics<?>> cache = new ConcurrentHashMap<>();
+
+	static MicrometerAddressResolverGroupMetrics<?> getOrCreate(
+			AddressResolverGroup<?> resolverGroup, MicrometerChannelMetricsRecorder recorder) {
+		return MapUtils.computeIfAbsent(cache, Objects.hash(resolverGroup, recorder),
+				key -> new MicrometerAddressResolverGroupMetrics<>(resolverGroup, recorder));
+	}
+
+	MicrometerAddressResolverGroupMetrics(AddressResolverGroup<T> resolverGroup, MicrometerChannelMetricsRecorder recorder) {
+		super(resolverGroup, recorder);
+	}
+
+	@Override
+	protected AddressResolver<T> newResolver(EventExecutor executor) {
+		return new MicrometerDelegatingAddressResolver<>((MicrometerChannelMetricsRecorder) recorder, resolverGroup.getResolver(executor));
+	}
+
+	static final class FutureHandlerContext extends Observation.Context implements ReactorNettyHandlerContext {
+		static final String CONTEXTUAL_NAME = "hostname resolution";
+		static final String TYPE = "client";
+
+		final String protocol;
+		final String remoteAddress;
+
+		// status is not known beforehand
+		String status;
+
+		FutureHandlerContext(String protocol, String remoteAddress) {
+			this.protocol = protocol;
+			this.remoteAddress = remoteAddress;
+		}
+
+		@Override
+		public String getContextualName() {
+			return CONTEXTUAL_NAME;
+		}
+
+		@Override
+		public Tags getHighCardinalityTags() {
+			return Tags.of(REACTOR_NETTY_PROTOCOL.of(protocol), REACTOR_NETTY_STATUS.of(status), REACTOR_NETTY_TYPE.of(TYPE));
+		}
+
+		@Override
+		public Tags getLowCardinalityTags() {
+			return Tags.of(REMOTE_ADDRESS.of(remoteAddress), STATUS.of(status));
+		}
+	}
+
+	static final class MicrometerDelegatingAddressResolver<T extends SocketAddress> extends DelegatingAddressResolver<T> {
+
+		final String name;
+		final String protocol;
+
+		MicrometerDelegatingAddressResolver(MicrometerChannelMetricsRecorder recorder, AddressResolver<T> resolver) {
+			super(recorder, resolver);
+			this.name = recorder.name();
+			this.protocol = recorder.protocol();
+		}
+
+		@Override
+		Future<List<T>> resolveAllInternal(SocketAddress address, Supplier<Future<List<T>>> resolver) {
+			// TODO
+			// Cannot invoke the recorder any more:
+			// 1. The recorder is one instance only, it is invoked for all name resolutions that can happen
+			// 2. The recorder does not have knowledge about name resolution lifecycle
+			// 3. There is no connection so we cannot hold the context information in the Channel
+			//
+			// Move the implementation from the recorder here
+			//
+			// Important:
+			// Cannot cache the Timer anymore - need to test the performance
+			String remoteAddress = formatSocketAddress(address);
+			FutureHandlerContext handlerContext = new FutureHandlerContext(protocol, remoteAddress);
+			Observation sample = Observation.start(name + ADDRESS_RESOLVER, handlerContext, REGISTRY);
+			return resolver.get()
+			               .addListener(future -> {
+			                   handlerContext.status = future.isSuccess() ? SUCCESS : ERROR;
+			                   sample.stop();
+			               });
+		}
+
+		@Override
+		Future<T> resolveInternal(SocketAddress address, Supplier<Future<T>> resolver) {
+			// TODO
+			// Cannot invoke the recorder any more:
+			// 1. The recorder is one instance only, it is invoked for all name resolutions that can happen
+			// 2. The recorder does not have knowledge about name resolution lifecycle
+			// 3. There is no connection so we cannot hold the context information in the Channel
+			//
+			// Move the implementation from the recorder here
+			//
+			// Important:
+			// Cannot cache the Timer anymore - need to test the performance
+			String remoteAddress = formatSocketAddress(address);
+			FutureHandlerContext handlerContext = new FutureHandlerContext(protocol, remoteAddress);
+			Observation observation = Observation.start(name + ADDRESS_RESOLVER, handlerContext, REGISTRY);
+			return resolver.get()
+			               .addListener(future -> {
+			                   handlerContext.status = future.isSuccess() ? SUCCESS : ERROR;
+			                   observation.stop();
+			               });
+		}
+	}
+}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -2925,7 +2925,7 @@ class HttpClientTest extends BaseHttpTest {
 
 			assertThat(resolversInternal.get()).isNotNull();
 			assertThat(resolversInternal.get().get(0)).isSameAs(resolversInternal.get().get(1));
-			assertThat(resolversInternal.get().get(0).getClass().getSimpleName()).isEqualTo("AddressResolverGroupMetrics");
+			assertThat(resolversInternal.get().get(0).getClass().getSimpleName()).isEqualTo("MicrometerAddressResolverGroupMetrics");
 		}
 		finally {
 			// Closing the executor cleans the AddressResolverGroup internal structures and closes the resolver


### PR DESCRIPTION
Connect, Hostname resolution and TLS handshake timers now are Observation

Related to #1952

Co-authored-by: Marcin Grzejszczak <mgrzejszczak@vmware.com>

Note: Context propagation and Timers caches will be tracked in separate PRs