### PR TITLE
When request decoding fails on HttpContent different than HttpRequest, obtain the request from the channel attributes

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -760,6 +760,12 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		if (msg instanceof HttpRequest) {
 			request = (HttpRequest) msg;
 		}
+		else {
+			ChannelOperations<?, ?> ops = ChannelOperations.get(ctx.channel());
+			if (ops instanceof HttpServerOperations) {
+				request = ((HttpServerOperations) ops).nettyRequest;
+			}
+		}
 		listener.onStateChange(new FailedHttpServerRequest(conn, listener, request, response, secure), REQUEST_DECODING_FAILED);
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1448,8 +1448,18 @@ class HttpServerTests extends BaseHttpTest {
 
 	@Test
 	void testDecodingFailureLastHttpContent() throws Exception {
+		AtomicReference<Throwable> error = new AtomicReference<>();
 		disposableServer =
 				createServer()
+				          .doOnConnection(conn -> conn.channel().pipeline().addAfter(NettyPipeline.HttpTrafficHandler, null,
+				                  new ChannelInboundHandlerAdapter() {
+
+				                      @Override
+				                      public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+				                          error.set(cause);
+				                          ctx.fireExceptionCaught(cause);
+				                      }
+				          }))
 				          .route(r -> r.put("/1", (req, res) -> req.receive()
 				                                                   .then(res.sendString(Mono.just("test"))
 				                                                            .then()))
@@ -1458,8 +1468,13 @@ class HttpServerTests extends BaseHttpTest {
 
 		doTestDecodingFailureLastHttpContent("PUT /1 HTTP/1.1\r\nHost: a.example.com\r\n" +
 				"Transfer-Encoding: chunked\r\n\r\nsomething\r\n\r\n", "400 Bad Request", "connection: close");
+
+		assertThat(error.get()).isNull();
+
 		doTestDecodingFailureLastHttpContent("PUT /2 HTTP/1.1\r\nHost: a.example.com\r\n" +
 				"Transfer-Encoding: chunked\r\n\r\nsomething\r\n\r\n", "200 OK");
+
+		assertThat(error.get()).isNull();
 	}
 
 	private void doTestDecodingFailureLastHttpContent(String message, String... expectations) throws Exception {


### PR DESCRIPTION
Fixes #2068