### PR TITLE
[doc] Extend the example for disabling the connection pool

### DIFF
--- a/docs/asciidoc/http-client-conn-provider.adoc
+++ b/docs/asciidoc/http-client-conn-provider.adoc
@@ -79,7 +79,7 @@ If you need to disable the connection pool, you can apply the following configur
 [source,java,indent=0]
 .{examplesdir}/pool/Application.java
 ----
-include::{examplesdir}/pool/Application.java[lines=18..35]
+include::{examplesdir}/pool/Application.java[lines=18..49]
 ----
 ====
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/pool/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/pool/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,25 @@ import reactor.netty.http.client.HttpClient;
 public class Application {
 
 	public static void main(String[] args) {
-		HttpClient client = HttpClient.newConnection();
+		HttpClient client =
+				HttpClient.newConnection()
+				          .doOnConnected(conn -> System.out.println("Connection " + conn.channel()));
 
 		String response =
+				// A new connection is established for every request
 				client.get()
-				      .uri("https://example.com/")
+				      .uri("https://httpbin.org/get")
+				      .responseContent()
+				      .aggregate()
+				      .asString()
+				      .block();
+
+		System.out.println("Response " + response);
+
+		response =
+				// A new connection is established for every request
+				client.post()
+				      .uri("https://httpbin.org/post")
 				      .responseContent()
 				      .aggregate()
 				      .asString()


### PR DESCRIPTION
Show that with one and the same `HttpClient` instance, one can
initiate many requests that always will use a new connection.

Related to comment https://github.com/reactor/reactor-netty/issues/1828#issuecomment-1060399563