### PR TITLE
Avoid NoSuchElementException when an acquiring connection is closing

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultPooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultPooledConnectionProvider.java
@@ -220,7 +220,8 @@ final class DefaultPooledConnectionProvider extends PooledConnectionProvider<Def
 						log.debug(format(c, "Immediately aborted pooled channel, re-acquiring new channel"));
 					}
 					pool.acquire(Duration.ofMillis(pendingAcquireTimeout))
-					    .subscribe(new DisposableAcquire(this));
+							.contextWrite(ctx -> ctx.put(CONTEXT_CALLER_EVENTLOOP, c.eventLoop()))
+							.subscribe(new DisposableAcquire(this));
 				}
 				else {
 					sink.error(new IOException("Error while acquiring from " + pool));


### PR DESCRIPTION
The following PR attemptsto avoid the following exception, which may happen when a connection is being acquired from the pool while the connection is concurrently closing:

```
java.util.NoSuchElementException: Context does not contain key: callereventloop
    at reactor.util.context.Context2.get(Context2.java:87)
    at reactor.netty.resources.DefaultPooledConnectionProvider$PooledConnectionAllocator.lambda$connectChannel$0(DefaultPooledConnectionProvider.java:498)
    at reactor.core.publisher.MonoCreate.subscribe(MonoCreate.java:57)
    at reactor.core.publisher.Mono.subscribe(Mono.java:4400)
    at reactor.core.publisher.Mono.subscribeWith(Mono.java:4515)
    at reactor.core.publisher.Mono.subscribe(Mono.java:4371)
    at reactor.core.publisher.Mono.subscribe(Mono.java:4307)
    at reactor.netty.internal.shaded.reactor.pool.SimpleDequePool.drainLoop(SimpleDequePool.java:407)
    at reactor.netty.internal.shaded.reactor.pool.SimpleDequePool.pendingOffer(SimpleDequePool.java:558)
    at reactor.netty.internal.shaded.reactor.pool.SimpleDequePool.doAcquire(SimpleDequePool.java:268)
    at reactor.netty.internal.shaded.reactor.pool.AbstractPool$Borrower.request(AbstractPool.java:432)
    at reactor.netty.resources.DefaultPooledConnectionProvider$DisposableAcquire.onSubscribe(DefaultPooledConnectionProvider.java:195)
    at reactor.netty.internal.shaded.reactor.pool.SimpleDequePool$QueueBorrowerMono.subscribe(SimpleDequePool.java:676)
    at reactor.netty.resources.DefaultPooledConnectionProvider$DisposableAcquire.run(DefaultPooledConnectionProvider.java:223)
    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
    at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:384)
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
```