### PR TITLE
Ensure channel promises support listeners when SOCKS proxy handler is used

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
@@ -108,6 +108,7 @@ public interface NettyPipeline {
 	String OnChannelReadIdle     = LEFT + "onChannelReadIdle";
 	String OnChannelWriteIdle    = LEFT + "onChannelWriteIdle";
 	String ProxyHandler          = LEFT + "proxyHandler";
+	String UnvoidHandler         = LEFT + "unvoidHandler";
 	String ProxyLoggingHandler   = LEFT + "proxyLoggingHandler";
 	String ProxyProtocolDecoder  = LEFT + "proxyProtocolDecoder";
 	String ProxyProtocolReader   = LEFT + "proxyProtocolReader";

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -27,7 +27,10 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.logging.LogLevel;
@@ -173,6 +176,17 @@ public final class ProxyProvider {
 		Objects.requireNonNull(channel, "channel");
 		ChannelPipeline pipeline = channel.pipeline();
 		pipeline.addFirst(NettyPipeline.ProxyHandler, newProxyHandler());
+		// For SOCKS proxy, the netty SOCKS handlers may register listeners in channel promises, so we need to register a
+		// special handler which ensures that any VoidPromise will be converted to "unvoided" promises (for support of listeners).
+		// Note: an example of a VoidPromise which does not support listeners is the MonoSendMany.SendManyInner promise.
+		if (this.type == Proxy.SOCKS4 || type == Proxy.SOCKS5) {
+			pipeline.addAfter(NettyPipeline.ProxyHandler, NettyPipeline.UnvoidHandler, new ChannelOutboundHandlerAdapter() {
+				@Override
+				public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+					ctx.write(msg, promise.unvoid());
+				}
+			});
+		}
 
 		if (pipeline.get(NettyPipeline.LoggingHandler) != null) {
 			pipeline.addBefore(NettyPipeline.ProxyHandler,

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -182,7 +182,8 @@ public final class ProxyProvider {
 		if (this.type == Proxy.SOCKS4 || type == Proxy.SOCKS5) {
 			pipeline.addAfter(NettyPipeline.ProxyHandler, NettyPipeline.UnvoidHandler, new ChannelOutboundHandlerAdapter() {
 				@Override
-				public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+				@SuppressWarnings("FutureReturnValueIgnored")
+				public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
 					ctx.write(msg, promise.unvoid());
 				}
 			});


### PR DESCRIPTION
When a SOCKS proxy is used with a TcpClient, and when more than one message are sent **before** the tunnel is fully established with the SOCKS proxy, then the messages are buffered by the netty _ProxyHandler_ and won't be forwarded to the destination server after the tunnel is fully established.

This is because when you write multiple messages like for example this:

```
   Connection connection = TcpClient.create().proxy(spec -> spec.type(ProxyProvider.Proxy.SOCKS5)... 
   connection.outbound().sendString(Flux.just("Message1", "Message2", ...)
```

Then if the tunnel is not yet established, the netty ProxyHandler will buffer the messages using a reactor-netty _MonoSendMany.SendManyInner_ ChannelPromise, where some listeners will be added.
But, the problem is that the MonoSendMany.SendManyInner is a kind of ChannelPromise which does not support listeners, and internally, the following exception is caught (but not logged) by netty:

```
java.lang.UnsupportedOperationException
	at reactor.netty.channel.MonoSendMany$SendManyInner.addListener(MonoSendMany.java:499)
	at reactor.netty.channel.MonoSendMany$SendManyInner.addListener(MonoSendMany.java:117)
	at io.netty.util.concurrent.PromiseCombiner.add(PromiseCombiner.java:111)
	at io.netty.util.concurrent.PromiseCombiner.add(PromiseCombiner.java:97)
	at io.netty.channel.PendingWriteQueue.removeAndWriteAll(PendingWriteQueue.java:154)
	at io.netty.handler.proxy.ProxyHandler.writePendingWrites(ProxyHandler.java:427)
	at io.netty.handler.proxy.ProxyHandler.setConnectSuccess(ProxyHandler.java:296)
	at io.netty.handler.proxy.ProxyHandler.channelRead(ProxyHandler.java:259)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:299)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)

```

The solution to this problem is to register a special handler after the netty ProxyHandler which ensures that all promises passed to the ProxyHandler are first converted to unvoid promises.

