### PR TITLE
Support 303 redirect

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -905,7 +905,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	}
 
 	/**
-	 * Specifies whether HTTP status 301|302|307|308 auto-redirect support is enabled.
+	 * Specifies whether HTTP status 301|302|303|307|308 auto-redirect support is enabled.
 	 *
 	 * <p><strong>Note:</strong> The sensitive headers {@link #followRedirect(boolean, Consumer) followRedirect}
 	 * are removed from the initialized request when redirecting to a different domain, they can be re-added

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -637,7 +637,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		return bootstrap.open();
 	}
 
-	static final Pattern FOLLOW_REDIRECT_CODES = Pattern.compile("30[1278]");
+	static final Pattern FOLLOW_REDIRECT_CODES = Pattern.compile("30[12378]");
 
 	static final BiPredicate<HttpClientRequest, HttpClientResponse> FOLLOW_REDIRECT_PREDICATE =
 			(req, res) -> FOLLOW_REDIRECT_CODES.matcher(res.status()

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -738,7 +738,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 						        .entries()
 						        .toString());
 			}
-			redirecting = new RedirectClientException(response.headers());
+			redirecting = new RedirectClientException(response.headers(), response.status());
 			return false;
 		}
 		return true;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/RedirectClientException.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/RedirectClientException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.util.Objects;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
 
 /**
  * An error for signalling that an error occurred during a communication over HTTP version
@@ -27,9 +28,11 @@ import io.netty.handler.codec.http.HttpHeaders;
 final class RedirectClientException extends RuntimeException {
 
 	final String location;
+	final HttpResponseStatus status;
 
-	RedirectClientException(HttpHeaders headers) {
+	RedirectClientException(HttpHeaders headers, HttpResponseStatus status) {
 		location = Objects.requireNonNull(headers.get(HttpHeaderNames.LOCATION));
+		this.status = Objects.requireNonNull(status);
 	}
 
 	@Override

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientOperationsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientOperationsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientOperationsTest.java
@@ -145,7 +145,8 @@ class HttpClientOperationsTest {
 		ops1.followRedirectPredicate((req, res) -> true);
 		ops1.started = true;
 		ops1.retrying = true;
-		ops1.redirecting = new RedirectClientException(new DefaultHttpHeaders().add(HttpHeaderNames.LOCATION, "/"));
+		ops1.redirecting = new RedirectClientException(new DefaultHttpHeaders().add(HttpHeaderNames.LOCATION, "/"),
+				HttpResponseStatus.MOVED_PERMANENTLY);
 
 		HttpClientOperations ops2 = new HttpClientOperations(ops1);
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
@@ -339,6 +339,9 @@ class HttpRedirectTest extends BaseHttpTest {
 				                       .get("/302", (req, res) ->
 				                          res.status(302)
 				                             .header(HttpHeaderNames.LOCATION, "http://localhost:" + serverPort + "/redirect"))
+				                       .post("/303", (req, res) ->
+				                          res.status(303)
+				                             .header(HttpHeaderNames.LOCATION, "http://localhost:" + serverPort + "/redirect"))
 				                       .get("/304", (req, res) -> res.status(304))
 				                       .get("/307", (req, res) ->
 				                          res.status(307)
@@ -368,6 +371,16 @@ class HttpRedirectTest extends BaseHttpTest {
 		StepVerifier.create(client.followRedirect(true)
 		                          .get()
 		                          .uri("/302")
+		                          .responseContent()
+		                          .aggregate()
+		                          .asString())
+		            .expectNextMatches("OK"::equals)
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(30));
+
+		StepVerifier.create(client.followRedirect(true)
+		                          .post()
+		                          .uri("/303")
 		                          .responseContent()
 		                          .aggregate()
 		                          .asString())


### PR DESCRIPTION
This PR enables HttpClient to automatically GET resource from Location URI on 303 response, given followRedirect is enabled.

From rfc2616 (https://datatracker.ietf.org/doc/html/rfc2616#section-10.3.4):
>    10.3.4 303 See Other
   The response to the request can be found under a different URI and
   SHOULD be retrieved using a GET method on that resource. This method
   exists primarily to allow the output of a POST-activated script to
   redirect the user agent to a selected resource. The new URI is not a
   substitute reference for the originally requested resource. The 303
   response MUST NOT be cached, but the response to the second
   (redirected) request might be cacheable.

A client configured as shown below will on received 303 response issue a GET request to location:
```java
var nettyHttpClient = HttpClient.create()
            .compress(true)
            .followRedirect(true);
```