### PR TITLE
NPE in Micrometer ssl handler when socket is closed while handshaking

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/MicrometerSslReadHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/MicrometerSslReadHandler.java
@@ -158,7 +158,12 @@ final class MicrometerSslReadHandler extends Observation.Context implements Reac
 			}
 			else {
 				status = ERROR;
-				observation.stop();
+
+				// We must check if observation is not null before closing it, because the channelActive
+				// method may not have been called if socket was closed while handshaking
+				if (observation != null) {
+					observation.stop();
+				}
 				ctx.fireExceptionCaught(handshake.cause());
 			}
 		}


### PR DESCRIPTION
This PR avoids a NPE in MicrometerSslReadHandler.userEventTriggered method, which has to check if the **observation** is not null before closing it. 
Indeed, if the remote peer closes the socket while handshaking is ongoing, then the userEventTriggered can be called while MicrometerSslReadHandler.channelActive method has not been called (and it's the channelActive which allocates the **observation**).
