### PR TITLE
Fixes #2083. Error adding IdleTimeoutHandler when client only supports HTTP/1.1

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -511,7 +511,8 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 				String baseName = null;
 				if (pipeline.get(NettyPipeline.HttpCodec) != null) {
 					baseName = NettyPipeline.HttpCodec;
-				} else if (pipeline.get(NettyPipeline.H2CUpgradeHandler) != null) {
+				}
+				else if (pipeline.get(NettyPipeline.H2CUpgradeHandler) != null) {
 					baseName = NettyPipeline.H2CUpgradeHandler;
 				} else {
 					ChannelHandler httpServerCodec = pipeline.get(HttpServerCodec.class);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -514,7 +514,8 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 				}
 				else if (pipeline.get(NettyPipeline.H2CUpgradeHandler) != null) {
 					baseName = NettyPipeline.H2CUpgradeHandler;
-				} else {
+				}
+				else {
 					ChannelHandler httpServerCodec = pipeline.get(HttpServerCodec.class);
 					if (httpServerCodec != null) {
 						baseName = pipeline.context(httpServerCodec).name();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -26,6 +26,7 @@ import java.util.function.BiPredicate;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
@@ -35,6 +36,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
@@ -507,10 +509,19 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 		static void addIdleTimeoutHandler(ChannelPipeline pipeline, @Nullable Duration idleTimeout) {
 			if (idleTimeout != null) {
 				String baseName = pipeline.get(NettyPipeline.HttpCodec) != null
-						? NettyPipeline.HttpCodec : NettyPipeline.H2CUpgradeHandler;
+						? NettyPipeline.HttpCodec : pipeline.get(NettyPipeline.H2CUpgradeHandler) != null
+						? NettyPipeline.H2CUpgradeHandler : null;
+
+				if (baseName == null) {
+					ChannelHandler httpServerCodec = pipeline.get(HttpServerCodec.class);
+					if (httpServerCodec != null) {
+						baseName = pipeline.context(httpServerCodec).name();
+					}
+				}
+
 				pipeline.addBefore(baseName,
-				                   NettyPipeline.IdleTimeoutHandler,
-				                   new IdleTimeoutHandler(idleTimeout.toMillis()));
+						NettyPipeline.IdleTimeoutHandler,
+						new IdleTimeoutHandler(idleTimeout.toMillis()));
 			}
 		}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -508,11 +508,12 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 
 		static void addIdleTimeoutHandler(ChannelPipeline pipeline, @Nullable Duration idleTimeout) {
 			if (idleTimeout != null) {
-				String baseName = pipeline.get(NettyPipeline.HttpCodec) != null
-						? NettyPipeline.HttpCodec : pipeline.get(NettyPipeline.H2CUpgradeHandler) != null
-						? NettyPipeline.H2CUpgradeHandler : null;
-
-				if (baseName == null) {
+				String baseName = null;
+				if (pipeline.get(NettyPipeline.HttpCodec) != null) {
+					baseName = NettyPipeline.HttpCodec;
+				} else if (pipeline.get(NettyPipeline.H2CUpgradeHandler) != null) {
+					baseName = NettyPipeline.H2CUpgradeHandler;
+				} else {
 					ChannelHandler httpServerCodec = pipeline.get(HttpServerCodec.class);
 					if (httpServerCodec != null) {
 						baseName = pipeline.context(httpServerCodec).name();
@@ -520,8 +521,8 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 				}
 
 				pipeline.addBefore(baseName,
-						NettyPipeline.IdleTimeoutHandler,
-						new IdleTimeoutHandler(idleTimeout.toMillis()));
+				                   NettyPipeline.IdleTimeoutHandler,
+				                   new IdleTimeoutHandler(idleTimeout.toMillis()));
 			}
 		}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
@@ -25,8 +25,6 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.concurrent.DefaultPromise;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Publisher;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -35,8 +33,6 @@ import reactor.core.publisher.Signal;
 import reactor.netty.BaseHttpTest;
 import reactor.netty.ByteBufFlux;
 import reactor.netty.ByteBufMono;
-import reactor.netty.Connection;
-import reactor.netty.ConnectionObserver;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.server.HttpServer;
 import reactor.netty.internal.shaded.reactor.pool.PoolAcquireTimeoutException;
@@ -47,7 +43,6 @@ import reactor.util.function.Tuple2;
 
 import java.security.cert.CertificateException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
@@ -58,7 +53,6 @@ import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Holds HTTP/2 specific tests.
@@ -191,7 +185,8 @@ class Http2Tests extends BaseHttpTest {
 				.verifyComplete();
 
 		// ensure no WARN with error
-		assertFalse(listAppender.list.stream().anyMatch(event -> event.getLevel() == Level.WARN));
+		assertThat(listAppender.list)
+				.noneMatch(event -> event.getLevel() == Level.WARN);
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
@@ -15,18 +15,12 @@
  */
 package reactor.netty.http;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
-import io.netty.util.concurrent.DefaultPromise;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Signal;

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
@@ -131,65 +131,6 @@ class Http2Tests extends BaseHttpTest {
 	}
 
 	@Test
-	void testIdleTimeoutWithHttp11AndH2cHandlesRequestsCorrectly() {
-		disposableServer =
-				createServer()
-				          .protocol(HttpProtocol.HTTP11, HttpProtocol.H2C)
-				          .idleTimeout(Duration.ofSeconds(60))
-				          .route(routes ->
-				              routes.post("/echo", (req, res) -> res.send(req.receive().retain())))
-				          .bindNow();
-
-		StepVerifier.create(
-				createClient(disposableServer.port())
-				          .protocol(HttpProtocol.H2C)
-				          .post()
-				          .uri("/echo")
-				          .send(ByteBufFlux.fromString(Mono.just("Hello world!")))
-				          .responseContent()
-				          .aggregate()
-				          .asString()
-						  .timeout(Duration.ofSeconds(10))
-				)
-				.expectNext("Hello world!")
-				.verifyComplete();
-	}
-
-	@Test
-	void testIdleTimeoutWithHttp11AndH2cHandlesHttp11RequestsCorrectly() {
-		ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-		Logger logger = (Logger) LoggerFactory.getLogger(DefaultPromise.class);
-		logger.addAppender(listAppender);
-		listAppender.start();
-
-		disposableServer =
-				createServer()
-				          .protocol(HttpProtocol.HTTP11, HttpProtocol.H2C)
-				          .idleTimeout(Duration.ofSeconds(60))
-				          .route(routes ->
-				              routes.post("/echo", (req, res) -> res.send(req.receive().retain())))
-				          .bindNow();
-
-		StepVerifier.create(
-				createClient(disposableServer.port())
-				          .protocol(HttpProtocol.HTTP11)
-				          .post()
-				          .uri("/echo")
-				          .send(ByteBufFlux.fromString(Mono.just("Hello world!")))
-				          .responseContent()
-				          .aggregate()
-				          .asString()
-						  .timeout(Duration.ofSeconds(10))
-				)
-				.expectNext("Hello world!")
-				.verifyComplete();
-
-		// ensure no WARN with error
-		assertThat(listAppender.list)
-				.noneMatch(event -> event.getLevel() == Level.WARN);
-	}
-
-	@Test
 	void testIssue1071MaxContentLengthSpecified() {
 		doTestIssue1071(1024, "doTestIssue1071", 200);
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
@@ -15,17 +15,21 @@
  */
 package reactor.netty.http;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.read.ListAppender;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.util.concurrent.DefaultPromise;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
@@ -550,5 +554,43 @@ class HttpProtocolsTests extends BaseHttpTest {
 		              expectedHeaderValue.equals(t.getT2().get("foo", "empty")))
 		      .expectComplete()
 		      .verify(Duration.ofSeconds(5));
+	}
+
+	@ParameterizedCompatibleCombinationsTest
+	void testIdleTimeoutAddedCorrectly(HttpServer server, HttpClient client) {
+		ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+		Logger logger = (Logger) LoggerFactory.getLogger(DefaultPromise.class);
+		logger.addAppender(listAppender);
+		listAppender.start();
+
+		disposableServer =
+				server.idleTimeout(Duration.ofSeconds(60))
+						.route(routes ->
+								routes.post("/echo", (req, res) -> res.send(req.receive().retain())))
+						.bindNow();
+
+		StepVerifier.create(
+						client.port(disposableServer.port())
+								.post()
+								.uri("/echo")
+								.send(ByteBufFlux.fromString(Mono.just("Hello world!")))
+								.responseContent()
+								.aggregate()
+								.asString()
+								.timeout(Duration.ofSeconds(10))
+				)
+				.expectNext("Hello world!")
+				.verifyComplete();
+
+		try {
+			// Wait till all logs are flushed
+			Thread.sleep(200);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+
+		// ensure no WARN with error
+		assertThat(listAppender.list)
+				.noneMatch(event -> event.getLevel() == Level.WARN);
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
@@ -29,7 +29,6 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.util.concurrent.DefaultPromise;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
@@ -585,7 +584,8 @@ class HttpProtocolsTests extends BaseHttpTest {
 		try {
 			// Wait till all logs are flushed
 			Thread.sleep(200);
-		} catch (InterruptedException e) {
+		}
+		catch (InterruptedException e) {
 			e.printStackTrace();
 		}
 


### PR DESCRIPTION
This PR fixes issue #2083 with the proposed solution by searching by class the `HttpServerCodec` given that search by name returns null for `httpCodec` when adding idle timeout handler to HttpServer and receiving a request from a client that only supports HTTP/1.1