### PR TITLE
Ensure server connections metrics are not reported for the client

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/AbstractChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/AbstractChannelMetricsHandler.java
@@ -45,13 +45,17 @@ public abstract class AbstractChannelMetricsHandler extends ChannelDuplexHandler
 
 	@Override
 	public void channelActive(ChannelHandlerContext ctx) {
-		recorder().recordServerConnectionOpened(ctx.channel().localAddress());
+		if (onServer) {
+			recorder().recordServerConnectionOpened(ctx.channel().localAddress());
+		}
 		ctx.fireChannelActive();
 	}
 
 	@Override
 	public void channelInactive(ChannelHandlerContext ctx) {
-		recorder().recordServerConnectionClosed(ctx.channel().localAddress());
+		if (onServer) {
+			recorder().recordServerConnectionClosed(ctx.channel().localAddress());
+		}
 		ctx.fireChannelInactive();
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -395,6 +395,11 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	void testServerConnectionsMicrometer() throws Exception {
 		disposableServer = httpServer.metrics(true, Function.identity()).bindNow();
 
+		AtomicReference<SocketAddress> clientAddress = new AtomicReference<>();
+		httpClient = httpClient.doAfterRequest((req, conn) ->
+				clientAddress.set(conn.channel().localAddress())
+		);
+
 		String uri = "/4";
 		String address = formatSocketAddress(disposableServer.address());
 		CountDownLatch latch = new CountDownLatch(1);
@@ -422,6 +427,12 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		// now check the server counters
 		checkGauge(SERVER_CONNECTIONS_TOTAL, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
 		checkGauge(SERVER_CONNECTIONS_ACTIVE, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
+
+		// These metrics are meant only for the servers,
+		// connections metrics for the clients are available from the connection pool
+		address = formatSocketAddress(clientAddress.get());
+		checkGauge(CLIENT_CONNECTIONS_TOTAL, false, 0, URI, HTTP, LOCAL_ADDRESS, address);
+		checkGauge(CLIENT_CONNECTIONS_ACTIVE, false, 0, URI, HTTP, LOCAL_ADDRESS, address);
 
 		disposableServer.disposeNow();
 	}
@@ -595,6 +606,8 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	private static final String SERVER_DATA_RECEIVED = HTTP_SERVER_PREFIX + DATA_RECEIVED;
 	private static final String SERVER_ERRORS = HTTP_SERVER_PREFIX + ERRORS;
 
+	private static final String CLIENT_CONNECTIONS_ACTIVE = HTTP_CLIENT_PREFIX + CONNECTIONS_ACTIVE;
+	private static final String CLIENT_CONNECTIONS_TOTAL = HTTP_CLIENT_PREFIX + CONNECTIONS_TOTAL;
 	private static final String CLIENT_RESPONSE_TIME = HTTP_CLIENT_PREFIX + RESPONSE_TIME;
 	private static final String CLIENT_DATA_SENT_TIME = HTTP_CLIENT_PREFIX + DATA_SENT_TIME;
 	private static final String CLIENT_DATA_RECEIVED_TIME = HTTP_CLIENT_PREFIX + DATA_RECEIVED_TIME;


### PR DESCRIPTION
Connection metrics for the client are provided with another name
and by the `ConnectionProvider`.