### PR TITLE
Wrong metric value for TLS handshake time

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,6 +115,7 @@ public interface NettyPipeline {
 	String SslHandler            = LEFT + "sslHandler";
 	String SslLoggingHandler     = LEFT + "sslLoggingHandler";
 	String SslReader             = LEFT + "sslReader";
+	String TlsMetricsHandler     = LEFT + "tlsMetricsHandler";
 	String WsCompressionHandler  = LEFT + "wsCompressionHandler";
 	String WsFrameAggregator     = LEFT + "wsFrameAggregator";
 

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/AbstractChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/AbstractChannelMetricsHandler.java
@@ -67,6 +67,12 @@ public abstract class AbstractChannelMetricsHandler extends ChannelDuplexHandler
 			             NettyPipeline.ConnectMetricsHandler,
 			             connectMetricsHandler());
 		}
+		if (ctx.pipeline().get(NettyPipeline.SslHandler) != null) {
+			ctx.pipeline()
+				.addBefore(NettyPipeline.SslHandler,
+						 NettyPipeline.TlsMetricsHandler,
+						 tlsMetricsHandler());
+		}
 
 		ctx.fireChannelRegistered();
 	}
@@ -119,6 +125,7 @@ public abstract class AbstractChannelMetricsHandler extends ChannelDuplexHandler
 	}
 
 	public abstract ChannelHandler connectMetricsHandler();
+	public abstract ChannelHandler tlsMetricsHandler();
 
 	public abstract ChannelMetricsRecorder recorder();
 

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@ package reactor.netty.channel;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
+import io.netty.handler.ssl.SslHandler;
 import reactor.util.annotation.Nullable;
 
 import java.net.SocketAddress;
@@ -47,6 +49,11 @@ public class ChannelMetricsHandler extends AbstractChannelMetricsHandler {
 	}
 
 	@Override
+	public ChannelHandler tlsMetricsHandler() {
+		return new TlsMetricsHandler(recorder);
+	}
+
+	@Override
 	public ChannelMetricsRecorder recorder() {
 		return recorder;
 	}
@@ -72,6 +79,32 @@ public class ChannelMetricsHandler extends AbstractChannelMetricsHandler {
 						Duration.ofNanos(System.nanoTime() - connectTimeStart),
 						future.isSuccess() ? SUCCESS : ERROR);
 			});
+		}
+	}
+
+	static class TlsMetricsHandler extends ChannelInboundHandlerAdapter {
+		protected final ChannelMetricsRecorder recorder;
+		TlsMetricsHandler(ChannelMetricsRecorder recorder) {
+			this.recorder = recorder;
+		}
+
+		@Override
+		public void channelActive(ChannelHandlerContext ctx) throws Exception {
+			long tlsHandshakeTimeStart = System.nanoTime();
+			ctx.pipeline().get(SslHandler.class)
+					.handshakeFuture()
+					.addListener(f -> {
+						ctx.pipeline().remove(this);
+						recordTlsHandshakeTime(ctx, tlsHandshakeTimeStart, f.isSuccess() ? SUCCESS : ERROR);
+					});
+			ctx.fireChannelActive();
+		}
+
+		protected void recordTlsHandshakeTime(ChannelHandlerContext ctx, long tlsHandshakeTimeStart, String status) {
+			recorder.recordTlsHandshakeTime(
+					ctx.channel().remoteAddress(),
+					Duration.ofNanos(System.nanoTime() - tlsHandshakeTimeStart),
+					status);
 		}
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
@@ -89,7 +89,7 @@ public class ChannelMetricsHandler extends AbstractChannelMetricsHandler {
 		}
 
 		@Override
-		public void channelActive(ChannelHandlerContext ctx) throws Exception {
+		public void channelActive(ChannelHandlerContext ctx) {
 			long tlsHandshakeTimeStart = System.nanoTime();
 			ctx.pipeline().get(SslHandler.class)
 					.handshakeFuture()

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
@@ -129,7 +129,7 @@ final class ContextAwareChannelMetricsHandler extends AbstractChannelMetricsHand
 		}
 	}
 
-	static class TlsMetricsHandler extends ChannelMetricsHandler.TlsMetricsHandler {
+	static final class TlsMetricsHandler extends ChannelMetricsHandler.TlsMetricsHandler {
 		TlsMetricsHandler(ContextAwareChannelMetricsRecorder recorder) {
 			super(recorder);
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,11 @@ final class ContextAwareChannelMetricsHandler extends AbstractChannelMetricsHand
 	@Override
 	public ChannelHandler connectMetricsHandler() {
 		return new ContextAwareConnectMetricsHandler(recorder());
+	}
+
+	@Override
+	public ChannelHandler tlsMetricsHandler() {
+		return new TlsMetricsHandler(recorder);
 	}
 
 	@Override
@@ -120,6 +125,24 @@ final class ContextAwareChannelMetricsHandler extends AbstractChannelMetricsHand
 			}
 			else {
 				recorder.recordConnectTime(address, Duration.ofNanos(System.nanoTime() - connectTimeStart), status);
+			}
+		}
+	}
+
+	static class TlsMetricsHandler extends ChannelMetricsHandler.TlsMetricsHandler {
+		TlsMetricsHandler(ContextAwareChannelMetricsRecorder recorder) {
+			super(recorder);
+		}
+
+		@Override
+		protected void recordTlsHandshakeTime(ChannelHandlerContext ctx, long tlsHandshakeTimeStart, String status) {
+			Connection connection = Connection.from(ctx.channel());
+			if (connection instanceof ConnectionObserver) {
+				((ContextAwareChannelMetricsRecorder) recorder).recordTlsHandshakeTime(
+						((ConnectionObserver) connection).currentContext(),
+						ctx.channel().remoteAddress(),
+						Duration.ofNanos(System.nanoTime() - tlsHandshakeTimeStart),
+						status);
 			}
 		}
 	}


### PR DESCRIPTION
This PR corrects a bad value for the TLS handshake duration time metric.
Before, the handshake start time was wrongly starting when the channel was registered, but the handshake start time must corresponds to the time just before the initial hanshake message is sent out by the netty SslHandler.

To correct the problem, we now register two handlers: 

- a tls metric handler which is registered just before the netty SslHandler. The start time of the handshake starts when the tls metric handler is activated (just before the ssl handler will send the initial handler)
- an ssl read handler, which is registered just after the netty SslHandler, which is used to just control reads, as before.
