### PR TITLE
Ensure PooledConnectionProvider check only for event loop in the thread local

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ColocatedEventLoopGroup.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ColocatedEventLoopGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ColocatedEventLoopGroup.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ColocatedEventLoopGroup.java
@@ -33,6 +33,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.ScheduledFuture;
+import reactor.util.annotation.Nullable;
 
 /**
  * Reuse local event loop if already working inside one.
@@ -124,10 +125,8 @@ final class ColocatedEventLoopGroup implements EventLoopGroup, Supplier<EventLoo
 
 	@Override
 	public EventLoop next() {
-		if (localLoop.isSet()) {
-			return localLoop.get();
-		}
-		return eventLoopGroup.next();
+		EventLoop loop = nextInternal();
+		return loop != null ? loop : eventLoopGroup.next();
 	}
 
 	@Override
@@ -217,5 +216,10 @@ final class ColocatedEventLoopGroup implements EventLoopGroup, Supplier<EventLoo
 		for (EventExecutor ex : eventLoopGroup) {
 			ex.execute(() -> localLoop.set(null));
 		}
+	}
+
+	@Nullable
+	EventLoop nextInternal() {
+		return localLoop.isSet() ? localLoop.get() : null;
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultPooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultPooledConnectionProvider.java
@@ -499,9 +499,15 @@ final class DefaultPooledConnectionProvider extends PooledConnectionProvider<Def
 		Publisher<PooledConnection> connectChannel() {
 			return Mono.create(sink -> {
 				PooledConnectionInitializer initializer = new PooledConnectionInitializer(sink);
-				EventLoop callerEventLoop = sink.contextView().get(CONTEXT_CALLER_EVENTLOOP);
-				TransportConnector.connect(config, remoteAddress, resolver, initializer, callerEventLoop)
-				                  .subscribe(initializer);
+				EventLoop callerEventLoop = sink.contextView().hasKey(CONTEXT_CALLER_EVENTLOOP) ?
+						sink.contextView().get(CONTEXT_CALLER_EVENTLOOP) : null;
+				if (callerEventLoop != null) {
+					TransportConnector.connect(config, remoteAddress, resolver, initializer, callerEventLoop)
+							.subscribe(initializer);
+				}
+				else {
+					TransportConnector.connect(config, remoteAddress, resolver, initializer).subscribe(initializer);
+				}
 			});
 		}
 


### PR DESCRIPTION
`EventLoopGroup.next()` should be called only in cases it will be used
for example establishing a connection.
`Pool.acquire(...)` in most cases will reuse the connections and in
these cases `EventLoopGroup.next()` invocation is not needed.