### PR TITLE
Deprecate reactor-netty-http-brave module

### DIFF
--- a/reactor-netty-http-brave/README.md
+++ b/reactor-netty-http-brave/README.md
@@ -1,5 +1,9 @@
 # Brave instrumentation for Reactor Netty HTTP
 
+:exclamation: This module is **DEPRECATED** as of `Reactor Netty 1.1.0` and will be removed in `Reactor Netty 2.0.0`.
+Prefer using the standard `HttpClient/HttpServer` metrics functionality which has integration with
+[Micrometer Observation API](https://github.com/micrometer-metrics/micrometer/wiki/Migrating-to-new-1.10.0-Observation-API)
+
 This module contains tracing decorators for `HttpClient` and `HttpServer`.
 
 ## Configuration

--- a/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/ReactorNettyHttpTracing.java
+++ b/reactor-netty-http-brave/src/main/java/reactor/netty/http/brave/ReactorNettyHttpTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,12 @@ import java.util.function.Function;
  *
  * @author Violeta Georgieva
  * @since 1.0.0
+ * @deprecated as of 1.1.0. Prefer using the standard {@link reactor.netty.http.client.HttpClient} and
+ * {@link reactor.netty.http.server.HttpServer} metrics functionality which has integration with
+ * <a href="https://github.com/micrometer-metrics/micrometer/wiki/Migrating-to-new-1.10.0-Observation-API">Micrometer Observation API</a>.
+ * This class will be removed in version 2.0.0.
  */
+@Deprecated
 public final class ReactorNettyHttpTracing {
 
 	/**

--- a/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpClientDecoratorTest.java
+++ b/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpClientDecoratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ public class ITTracingHttpClientDecoratorTest extends ITHttpAsyncClient<HttpClie
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	protected HttpClient newClient(int port) {
 		ReactorNettyHttpTracing reactorNettyHttpTracing = ReactorNettyHttpTracing.create(httpTracing, s -> null);
 

--- a/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpServerDecoratorTest.java
+++ b/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpServerDecoratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ public class ITTracingHttpServerDecoratorTest extends ITHttpServer {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	protected void init() {
 		HttpServerRoutes routes =
 				HttpServerRoutes.newRoutes()
@@ -136,6 +137,7 @@ public class ITTracingHttpServerDecoratorTest extends ITHttpServer {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testBadRequest() throws IOException {
 		if (disposableServer != null) {
 			disposableServer.disposeNow();


### PR DESCRIPTION
An integration with `Micrometer Observation API` is provided as a replacement
for `Reactor Netty <-> Brave` integration