### PR TITLE
Update reactor-netty-http timers to use the new Observation

### DIFF
--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -381,6 +381,7 @@ See <<observability-metrics-http-client-data-received-time>>
 | reactor.netty.http.client.data.sent.time | Timer | Time spent in sending outgoing data.
 See <<observability-metrics-http-client-data-sent-time>>
 | reactor.netty.http.client.response.time | Timer | Total time for the request/response
+See <<observability-metrics-http-client-response-time>>
 |=======
 
 These additional metrics are also available:

--- a/docs/asciidoc/http-server.adoc
+++ b/docs/asciidoc/http-server.adoc
@@ -575,6 +575,7 @@ See <<observability-metrics-http-server-data-received-time>>
 | reactor.netty.http.server.data.sent.time | Timer | Time spent in sending outgoing data.
 See <<observability-metrics-http-server-data-sent-time>>
 | reactor.netty.http.server.response.time | Timer | Total time for the request/response
+See <<observability-metrics-http-server-response-time>>
 |=======
 
 These additional metrics are also available:

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
@@ -41,7 +41,7 @@ final class SniProvider {
 	 * @param channel the channel
 	 * @param sslDebug if true SSL debugging on the server side will be enabled
 	 */
-	void addSniHandler(Channel channel, boolean sslDebug) {
+	void addSniHandler(Channel channel, boolean sslDebug, boolean enableTracing) {
 		ChannelPipeline pipeline = channel.pipeline();
 		if (pipeline.get(NettyPipeline.NonSslRedirectDetector) != null) {
 			pipeline.addAfter(NettyPipeline.NonSslRedirectDetector, NettyPipeline.SslHandler, newSniHandler());
@@ -49,7 +49,7 @@ final class SniProvider {
 		else {
 			pipeline.addFirst(NettyPipeline.SslHandler, newSniHandler());
 		}
-		SslProvider.addSslReadHandler(pipeline, sslDebug, true);
+		SslProvider.addSslReadHandler(pipeline, sslDebug, true, enableTracing);
 	}
 
 	final Map<String, SslProvider> confPerDomainName;

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
@@ -40,6 +40,7 @@ final class SniProvider {
 	 *
 	 * @param channel the channel
 	 * @param sslDebug if true SSL debugging on the server side will be enabled
+	 * @param enableTracing if true enables the integration with Micrometer Tracing
 	 */
 	void addSniHandler(Channel channel, boolean sslDebug, boolean enableTracing) {
 		ChannelPipeline pipeline = channel.pipeline();

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -522,9 +522,13 @@ public final class SslProvider {
 	}
 
 	public void addSslHandler(Channel channel, @Nullable SocketAddress remoteAddress, boolean sslDebug) {
+		addSslHandler(channel, remoteAddress, sslDebug, true);
+	}
+
+	public void addSslHandler(Channel channel, @Nullable SocketAddress remoteAddress, boolean sslDebug, boolean enableTracing) {
 		Objects.requireNonNull(channel, "channel");
 		if (sniProvider != null) {
-			sniProvider.addSniHandler(channel, sslDebug);
+			sniProvider.addSniHandler(channel, sslDebug, enableTracing);
 			return;
 		}
 
@@ -560,7 +564,7 @@ public final class SslProvider {
 			pipeline.addFirst(NettyPipeline.SslHandler, sslHandler);
 		}
 
-		addSslReadHandler(pipeline, sslDebug, remoteAddress == null);
+		addSslReadHandler(pipeline, sslDebug, remoteAddress == null, enableTracing);
 	}
 
 	@Override
@@ -590,9 +594,9 @@ public final class SslProvider {
 		return Objects.hash(builderHashCode);
 	}
 
-	static void addSslReadHandler(ChannelPipeline pipeline, boolean sslDebug, boolean onServer) {
+	static void addSslReadHandler(ChannelPipeline pipeline, boolean sslDebug, boolean onServer, boolean enableTracing) {
 		ChannelHandler handler = pipeline.get(NettyPipeline.ChannelMetricsHandler);
-		ChannelHandler sslReadHandler = handler instanceof MicrometerChannelMetricsHandler ?
+		ChannelHandler sslReadHandler = handler instanceof MicrometerChannelMetricsHandler && enableTracing ?
 				new MicrometerSslReadHandler(((MicrometerChannelMetricsHandler) handler).recorder(), onServer) :
 				new SslReadHandler();
 		if (pipeline.get(NettyPipeline.LoggingHandler) != null) {

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -108,6 +108,7 @@ dependencies {
 
 	//Metrics
 	compileOnly "io.micrometer:micrometer-api:$micrometerVersion"
+	compileOnly "io.micrometer:micrometer-tracing-api:$micrometerTracingVersion"
 
 	// Logging
 	compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
@@ -133,6 +134,7 @@ dependencies {
 	testImplementation "io.projectreactor.tools:blockhound-junit-platform:$blockHoundVersion"
 	testImplementation "io.micrometer:micrometer-api:$micrometerVersion"
 	testImplementation "io.micrometer:micrometer-test:$micrometerVersion"
+	testImplementation "io.micrometer:micrometer-tracing-integration-test:$micrometerTracingVersion"
 
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelDuplexHandler {
 				contextView = ops.currentContextView();
 			}
 
-			dataSentTime = System.nanoTime();
+			startWrite((HttpRequest) msg, ctx.channel().remoteAddress());
 		}
 
 		if (msg instanceof ByteBufHolder) {
@@ -97,7 +97,7 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelDuplexHandler {
 		if (msg instanceof HttpResponse) {
 			status = ((HttpResponse) msg).status().codeAsText().toString();
 
-			dataReceivedTime = System.nanoTime();
+			startRead((HttpResponse) msg, ctx.channel().remoteAddress());
 		}
 
 		if (msg instanceof ByteBufHolder) {
@@ -149,6 +149,25 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelDuplexHandler {
 		recorder().recordDataSent(address, path, dataSent);
 	}
 
+	protected void reset() {
+		path = null;
+		method = null;
+		status = null;
+		contextView = null;
+		dataReceived = 0;
+		dataSent = 0;
+		dataReceivedTime = 0;
+		dataSentTime = 0;
+	}
+
+	protected void startRead(HttpResponse msg, SocketAddress address) {
+		dataReceivedTime = System.nanoTime();
+	}
+
+	protected void startWrite(HttpRequest msg, SocketAddress address) {
+		dataSentTime = System.nanoTime();
+	}
+
 	private String resolveUri(ChannelHandlerContext ctx) {
 		ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
 		if (channelOps instanceof HttpClientOperations) {
@@ -158,16 +177,5 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelDuplexHandler {
 		else {
 			return "unknown";
 		}
-	}
-
-	private void reset() {
-		path = null;
-		method = null;
-		status = null;
-		contextView = null;
-		dataReceived = 0;
-		dataSent = 0;
-		dataReceivedTime = 0;
-		dataSentTime = 0;
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -567,9 +567,16 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 
 		if (metricsRecorder != null) {
 			if (metricsRecorder instanceof HttpClientMetricsRecorder) {
-				ChannelHandler handler = metricsRecorder instanceof ContextAwareHttpClientMetricsRecorder ?
-						new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) metricsRecorder, uriTagValue) :
-						new HttpClientMetricsHandler((HttpClientMetricsRecorder) metricsRecorder, uriTagValue);
+				ChannelHandler handler;
+				if (metricsRecorder instanceof MicrometerHttpClientMetricsRecorder) {
+					handler = new MicrometerHttpClientMetricsHandler((MicrometerHttpClientMetricsRecorder) metricsRecorder, uriTagValue);
+				}
+				else if (metricsRecorder instanceof ContextAwareHttpClientMetricsRecorder) {
+					handler = new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) metricsRecorder, uriTagValue);
+				}
+				else {
+					handler = new HttpClientMetricsHandler((HttpClientMetricsRecorder) metricsRecorder, uriTagValue);
+				}
 				p.addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.HttpMetricsHandler, handler);
 			}
 		}
@@ -599,9 +606,16 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 
 		if (metricsRecorder != null) {
 			if (metricsRecorder instanceof HttpClientMetricsRecorder) {
-				ChannelHandler handler = metricsRecorder instanceof ContextAwareHttpClientMetricsRecorder ?
-						new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) metricsRecorder, uriTagValue) :
-						new HttpClientMetricsHandler((HttpClientMetricsRecorder) metricsRecorder, uriTagValue);
+				ChannelHandler handler;
+				if (metricsRecorder instanceof MicrometerHttpClientMetricsRecorder) {
+					handler = new MicrometerHttpClientMetricsHandler((MicrometerHttpClientMetricsRecorder) metricsRecorder, uriTagValue);
+				}
+				else if (metricsRecorder instanceof ContextAwareHttpClientMetricsRecorder) {
+					handler = new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) metricsRecorder, uriTagValue);
+				}
+				else {
+					handler = new HttpClientMetricsHandler((HttpClientMetricsRecorder) metricsRecorder, uriTagValue);
+				}
 				p.addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.HttpMetricsHandler, handler);
 			}
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientObservations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientObservations.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.client;
+
+import io.micrometer.api.instrument.docs.DocumentedObservation;
+import io.micrometer.api.instrument.docs.TagKey;
+
+/**
+ * {@link HttpClient} observations.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum HttpClientObservations implements DocumentedObservation {
+
+	/**
+	 * Response metric.
+	 */
+	HTTP_CLIENT_RESPONSE_TIME {
+		@Override
+		public TagKey[] getHighCardinalityTagKeys() {
+			return ResponseTimeHighCardinalityTags.values();
+		}
+
+		@Override
+		public TagKey[] getLowCardinalityTagKeys() {
+			return ResponseTimeLowCardinalityTags.values();
+		}
+
+		@Override
+		public String getName() {
+			return "reactor.netty.http.client.response.time";
+		}
+	};
+
+	/**
+	 * Response High Cardinality Tags.
+	 */
+	enum ResponseTimeHighCardinalityTags implements TagKey {
+
+		/**
+		 * Reactor Netty protocol (always http).
+		 */
+		REACTOR_NETTY_PROTOCOL {
+			@Override
+			public String getKey() {
+				return "reactor.netty.protocol";
+			}
+		},
+
+		/**
+		 * Reactor Netty status.
+		 */
+		REACTOR_NETTY_STATUS {
+			@Override
+			public String getKey() {
+				return "reactor.netty.status";
+			}
+		},
+
+		/**
+		 * Reactor Netty type (always client).
+		 */
+		REACTOR_NETTY_TYPE {
+			@Override
+			public String getKey() {
+				return "reactor.netty.type";
+			}
+		}
+	}
+
+	/**
+	 * Response Low Cardinality Tags.
+	 */
+	enum ResponseTimeLowCardinalityTags implements TagKey {
+
+		/**
+		 * METHOD.
+		 */
+		METHOD {
+			@Override
+			public String getKey() {
+				return "method";
+			}
+		},
+
+		/**
+		 * Remote address.
+		 */
+		REMOTE_ADDRESS {
+			@Override
+			public String getKey() {
+				return "remote.address";
+			}
+		},
+
+		/**
+		 * STATUS.
+		 */
+		STATUS {
+			@Override
+			public String getKey() {
+				return "status";
+			}
+		},
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String getKey() {
+				return "uri";
+			}
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSpans.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSpans.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.client;
+
+import io.micrometer.api.instrument.docs.DocumentedObservation;
+import io.micrometer.api.instrument.docs.TagKey;
+import io.micrometer.tracing.docs.DocumentedSpan;
+
+/**
+ * {@link HttpClient} spans.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum HttpClientSpans implements DocumentedSpan {
+
+	/**
+	 * Response Span.
+	 */
+	HTTP_CLIENT_RESPONSE_SPAN {
+		@Override
+		public String getName() {
+			return "%s";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ResponseTimeHighCardinalityTags.values();
+		}
+
+		@Override
+		public DocumentedObservation overridesDefaultSpanFrom() {
+			return HttpClientObservations.HTTP_CLIENT_RESPONSE_TIME;
+		}
+	};
+
+	enum ResponseTimeHighCardinalityTags implements TagKey {
+
+		/**
+		 * Reactor Netty protocol (always http).
+		 */
+		REACTOR_NETTY_PROTOCOL {
+			@Override
+			public String getKey() {
+				return "reactor.netty.protocol";
+			}
+		},
+
+		/**
+		 * Reactor Netty status.
+		 */
+		REACTOR_NETTY_STATUS {
+			@Override
+			public String getKey() {
+				return "reactor.netty.status";
+			}
+		},
+
+		/**
+		 * Reactor Netty type (always client).
+		 */
+		REACTOR_NETTY_TYPE {
+			@Override
+			public String getKey() {
+				return "reactor.netty.type";
+			}
+		},
+
+		/**
+		 * Remote address.
+		 */
+		REMOTE_ADDRESS {
+			@Override
+			public String getKey() {
+				return "remote.address";
+			}
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.client;
+
+import io.micrometer.api.instrument.Tags;
+import io.micrometer.api.instrument.observation.Observation;
+import io.micrometer.api.instrument.transport.http.HttpClientRequest;
+import io.micrometer.api.instrument.transport.http.HttpClientResponse;
+import io.micrometer.api.instrument.transport.http.context.HttpClientContext;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import reactor.netty.observability.ReactorNettyHandlerContext;
+import reactor.util.annotation.Nullable;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.function.Function;
+
+import static reactor.netty.Metrics.REGISTRY;
+import static reactor.netty.Metrics.RESPONSE_TIME;
+import static reactor.netty.Metrics.formatSocketAddress;
+import static reactor.netty.http.client.HttpClientObservations.ResponseTimeHighCardinalityTags.REACTOR_NETTY_PROTOCOL;
+import static reactor.netty.http.client.HttpClientObservations.ResponseTimeHighCardinalityTags.REACTOR_NETTY_STATUS;
+import static reactor.netty.http.client.HttpClientObservations.ResponseTimeHighCardinalityTags.REACTOR_NETTY_TYPE;
+import static reactor.netty.http.client.HttpClientObservations.ResponseTimeLowCardinalityTags.METHOD;
+import static reactor.netty.http.client.HttpClientObservations.ResponseTimeLowCardinalityTags.REMOTE_ADDRESS;
+import static reactor.netty.http.client.HttpClientObservations.ResponseTimeLowCardinalityTags.STATUS;
+import static reactor.netty.http.client.HttpClientObservations.ResponseTimeLowCardinalityTags.URI;
+
+/**
+ * @author Marcin Grzejszczak
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetricsHandler {
+	final MicrometerHttpClientMetricsRecorder recorder;
+
+	ResponseTimeHandlerContext responseTimeHandlerContext;
+	Observation responseTimeObservation;
+
+	MicrometerHttpClientMetricsHandler(MicrometerHttpClientMetricsRecorder recorder,
+			@Nullable Function<String, String> uriTagValue) {
+		super(uriTagValue);
+		this.recorder = recorder;
+	}
+
+	@Override
+	protected HttpClientMetricsRecorder recorder() {
+		return recorder;
+	}
+
+	@Override
+	protected void recordRead(SocketAddress address) {
+		recorder().recordDataReceivedTime(address,
+				path, method, status,
+				Duration.ofNanos(System.nanoTime() - dataReceivedTime));
+
+		recorder().recordDataReceived(address, path, dataReceived);
+
+		// TODO
+		// Cannot invoke the recorder any more:
+		// 1. The recorder is one instance only, it is invoked for all requests that can happen
+		// 2. The recorder does not have knowledge about request lifecycle
+		//
+		// Move the implementation from the recorder here
+		//
+		// Important:
+		// Cannot cache the Timer anymore - need to test the performance
+		responseTimeHandlerContext.status = status;
+		responseTimeObservation.stop();
+	}
+
+	@Override
+	protected void reset() {
+		super.reset();
+		responseTimeHandlerContext = null;
+		responseTimeObservation = null;
+	}
+
+	// reading the response
+	@Override
+	protected void startRead(HttpResponse msg, SocketAddress address) {
+		super.startRead(msg, address);
+
+		responseTimeHandlerContext.setResponse(new ObservationHttpClientResponse(msg));
+	}
+
+	// writing the request
+	@Override
+	protected void startWrite(HttpRequest msg, SocketAddress address) {
+		super.startWrite(msg, address);
+
+		HttpClientRequest httpClientRequest = new ObservationHttpClientRequest(msg, method, path);
+		responseTimeHandlerContext = new ResponseTimeHandlerContext(httpClientRequest, address, recorder.protocol());
+		responseTimeObservation = Observation.start(recorder.name() + RESPONSE_TIME, responseTimeHandlerContext, REGISTRY);
+	}
+
+	static final class ObservationHttpClientRequest implements HttpClientRequest {
+
+		final String method;
+		final HttpRequest nettyRequest;
+		final String path;
+
+		ObservationHttpClientRequest(HttpRequest nettyRequest, String method, String path) {
+			this.method = method;
+			this.nettyRequest = nettyRequest;
+			this.path = path;
+		}
+
+		@Override
+		public String header(String name) {
+			return nettyRequest.headers().get(name);
+		}
+
+		@Override
+		public void header(String name, String value) {
+			nettyRequest.headers().set(name, value);
+		}
+
+		@Override
+		public Collection<String> headerNames() {
+			return nettyRequest.headers().names();
+		}
+
+		@Override
+		public String method() {
+			return method;
+		}
+
+		@Override
+		public String path() {
+			return path;
+		}
+
+		@Override
+		public Object unwrap() {
+			return nettyRequest;
+		}
+
+		@Override
+		public String url() {
+			return nettyRequest.uri();
+		}
+	}
+
+	static final class ObservationHttpClientResponse implements HttpClientResponse {
+
+		final HttpResponse nettyResponse;
+
+		ObservationHttpClientResponse(HttpResponse nettyResponse) {
+			this.nettyResponse = nettyResponse;
+		}
+
+		@Override
+		public Collection<String> headerNames() {
+			return nettyResponse.headers().names();
+		}
+
+		@Override
+		public int statusCode() {
+			return nettyResponse.status().code();
+		}
+
+		@Override
+		public Object unwrap() {
+			return nettyResponse;
+		}
+	}
+
+	static final class ResponseTimeHandlerContext extends HttpClientContext implements ReactorNettyHandlerContext {
+		static final String CONTEXTUAL_NAME = "response received";
+		static final String TYPE = "client";
+
+		final String method;
+		final String path;
+		final String protocol;
+		final String remoteAddress;
+
+		// status might not be known beforehand
+		String status;
+
+		ResponseTimeHandlerContext(HttpClientRequest request, SocketAddress remoteAddress, String protocol) {
+			super(request);
+			this.method = request.method();
+			this.path = request.path();
+			this.protocol = protocol;
+			this.remoteAddress = formatSocketAddress(remoteAddress);
+			put(HttpClientRequest.class, request);
+		}
+
+		@Override
+		public String getContextualName() {
+			return CONTEXTUAL_NAME;
+		}
+
+		@Override
+		public Tags getHighCardinalityTags() {
+			return Tags.of(REACTOR_NETTY_PROTOCOL.of(protocol), REACTOR_NETTY_STATUS.of(status), REACTOR_NETTY_TYPE.of(TYPE));
+		}
+
+		@Override
+		public Tags getLowCardinalityTags() {
+			return Tags.of(METHOD.of(method), REMOTE_ADDRESS.of(remoteAddress), STATUS.of(status), URI.of(path));
+		}
+
+		@Override
+		public HttpClientContext setResponse(HttpClientResponse response) {
+			put(HttpClientResponse.class, response);
+			return super.setResponse(response);
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/observability/ReactorNettyHttpClientTracingObservationHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/observability/ReactorNettyHttpClientTracingObservationHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.observability;
+
+import io.micrometer.api.instrument.Tag;
+import io.micrometer.api.instrument.observation.Observation;
+import io.micrometer.api.instrument.transport.http.HttpClientRequest;
+import io.micrometer.api.instrument.transport.http.context.HttpClientContext;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.HttpClientTracingObservationHandler;
+import io.micrometer.tracing.http.HttpClientHandler;
+import reactor.netty.observability.ReactorNettyHandlerContext;
+
+import static reactor.netty.Metrics.REMOTE_ADDRESS;
+
+/**
+ * Reactor Netty specific {@link HttpClientTracingObservationHandler}
+ *
+ * @author Marcin Grzejszczak
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+public final class ReactorNettyHttpClientTracingObservationHandler extends HttpClientTracingObservationHandler {
+
+	/**
+	 * Creates a new instance of {@link HttpClientTracingObservationHandler}.
+	 *
+	 * @param tracer  tracer
+	 * @param handler http client handler
+	 */
+	public ReactorNettyHttpClientTracingObservationHandler(Tracer tracer, HttpClientHandler handler) {
+		super(tracer, handler);
+	}
+
+	@Override
+	public void tagSpan(HttpClientContext context, Span span) {
+		for (Tag tag : context.getHighCardinalityTags()) {
+			span.tag(tag.getKey(), tag.getValue());
+		}
+		for (Tag tag : context.getLowCardinalityTags()) {
+			if (tag.getKey().equals(REMOTE_ADDRESS)) {
+				span.tag(tag.getKey(), tag.getValue());
+				break;
+			}
+		}
+	}
+
+	@Override
+	public boolean supportsContext(Observation.Context context) {
+		return context instanceof ReactorNettyHandlerContext &&
+				super.supportsContext(context) &&
+				context.get(HttpClientRequest.class) != null;
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/observability/ReactorNettyHttpServerTracingObservationHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/observability/ReactorNettyHttpServerTracingObservationHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.observability;
+
+import io.micrometer.api.instrument.Tag;
+import io.micrometer.api.instrument.observation.Observation;
+import io.micrometer.api.instrument.transport.http.HttpServerRequest;
+import io.micrometer.api.instrument.transport.http.context.HttpServerContext;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.HttpServerTracingObservationHandler;
+import io.micrometer.tracing.http.HttpServerHandler;
+import reactor.netty.observability.ReactorNettyHandlerContext;
+
+/**
+ * Reactor Netty specific {@link HttpServerTracingObservationHandler}
+ *
+ * @author Marcin Grzejszczak
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+public final class ReactorNettyHttpServerTracingObservationHandler extends HttpServerTracingObservationHandler {
+
+	/**
+	 * Creates a new instance of {@link HttpServerTracingObservationHandler}.
+	 *
+	 * @param tracer  tracer
+	 * @param handler http server handler
+	 */
+	public ReactorNettyHttpServerTracingObservationHandler(Tracer tracer, HttpServerHandler handler) {
+		super(tracer, handler);
+	}
+
+	@Override
+	public void tagSpan(HttpServerContext context, Span span) {
+		for (Tag tag : context.getHighCardinalityTags()) {
+			span.tag(tag.getKey(), tag.getValue());
+		}
+	}
+
+	@Override
+	public boolean supportsContext(Observation.Context context) {
+		return context instanceof ReactorNettyHandlerContext &&
+				super.supportsContext(context) &&
+				context.get(HttpServerRequest.class) != null;
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -545,9 +545,16 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 
 		if (metricsRecorder != null) {
 			if (metricsRecorder instanceof HttpServerMetricsRecorder) {
-				ChannelHandler handler = metricsRecorder instanceof ContextAwareHttpServerMetricsRecorder ?
-						new ContextAwareHttpServerMetricsHandler((ContextAwareHttpServerMetricsRecorder) metricsRecorder, uriTagValue) :
-						new HttpServerMetricsHandler((HttpServerMetricsRecorder) metricsRecorder, uriTagValue);
+				ChannelHandler handler;
+				if (metricsRecorder instanceof MicrometerHttpServerMetricsRecorder) {
+					handler = new MicrometerHttpServerMetricsHandler((MicrometerHttpServerMetricsRecorder) metricsRecorder, uriTagValue);
+				}
+				else if (metricsRecorder instanceof ContextAwareHttpServerMetricsRecorder) {
+					handler = new ContextAwareHttpServerMetricsHandler((ContextAwareHttpServerMetricsRecorder) metricsRecorder, uriTagValue);
+				}
+				else {
+					handler = new HttpServerMetricsHandler((HttpServerMetricsRecorder) metricsRecorder, uriTagValue);
+				}
 				p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.HttpMetricsHandler, handler);
 				if (metricsRecorder instanceof MicrometerHttpServerMetricsRecorder) {
 					// For sake of performance, we can remove the ChannelMetricsHandler because the MicrometerHttpServerMetricsRecorder
@@ -596,9 +603,16 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 
 		if (metricsRecorder != null) {
 			if (metricsRecorder instanceof HttpServerMetricsRecorder) {
-				ChannelHandler handler = metricsRecorder instanceof ContextAwareHttpServerMetricsRecorder ?
-						new ContextAwareHttpServerMetricsHandler((ContextAwareHttpServerMetricsRecorder) metricsRecorder, uriTagValue) :
-						new HttpServerMetricsHandler((HttpServerMetricsRecorder) metricsRecorder, uriTagValue);
+				ChannelHandler handler;
+				if (metricsRecorder instanceof MicrometerHttpServerMetricsRecorder) {
+					handler = new MicrometerHttpServerMetricsHandler((MicrometerHttpServerMetricsRecorder) metricsRecorder, uriTagValue);
+				}
+				else if (metricsRecorder instanceof ContextAwareHttpServerMetricsRecorder) {
+					handler = new ContextAwareHttpServerMetricsHandler((ContextAwareHttpServerMetricsRecorder) metricsRecorder, uriTagValue);
+				}
+				else {
+					handler = new HttpServerMetricsHandler((HttpServerMetricsRecorder) metricsRecorder, uriTagValue);
+				}
 				p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.HttpMetricsHandler, handler);
 				if (metricsRecorder instanceof MicrometerHttpServerMetricsRecorder) {
 					// For sake of performance, we can remove the ChannelMetricsHandler because the MicrometerHttpServerMetricsRecorder
@@ -931,7 +945,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 					pipeline.addFirst(NettyPipeline.NonSslRedirectDetector, nonSslRedirectDetector);
 				}
 				else {
-					sslProvider.addSslHandler(channel, remoteAddress, SSL_DEBUG);
+					sslProvider.addSslHandler(channel, remoteAddress, SSL_DEBUG, false);
 				}
 
 				if ((protocols & h11orH2) == h11orH2) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerObservations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerObservations.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.micrometer.api.instrument.docs.DocumentedObservation;
+import io.micrometer.api.instrument.docs.TagKey;
+
+/**
+ * {@link HttpServer} observations.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum HttpServerObservations implements DocumentedObservation {
+
+	/**
+	 * Response metric.
+	 */
+	HTTP_SERVER_RESPONSE_TIME {
+		@Override
+		public TagKey[] getHighCardinalityTagKeys() {
+			return ResponseTimeHighCardinalityTags.values();
+		}
+
+		@Override
+		public TagKey[] getLowCardinalityTagKeys() {
+			return ResponseTimeLowCardinalityTags.values();
+		}
+
+		@Override
+		public String getName() {
+			return "reactor.netty.http.server.response.time";
+		}
+	};
+
+	/**
+	 * Response High Cardinality Tags.
+	 */
+	enum ResponseTimeHighCardinalityTags implements TagKey {
+
+		/**
+		 * Reactor Netty protocol (always http).
+		 */
+		REACTOR_NETTY_PROTOCOL {
+			@Override
+			public String getKey() {
+				return "reactor.netty.protocol";
+			}
+		},
+
+		/**
+		 * Reactor Netty status.
+		 */
+		REACTOR_NETTY_STATUS {
+			@Override
+			public String getKey() {
+				return "reactor.netty.status";
+			}
+		},
+
+		/**
+		 * Reactor Netty type (always server).
+		 */
+		REACTOR_NETTY_TYPE {
+			@Override
+			public String getKey() {
+				return "reactor.netty.type";
+			}
+		}
+	}
+
+	/**
+	 * Response Low Cardinality Tags.
+	 */
+	enum ResponseTimeLowCardinalityTags implements TagKey {
+
+		/**
+		 * METHOD.
+		 */
+		METHOD {
+			@Override
+			public String getKey() {
+				return "method";
+			}
+		},
+
+		/**
+		 * STATUS.
+		 */
+		STATUS {
+			@Override
+			public String getKey() {
+				return "status";
+			}
+		},
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String getKey() {
+				return "uri";
+			}
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerSpans.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerSpans.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.micrometer.api.instrument.docs.DocumentedObservation;
+import io.micrometer.api.instrument.docs.TagKey;
+import io.micrometer.tracing.docs.DocumentedSpan;
+
+/**
+ * {@link HttpServer} spans.
+ *
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+enum HttpServerSpans implements DocumentedSpan {
+
+	/**
+	 * Response Span.
+	 */
+	HTTP_SERVER_RESPONSE_SPAN {
+		@Override
+		public String getName() {
+			return "%s";
+		}
+
+		@Override
+		public TagKey[] getTagKeys() {
+			return ResponseTimeHighCardinalityTags.values();
+		}
+
+		@Override
+		public DocumentedObservation overridesDefaultSpanFrom() {
+			return HttpServerObservations.HTTP_SERVER_RESPONSE_TIME;
+		}
+	};
+
+	enum ResponseTimeHighCardinalityTags implements TagKey {
+
+		/**
+		 * Reactor Netty protocol (always http).
+		 */
+		REACTOR_NETTY_PROTOCOL {
+			@Override
+			public String getKey() {
+				return "reactor.netty.protocol";
+			}
+		},
+
+		/**
+		 * Reactor Netty status.
+		 */
+		REACTOR_NETTY_STATUS {
+			@Override
+			public String getKey() {
+				return "reactor.netty.status";
+			}
+		},
+
+		/**
+		 * Reactor Netty type (always server).
+		 */
+		REACTOR_NETTY_TYPE {
+			@Override
+			public String getKey() {
+				return "reactor.netty.type";
+			}
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.micrometer.api.instrument.Tags;
+import io.micrometer.api.instrument.observation.Observation;
+import io.micrometer.api.instrument.transport.http.HttpServerRequest;
+import io.micrometer.api.instrument.transport.http.HttpServerResponse;
+import io.micrometer.api.instrument.transport.http.context.HttpServerContext;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import reactor.netty.observability.ReactorNettyHandlerContext;
+import reactor.util.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.function.Function;
+
+import static reactor.netty.Metrics.REGISTRY;
+import static reactor.netty.Metrics.RESPONSE_TIME;
+import static reactor.netty.http.server.HttpServerObservations.ResponseTimeHighCardinalityTags.REACTOR_NETTY_PROTOCOL;
+import static reactor.netty.http.server.HttpServerObservations.ResponseTimeHighCardinalityTags.REACTOR_NETTY_STATUS;
+import static reactor.netty.http.server.HttpServerObservations.ResponseTimeHighCardinalityTags.REACTOR_NETTY_TYPE;
+import static reactor.netty.http.server.HttpServerObservations.ResponseTimeLowCardinalityTags.METHOD;
+import static reactor.netty.http.server.HttpServerObservations.ResponseTimeLowCardinalityTags.STATUS;
+import static reactor.netty.http.server.HttpServerObservations.ResponseTimeLowCardinalityTags.URI;
+
+/**
+ * @author Marcin Grzejszczak
+ * @author Violeta Georgieva
+ * @since 1.1.0
+ */
+final class MicrometerHttpServerMetricsHandler extends AbstractHttpServerMetricsHandler {
+	final MicrometerHttpServerMetricsRecorder recorder;
+	final String responseTimeName;
+
+	ResponseTimeHandlerContext responseTimeHandlerContext;
+	Observation responseTimeObservation;
+
+	MicrometerHttpServerMetricsHandler(MicrometerHttpServerMetricsRecorder recorder,
+			@Nullable Function<String, String> uriTagValue) {
+		super(uriTagValue);
+		this.recorder = recorder;
+		this.responseTimeName = recorder.name() + RESPONSE_TIME;
+	}
+
+	@Override
+	protected HttpServerMetricsRecorder recorder() {
+		return recorder;
+	}
+
+	@Override
+	protected void recordWrite(HttpServerOperations ops, String path, String method, String status) {
+		Duration dataSentTimeDuration = Duration.ofNanos(System.nanoTime() - dataSentTime);
+		recorder().recordDataSentTime(path, method, status, dataSentTimeDuration);
+
+		// Always take the remote address from the operations in order to consider proxy information
+		recorder().recordDataSent(ops.remoteAddress(), path, dataSent);
+
+		// TODO
+		// Cannot invoke the recorder any more:
+		// 1. The recorder is one instance only, it is invoked for all requests that can happen
+		// 2. The recorder does not have knowledge about request lifecycle
+		//
+		// Move the implementation from the recorder here
+		//
+		// Important:
+		// Cannot cache the Timer anymore - need to test the performance
+		responseTimeObservation.stop();
+
+		responseTimeHandlerContext = null;
+		responseTimeObservation = null;
+	}
+
+	@Override
+	protected void startRead(HttpServerOperations ops, String path, String method) {
+		super.startRead(ops, path, method);
+
+		responseTimeHandlerContext = new ResponseTimeHandlerContext(
+				new ObservationHttpServerRequest(ops.nettyRequest, method, path), recorder.protocol());
+		responseTimeObservation = Observation.start(this.responseTimeName, responseTimeHandlerContext, REGISTRY);
+	}
+
+	// response
+	@Override
+	protected void startWrite(HttpServerOperations ops, String path, String method, String status) {
+		super.startWrite(ops, path, method, status);
+
+		if (responseTimeObservation == null) {
+			responseTimeHandlerContext = new ResponseTimeHandlerContext(
+					new ObservationHttpServerRequest(ops.nettyRequest, method, path), recorder.protocol());
+			responseTimeObservation = Observation.start(this.responseTimeName, responseTimeHandlerContext, REGISTRY);
+		}
+		responseTimeHandlerContext.setResponse(new ObservationHttpServerResponse(ops.nettyResponse));
+		responseTimeHandlerContext.status = status;
+	}
+
+	static final class ObservationHttpServerRequest implements HttpServerRequest {
+
+		final String method;
+		final HttpRequest nettyRequest;
+		final String path;
+
+		ObservationHttpServerRequest(HttpRequest nettyRequest, String method, String path) {
+			this.method = method;
+			this.nettyRequest = nettyRequest;
+			this.path = path;
+		}
+
+		@Override
+		public String header(String name) {
+			return nettyRequest.headers().get(name);
+		}
+
+		@Override
+		public Collection<String> headerNames() {
+			return nettyRequest.headers().names();
+		}
+
+		@Override
+		public String method() {
+			return method;
+		}
+
+		@Override
+		public String path() {
+			return path;
+		}
+
+		@Override
+		public Object unwrap() {
+			return nettyRequest;
+		}
+
+		@Override
+		public String url() {
+			return nettyRequest.uri();
+		}
+	}
+
+	static final class ObservationHttpServerResponse implements HttpServerResponse {
+
+		final HttpResponse nettyResponse;
+
+		ObservationHttpServerResponse(HttpResponse nettyResponse) {
+			this.nettyResponse = nettyResponse;
+		}
+
+		@Override
+		public Collection<String> headerNames() {
+			return nettyResponse.headers().names();
+		}
+
+		@Override
+		public int statusCode() {
+			return nettyResponse.status().code();
+		}
+
+		@Override
+		public Object unwrap() {
+			return nettyResponse;
+		}
+	}
+
+	static final class ResponseTimeHandlerContext extends HttpServerContext implements ReactorNettyHandlerContext {
+		static final String CONTEXTUAL_NAME = "response sent";
+		static final String TYPE = "server";
+
+		final String method;
+		final String path;
+		final String protocol;
+
+		// status might not be known beforehand
+		String status;
+
+		ResponseTimeHandlerContext(HttpServerRequest request, String protocol) {
+			super(request);
+			this.method = request.method();
+			this.path = request.path();
+			this.protocol = protocol;
+			put(HttpServerRequest.class, request);
+		}
+
+		@Override
+		public String getContextualName() {
+			return CONTEXTUAL_NAME;
+		}
+
+		@Override
+		public Tags getHighCardinalityTags() {
+			// TODO cache
+			return Tags.of(REACTOR_NETTY_PROTOCOL.of(protocol), REACTOR_NETTY_STATUS.of(status), REACTOR_NETTY_TYPE.of(TYPE));
+		}
+
+		@Override
+		public Tags getLowCardinalityTags() {
+			return Tags.of(METHOD.of(method), STATUS.of(status), URI.of(path));
+		}
+
+		@Override
+		public HttpServerContext setResponse(HttpServerResponse response) {
+			put(HttpServerResponse.class, response);
+			return super.setResponse(response);
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/observability/ObservabilitySmokeTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/observability/ObservabilitySmokeTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.observability;
+
+import java.nio.charset.Charset;
+import java.security.cert.CertificateException;
+import java.time.Duration;
+import java.util.Deque;
+import java.util.Random;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.micrometer.api.instrument.Metrics;
+import io.micrometer.api.instrument.observation.ObservationHandler;
+import io.micrometer.api.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.test.SampleTestRunner;
+import io.micrometer.tracing.test.reporter.BuildingBlocks;
+import io.micrometer.tracing.test.simple.SpansAssert;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import reactor.core.publisher.Mono;
+import reactor.netty.ByteBufMono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.Http11SslContextSpec;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.server.HttpServer;
+import reactor.netty.observability.ReactorNettyTracingObservationHandler;
+import reactor.test.StepVerifier;
+
+import static reactor.netty.Metrics.REGISTRY;
+
+@SuppressWarnings("rawtypes")
+class ObservabilitySmokeTest extends SampleTestRunner {
+	static final SimpleMeterRegistry simpleMeterRegistry = new SimpleMeterRegistry();
+
+	static String content;
+	static DisposableServer disposableServer;
+	static SelfSignedCertificate ssc;
+
+	ObservabilitySmokeTest() {
+		super(SampleTestRunner.SampleRunnerConfig.builder().build(), REGISTRY);
+	}
+
+	@BeforeAll
+	static void setUp() throws CertificateException {
+		ssc = new SelfSignedCertificate();
+
+		byte[] bytes = new byte[1024 * 8];
+		Random rndm = new Random();
+		rndm.nextBytes(bytes);
+		content = new String(bytes, Charset.defaultCharset());
+
+		Metrics.addRegistry(simpleMeterRegistry);
+	}
+
+	@AfterEach
+	void setupRegistry() {
+		if (disposableServer != null) {
+			disposableServer.disposeNow();
+		}
+
+		simpleMeterRegistry.clear();
+	}
+
+	@AfterAll
+	static void tearDown() {
+		Metrics.removeRegistry(simpleMeterRegistry);
+	}
+
+	@Override
+	public BiConsumer<BuildingBlocks, Deque<ObservationHandler>> customizeObservationHandlers() {
+		return (bb, timerRecordingHandlers) -> {
+			ObservationHandler defaultHandler = timerRecordingHandlers.removeLast();
+			timerRecordingHandlers.addLast(new ReactorNettyTracingObservationHandler(bb.getTracer()));
+			timerRecordingHandlers.addLast(defaultHandler);
+			timerRecordingHandlers.addFirst(new ReactorNettyHttpClientTracingObservationHandler(bb.getTracer(), bb.getHttpClientHandler()));
+			timerRecordingHandlers.addFirst(new ReactorNettyHttpServerTracingObservationHandler(bb.getTracer(), bb.getHttpServerHandler()));
+		};
+	}
+
+	@Override
+	public TracingSetup[] getTracingSetup() {
+		return new TracingSetup[] {TracingSetup.ZIPKIN_BRAVE};
+	}
+
+	@Override
+	public SampleTestRunnerConsumer yourCode() {
+		return (bb, meterRegistry) -> {
+			Http11SslContextSpec serverCtxHttp11 = Http11SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+			disposableServer =
+					HttpServer.create()
+					          .wiretap(true)
+					          .metrics(true, Function.identity())
+					          .secure(spec -> spec.sslContext(serverCtxHttp11))
+					          .route(r -> r.post("/post", (req, res) -> res.send(req.receive().retain())))
+					          .bindNow();
+
+			Http11SslContextSpec clientCtxHttp11 =
+					Http11SslContextSpec.forClient()
+					                    .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+			HttpClient client =
+					HttpClient.create()
+					          .port(disposableServer.port())
+					          .host("localhost")
+					          .wiretap(true)
+					          .metrics(true, Function.identity())
+					          .secure(spec -> spec.sslContext(clientCtxHttp11));
+
+			client.post()
+			      .uri("/post")
+			      .send(ByteBufMono.fromString(Mono.just(content)))
+			      .responseSingle((res, bytebuf) -> bytebuf.asString())
+			      .as(StepVerifier::create)
+			      .expectNext(content)
+			      .expectComplete()
+			      .verify(Duration.ofSeconds(10));
+
+			Span current = bb.getTracer().currentSpan();
+
+			SpansAssert.assertThat(bb.getFinishedSpans().stream().filter(f -> f.getTraceId().equals(current.context().traceId()))
+			           .collect(Collectors.toList()))
+			           .hasASpanWithName("connect")
+			           .hasASpanWithName("tls handshake")
+			           .hasASpanWithName("POST");
+		};
+	}
+}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/observability/ObservabilitySmokeTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/observability/ObservabilitySmokeTest.java
@@ -72,7 +72,7 @@ class ObservabilitySmokeTest extends SampleTestRunner {
 	}
 
 	@AfterEach
-	void setupRegistry() {
+	void cleanRegistry() {
 		if (disposableServer != null) {
 			disposableServer.disposeNow();
 		}


### PR DESCRIPTION
HttpClient/HttpServer response times now are Observation

Related to #1952

Co-authored-by: Marcin Grzejszczak <mgrzejszczak@vmware.com>