### PR TITLE
[tests] Switch to ChannelHandlerAdapter

### DIFF
--- a/reactor-netty-core/src/test/java/reactor/netty/ConnectionTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.codec.http.HttpServerCodec;
@@ -61,12 +60,12 @@ class ConnectionTest {
 
 	@BeforeEach
 	void init() {
-		anotherRight = new ChannelDuplexHandler();
+		anotherRight = new ChannelHandlerAdapter(){};
 		channel = new EmbeddedChannel();
 		decoder = new LineBasedFrameDecoder(12);
 		encoder = new LineBasedFrameDecoder(12);
-		httpTrafficHandlerMock = new ChannelDuplexHandler();
-		reactiveBridgeMock = new ChannelInboundHandlerAdapter();
+		httpTrafficHandlerMock = new ChannelHandlerAdapter(){};
+		reactiveBridgeMock = new ChannelHandlerAdapter(){};
 		testContext = () -> channel;
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -60,8 +60,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelId;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
@@ -2974,13 +2974,13 @@ class HttpClientTest extends BaseHttpTest {
 	void testCustomHandlerAddedOnChannelInitAlwaysAvailable() {
 		doTestCustomHandlerAddedOnCallbackAlwaysAvailable(
 				client -> client.doOnChannelInit((observer, channel, address) ->
-						Connection.from(channel).addHandlerLast("custom", new ChannelDuplexHandler())));
+						Connection.from(channel).addHandlerLast("custom", new ChannelHandlerAdapter(){})));
 	}
 
 	@Test
 	void testCustomHandlerAddedOnChannelConnectedAlwaysAvailable() {
 		doTestCustomHandlerAddedOnCallbackAlwaysAvailable(
-				client -> client.doOnConnected(conn -> conn.addHandlerLast("custom", new ChannelDuplexHandler())));
+				client -> client.doOnConnected(conn -> conn.addHandlerLast("custom", new ChannelHandlerAdapter(){})));
 	}
 
 	private void doTestCustomHandlerAddedOnCallbackAlwaysAvailable(Function<HttpClient, HttpClient> customizer) {


### PR DESCRIPTION
This is in preparation for integration with Netty 5.
`ChannelDuplexHandler` and `ChannelInboundHandlerAdapter` are removed in Netty 5.