### PR TITLE
[test] Remove maxGranularity in order to see parameterized tests failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -276,7 +276,6 @@ subprojects {
 		testLogging {
 			showExceptions true
 			exceptionFormat "full"
-			maxGranularity 3
 		}
 
 		onOutput { descriptor, event ->


### PR DESCRIPTION
According to gradle doc - the default for `maxGranularity` is `-1` and this is `-1 denotes the highest granularity and corresponds to an atomic test`