### PR TITLE
Netty's native code is separated from the java code

### DIFF
--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -65,18 +65,18 @@ dependencies {
 	}
 	else {
 		// MacOS binaries are not available for Netty SNAPSHOT version
-		api "io.netty:netty5-resolver-dns-native-macos:$nettyVersion"
+		api "io.netty:netty5-resolver-dns-classes-macos:$nettyVersion"
 	}
 	//transport resolution: typical build forces epoll but not kqueue transitively
 	//on the other hand, if we want to make transport-specific tests, we'll make all
 	// native optional at compile time and add correct native/nio to testRuntime
 	if (project.hasProperty("forceTransport")) {
 		//so that the main code compiles
-		compileOnly "io.netty:netty5-transport-native-epoll:$nettyVersion"
-		compileOnly "io.netty:netty5-transport-native-kqueue:$nettyVersion"
+		compileOnly "io.netty:netty5-transport-classes-epoll:$nettyVersion"
+		compileOnly "io.netty:netty5-transport-classes-kqueue:$nettyVersion"
 		//compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
-		testImplementation "io.netty:netty5-transport-native-epoll:$nettyVersion"
-		testImplementation "io.netty:netty5-transport-native-kqueue:$nettyVersion"
+		testImplementation "io.netty:netty5-transport-classes-epoll:$nettyVersion"
+		testImplementation "io.netty:netty5-transport-classes-kqueue:$nettyVersion"
 		//testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 		//now we explicitly add correctly qualified native, or do nothing if we want to test NIO
 		if (forceTransport == "native") {
@@ -97,9 +97,9 @@ dependencies {
 	else {
 		//classic build to be distributed
 		api "io.netty:netty5-transport-native-epoll:$nettyVersion:linux-x86_64"
-		compileOnly "io.netty:netty5-transport-native-kqueue:$nettyVersion"
+		compileOnly "io.netty:netty5-transport-classes-kqueue:$nettyVersion"
 		//compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
-		testImplementation "io.netty:netty5-transport-native-kqueue:$nettyVersion"
+		testImplementation "io.netty:netty5-transport-classes-kqueue:$nettyVersion"
 		//testImplementation "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 	}
 

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -75,7 +75,7 @@ dependencies {
 	}
 	else {
 		// MacOS binaries are not available for Netty SNAPSHOT version
-		api "io.netty:netty5-resolver-dns-native-macos:$nettyVersion"
+		api "io.netty:netty5-resolver-dns-classes-macos:$nettyVersion"
 	}
 	compileOnly "io.netty.contrib:netty-codec-haproxy:$nettyContribVersion"
 	//transport resolution: typical build forces epoll but not kqueue transitively
@@ -83,8 +83,8 @@ dependencies {
 	// native optional at compile time and add correct native/nio to testRuntime
 	if (project.hasProperty("forceTransport")) {
 		//so that the main code compiles
-		compileOnly "io.netty:netty5-transport-native-epoll:$nettyVersion"
-		compileOnly "io.netty:netty5-transport-native-kqueue:$nettyVersion"
+		compileOnly "io.netty:netty5-transport-classes-epoll:$nettyVersion"
+		compileOnly "io.netty:netty5-transport-classes-kqueue:$nettyVersion"
 		//compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 		//now we explicitly add correctly qualified native, or do nothing if we want to test NIO
 		if (forceTransport == "native") {
@@ -105,7 +105,7 @@ dependencies {
 	else {
 		//classic build to be distributed
 		api "io.netty:netty5-transport-native-epoll:$nettyVersion:linux-x86_64"
-		compileOnly "io.netty:netty5-transport-native-kqueue:$nettyVersion"
+		compileOnly "io.netty:netty5-transport-classes-kqueue:$nettyVersion"
 		//compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 	}
 

--- a/reactor-netty/build.gradle
+++ b/reactor-netty/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	compileOnly "io.micrometer:micrometer-core:$micrometerVersion"
 	compileOnly "io.micrometer:micrometer-tracing-api:$micrometerTracingVersion"
 	compileOnly "io.netty.contrib:netty-codec-haproxy:$nettyContribVersion"
-	compileOnly "io.netty:netty5-transport-native-kqueue:$nettyVersion"
+	compileOnly "io.netty:netty5-transport-classes-kqueue:$nettyVersion"
 	//compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 	compileOnly "io.projectreactor.addons:reactor-pool:$reactorPoolVersion"
 }


### PR DESCRIPTION
`*-native-*` is the artifact for the native code
`*-classes-*` is the artifact for the java code

Related to #1873