### PR TITLE
Improve readability of preliminary how-to-fix hint in CI

### DIFF
--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -25,7 +25,7 @@ jobs:
         if: failure()
         # the foreground (38;5) color code 208 is orange. we also have bold, white bg (38;5;0;48;5;255m), white fg on black bg...
         run: |
-          echo -e "\n\033[38;5;0;48;5;208m \u001b[1mHow to deal with errors in preliminary job: \u001b[0m\033[0m"
+          echo -e "\n\033[38;5;0;48;5;208m \u001b[1m How to deal with errors in preliminary job: \u001b[0m\033[0m"
           echo "(Have a look at the steps above to see what failed exactly)"
           echo -e "\n - \u001b[1mSpotless (license headers)\u001b[0m failures on touched java files \033[38;5;255;48;5;0m\u001b[1mcan be automatically fixed by running\u001b[0m:"
           echo -e "   \033[38;5;0;48;5;255m ./gradlew spotlessApply \033[0m"

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -23,13 +23,15 @@ jobs:
         run: ./gradlew clean japicmp
       - name: how to fix
         if: failure()
-        # the foreground (38;5) color code 022 is green
+        # the foreground (38;5) color code 208 is orange. we also have bold, white bg (38;5;0;48;5;255m), white fg on black bg...
         run: |
-          echo "Tips for fixing errors in preliminary job:"
-          echo -e "\033[38;5;255;48;5;022m ✅ License headers of touched java files can be automatically fixed by running:\033[0m\n\033[38;5;208;48;5;022m./gradlew spotlessApply\033[0m"
+          echo -e "\n\033[38;5;0;48;5;208m \u001b[1mHow to deal with errors in preliminary job: \u001b[0m\033[0m"
+          echo "(Have a look at the steps above to see what failed exactly)"
+          echo -e "\n - \u001b[1mSpotless (license headers)\u001b[0m failures on touched java files \033[38;5;255;48;5;0m\u001b[1mcan be automatically fixed by running\u001b[0m:"
+          echo -e "   \033[38;5;0;48;5;255m ./gradlew spotlessApply \033[0m"
+          echo -e "\n - \u001b[1mAPI Compatibility\u001b[0m failures should be considered carefully and \033[38;5;255;48;5;0m\u001b[1mdiscussed with maintainers in the PR\u001b[0m"
+          echo "   If there are failures, the detail should be available in the logs of the api compatibility step above"
           echo ""
-          echo -e "\033[38;5;255;48;5;202m ⚠️ JApiCmp failures should be considered carefully and discussed with maintainers in the PR\033[0m"
-          echo "If there are failures, the detail should be available in the logs of the api compatibility step above"
           exit -1
 
   build:


### PR DESCRIPTION
The message is intended as a hint on how to fix failing steps above it.
This commit makes itmore explicit, both in text and by the choice of
color coding.

Previously, the separate hints had some colored background, green and
orange respectively. This made it look like the japicmp step was the one
detected as failed, which was counterintuitive.

The message now explicitly tells the reader to look at the previous
steps in the job, and the colors have been changed to:
 - drive focus to the whole message by having a header with orange bg
 - highlight the individual calls to action with white font on black bg
 - highlight the gradle command with black font on white bg