### PR TITLE
Update Reactor Netty version to 2.0.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,7 @@ spotless {
 		enforceCheck false
 	}
 	else {
-		String spotlessBranch = "origin/main"
+		String spotlessBranch = "origin/netty5"
 		println "[Spotless] Local run detected, ratchet from $spotlessBranch"
 		ratchetFrom spotlessBranch
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 reactorPoolVersion=1.0.0-SNAPSHOT
-version=1.1.0-SNAPSHOT
-reactorNettyQuicVersion=0.1.0-SNAPSHOT
+version=2.0.0-SNAPSHOT
+reactorNettyQuicVersion=0.2.0-SNAPSHOT
 reactorCoreVersion=3.5.0-SNAPSHOT
 reactorAddonsVersion=3.5.0-SNAPSHOT
 compatibleVersion=1.0.18


### PR DESCRIPTION
Reactor Netty QUIC version to 0.2.0-SNAPSHOT

This branch is meant to be Reactor Netty integration with Netty 5