### PR TITLE
[tests] Add SocketException to the list with possible exceptions

### DIFF
--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -1316,7 +1316,8 @@ class HttpClientTest extends BaseHttpTest {
 		                error.set(t);
 		                return t.getMessage() != null &&
 		                               (t.getMessage().contains("Connection reset by peer") ||
-				                                t.getMessage().contains("readAddress(..)") || // https://github.com/reactor/reactor-netty/issues/1673
+		                                        t.getMessage().contains("Connection reset") ||
+		                                        t.getMessage().contains("readAddress(..)") || // https://github.com/reactor/reactor-netty/issues/1673
 		                                        t.getMessage().contains("Connection prematurely closed BEFORE response"));
 		            })
 		            .verify(Duration.ofSeconds(30));


### PR DESCRIPTION
`SocketException` with message `Connection reset` may be thrown
when running the tests with Java 17

This change is added for `1.0.x` because one may decide to build Reactor Netty with Java 17