### PR TITLE
Optimize Http2Pool by reducing calls to CLDQ size method

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -523,7 +523,8 @@ final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.
 	int addPending(ConcurrentLinkedDeque<Borrower> borrowers, Borrower borrower, boolean first) {
 		if (first) {
 			borrowers.offerFirst(borrower);
-		} else {
+		}
+		else {
 			borrowers.offerLast(borrower);
 		}
 		return PENDING_SIZE.incrementAndGet(this);

--- a/reactor-netty-http/src/test/java/reactor/netty/resources/PooledConnectionProviderDefaultMetricsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/resources/PooledConnectionProviderDefaultMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The PR provides an enhancement for the Http2Pool in order to reduce  _ConcurrentLinkedDeque.size()_ method calls, which is not a constant time operation. 

Indeed, it has been observed that the CLDQ size method may consume around 18% of CPU when there is a high load of http client requests while all streams are currently unavailable.



