### PR TITLE
Deprecated Connection#addHandler(...)

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/Connection.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/Connection.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/Connection.java
@@ -84,8 +84,10 @@ public interface Connection extends DisposableChannel {
 	 * @param handler handler instance
 	 *
 	 * @return this Connection
-
+	 * @deprecated as of 1.0.17. Use {@link #addHandlerFirst(ChannelHandler)} or {@link #addHandlerLast(ChannelHandler)}.
+	 * This method will be removed in version 1.2.0.
 	 */
+	@Deprecated
 	default Connection addHandler(ChannelHandler handler) {
 		return addHandler(handler.getClass().getSimpleName(), handler);
 	}
@@ -107,7 +109,10 @@ public interface Connection extends DisposableChannel {
 	 * @param handler handler instance
 	 *
 	 * @return this Connection
+	 * @deprecated as of 1.0.17. Use {@link #addHandlerFirst(String, ChannelHandler)} or
+	 * {@link #addHandlerLast(String, ChannelHandler)}. This method will be removed in version 1.2.0.
 	 */
+	@Deprecated
 	default Connection addHandler(String name, ChannelHandler handler) {
 		if (handler instanceof ChannelOutboundHandler) {
 			addHandlerFirst(name, handler);

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpClientTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpClientTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpClientTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpClientTests.java
@@ -256,7 +256,7 @@ public class TcpClientTests {
 
 	@Test
 	void tcpClientHandlesLineFeedDataFixedPool() throws InterruptedException {
-		Consumer<? super Connection> channelInit = c -> c.addHandler("codec", new LineBasedFrameDecoder(8 * 1024));
+		Consumer<? super Connection> channelInit = c -> c.addHandlerLast("codec", new LineBasedFrameDecoder(8 * 1024));
 
 		ConnectionProvider p = ConnectionProvider.newConnection();
 
@@ -269,7 +269,7 @@ public class TcpClientTests {
 
 	@Test
 	void tcpClientHandlesLineFeedDataElasticPool() throws InterruptedException {
-		Consumer<? super Connection> channelInit = c -> c.addHandler("codec", new LineBasedFrameDecoder(8 * 1024));
+		Consumer<? super Connection> channelInit = c -> c.addHandlerLast("codec", new LineBasedFrameDecoder(8 * 1024));
 
 		tcpClientHandlesLineFeedData(
 				TcpClient.create(ConnectionProvider.create("tcpClientHandlesLineFeedDataElasticPool", Integer.MAX_VALUE))

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
@@ -611,7 +611,7 @@ class TcpServerTests {
 
 		DisposableServer server =
 				TcpServer.create()
-				         .handle((in, out) -> in.withConnection(c -> c.addHandler(new JsonObjectDecoder()))
+				         .handle((in, out) -> in.withConnection(c -> c.addHandlerLast(new JsonObjectDecoder()))
 				                                .receive()
 				                                .asString()
 				                                .log("serve")
@@ -627,7 +627,7 @@ class TcpServerTests {
 		Connection client = TcpClient.create()
 		                             .port(server.port())
 		                             .handle((in, out) -> {
-		                                 in.withConnection(c -> c.addHandler(new JsonObjectDecoder()))
+		                                 in.withConnection(c -> c.addHandlerLast(new JsonObjectDecoder()))
 		                                   .receive()
 		                                   .asString()
 		                                   .log("receive")

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/lifecycle/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/lifecycle/Application.java
@@ -26,10 +26,10 @@ public class Application {
 		HttpClient client =
 				HttpClient.create()
 				          .doOnConnected(conn ->
-				              conn.addHandler(new ReadTimeoutHandler(10, TimeUnit.SECONDS)))   //<1>
+				              conn.addHandlerFirst(new ReadTimeoutHandler(10, TimeUnit.SECONDS)))   //<1>
 				          .doOnChannelInit((observer, channel, remoteAddress) ->
 				              channel.pipeline()
-				                     .addFirst(new LoggingHandler("reactor.netty.examples"))); //<2>
+				                     .addFirst(new LoggingHandler("reactor.netty.examples")));      //<2>
 
 		client.get()
 		      .uri("https://example.com/")

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/lifecycle/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/lifecycle/Application.java
@@ -27,10 +27,10 @@ public class Application {
 		DisposableServer server =
 				HttpServer.create()
 				          .doOnConnection(conn ->
-				              conn.addHandler(new ReadTimeoutHandler(10, TimeUnit.SECONDS))) //<1>
+				              conn.addHandlerFirst(new ReadTimeoutHandler(10, TimeUnit.SECONDS))) //<1>
 				          .doOnChannelInit((observer, channel, remoteAddress) ->
 				              channel.pipeline()
-				                     .addFirst(new LoggingHandler("reactor.netty.examples")))//<2>
+				                     .addFirst(new LoggingHandler("reactor.netty.examples")))    //<2>
 				          .bindNow();
 
 		server.onDispose()

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/lifecycle/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/lifecycle/Application.java
@@ -29,10 +29,10 @@ public class Application {
 				         .host("example.com")
 				         .port(80)
 				         .doOnConnected(conn ->
-				             conn.addHandler(new ReadTimeoutHandler(10, TimeUnit.SECONDS))) //<1>
+				             conn.addHandlerFirst(new ReadTimeoutHandler(10, TimeUnit.SECONDS))) //<1>
 				         .doOnChannelInit((observer, channel, remoteAddress) ->
 				             channel.pipeline()
-				                    .addFirst(new LoggingHandler("reactor.netty.examples")))//<2>
+				                    .addFirst(new LoggingHandler("reactor.netty.examples")))     //<2>
 				         .connectNow();
 
 		connection.onDispose()

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/lifecycle/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/lifecycle/Application.java
@@ -27,10 +27,10 @@ public class Application {
 		DisposableServer server =
 				TcpServer.create()
 				         .doOnConnection(conn ->
-				             conn.addHandler(new ReadTimeoutHandler(10, TimeUnit.SECONDS))) //<1>
+				             conn.addHandlerFirst(new ReadTimeoutHandler(10, TimeUnit.SECONDS))) //<1>
 				         .doOnChannelInit((observer, channel, remoteAddress) ->
 				             channel.pipeline()
-				                    .addFirst(new LoggingHandler("reactor.netty.examples")))//<2>
+				                    .addFirst(new LoggingHandler("reactor.netty.examples")))     //<2>
 				         .bindNow();
 
 		server.onDispose()

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/lifecycle/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/lifecycle/Application.java
@@ -28,10 +28,10 @@ public class Application {
 				UdpClient.create()
 				         .host("example.com")
 				         .port(80)
-				         .doOnConnected(conn -> conn.addHandler(new LineBasedFrameDecoder(8192))) //<1>
+				         .doOnConnected(conn -> conn.addHandlerLast(new LineBasedFrameDecoder(8192))) //<1>
 				         .doOnChannelInit((observer, channel, remoteAddress) ->
 				             channel.pipeline()
-				                    .addFirst(new LoggingHandler("reactor.netty.examples")))      //<2>
+				                    .addFirst(new LoggingHandler("reactor.netty.examples")))           //<2>
 				         .connectNow(Duration.ofSeconds(30));
 
 		connection.onDispose()

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/lifecycle/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/lifecycle/Application.java
@@ -26,10 +26,10 @@ public class Application {
 	public static void main(String[] args) {
 		Connection server =
 				UdpServer.create()
-				         .doOnBound(conn -> conn.addHandler(new LineBasedFrameDecoder(8192))) //<1>
+				         .doOnBound(conn -> conn.addHandlerLast(new LineBasedFrameDecoder(8192))) //<1>
 				         .doOnChannelInit((observer, channel, remoteAddress) ->
 				             channel.pipeline()
-				                    .addFirst(new LoggingHandler("reactor.netty.examples")))  //<2>
+				                    .addFirst(new LoggingHandler("reactor.netty.examples")))      //<2>
 				         .bindNow(Duration.ofSeconds(30));
 
 		server.onDispose()

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
@@ -252,6 +252,7 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public HttpOperations<INBOUND, OUTBOUND> addHandler(String name, ChannelHandler handler) {
 		super.addHandler(name, handler);
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -754,7 +754,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			ChannelOperations.addReactiveBridge(ch, opsFactory, obs);
 
 			if (responseTimeoutMillis > -1) {
-				Connection.from(ch).addHandler(NettyPipeline.ResponseTimeoutHandler,
+				Connection.from(ch).addHandlerFirst(NettyPipeline.ResponseTimeoutHandler,
 						new ReadTimeoutHandler(responseTimeoutMillis, TimeUnit.MILLISECONDS));
 			}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -193,6 +193,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public HttpClientOperations addHandler(ChannelHandler handler) {
 		super.addHandler(handler);
 		return this;
@@ -562,7 +563,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 		}
 		listener().onStateChange(this, HttpClientState.REQUEST_SENT);
 		if (responseTimeout != null) {
-			addHandler(NettyPipeline.ResponseTimeoutHandler,
+			addHandlerFirst(NettyPipeline.ResponseTimeoutHandler,
 					new ReadTimeoutHandler(responseTimeout.toMillis(), TimeUnit.MILLISECONDS));
 		}
 		channel().read();

--- a/reactor-netty-http/src/test/java/reactor/netty/channel/ChannelOperationsHandlerTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/channel/ChannelOperationsHandlerTest.java
@@ -74,7 +74,7 @@ class ChannelOperationsHandlerTest extends BaseHttpTest {
 		AtomicInteger counter = new AtomicInteger();
 		disposableServer =
 				createServer()
-				          .doOnConnection(conn -> conn.addHandler(new LineBasedFrameDecoder(10)))
+				          .doOnConnection(conn -> conn.addHandlerLast(new LineBasedFrameDecoder(10)))
 				          .handle((req, res) ->
 				                  req.receive()
 				                     .asString()

--- a/reactor-netty-http/src/test/java/reactor/netty/channel/ChannelOperationsHandlerTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/channel/ChannelOperationsHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
@@ -687,7 +687,7 @@ class HttpRedirectTest extends BaseHttpTest {
 		ConnectionProvider provider = ConnectionProvider.create("doTestBuffersForRedirectWithContentShouldBeReleased", 1);
 		final List<Integer> redirectBufferRefCounts = new ArrayList<>();
 		HttpClient.create(provider)
-		          .doOnRequest((r, c) -> c.addHandler("test-buffer-released", new ChannelInboundHandlerAdapter() {
+		          .doOnRequest((r, c) -> c.addHandlerLast("test-buffer-released", new ChannelInboundHandlerAdapter() {
 
 		              @Override
 		              public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -318,6 +318,7 @@ class HttpServerTests extends BaseHttpTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	void flushOnComplete() {
 
 		Flux<String> flux = Flux.range(0, 100)


### PR DESCRIPTION
In Netty 5 there isn't separate `ChannelHandler` for inbound and outbound.
`Connection#addHandler(...)` can't make any more a decision whether to add
a handler as first or last. (as first are added handlers for outbound, as last - for inbound).