### PR TITLE
[tests] Add bouncycastle dependency

### DIFF
--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -149,6 +149,7 @@ dependencies {
 		// https://github.com/netty/netty/issues/10317
 		// Necessary for generating SelfSignedCertificate on Java version >= 15
 		testRuntimeOnly "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
+		noMicrometerTestRuntimeOnly "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
 	}
 
 	// noMicrometerTest sourceSet (must not include Micrometer)


### PR DESCRIPTION
Add `bouncycastle` dependency for `noMicrometer` tests similar to the standard tests.

This change is added for `1.0.x` because one may decide to build Reactor Netty with java version where one won't be able to create a `SelfSignedCertificate`