### PR TITLE
Do not override the contextual name for HttpClientContext/HttpServerContext

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
@@ -182,7 +182,6 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 	}
 
 	static final class ResponseTimeHandlerContext extends HttpClientContext implements ReactorNettyHandlerContext {
-		static final String CONTEXTUAL_NAME = "response received";
 		static final String TYPE = "client";
 
 		final String method;
@@ -200,11 +199,6 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 			this.protocol = protocol;
 			this.remoteAddress = formatSocketAddress(remoteAddress);
 			put(HttpClientRequest.class, request);
-		}
-
-		@Override
-		public String getContextualName() {
-			return CONTEXTUAL_NAME;
 		}
 
 		@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java
@@ -176,7 +176,6 @@ final class MicrometerHttpServerMetricsHandler extends AbstractHttpServerMetrics
 	}
 
 	static final class ResponseTimeHandlerContext extends HttpServerContext implements ReactorNettyHandlerContext {
-		static final String CONTEXTUAL_NAME = "response sent";
 		static final String TYPE = "server";
 
 		final String method;
@@ -192,11 +191,6 @@ final class MicrometerHttpServerMetricsHandler extends AbstractHttpServerMetrics
 			this.path = request.path();
 			this.protocol = protocol;
 			put(HttpServerRequest.class, request);
-		}
-
-		@Override
-		public String getContextualName() {
-			return CONTEXTUAL_NAME;
 		}
 
 		@Override


### PR DESCRIPTION
`HttpClientTracingObservationHandler`/`HttpServerTracingObservationHandler`
provides contextual name based on the request method
`io.micrometer.tracing.handler.HttpClientTracingObservationHandler#getSpanName`
`io.micrometer.tracing.handler.HttpServerTracingObservationHandler#getSpanName`

Related to #1952