### PR TITLE
Update to Netty 5.0.0.Alpha2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ ext {
 	logbackVersion = '1.2.11'
 
 	// Netty
-	nettyDefaultVersion = '4.1.77.Final'
+	nettyDefaultVersion = '5.0.0.Alpha2'
 	if (!project.hasProperty("forceNettyVersion")) {
 		nettyVersion = nettyDefaultVersion
 	}
@@ -105,6 +105,8 @@ ext {
 		nettyVersion = forceNettyVersion
 		println "Netty version defined from command line: ${forceNettyVersion}"
 	}
+	nettyByteBufVersion = '4.1.77.Final'
+	nettyContribVersion = '5.0.0.Final-SNAPSHOT'
 	//nettyIoUringVersion = '0.0.14.Final'
 	//nettyQuicVersion = '0.0.27.Final'
 
@@ -132,7 +134,7 @@ ext {
 					"https://fasterxml.github.io/jackson-databind/javadoc/2.5/",
 					"https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/",
 					"https://projectreactor.io/docs/core/release/api/",
-					"https://netty.io/4.1/api/",
+					"https://netty.io/5.0/api/",
 					"https://projectreactor.io/docs/netty/release/api/",] as String[]
 }
 

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -51,39 +51,40 @@ dependencies {
 	// JSR-305 annotations
 	compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
 
-	api "io.netty:netty-handler:$nettyVersion"
-	api "io.netty:netty-handler-proxy:$nettyVersion"
-	api "io.netty:netty-resolver-dns:$nettyVersion"
+	api "io.netty:netty-buffer:$nettyByteBufVersion"
+	api "io.netty:netty5-handler:$nettyVersion"
+	api "io.netty.contrib:netty-handler-proxy:$nettyContribVersion"
+	api "io.netty:netty5-resolver-dns:$nettyVersion"
 	if (!"$nettyVersion".endsWithAny("SNAPSHOT")) {
 		if (osdetector.classifier == "osx-x86_64" || osdetector.classifier == "osx-aarch_64") {
-			api "io.netty:netty-resolver-dns-native-macos:$nettyVersion$os_suffix"
+			api "io.netty:netty5-resolver-dns-native-macos:$nettyVersion$os_suffix"
 		}
 		else {
-			api "io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
+			api "io.netty:netty5-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
 		}
 	}
 	else {
 		// MacOS binaries are not available for Netty SNAPSHOT version
-		api "io.netty:netty-resolver-dns-native-macos:$nettyVersion"
+		api "io.netty:netty5-resolver-dns-native-macos:$nettyVersion"
 	}
 	//transport resolution: typical build forces epoll but not kqueue transitively
 	//on the other hand, if we want to make transport-specific tests, we'll make all
 	// native optional at compile time and add correct native/nio to testRuntime
 	if (project.hasProperty("forceTransport")) {
 		//so that the main code compiles
-		compileOnly "io.netty:netty-transport-native-epoll:$nettyVersion"
-		compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		compileOnly "io.netty:netty5-transport-native-epoll:$nettyVersion"
+		compileOnly "io.netty:netty5-transport-native-kqueue:$nettyVersion"
 		//compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
-		testImplementation "io.netty:netty-transport-native-epoll:$nettyVersion"
-		testImplementation "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		testImplementation "io.netty:netty5-transport-native-epoll:$nettyVersion"
+		testImplementation "io.netty:netty5-transport-native-kqueue:$nettyVersion"
 		//testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 		//now we explicitly add correctly qualified native, or do nothing if we want to test NIO
 		if (forceTransport == "native") {
 			if (osdetector.os == "osx") {
-				testImplementation "io.netty:netty-transport-native-kqueue:$nettyVersion$os_suffix"
+				testImplementation "io.netty:netty5-transport-native-kqueue:$nettyVersion$os_suffix"
 			}
 			else if (osdetector.os == "linux") {
-				testImplementation "io.netty:netty-transport-native-epoll:$nettyVersion$os_suffix"
+				testImplementation "io.netty:netty5-transport-native-epoll:$nettyVersion$os_suffix"
 			}
 		}
 		//else if (forceTransport == "io_uring" && osdetector.os == "linux") {
@@ -95,10 +96,10 @@ dependencies {
 	}
 	else {
 		//classic build to be distributed
-		api "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
-		compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		api "io.netty:netty5-transport-native-epoll:$nettyVersion:linux-x86_64"
+		compileOnly "io.netty:netty5-transport-native-kqueue:$nettyVersion"
 		//compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
-		testImplementation "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		testImplementation "io.netty:netty5-transport-native-kqueue:$nettyVersion"
 		//testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 	}
 
@@ -133,6 +134,7 @@ dependencies {
 	testImplementation "io.projectreactor.tools:blockhound-junit-platform:$blockHoundVersion"
 	testImplementation "io.micrometer:micrometer-core:$micrometerVersion"
 	testImplementation "io.micrometer:micrometer-test:$micrometerVersion"
+	testImplementation "io.netty.contrib:netty-codec-extras:$nettyContribVersion"
 
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/reactor-netty-examples/build.gradle
+++ b/reactor-netty-examples/build.gradle
@@ -20,12 +20,13 @@ dependencies {
 
 	api "io.micrometer:micrometer-core:$micrometerVersion"
 
-	api "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
+	api "io.netty:netty-buffer:$nettyByteBufVersion"
+	api "io.netty:netty5-transport-native-epoll:$nettyVersion:linux-x86_64"
 
 	runtimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 	runtimeOnly "io.netty:netty-tcnative-boringssl-static:$boringSslVersion$os_suffix"
 	// Needed for proxy testing
-	runtimeOnly "io.netty:netty-handler-proxy:$nettyVersion"
+	runtimeOnly "io.netty.contrib:netty-handler-proxy:$nettyContribVersion"
 }
 
 description = "Examples for the Reactor Netty library"

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -60,38 +60,39 @@ dependencies {
 	// JSR-305 annotations
 	compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
 
-	api "io.netty:netty-codec-http:$nettyVersion"
-	api "io.netty:netty-codec-http2:$nettyVersion"
-	api "io.netty:netty-resolver-dns:$nettyVersion"
+	api "io.netty:netty-buffer:$nettyByteBufVersion"
+	api "io.netty:netty5-codec-http:$nettyVersion"
+	api "io.netty:netty5-codec-http2:$nettyVersion"
+	api "io.netty:netty5-resolver-dns:$nettyVersion"
 	// MacOS binaries are not available for Netty SNAPSHOT version
 	if (!"$nettyVersion".endsWithAny("SNAPSHOT")) {
 		if (osdetector.classifier == "osx-x86_64" || osdetector.classifier == "osx-aarch_64") {
-			api "io.netty:netty-resolver-dns-native-macos:$nettyVersion$os_suffix"
+			api "io.netty:netty5-resolver-dns-native-macos:$nettyVersion$os_suffix"
 		}
 		else {
-			api "io.netty:netty-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
+			api "io.netty:netty5-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
 		}
 	}
 	else {
 		// MacOS binaries are not available for Netty SNAPSHOT version
-		api "io.netty:netty-resolver-dns-native-macos:$nettyVersion"
+		api "io.netty:netty5-resolver-dns-native-macos:$nettyVersion"
 	}
-	compileOnly "io.netty:netty-codec-haproxy:$nettyVersion"
+	compileOnly "io.netty.contrib:netty-codec-haproxy:$nettyContribVersion"
 	//transport resolution: typical build forces epoll but not kqueue transitively
 	//on the other hand, if we want to make transport-specific tests, we'll make all
 	// native optional at compile time and add correct native/nio to testRuntime
 	if (project.hasProperty("forceTransport")) {
 		//so that the main code compiles
-		compileOnly "io.netty:netty-transport-native-epoll:$nettyVersion"
-		compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		compileOnly "io.netty:netty5-transport-native-epoll:$nettyVersion"
+		compileOnly "io.netty:netty5-transport-native-kqueue:$nettyVersion"
 		//compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 		//now we explicitly add correctly qualified native, or do nothing if we want to test NIO
 		if (forceTransport == "native") {
 			if (osdetector.os == "osx") {
-				testRuntimeOnly "io.netty:netty-transport-native-kqueue:$nettyVersion$os_suffix"
+				testRuntimeOnly "io.netty:netty5-transport-native-kqueue:$nettyVersion$os_suffix"
 			}
 			else if (osdetector.os == "linux") {
-				testRuntimeOnly "io.netty:netty-transport-native-epoll:$nettyVersion$os_suffix"
+				testRuntimeOnly "io.netty:netty5-transport-native-epoll:$nettyVersion$os_suffix"
 			}
 		}
 		//else if (forceTransport == "io_uring" && osdetector.os == "linux") {
@@ -103,8 +104,8 @@ dependencies {
 	}
 	else {
 		//classic build to be distributed
-		api "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
-		compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
+		api "io.netty:netty5-transport-native-epoll:$nettyVersion:linux-x86_64"
+		compileOnly "io.netty:netty5-transport-native-kqueue:$nettyVersion"
 		//compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 	}
 
@@ -139,6 +140,7 @@ dependencies {
 	testImplementation "io.micrometer:micrometer-core:$micrometerVersion"
 	testImplementation "io.micrometer:micrometer-test:$micrometerVersion"
 	testImplementation "io.micrometer:micrometer-tracing-integration-test:$micrometerTracingVersion"
+	testImplementation "io.netty.contrib:netty-codec-extras:$nettyContribVersion"
 
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
@@ -146,8 +148,8 @@ dependencies {
 	testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 
 	// Needed for proxy testing
-	testRuntimeOnly "io.netty:netty-handler-proxy:$nettyVersion"
-	testRuntimeOnly "io.netty:netty-codec-haproxy:$nettyVersion"
+	testRuntimeOnly "io.netty.contrib:netty-handler-proxy:$nettyContribVersion"
+	testRuntimeOnly "io.netty.contrib:netty-codec-haproxy:$nettyContribVersion"
 	// Needed for HTTP/2 testing
 	testRuntimeOnly "io.netty:netty-tcnative-boringssl-static:$boringSslVersion$os_suffix"
 

--- a/reactor-netty/build.gradle
+++ b/reactor-netty/build.gradle
@@ -25,8 +25,8 @@ dependencies {
 
 	compileOnly "io.micrometer:micrometer-core:$micrometerVersion"
 	compileOnly "io.micrometer:micrometer-tracing-api:$micrometerTracingVersion"
-	compileOnly "io.netty:netty-codec-haproxy:$nettyVersion"
-	compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
+	compileOnly "io.netty.contrib:netty-codec-haproxy:$nettyContribVersion"
+	compileOnly "io.netty:netty5-transport-native-kqueue:$nettyVersion"
 	//compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 	compileOnly "io.projectreactor.addons:reactor-pool:$reactorPoolVersion"
 }


### PR DESCRIPTION
- Add dependency to `Netty Contrib` (`codec-haproxy`, `codec-extras`, `socks-proxy`) `5.0.0.Final-SNAPSHOT`
- Add dependency to `netty-buffer:4.1.77.Final`
- Update artifactId to `netty5-*`

Related to #1873