### PR TITLE
Temporary exclude reactor-netty-incubator-quic as there is no version for Netty 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ ext {
 		println "Netty version defined from command line: ${forceNettyVersion}"
 	}
 	nettyIoUringVersion = '0.0.14.Final'
-	nettyQuicVersion = '0.0.27.Final'
+	//nettyQuicVersion = '0.0.27.Final'
 
 	// Testing
 	jacksonDatabindVersion = '2.13.3'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 reactorPoolVersion=1.0.0-SNAPSHOT
 version=2.0.0-SNAPSHOT
-reactorNettyQuicVersion=0.2.0-SNAPSHOT
+#reactorNettyQuicVersion=0.2.0-SNAPSHOT
 reactorCoreVersion=3.5.0-SNAPSHOT
 reactorAddonsVersion=3.5.0-SNAPSHOT
 compatibleVersion=1.0.18

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,6 @@ rootProject.name = 'reactor-netty'
 include 'reactor-netty-core'
 include 'reactor-netty-http'
 include 'reactor-netty-http-brave'
-include 'reactor-netty-incubator-quic'
+//include 'reactor-netty-incubator-quic'
 include 'reactor-netty-examples'
 include 'reactor-netty'


### PR DESCRIPTION
The new integration will be handled with #2215