### PR TITLE
Enable HttpClient/HttpServer metrics when protocol is H2/H2C

### DIFF
--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -56,3 +56,10 @@ jobs:
           java-version: '8'
       - name: Build with Gradle
         run: ./gradlew clean check --no-daemon -x spotlessCheck -PforceTransport=${{ matrix.transport }}
+      - name: Archive tests output
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: tests_output_${{ matrix.os }}_${{ matrix.transport }}
+          path: reactor-netty-http/build/test-results/test/binary/output.bin
+

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -61,5 +61,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: tests_output_${{ matrix.os }}_${{ matrix.transport }}
-          path: reactor-netty-http/build/test-results/test/binary/output.bin
+          path: reactor-netty-http/build/reports/tests/test
 

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -56,10 +56,3 @@ jobs:
           java-version: '8'
       - name: Build with Gradle
         run: ./gradlew clean check --no-daemon -x spotlessCheck -PforceTransport=${{ matrix.transport }}
-      - name: Archive tests output
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: tests_output_${{ matrix.os }}_${{ matrix.transport }}
-          path: reactor-netty-http/build/reports/tests/test
-

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
@@ -61,6 +61,18 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelDuplexHandler {
 		this.uriTagValue = uriTagValue;
 	}
 
+	protected AbstractHttpClientMetricsHandler(AbstractHttpClientMetricsHandler copy) {
+		this.contextView = copy.contextView;
+		this.dataReceived = copy.dataReceived;
+		this.dataReceivedTime = copy.dataReceivedTime;
+		this.dataSent = copy.dataSent;
+		this.dataSentTime = copy.dataSentTime;
+		this.method = copy.method;
+		this.path = copy.path;
+		this.status = copy.status;
+		this.uriTagValue = copy.uriTagValue;
+	}
+
 	@Override
 	@SuppressWarnings("FutureReturnValueIgnored")
 	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsHandler.java
@@ -36,6 +36,11 @@ final class ContextAwareHttpClientMetricsHandler extends AbstractHttpClientMetri
 		this.recorder = recorder;
 	}
 
+	ContextAwareHttpClientMetricsHandler(ContextAwareHttpClientMetricsHandler copy) {
+		super(copy);
+		this.recorder = copy.recorder;
+	}
+
 	@Override
 	protected ContextAwareHttpClientMetricsRecorder recorder() {
 		return recorder;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -84,6 +84,7 @@ import reactor.netty.transport.logging.AdvancedByteBufFormat;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 
 import static reactor.netty.ReactorNetty.format;
 import static reactor.netty.http.client.Http2ConnectionProvider.OWNER;
@@ -553,7 +554,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		Http2FrameCodec http2FrameCodec = http2FrameCodecBuilder.build();
 
 		Http2ClientUpgradeCodec upgradeCodec = new Http2ClientUpgradeCodec(http2FrameCodec,
-				new H2CleartextCodec(http2FrameCodec, opsFactory, acceptGzip));
+				new H2CleartextCodec(http2FrameCodec, opsFactory, acceptGzip, metricsRecorder, uriTagValue));
 
 		HttpClientUpgradeHandler upgradeHandler = new HttpClientUpgradeHandler(httpClientCodec, upgradeCodec, decoder.h2cMaxContentLength());
 
@@ -607,11 +608,17 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		}
 	}
 
-	static Future<Http2StreamChannel> openStream(Channel channel, Http2ConnectionProvider.DisposableAcquire owner,
-			ConnectionObserver observer, ChannelOperations.OnSetup opsFactory, boolean acceptGzip) {
+	static Future<Http2StreamChannel> openStream(
+			Channel channel,
+			Http2ConnectionProvider.DisposableAcquire owner,
+			ConnectionObserver observer,
+			ChannelOperations.OnSetup opsFactory,
+			boolean acceptGzip,
+			@Nullable ChannelMetricsRecorder metricsRecorder,
+			@Nullable Function<String, String> uriTagValue) {
 		Http2StreamChannelBootstrap bootstrap = new Http2StreamChannelBootstrap(channel);
 		bootstrap.option(ChannelOption.AUTO_READ, false);
-		bootstrap.handler(new H2Codec(owner, observer, opsFactory, acceptGzip));
+		bootstrap.handler(new H2Codec(owner, observer, opsFactory, acceptGzip, metricsRecorder, uriTagValue));
 		return bootstrap.open();
 	}
 
@@ -648,12 +655,21 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 
 		final boolean acceptGzip;
 		final Http2FrameCodec http2FrameCodec;
+		final ChannelMetricsRecorder metricsRecorder;
 		final ChannelOperations.OnSetup opsFactory;
+		final Function<String, String> uriTagValue;
 
-		H2CleartextCodec(Http2FrameCodec http2FrameCodec, ChannelOperations.OnSetup opsFactory, boolean acceptGzip) {
+		H2CleartextCodec(
+				Http2FrameCodec http2FrameCodec,
+				ChannelOperations.OnSetup opsFactory,
+				boolean acceptGzip,
+				@Nullable ChannelMetricsRecorder metricsRecorder,
+				@Nullable Function<String, String> uriTagValue) {
 			this.acceptGzip = acceptGzip;
 			this.http2FrameCodec = http2FrameCodec;
+			this.metricsRecorder = metricsRecorder;
 			this.opsFactory = opsFactory;
+			this.uriTagValue = uriTagValue;
 		}
 
 		@Override
@@ -672,11 +688,12 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			if (responseTimeoutHandler != null) {
 				pipeline.remove(NettyPipeline.ResponseTimeoutHandler);
 				http2MultiplexHandler = new Http2MultiplexHandler(new H2Codec(opsFactory, acceptGzip),
-						new H2Codec(owner, obs, opsFactory, acceptGzip, responseTimeoutHandler.getReaderIdleTimeInMillis()));
+						new H2Codec(owner, obs, opsFactory, acceptGzip, metricsRecorder,
+								responseTimeoutHandler.getReaderIdleTimeInMillis(), uriTagValue));
 			}
 			else {
 				http2MultiplexHandler = new Http2MultiplexHandler(new H2Codec(opsFactory, acceptGzip),
-						new H2Codec(owner, obs, opsFactory, acceptGzip));
+						new H2Codec(owner, obs, opsFactory, acceptGzip, metricsRecorder, uriTagValue));
 			}
 			pipeline.addAfter(ctx.name(), NettyPipeline.HttpCodec, http2FrameCodec)
 			        .addAfter(NettyPipeline.HttpCodec, NettyPipeline.H2MultiplexHandler, http2MultiplexHandler);
@@ -690,30 +707,23 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 
 	static final class H2Codec extends ChannelInitializer<Channel> {
 		final boolean acceptGzip;
+		final ChannelMetricsRecorder metricsRecorder;
 		final ConnectionObserver observer;
 		final ChannelOperations.OnSetup opsFactory;
 		final Http2ConnectionProvider.DisposableAcquire owner;
 		final long responseTimeoutMillis;
+		final Function<String, String> uriTagValue;
 
 		H2Codec(boolean acceptGzip) {
 			// Handle inbound streams (server pushes)
 			// TODO this is not supported
-			this(null, null, null, acceptGzip, -1);
+			this(null, null, null, acceptGzip, null, -1, null);
 		}
 
 		H2Codec(@Nullable ChannelOperations.OnSetup opsFactory, boolean acceptGzip) {
 			// Handle inbound streams (server pushes)
 			// TODO this is not supported
-			this(null, null, opsFactory, acceptGzip, -1);
-		}
-
-		H2Codec(
-				@Nullable Http2ConnectionProvider.DisposableAcquire owner,
-				@Nullable ConnectionObserver observer,
-				@Nullable ChannelOperations.OnSetup opsFactory,
-				boolean acceptGzip) {
-			// Handle outbound and upgrade streams
-			this(owner, observer, opsFactory, acceptGzip, -1);
+			this(null, null, opsFactory, acceptGzip, null, -1, null);
 		}
 
 		H2Codec(
@@ -721,20 +731,35 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 				@Nullable ConnectionObserver observer,
 				@Nullable ChannelOperations.OnSetup opsFactory,
 				boolean acceptGzip,
-				long responseTimeoutMillis) {
+				@Nullable ChannelMetricsRecorder metricsRecorder,
+				@Nullable Function<String, String> uriTagValue) {
+			// Handle outbound and upgrade streams
+			this(owner, observer, opsFactory, acceptGzip, metricsRecorder, -1, uriTagValue);
+		}
+
+		H2Codec(
+				@Nullable Http2ConnectionProvider.DisposableAcquire owner,
+				@Nullable ConnectionObserver observer,
+				@Nullable ChannelOperations.OnSetup opsFactory,
+				boolean acceptGzip,
+				@Nullable ChannelMetricsRecorder metricsRecorder,
+				long responseTimeoutMillis,
+				@Nullable Function<String, String> uriTagValue) {
 			// Handle outbound and upgrade streams
 			this.acceptGzip = acceptGzip;
+			this.metricsRecorder = metricsRecorder;
 			this.observer = observer;
 			this.opsFactory = opsFactory;
 			this.owner = owner;
 			this.responseTimeoutMillis = responseTimeoutMillis;
+			this.uriTagValue = uriTagValue;
 		}
 
 		@Override
 		protected void initChannel(Channel ch) {
 			if (observer != null && opsFactory != null && owner != null) {
 				Http2ConnectionProvider.registerClose(ch, owner);
-				addStreamHandlers(ch, observer.then(StreamConnectionObserver.INSTANCE), opsFactory);
+				addStreamHandlers(ch, observer.then(new StreamConnectionObserver(owner.currentContext())), opsFactory);
 			}
 			else {
 				// Handle server pushes (inbound streams)
@@ -752,6 +777,27 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			}
 
 			ChannelOperations.addReactiveBridge(ch, opsFactory, obs);
+
+			if (metricsRecorder != null) {
+				if (metricsRecorder instanceof HttpClientMetricsRecorder) {
+					ChannelHandler handler;
+					Channel parent = ch.parent();
+					ChannelHandler existingHandler = parent.pipeline().get(NettyPipeline.HttpMetricsHandler);
+					if (existingHandler != null) {
+						// This use case can happen only in HTTP/2 clear text connection upgrade
+						parent.pipeline().remove(NettyPipeline.HttpMetricsHandler);
+						handler = metricsRecorder instanceof ContextAwareHttpClientMetricsRecorder ?
+								new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsHandler) existingHandler) :
+								new HttpClientMetricsHandler((HttpClientMetricsHandler) existingHandler);
+					}
+					else {
+						handler = metricsRecorder instanceof ContextAwareHttpClientMetricsRecorder ?
+								new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) metricsRecorder, uriTagValue) :
+								new HttpClientMetricsHandler((HttpClientMetricsRecorder) metricsRecorder, uriTagValue);
+					}
+					pipeline.addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.HttpMetricsHandler, handler);
+				}
+			}
 
 			if (responseTimeoutMillis > -1) {
 				Connection.from(ch).addHandlerFirst(NettyPipeline.ResponseTimeoutHandler,
@@ -937,7 +983,16 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 
 	static final class StreamConnectionObserver implements ConnectionObserver {
 
-		static final StreamConnectionObserver INSTANCE = new StreamConnectionObserver();
+		final Context context;
+
+		StreamConnectionObserver(Context context) {
+			this.context = context;
+		}
+
+		@Override
+		public Context currentContext() {
+			return context;
+		}
 
 		@Override
 		@SuppressWarnings("FutureReturnValueIgnored")

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMetricsHandler.java
@@ -31,6 +31,11 @@ final class HttpClientMetricsHandler extends AbstractHttpClientMetricsHandler {
 		this.recorder = recorder;
 	}
 
+	HttpClientMetricsHandler(HttpClientMetricsHandler copy) {
+		super(copy);
+		this.recorder = copy.recorder;
+	}
+
 	@Override
 	protected HttpClientMetricsRecorder recorder() {
 		return recorder;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http2.Http2StreamChannel;
 import reactor.netty.channel.ChannelOperations;
 import reactor.util.annotation.Nullable;
 
@@ -52,12 +53,20 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 		this.uriTagValue = uriTagValue;
 	}
 
+	protected AbstractHttpServerMetricsHandler(AbstractHttpServerMetricsHandler copy) {
+		this.dataReceived = copy.dataReceived;
+		this.dataReceivedTime = copy.dataReceivedTime;
+		this.dataSent = copy.dataSent;
+		this.dataSentTime = copy.dataSentTime;
+		this.uriTagValue = copy.uriTagValue;
+	}
+
 	@Override
 	public void channelActive(ChannelHandlerContext ctx) {
 		// For custom user recorders, we don't propagate the channelActive event, because this will be done
 		// by the ChannelMetricsHandler itself. ChannelMetricsHandler is only present when the recorder is
 		// not our MicrometerHttpServerMetricsRecorder. See HttpServerConfig class.
-		if (recorder() instanceof MicrometerHttpServerMetricsRecorder) {
+		if (!(ctx.channel() instanceof Http2StreamChannel) && recorder() instanceof MicrometerHttpServerMetricsRecorder) {
 			recorder().recordServerConnectionOpened(ctx.channel().localAddress());
 		}
 		ctx.fireChannelActive();
@@ -65,7 +74,7 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 
 	@Override
 	public void channelInactive(ChannelHandlerContext ctx) {
-		if (recorder() instanceof MicrometerHttpServerMetricsRecorder) {
+		if (!(ctx.channel() instanceof Http2StreamChannel) && recorder() instanceof MicrometerHttpServerMetricsRecorder) {
 			recorder().recordServerConnectionClosed(ctx.channel().localAddress());
 		}
 		ctx.fireChannelInactive();
@@ -98,7 +107,10 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 					HttpServerOperations ops = (HttpServerOperations) channelOps;
 					recordWrite(ops, uriTagValue == null ? ops.path : uriTagValue.apply(ops.path),
 							ops.method().name(), ops.status().codeAsText().toString());
-					recordInactiveConnection(ops);
+					if (!ops.isHttp2()) {
+						// This metric is not applicable for HTTP/2
+						recordInactiveConnection(ops);
+					}
 				}
 
 				dataSent = 0;
@@ -116,7 +128,10 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 			ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
 			if (channelOps instanceof HttpServerOperations) {
 				HttpServerOperations ops = (HttpServerOperations) channelOps;
-				recordActiveConnection(ops);
+				if (!ops.isHttp2()) {
+					// This metric is not applicable for HTTP/2
+					recordActiveConnection(ops);
+				}
 			}
 		}
 
@@ -188,5 +203,4 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 	protected void recordInactiveConnection(HttpServerOperations ops) {
 		recorder().recordServerConnectionInactive(ops.hostAddress());
 	}
-
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsHandler.java
@@ -35,6 +35,11 @@ final class ContextAwareHttpServerMetricsHandler extends AbstractHttpServerMetri
 		this.recorder = recorder;
 	}
 
+	ContextAwareHttpServerMetricsHandler(ContextAwareHttpServerMetricsHandler copy) {
+		super(copy);
+		this.recorder = copy.recorder;
+	}
+
 	@Override
 	protected ContextAwareHttpServerMetricsRecorder recorder() {
 		return recorder;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -701,6 +701,11 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		}
 
 		@Override
+		public ChannelHandler tlsMetricsHandler() {
+			return null;
+		}
+
+		@Override
 		public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
 			ctx.fireExceptionCaught(cause);
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
@@ -49,6 +50,7 @@ import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
 import reactor.netty.NettyPipeline;
 import reactor.netty.ReactorNetty;
+import reactor.netty.channel.AbstractChannelMetricsHandler;
 import reactor.netty.channel.ChannelMetricsRecorder;
 import reactor.netty.channel.ChannelOperations;
 import reactor.netty.http.Http2SettingsSpec;
@@ -404,8 +406,10 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 			@Nullable BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> forwardedHeaderHandler,
 			ConnectionObserver listener,
 			@Nullable BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>> mapHandle,
+			@Nullable ChannelMetricsRecorder metricsRecorder,
 			int minCompressionSize,
-			ChannelOperations.OnSetup opsFactory) {
+			ChannelOperations.OnSetup opsFactory,
+			@Nullable Function<String, String> uriTagValue) {
 		ChannelPipeline pipeline = ch.pipeline();
 		if (accessLogEnabled) {
 			pipeline.addLast(NettyPipeline.AccessLogHandler, AccessLogHandlerFactory.H2.create(accessLog));
@@ -422,6 +426,33 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		}
 
 		ChannelOperations.addReactiveBridge(ch, opsFactory, listener);
+
+		if (metricsRecorder != null) {
+			if (metricsRecorder instanceof HttpServerMetricsRecorder) {
+				ChannelHandler handler;
+				Channel parent = ch.parent();
+				ChannelHandler existingHandler = parent.pipeline().get(NettyPipeline.HttpMetricsHandler);
+				if (existingHandler != null) {
+					// This use case can happen only in HTTP/2 clear text connection upgrade
+					if (metricsRecorder instanceof MicrometerHttpServerMetricsRecorder) {
+						parent.pipeline().replace(NettyPipeline.HttpMetricsHandler, NettyPipeline.ChannelMetricsHandler,
+								new H2ChannelMetricsHandler(metricsRecorder));
+					}
+					else {
+						parent.pipeline().remove(NettyPipeline.HttpMetricsHandler);
+					}
+					handler = metricsRecorder instanceof ContextAwareHttpServerMetricsRecorder ?
+							new ContextAwareHttpServerMetricsHandler((ContextAwareHttpServerMetricsHandler) existingHandler) :
+							new HttpServerMetricsHandler((HttpServerMetricsHandler) existingHandler);
+				}
+				else {
+					handler = metricsRecorder instanceof ContextAwareHttpServerMetricsRecorder ?
+							new ContextAwareHttpServerMetricsHandler((ContextAwareHttpServerMetricsRecorder) metricsRecorder, uriTagValue) :
+							new HttpServerMetricsHandler((HttpServerMetricsRecorder) metricsRecorder, uriTagValue);
+				}
+				pipeline.addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.HttpMetricsHandler, handler);
+			}
+		}
 
 		if (log.isDebugEnabled()) {
 			log.debug(format(ch, "Initialized HTTP/2 stream pipeline {}"), pipeline);
@@ -471,8 +502,10 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 			Http2Settings http2Settings,
 			ConnectionObserver listener,
 			@Nullable BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>> mapHandle,
+			@Nullable ChannelMetricsRecorder metricsRecorder,
 			int minCompressionSize,
 			ChannelOperations.OnSetup opsFactory,
+			@Nullable Function<String, String> uriTagValue,
 			boolean validate) {
 		p.remove(NettyPipeline.ReactiveBridge);
 
@@ -489,7 +522,17 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		p.addLast(NettyPipeline.HttpCodec, http2FrameCodecBuilder.build())
 		 .addLast(NettyPipeline.H2MultiplexHandler,
 		          new Http2MultiplexHandler(new H2Codec(accessLogEnabled, accessLog, compressPredicate, cookieDecoder,
-		                  cookieEncoder, formDecoderProvider, forwardedHeaderHandler, listener, mapHandle, minCompressionSize, opsFactory)));
+		                  cookieEncoder, formDecoderProvider, forwardedHeaderHandler, listener, mapHandle,
+		                  metricsRecorder, minCompressionSize, opsFactory, uriTagValue)));
+
+		if (metricsRecorder != null) {
+			if (metricsRecorder instanceof MicrometerHttpServerMetricsRecorder) {
+				// For sake of performance, we can replace the ChannelMetricsHandler because the MicrometerHttpServerMetricsRecorder
+				// is interested only in connections metrics .
+				p.replace(NettyPipeline.ChannelMetricsHandler, NettyPipeline.ChannelMetricsHandler,
+						new H2ChannelMetricsHandler(metricsRecorder));
+			}
+		}
 	}
 
 	static void configureHttp11OrH2CleartextPipeline(ChannelPipeline p,
@@ -517,8 +560,8 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 
 		Http11OrH2CleartextCodec upgrader = new Http11OrH2CleartextCodec(accessLogEnabled, accessLog, compressPredicate,
 				cookieDecoder, cookieEncoder, p.get(NettyPipeline.LoggingHandler) != null, formDecoderProvider,
-				forwardedHeaderHandler, http2Settings, listener, mapHandle, minCompressionSize, opsFactory,
-				decoder.validateHeaders());
+				forwardedHeaderHandler, http2Settings, listener, mapHandle, metricsRecorder, minCompressionSize, opsFactory,
+				uriTagValue, decoder.validateHeaders());
 
 		ChannelHandler http2ServerHandler = new H2CleartextCodec(upgrader);
 		CleartextHttp2ServerUpgradeHandler h2cUpgradeHandler = new CleartextHttp2ServerUpgradeHandler(
@@ -633,25 +676,69 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 	 */
 	static final boolean SSL_DEBUG = Boolean.parseBoolean(System.getProperty(ReactorNetty.SSL_SERVER_DEBUG, "false"));
 
+	static final class H2ChannelMetricsHandler extends AbstractChannelMetricsHandler {
+
+		final ChannelMetricsRecorder recorder;
+
+		H2ChannelMetricsHandler(ChannelMetricsRecorder recorder) {
+			super(null, true);
+			this.recorder = recorder;
+		}
+
+		@Override
+		public void channelRead(ChannelHandlerContext ctx, Object msg) {
+			ctx.fireChannelRead(msg);
+		}
+
+		@Override
+		public void channelRegistered(ChannelHandlerContext ctx) {
+			ctx.fireChannelRegistered();
+		}
+
+		@Override
+		public ChannelHandler connectMetricsHandler() {
+			return null;
+		}
+
+		@Override
+		public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+			ctx.fireExceptionCaught(cause);
+		}
+
+		@Override
+		public ChannelMetricsRecorder recorder() {
+			return recorder;
+		}
+
+		@Override
+		@SuppressWarnings("FutureReturnValueIgnored")
+		public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+			//"FutureReturnValueIgnored" this is deliberate
+			ctx.write(msg, promise);
+		}
+	}
+
 	static final class H2CleartextCodec extends ChannelHandlerAdapter {
 
 		final Http11OrH2CleartextCodec upgrader;
 		final boolean addHttp2FrameCodec;
+		final boolean removeMetricsHandler;
 
 		/**
 		 * Used when full H2 preface is received
 		 */
 		H2CleartextCodec(Http11OrH2CleartextCodec upgrader) {
-			this(upgrader, true);
+			this(upgrader, true, true);
 		}
 
 		/**
 		 * Used when upgrading from HTTP/1.1 to H2. When an upgrade happens {@link Http2FrameCodec}
 		 * is added by {@link Http2ServerUpgradeCodec}
 		 */
-		H2CleartextCodec(Http11OrH2CleartextCodec upgrader, boolean addHttp2FrameCodec) {
+		H2CleartextCodec(Http11OrH2CleartextCodec upgrader, boolean addHttp2FrameCodec, boolean removeMetricsHandler) {
 			this.upgrader = upgrader;
 			this.addHttp2FrameCodec = addHttp2FrameCodec;
+			this.removeMetricsHandler = removeMetricsHandler;
 		}
 
 		@Override
@@ -672,6 +759,17 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 			if (pipeline.get(NettyPipeline.CompressionHandler) != null) {
 				pipeline.remove(NettyPipeline.CompressionHandler);
 			}
+			if (removeMetricsHandler && pipeline.get(NettyPipeline.HttpMetricsHandler) != null) {
+				AbstractHttpServerMetricsHandler handler =
+						(AbstractHttpServerMetricsHandler) pipeline.get(NettyPipeline.HttpMetricsHandler);
+				if (handler.recorder() instanceof MicrometerHttpServerMetricsRecorder) {
+					pipeline.replace(NettyPipeline.HttpMetricsHandler, NettyPipeline.ChannelMetricsHandler,
+							new H2ChannelMetricsHandler(handler.recorder()));
+				}
+				else {
+					pipeline.remove(NettyPipeline.HttpMetricsHandler);
+				}
+			}
 			pipeline.remove(NettyPipeline.HttpTrafficHandler);
 			pipeline.remove(NettyPipeline.ReactiveBridge);
 		}
@@ -689,8 +787,10 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		final ConnectionObserver                                      listener;
 		final BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>>
 		                                                              mapHandle;
+		final ChannelMetricsRecorder                                  metricsRecorder;
 		final int                                                     minCompressionSize;
 		final ChannelOperations.OnSetup                               opsFactory;
+		final Function<String, String>                                uriTagValue;
 
 		H2Codec(
 				boolean accessLogEnabled,
@@ -702,8 +802,10 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 				@Nullable BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> forwardedHeaderHandler,
 				ConnectionObserver listener,
 				@Nullable BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>> mapHandle,
+				@Nullable ChannelMetricsRecorder metricsRecorder,
 				int minCompressionSize,
-				ChannelOperations.OnSetup opsFactory) {
+				ChannelOperations.OnSetup opsFactory,
+				@Nullable Function<String, String> uriTagValue) {
 			this.accessLogEnabled = accessLogEnabled;
 			this.accessLog = accessLog;
 			this.compressPredicate = compressPredicate;
@@ -713,15 +815,18 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 			this.forwardedHeaderHandler = forwardedHeaderHandler;
 			this.listener = listener;
 			this.mapHandle = mapHandle;
+			this.metricsRecorder = metricsRecorder;
 			this.minCompressionSize = minCompressionSize;
 			this.opsFactory = opsFactory;
+			this.uriTagValue = uriTagValue;
 		}
 
 		@Override
 		protected void initChannel(Channel ch) {
 			ch.pipeline().remove(this);
 			addStreamHandlers(ch, accessLogEnabled, accessLog, compressPredicate, cookieDecoder, cookieEncoder,
-					formDecoderProvider, forwardedHeaderHandler, listener, mapHandle, minCompressionSize, opsFactory);
+					formDecoderProvider, forwardedHeaderHandler, listener, mapHandle, metricsRecorder,
+					minCompressionSize, opsFactory, uriTagValue);
 		}
 	}
 
@@ -739,8 +844,10 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		final ConnectionObserver                                      listener;
 		final BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>>
 		                                                              mapHandle;
+		final ChannelMetricsRecorder                                  metricsRecorder;
 		final int                                                     minCompressionSize;
 		final ChannelOperations.OnSetup                               opsFactory;
+		final Function<String, String>                                uriTagValue;
 
 		Http11OrH2CleartextCodec(
 				boolean accessLogEnabled,
@@ -754,8 +861,10 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 				Http2Settings http2Settings,
 				ConnectionObserver listener,
 				@Nullable BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>> mapHandle,
+				@Nullable ChannelMetricsRecorder metricsRecorder,
 				int minCompressionSize,
 				ChannelOperations.OnSetup opsFactory,
+				@Nullable Function<String, String> uriTagValue,
 				boolean validate) {
 			this.accessLogEnabled = accessLogEnabled;
 			this.accessLog = accessLog;
@@ -777,8 +886,10 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 			this.http2FrameCodec = http2FrameCodecBuilder.build();
 			this.listener = listener;
 			this.mapHandle = mapHandle;
+			this.metricsRecorder = metricsRecorder;
 			this.minCompressionSize = minCompressionSize;
 			this.opsFactory = opsFactory;
+			this.uriTagValue = uriTagValue;
 		}
 
 		/**
@@ -788,14 +899,15 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		protected void initChannel(Channel ch) {
 			ch.pipeline().remove(this);
 			addStreamHandlers(ch, accessLogEnabled, accessLog, compressPredicate, cookieDecoder, cookieEncoder,
-					formDecoderProvider, forwardedHeaderHandler, listener, mapHandle, minCompressionSize, opsFactory);
+					formDecoderProvider, forwardedHeaderHandler, listener, mapHandle, metricsRecorder,
+					minCompressionSize, opsFactory, uriTagValue);
 		}
 
 		@Override
 		@Nullable
 		public HttpServerUpgradeHandler.UpgradeCodec newUpgradeCodec(CharSequence protocol) {
 			if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
-				return new Http2ServerUpgradeCodec(http2FrameCodec, new H2CleartextCodec(this, false));
+				return new Http2ServerUpgradeCodec(http2FrameCodec, new H2CleartextCodec(this, false, false));
 			}
 			else {
 				return null;
@@ -855,8 +967,8 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 
 			if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
 				configureH2Pipeline(p, accessLogEnabled, accessLog, compressPredicate, cookieDecoder, cookieEncoder,
-						formDecoderProvider, forwardedHeaderHandler, http2Settings, listener, mapHandle, minCompressionSize,
-						opsFactory, decoder.validateHeaders());
+						formDecoderProvider, forwardedHeaderHandler, http2Settings, listener, mapHandle,
+						metricsRecorder, minCompressionSize, opsFactory, uriTagValue, decoder.validateHeaders());
 				return;
 			}
 
@@ -972,8 +1084,10 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 							http2Settings,
 							observer,
 							mapHandle,
+							metricsRecorder,
 							minCompressionSize,
 							opsFactory,
+							uriTagValue,
 							decoder.validateHeaders());
 				}
 			}
@@ -1031,8 +1145,10 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 							http2Settings,
 							observer,
 							mapHandle,
+							metricsRecorder,
 							minCompressionSize,
 							opsFactory,
+							uriTagValue,
 							decoder.validateHeaders());
 					needRead = true;
 				}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMetricsHandler.java
@@ -31,6 +31,11 @@ final class HttpServerMetricsHandler extends AbstractHttpServerMetricsHandler {
 		this.recorder = recorder;
 	}
 
+	HttpServerMetricsHandler(HttpServerMetricsHandler copy) {
+		super(copy);
+		this.recorder = copy.recorder;
+	}
+
 	@Override
 	protected HttpServerMetricsRecorder recorder() {
 		return recorder;

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -279,12 +279,12 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		else if (clientProtocols.length == 2 &&
 				Arrays.equals(clientProtocols, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11})) {
 			numWrites = new int[]{4, 6};
-			numReads = new int[]{3, 4};
+			numReads = new int[]{2, 4};
 			bytesWrite = new int[]{287, 345};
 			bytesRead = new int[]{108, 119};
 		}
 		else if (protocols.contains(HttpProtocol.H2)) {
-			numReads = new int[]{3, 4};
+			numReads = new int[]{2, 4};
 		}
 		else if (protocols.contains(HttpProtocol.H2C)) {
 			numReads = new int[]{2, 3};
@@ -755,7 +755,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	private void checkDistributionSummary(String name, String[] tags, long expectedCount, double expectedAmount) {
 		DistributionSummary summary = registry.find(name).tags(tags).summary();
 		assertThat(summary).isNotNull();
-		assertThat(summary.count()).isEqualTo(expectedCount);
+		assertThat(summary.count()).isGreaterThanOrEqualTo(expectedCount);
 		assertThat(summary.totalAmount()).isGreaterThanOrEqualTo(expectedAmount);
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -279,14 +279,11 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		else if (clientProtocols.length == 2 &&
 				Arrays.equals(clientProtocols, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11})) {
 			numWrites = new int[]{4, 6};
-			numReads = new int[]{2, 4};
+			numReads = new int[]{2, 3};
 			bytesWrite = new int[]{287, 345};
 			bytesRead = new int[]{108, 119};
 		}
-		else if (protocols.contains(HttpProtocol.H2)) {
-			numReads = new int[]{2, 4};
-		}
-		else if (protocols.contains(HttpProtocol.H2C)) {
+		else if (protocols.contains(HttpProtocol.H2) || protocols.contains(HttpProtocol.H2C)) {
 			numReads = new int[]{2, 3};
 		}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -23,6 +23,7 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -43,6 +44,7 @@ import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.server.ContextAwareHttpServerMetricsRecorder;
 import reactor.netty.http.server.HttpServer;
 import reactor.netty.http.server.HttpServerMetricsRecorder;
+import reactor.netty.http.server.HttpServerRequest;
 import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.tcp.SslProvider.ProtocolSslContextSpec;
 import reactor.test.StepVerifier;
@@ -54,6 +56,8 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.security.cert.CertificateException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -95,16 +99,23 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 	static SelfSignedCertificate ssc;
 	static Http11SslContextSpec serverCtx11;
+	static Http2SslContextSpec serverCtx2;
 	static Http11SslContextSpec clientCtx11;
+	static Http2SslContextSpec clientCtx2;
 
 	@BeforeAll
 	static void createSelfSignedCertificate() throws CertificateException {
 		ssc = new SelfSignedCertificate();
 		serverCtx11 = Http11SslContextSpec.forServer(ssc.certificate(), ssc.privateKey())
 		                                  .configure(builder -> builder.sslProvider(SslProvider.JDK));
+		serverCtx2 = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey())
+		                                .configure(builder -> builder.sslProvider(SslProvider.JDK));
 		clientCtx11 = Http11SslContextSpec.forClient()
 		                                  .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE)
 		                                                               .sslProvider(SslProvider.JDK));
+		clientCtx2 = Http2SslContextSpec.forClient()
+		                                .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE)
+		                                .sslProvider(SslProvider.JDK));
 	}
 
 	/**
@@ -122,16 +133,17 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		httpServer = createServer()
 				.host("127.0.0.1")
 				.metrics(true, Function.identity())
+				.httpRequestDecoder(spec -> spec.h2cMaxContentLength(256))
 				.route(r -> r.post("/1", (req, res) -> res.header("Connection", "close")
 								.send(req.receive().retain().delayElements(Duration.ofMillis(10))))
 						.post("/2", (req, res) -> res.header("Connection", "close")
 								.send(req.receive().retain().delayElements(Duration.ofMillis(10))))
 						.post("/4", (req, res) -> res.header("Connection", "close")
 								.send(req.receive().retain().doOnNext(b ->
-										checkServerConnectionsMicrometer(req.hostAddress()))))
+										checkServerConnectionsMicrometer(req))))
 						.post("/5", (req, res) -> res.header("Connection", "close")
 								.send(req.receive().retain().doOnNext(b ->
-										checkServerConnectionsRecorder(req.hostAddress())))));
+										checkServerConnectionsRecorder(req)))));
 
 		provider = ConnectionProvider.create("HttpMetricsHandlerTests", 1);
 		httpClient = createClient(provider, () -> disposableServer.address())
@@ -149,8 +161,6 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		Metrics.removeRegistry(registry);
 		registry.clear();
 		registry.close();
-
-		ServerRecorder.INSTANCE.reset();
 	}
 
 	@ParameterizedTest
@@ -183,8 +193,23 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 		InetSocketAddress sa = (InetSocketAddress) serverAddress.get();
 
+		int[] numWrites = new int[]{14, 25};
+		int[] bytesWrite = new int[]{160, 243};
+		int connIndex = 1;
+		if (clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11) {
+			numWrites = new int[]{14, 28};
+			bytesWrite = new int[]{151, 310};
+			connIndex = 2;
+		}
+		else if (clientProtocols.length == 2 &&
+				Arrays.equals(clientProtocols, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11})) {
+			numWrites = new int[]{17, 28};
+			bytesWrite = new int[]{315, 435};
+		}
+
 		Thread.sleep(1000);
-		checkExpectationsExisting("/1", sa.getHostString() + ":" + sa.getPort(), 1, serverCtx != null);
+		checkExpectationsExisting("/1", sa.getHostString() + ":" + sa.getPort(), 1, serverCtx != null,
+				numWrites[0], bytesWrite[0]);
 
 		CountDownLatch latch2 = new CountDownLatch(1);
 		StepVerifier.create(httpClient.doOnResponse((res, conn) ->
@@ -206,7 +231,8 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		sa = (InetSocketAddress) serverAddress.get();
 
 		Thread.sleep(1000);
-		checkExpectationsExisting("/2", sa.getHostString() + ":" + sa.getPort(), 2, serverCtx != null);
+		checkExpectationsExisting("/2", sa.getHostString() + ":" + sa.getPort(), connIndex, serverCtx != null,
+				numWrites[1], bytesWrite[1]);
 	}
 
 	@ParameterizedTest
@@ -238,8 +264,35 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 		InetSocketAddress sa = (InetSocketAddress) serverAddress.get();
 
+		List<HttpProtocol> protocols = Arrays.asList(clientProtocols);
+		int[] numWrites = new int[]{5, 7};
+		int[] numReads = new int[]{1, 2};
+		int[] bytesWrite = new int[]{106, 122};
+		int[] bytesRead = new int[]{37, 48};
+		int connIndex = 1;
+		if (clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11) {
+			numWrites = new int[]{1, 2};
+			bytesWrite = new int[]{123, 246};
+			bytesRead = new int[]{64, 128};
+			connIndex = 2;
+		}
+		else if (clientProtocols.length == 2 &&
+				Arrays.equals(clientProtocols, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11})) {
+			numWrites = new int[]{4, 6};
+			numReads = new int[]{3, 4};
+			bytesWrite = new int[]{287, 345};
+			bytesRead = new int[]{108, 119};
+		}
+		else if (protocols.contains(HttpProtocol.H2)) {
+			numReads = new int[]{3, 4};
+		}
+		else if (protocols.contains(HttpProtocol.H2C)) {
+			numReads = new int[]{2, 3};
+		}
+
 		Thread.sleep(1000);
-		checkExpectationsNonExisting(sa.getHostString() + ":" + sa.getPort(), 1, serverCtx != null);
+		checkExpectationsNonExisting(sa.getHostString() + ":" + sa.getPort(), 1, 1, serverCtx != null,
+				numWrites[0], numReads[0], bytesWrite[0], bytesRead[0]);
 
 		CountDownLatch latch2 = new CountDownLatch(1);
 		StepVerifier.create(httpClient.doOnResponse((res, conn) ->
@@ -260,7 +313,8 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		sa = (InetSocketAddress) serverAddress.get();
 
 		Thread.sleep(1000);
-		checkExpectationsNonExisting(sa.getHostString() + ":" + sa.getPort(), 2, serverCtx != null);
+		checkExpectationsNonExisting(sa.getHostString() + ":" + sa.getPort(), connIndex, 2, serverCtx != null,
+				numWrites[1], numReads[1], bytesWrite[1], bytesRead[1]);
 	}
 
 	@ParameterizedTest
@@ -295,8 +349,20 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 		InetSocketAddress sa = (InetSocketAddress) serverAddress.get();
 
+		int numWrites = 14;
+		int bytesWrite = 160;
+		if (clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11) {
+			bytesWrite = 151;
+		}
+		else if (clientProtocols.length == 2 &&
+				Arrays.equals(clientProtocols, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11})) {
+			numWrites = 17;
+			bytesWrite = 315;
+		}
+
 		Thread.sleep(1000);
-		checkExpectationsExisting("testUriTagValueResolver", sa.getHostString() + ":" + sa.getPort(), 1, serverCtx != null);
+		checkExpectationsExisting("testUriTagValueResolver", sa.getHostString() + ":" + sa.getPort(), 1,
+				serverCtx != null, numWrites, bytesWrite);
 	}
 
 	/**
@@ -343,8 +409,20 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 		InetSocketAddress sa = (InetSocketAddress) serverAddress.get();
 
+		int[] numWrites = new int[]{14, 28};
+		int[] bytesWrite = new int[]{160, 320};
+		if (clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11) {
+			bytesWrite = new int[]{151, 302};
+		}
+		else if (clientProtocols.length == 2 &&
+				Arrays.equals(clientProtocols, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11})) {
+			numWrites = new int[]{17, 34};
+			bytesWrite = new int[]{315, 630};
+		}
+
 		Thread.sleep(1000);
-		checkExpectationsExisting("testUriTagValueFunctionNotShared_1", sa.getHostString() + ":" + sa.getPort(), 1, serverCtx != null);
+		checkExpectationsExisting("testUriTagValueFunctionNotShared_1", sa.getHostString() + ":" + sa.getPort(),
+				1, serverCtx != null, numWrites[0], bytesWrite[0]);
 
 		CountDownLatch latch2 = new CountDownLatch(1);
 		httpClient.doOnResponse((res, conn) -> conn.channel()
@@ -367,7 +445,8 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		sa = (InetSocketAddress) serverAddress.get();
 
 		Thread.sleep(1000);
-		checkExpectationsExisting("testUriTagValueFunctionNotShared_2", sa.getHostString() + ":" + sa.getPort(), 2, serverCtx != null);
+		checkExpectationsExisting("testUriTagValueFunctionNotShared_2", sa.getHostString() + ":" + sa.getPort(),
+				2, serverCtx != null, numWrites[1], bytesWrite[1]);
 	}
 
 	@ParameterizedTest
@@ -437,6 +516,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@MethodSource("httpCompatibleProtocols")
 	void testServerConnectionsMicrometer(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
 			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
+		boolean isHttp11 = clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11;
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
 				.metrics(true, Function.identity()).bindNow();
 
@@ -471,8 +551,13 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		// ensure that the server counters have been updated. For the moment, wait 1 sec.
 		Thread.sleep(1000);
 		// now check the server counters
-		checkGauge(SERVER_CONNECTIONS_TOTAL, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
-		checkGauge(SERVER_CONNECTIONS_ACTIVE, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
+		if (isHttp11) {
+			checkGauge(SERVER_CONNECTIONS_TOTAL, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
+			checkGauge(SERVER_CONNECTIONS_ACTIVE, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
+		}
+		else {
+			checkGauge(SERVER_CONNECTIONS_TOTAL, true, 1, URI, HTTP, LOCAL_ADDRESS, address);
+		}
 
 		// These metrics are meant only for the servers,
 		// connections metrics for the clients are available from the connection pool
@@ -487,8 +572,17 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@MethodSource("httpCompatibleProtocols")
 	void testServerConnectionsRecorder(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
 			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
+		// Invoke ServerRecorder.INSTANCE.reset() here as disposableServer.dispose (AfterEach) might be invoked after
+		// ServerRecorder.INSTANCE.reset() (AfterEach) and thus leave ServerRecorder.INSTANCE in a bad state
+		ServerRecorder.INSTANCE.reset();
+		boolean isHttp11 = clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11;
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
-				.metrics(true, () -> ServerRecorder.INSTANCE, Function.identity()).bindNow();
+				.metrics(true, () -> {
+							ServerRecorder.INSTANCE.done = isHttp11 ? new CountDownLatch(4) : new CountDownLatch(1);
+							return ServerRecorder.INSTANCE;
+						},
+						Function.identity())
+				.bindNow();
 		String address = formatSocketAddress(disposableServer.address());
 
 		CountDownLatch latch = new CountDownLatch(1);
@@ -512,10 +606,15 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 		assertThat(latch.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
 		assertThat(ServerRecorder.INSTANCE.done.await(30, TimeUnit.SECONDS)).as("recorder latch await").isTrue();
-		assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(0);
-		assertThat(ServerRecorder.INSTANCE.onActiveConnectionsAmount.get()).isEqualTo(0);
-		assertThat(ServerRecorder.INSTANCE.onActiveConnectionsLocalAddr.get()).isEqualTo(address);
-		assertThat(ServerRecorder.INSTANCE.onInactiveConnectionsLocalAddr.get()).isEqualTo(address);
+		if (isHttp11) {
+			assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(0);
+			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsAmount.get()).isEqualTo(0);
+			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsLocalAddr.get()).isEqualTo(address);
+			assertThat(ServerRecorder.INSTANCE.onInactiveConnectionsLocalAddr.get()).isEqualTo(address);
+		}
+		else {
+			assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(1);
+		}
 
 		disposableServer.disposeNow();
 	}
@@ -545,22 +644,29 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		checkCounter(CLIENT_ERRORS, summaryTags, true, 2);
 	}
 
-	private void checkServerConnectionsMicrometer(InetSocketAddress localAddress) {
-		String address = formatSocketAddress(localAddress);
+	private void checkServerConnectionsMicrometer(HttpServerRequest request) {
+		String address = formatSocketAddress(request.hostAddress());
+		boolean isHttp2 = request.requestHeaders().contains(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text());
 		checkGauge(SERVER_CONNECTIONS_TOTAL, true, 1, URI, HTTP, LOCAL_ADDRESS, address);
-		checkGauge(SERVER_CONNECTIONS_ACTIVE, true, 1, URI, HTTP, LOCAL_ADDRESS, address);
+		if (!isHttp2) {
+			checkGauge(SERVER_CONNECTIONS_ACTIVE, true, 1, URI, HTTP, LOCAL_ADDRESS, address);
+		}
 	}
 
-	private void checkServerConnectionsRecorder(InetSocketAddress localAddress) {
-		String address = formatSocketAddress(localAddress);
-		assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get() == 1).isTrue();
+	private void checkServerConnectionsRecorder(HttpServerRequest request) {
+		String address = formatSocketAddress(request.hostAddress());
+		boolean isHttp2 = request.requestHeaders().contains(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text());
+		assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(1);
 		assertThat(ServerRecorder.INSTANCE.onServerConnectionsLocalAddr.get()).isEqualTo(address);
-		assertThat(ServerRecorder.INSTANCE.onActiveConnectionsAmount.get() == 1).isTrue();
-		assertThat(ServerRecorder.INSTANCE.onActiveConnectionsLocalAddr.get()).isEqualTo(address);
+		if (!isHttp2) {
+			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsAmount.get()).isEqualTo(1);
+			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsLocalAddr.get()).isEqualTo(address);
+		}
 		assertThat(ServerRecorder.INSTANCE.onInactiveConnectionsLocalAddr.get()).isNull();
 	}
 
-	private void checkExpectationsExisting(String uri, String serverAddress, int index, boolean checkTls) {
+	private void checkExpectationsExisting(String uri, String serverAddress, int connIndex, boolean checkTls,
+			int numWrites, double expectedSentAmount) {
 		String[] timerTags1 = new String[] {URI, uri, METHOD, "POST", STATUS, "200"};
 		String[] timerTags2 = new String[] {URI, uri, METHOD, "POST"};
 		String[] summaryTags1 = new String[] {URI, uri};
@@ -581,19 +687,20 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		checkTimer(CLIENT_RESPONSE_TIME, timerTags1, 1);
 		checkTimer(CLIENT_DATA_SENT_TIME, timerTags2, 1);
 		checkTimer(CLIENT_DATA_RECEIVED_TIME, timerTags1, 1);
-		checkTimer(CLIENT_CONNECT_TIME, timerTags3, index);
+		checkTimer(CLIENT_CONNECT_TIME, timerTags3, connIndex);
 		if (checkTls) {
-			checkTlsTimer(CLIENT_TLS_HANDSHAKE_TIME, timerTags3, index);
+			checkTlsTimer(CLIENT_TLS_HANDSHAKE_TIME, timerTags3, connIndex);
 		}
 		checkDistributionSummary(CLIENT_DATA_SENT, summaryTags1, 1, 12);
 		checkDistributionSummary(CLIENT_DATA_RECEIVED, summaryTags1, 1, 12);
 		checkCounter(CLIENT_ERRORS, summaryTags1, false, 0);
-		checkDistributionSummary(CLIENT_DATA_SENT, summaryTags2, 14 * index, 151 * index);
+		checkDistributionSummary(CLIENT_DATA_SENT, summaryTags2, numWrites, expectedSentAmount);
 		//checkDistributionSummary(CLIENT_DATA_RECEIVED, summaryTags2, true, 3*index, 84*index);
 		checkCounter(CLIENT_ERRORS, summaryTags2, false, 0);
 	}
 
-	private void checkExpectationsNonExisting(String serverAddress, int index, boolean checkTls) {
+	private void checkExpectationsNonExisting(String serverAddress, int connIndex, int index, boolean checkTls,
+			int numWrites, int numReads, double expectedSentAmount, double expectedReceivedAmount) {
 		String uri = "/3";
 		String[] timerTags1 = new String[] {URI, uri, METHOD, "GET", STATUS, "404"};
 		String[] timerTags2 = new String[] {URI, uri, METHOD, "GET"};
@@ -614,14 +721,14 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		checkTimer(CLIENT_RESPONSE_TIME, timerTags1, index);
 		checkTimer(CLIENT_DATA_SENT_TIME, timerTags2, index);
 		checkTimer(CLIENT_DATA_RECEIVED_TIME, timerTags1, index);
-		checkTimer(CLIENT_CONNECT_TIME, timerTags3, index);
+		checkTimer(CLIENT_CONNECT_TIME, timerTags3, connIndex);
 		if (checkTls) {
-			checkTlsTimer(CLIENT_TLS_HANDSHAKE_TIME, timerTags3, index);
+			checkTlsTimer(CLIENT_TLS_HANDSHAKE_TIME, timerTags3, connIndex);
 		}
 		checkDistributionSummary(CLIENT_DATA_RECEIVED, summaryTags1, index, 0);
 		checkCounter(CLIENT_ERRORS, summaryTags1, false, 0);
-		checkDistributionSummary(CLIENT_DATA_SENT, summaryTags2, index, 123 * index);
-		checkDistributionSummary(CLIENT_DATA_RECEIVED, summaryTags2, index, 64 * index);
+		checkDistributionSummary(CLIENT_DATA_SENT, summaryTags2, numWrites, expectedSentAmount);
+		checkDistributionSummary(CLIENT_DATA_RECEIVED, summaryTags2, numReads, expectedReceivedAmount);
 		checkCounter(CLIENT_ERRORS, summaryTags2, false, 0);
 	}
 
@@ -649,14 +756,14 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		DistributionSummary summary = registry.find(name).tags(tags).summary();
 		assertThat(summary).isNotNull();
 		assertThat(summary.count()).isEqualTo(expectedCount);
-		assertThat(summary.totalAmount() >= expectedAmount).isTrue();
+		assertThat(summary.totalAmount()).isGreaterThanOrEqualTo(expectedAmount);
 	}
 
 	void checkCounter(String name, String[] tags, boolean exists, double expectedCount) {
 		Counter counter = registry.find(name).tags(tags).counter();
 		if (exists) {
 			assertThat(counter).isNotNull();
-			assertThat(counter.count() >= expectedCount).isTrue();
+			assertThat(counter.count()).isGreaterThanOrEqualTo(expectedCount);
 		}
 		else {
 			assertThat(counter).isNull();
@@ -667,7 +774,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		Gauge gauge = registry.find(name).tags(tags).gauge();
 		if (exists) {
 			assertThat(gauge).isNotNull();
-			assertThat(gauge.value() == expectedCount).isTrue();
+			assertThat(gauge.value()).isEqualTo(expectedCount);
 		}
 		else {
 			assertThat(gauge).isNull();
@@ -678,7 +785,21 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		return Stream.of(
 				Arguments.of(new HttpProtocol[]{HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11}, null, null),
 				Arguments.of(new HttpProtocol[]{HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11},
-						Named.of("Http11SslContextSpec", serverCtx11), Named.of("Http11SslContextSpec", clientCtx11))
+						Named.of("Http11SslContextSpec", serverCtx11), Named.of("Http11SslContextSpec", clientCtx11)),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2}, new HttpProtocol[]{HttpProtocol.H2},
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2)),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2}, new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11},
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2)),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11},
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http11SslContextSpec", clientCtx11)),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2},
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2)),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11},
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2)),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C}, new HttpProtocol[]{HttpProtocol.H2C}, null, null),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11}, null, null),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C}, null, null),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, null, null)
 		);
 	}
 


### PR DESCRIPTION
Ensure Reactor Context is properly propagated on the client side when H2/H2C.