### PR TITLE
Allow to configure connection pool aquire timers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ spotless {
 		enforceCheck false
 	}
 	else {
-		String spotlessBranch = "1.0.x"
+		String spotlessBranch = "origin/1.0.x"
 		println "[Spotless] Local run detected, ratchet from $spotlessBranch"
 		ratchetFrom spotlessBranch
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ spotless {
 		enforceCheck false
 	}
 	else {
-		String spotlessBranch = "origin/1.0.x"
+		String spotlessBranch = "1.0.x"
 		println "[Spotless] Local run detected, ratchet from $spotlessBranch"
 		ratchetFrom spotlessBranch
 	}

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -593,10 +593,10 @@ public interface ConnectionProvider extends Disposable {
 		}
 
 		/**
-		 * Set the function to applly when scheduling timers for connection acquisitions.
+		 * Set the function to apply when scheduling pending acquisition timers.
 		 * By default, the {@link Schedulers#parallel()} will be used.
 		 *
-		 * @param acquireTimer the function to applly when scheduling timers for connection acquisitions
+		 * @param acquireTimer the function to apply when scheduling pending acquisition timers
 		 * @return {@literal this}
 		 * @since 1.0.19
 		 */

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -442,10 +442,6 @@ public interface ConnectionProvider extends Disposable {
 		static final Duration EVICT_IN_BACKGROUND_DISABLED       = Duration.ZERO;
 		static final int PENDING_ACQUIRE_MAX_COUNT_NOT_SPECIFIED = -2;
 
-		/**
-		 * Default timer service used for scheduling connection acquisition timers.
-		 */
-
 		Duration evictionInterval       = EVICT_IN_BACKGROUND_DISABLED;
 		int      maxConnections         = DEFAULT_POOL_MAX_CONNECTIONS;
 		int      pendingAcquireMaxCount = PENDING_ACQUIRE_MAX_COUNT_NOT_SPECIFIED;

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -370,7 +370,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 		final Supplier<? extends MeterRegistrar> registrar;
 		final Clock clock;
 		final Duration disposeTimeout;
-		final BiFunction<Runnable, Duration, Disposable> acquireTimer;
+		final BiFunction<Runnable, Duration, Disposable> pendingAcquireTimer;
 		final AllocationStrategy<?> allocationStrategy;
 
 		PoolFactory(ConnectionPoolSpec<?> conf, Duration disposeTimeout) {
@@ -391,7 +391,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 			this.registrar = conf.registrar;
 			this.clock = clock;
 			this.disposeTimeout = disposeTimeout;
-			this.acquireTimer = conf.acquireTimer;
+			this.pendingAcquireTimer = conf.pendingAcquireTimer;
 			this.allocationStrategy = conf.allocationStrategy;
 		}
 
@@ -432,7 +432,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 					                           || (maxLifeTime != -1 && meta.lifeTime() >= maxLifeTime)))
 					           .maxPendingAcquire(pendingAcquireMaxCount)
 					           .evictInBackground(evictionInterval)
-							   .acquireTimer(acquireTimer);
+							   .pendingAcquireTimer(pendingAcquireTimer);
 
 			if (DEFAULT_POOL_GET_PERMITS_SAMPLING_RATE > 0d && DEFAULT_POOL_GET_PERMITS_SAMPLING_RATE <= 1d
 					&& DEFAULT_POOL_RETURN_PERMITS_SAMPLING_RATE > 0d && DEFAULT_POOL_RETURN_PERMITS_SAMPLING_RATE <= 1d) {

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -431,8 +431,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 					                   .or((poolable, meta) -> (maxIdleTime != -1 && meta.idleTime() >= maxIdleTime)
 					                           || (maxLifeTime != -1 && meta.lifeTime() >= maxLifeTime)))
 					           .maxPendingAcquire(pendingAcquireMaxCount)
-					           .evictInBackground(evictionInterval)
-							   .pendingAcquireTimer(pendingAcquireTimer);
+					           .evictInBackground(evictionInterval);
 
 			if (DEFAULT_POOL_GET_PERMITS_SAMPLING_RATE > 0d && DEFAULT_POOL_GET_PERMITS_SAMPLING_RATE <= 1d
 					&& DEFAULT_POOL_RETURN_PERMITS_SAMPLING_RATE > 0d && DEFAULT_POOL_RETURN_PERMITS_SAMPLING_RATE <= 1d) {
@@ -449,6 +448,10 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 				else {
 					poolBuilder = poolBuilder.allocationStrategy(new DelegatingAllocationStrategy(allocationStrategy.copy()));
 				}
+			}
+
+			if (pendingAcquireTimer != null) {
+				poolBuilder = poolBuilder.pendingAcquireTimer(pendingAcquireTimer);
 			}
 
 			if (clock != null) {

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/ConnectionProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/ConnectionProviderTest.java
@@ -16,12 +16,14 @@
 package reactor.netty.resources;
 
 import org.junit.jupiter.api.Test;
+import reactor.core.Disposable;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +33,7 @@ class ConnectionProviderTest {
 	static final TestAllocationStrategy TEST_ALLOCATION_STRATEGY = new TestAllocationStrategy();
 	static final String TEST_STRING = "";
 	static final Supplier<ConnectionProvider.MeterRegistrar> TEST_SUPPLIER = () -> (a, b, c, d) -> {};
+	static final BiFunction<Runnable, Duration, Disposable> TEST_BI_FUNCTION = (r, duration) -> () -> {};
 
 	@Test
 	void testBuilderCopyConstructor() throws IllegalAccessException {
@@ -73,6 +76,9 @@ class ConnectionProviderTest {
 		}
 		else if (int.class == clazz) {
 			field.setInt(builder, 1);
+		}
+		else if (BiFunction.class == clazz) {
+			field.set(builder, TEST_BI_FUNCTION);
 		}
 		else {
 			throw new IllegalArgumentException("Unknown field type " + clazz);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -758,7 +758,7 @@ final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.
 				int permits = pool.poolConfig.allocationStrategy().estimatePermitCount();
 				int pending = pool.pendingSize;
 				if (!acquireTimeout.isZero() && permits + estimateStreamsCount <= pending) {
-					timeoutTask = pool.poolConfig.acquireTimer().apply(this, acquireTimeout);
+					timeoutTask = pool.poolConfig.pendingAcquireTimer().apply(this, acquireTimeout);
 				}
 				pool.doAcquire(this);
 			}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -34,7 +33,6 @@ import reactor.core.Disposables;
 import reactor.core.Scannable;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
-import reactor.core.scheduler.Schedulers;
 import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
 import reactor.netty.channel.ChannelOperations;
@@ -590,7 +588,7 @@ final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.
 		public void request(long n) {
 			if (Operators.validate(n)) {
 				if (!acquireTimeout.isZero()) {
-					timeoutTask = Schedulers.parallel().schedule(this, acquireTimeout.toMillis(), TimeUnit.MILLISECONDS);
+					timeoutTask = pool.poolConfig.acquireTimer().apply(this, acquireTimeout);
 				}
 				pool.doAcquire(this);
 			}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
@@ -21,9 +21,11 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Signal;
+import reactor.core.scheduler.Schedulers;
 import reactor.netty.BaseHttpTest;
 import reactor.netty.ByteBufFlux;
 import reactor.netty.ByteBufMono;
@@ -43,6 +45,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
@@ -159,14 +162,35 @@ class Http2Tests extends BaseHttpTest {
 
 	@Test
 	void testMaxActiveStreams_1_CustomPool() throws Exception {
-		ConnectionProvider provider =
+		doTestMaxActiveStreams_1_CustomPool(null);
+	}
+
+	@Test
+	void testMaxActiveStreams_1_CustomPool_Custom_AcquireTimer() throws Exception {
+		CountDownLatch latch = new CountDownLatch(1);
+		BiFunction<Runnable, Duration, Disposable> timer = (r, d) -> {
+			Runnable wrapped = () -> {
+				r.run();
+				latch.countDown();
+			};
+			return Schedulers.single().schedule(wrapped, d.toNanos(), TimeUnit.NANOSECONDS);
+		};
+		doTestMaxActiveStreams_1_CustomPool(timer);
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+	}
+
+	void doTestMaxActiveStreams_1_CustomPool(BiFunction<Runnable, Duration, Disposable> acquireTimer) throws Exception {
+		ConnectionProvider.Builder builder =
 				ConnectionProvider.builder("testMaxActiveStreams_1_CustomPool")
-				                  .maxConnections(1)
-				                  .pendingAcquireTimeout(Duration.ofMillis(10)) // the default is 45s
-				                  .build();
+						.maxConnections(1)
+						.pendingAcquireTimeout(Duration.ofMillis(10)); // the default is 45s
+		if (acquireTimer != null) {
+			builder.acquireTimer(acquireTimer);
+		}
+		ConnectionProvider provider = builder.build();
 		doTestMaxActiveStreams(HttpClient.create(provider), 1, 1, 1);
 		provider.disposeLater()
-		        .block();
+				.block();
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
@@ -179,13 +179,13 @@ class Http2Tests extends BaseHttpTest {
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
-	void doTestMaxActiveStreams_1_CustomPool(BiFunction<Runnable, Duration, Disposable> acquireTimer) throws Exception {
+	void doTestMaxActiveStreams_1_CustomPool(BiFunction<Runnable, Duration, Disposable> pendingAcquireTimer) throws Exception {
 		ConnectionProvider.Builder builder =
 				ConnectionProvider.builder("testMaxActiveStreams_1_CustomPool")
 						.maxConnections(1)
 						.pendingAcquireTimeout(Duration.ofMillis(10)); // the default is 45s
-		if (acquireTimer != null) {
-			builder.acquireTimer(acquireTimer);
+		if (pendingAcquireTimer != null) {
+			builder = builder.pendingAcquireTimer(pendingAcquireTimer);
 		}
 		ConnectionProvider provider = builder.build();
 		doTestMaxActiveStreams(HttpClient.create(provider), 1, 1, 1);

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
@@ -852,7 +852,7 @@ class Http2PoolTest {
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
-	private void doMaxLifeTimeMaxConnectionsReached(BiFunction<Runnable, Duration, Disposable> acquireTimer) throws Exception {
+	private void doMaxLifeTimeMaxConnectionsReached(BiFunction<Runnable, Duration, Disposable> pendingAcquireTimer) throws Exception {
 		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
 				PoolBuilder.from(Mono.fromSupplier(() -> {
 				               Channel channel = new EmbeddedChannel(
@@ -863,8 +863,8 @@ class Http2PoolTest {
 				           .idleResourceReuseLruOrder()
 				           .maxPendingAcquireUnbounded()
 				           .sizeBetween(0, 1);
-		if (acquireTimer != null) {
-			poolBuilder.acquireTimer(acquireTimer);
+		if (pendingAcquireTimer != null) {
+			poolBuilder = poolBuilder.pendingAcquireTimer(pendingAcquireTimer);
 		}
 		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, null, -1, 10));
 


### PR DESCRIPTION
This draft PR is an improvement to allow http client users to specify a hook function that can be used to configure a custom scheduler to schedule timers for pending connections acquisition.

By default, it's the **Schedulers.parallel** scheduler which is used, as before, but the intent is to let users to specify their own implementation for the timer service used by reactor-netty (timer scheduled for pending connections pool acquisition).

Example usage of a client that is configured with a netty hashed wheel timer service:
```
        HashedWheelTimer timer = new HashedWheelTimer(10, TimeUnit.MILLISECONDS, 1024);

        ConnectionProvider provider = ConnectionProvider
                .builder(POOL_NAME)
                .pendingAcquireTimeout(Duration.ofMillis(10000))
                .pendingAcquireTimer((r, d) -> {
                    Timeout t = timer.newTimeout(timeout -> r.run(), d.toNanos(), TimeUnit.NANOSECONDS);
                    return () -> t.cancel();
                })
                .build();
```