### PR TITLE
[reactor-netty-examples] Change package io.netty.* to io.netty5.*

### DIFF
--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/channeloptions/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/channeloptions/Application.java
@@ -15,9 +15,9 @@
  */
 package reactor.netty.examples.documentation.http.client.channeloptions;
 
-import io.netty.channel.ChannelOption;
-import io.netty.channel.epoll.EpollChannelOption;
-//import io.netty.channel.socket.nio.NioChannelOption;
+import io.netty5.channel.ChannelOption;
+import io.netty5.channel.epoll.EpollChannelOption;
+//import io.netty5.channel.socket.nio.NioChannelOption;
 //import jdk.net.ExtendedSocketOptions;
 import reactor.netty.http.client.HttpClient;
 import java.net.InetSocketAddress;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/http2/H2Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/http2/H2Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.http.client.http2;
 
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty5.handler.codec.http.HttpHeaders;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.client.HttpClient;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/http2/H2CApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/http2/H2CApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.http.client.http2;
 
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty5.handler.codec.http.HttpHeaders;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.client.HttpClient;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/lifecycle/Application.java
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.documentation.http.client.lifecycle;
 
-import io.netty.handler.logging.LoggingHandler;
-import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty5.handler.logging.LoggingHandler;
+import io.netty5.handler.timeout.ReadTimeoutHandler;
 import reactor.netty.http.client.HttpClient;
 import java.util.concurrent.TimeUnit;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/resolver/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/resolver/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.http.client.resolver.custom;
 
-import io.netty.resolver.DefaultAddressResolverGroup;
+import io.netty5.resolver.DefaultAddressResolverGroup;
 import reactor.netty.http.client.HttpClient;
 
 public class Application {

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/send/headers/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/send/headers/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.http.client.send.headers;
 
-import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty5.handler.codec.http.HttpHeaderNames;
 import reactor.core.publisher.Mono;
 import reactor.netty.ByteBufFlux;
 import reactor.netty.http.client.HttpClient;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/sni/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/sni/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.documentation.http.client.sni;
 
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
+import io.netty5.handler.ssl.SslContext;
+import io.netty5.handler.ssl.SslContextBuilder;
 import reactor.netty.http.client.HttpClient;
 
 import javax.net.ssl.SNIHostName;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/uds/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/uds/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.http.client.uds;
 
-import io.netty.channel.unix.DomainSocketAddress;
+import io.netty5.channel.unix.DomainSocketAddress;
 import reactor.netty.http.client.HttpClient;
 
 public class Application {

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/websocket/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/websocket/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package reactor.netty.examples.documentation.http.client.websocket;
 
 import io.netty.buffer.Unpooled;
-import io.netty.util.CharsetUtil;
+import io.netty5.util.CharsetUtil;
 import reactor.core.publisher.Flux;
 import reactor.netty.http.client.HttpClient;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/wiretap/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.http.client.wiretap.custom;
 
-import io.netty.handler.logging.LogLevel;
+import io.netty5.handler.logging.LogLevel;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.transport.logging.AdvancedByteBufFormat;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/channeloptions/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/channeloptions/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.http.server.channeloptions;
 
-import io.netty.channel.ChannelOption;
+import io.netty5.channel.ChannelOption;
 import reactor.netty.DisposableServer;
 import reactor.netty.http.server.HttpServer;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/lifecycle/Application.java
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.documentation.http.server.lifecycle;
 
-import io.netty.handler.logging.LoggingHandler;
-import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty5.handler.logging.LoggingHandler;
+import io.netty5.handler.timeout.ReadTimeoutHandler;
 import reactor.netty.DisposableServer;
 import reactor.netty.http.server.HttpServer;
 import java.util.concurrent.TimeUnit;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/send/headers/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/send/headers/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.documentation.http.server.send.headers;
 
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty5.handler.codec.http.HttpHeaderNames;
+import io.netty5.handler.codec.http.HttpResponseStatus;
 import reactor.core.publisher.Mono;
 import reactor.netty.DisposableServer;
 import reactor.netty.http.server.HttpServer;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/sni/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/sni/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.documentation.http.server.sni;
 
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
+import io.netty5.handler.ssl.SslContext;
+import io.netty5.handler.ssl.SslContextBuilder;
 import reactor.netty.DisposableServer;
 import reactor.netty.http.server.HttpServer;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/uds/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/uds/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.http.server.uds;
 
-import io.netty.channel.unix.DomainSocketAddress;
+import io.netty5.channel.unix.DomainSocketAddress;
 import reactor.netty.DisposableServer;
 import reactor.netty.http.server.HttpServer;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/wiretap/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.http.server.wiretap.custom;
 
-import io.netty.handler.logging.LogLevel;
+import io.netty5.handler.logging.LogLevel;
 import reactor.netty.DisposableServer;
 import reactor.netty.http.server.HttpServer;
 import reactor.netty.transport.logging.AdvancedByteBufFormat;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/channeloptions/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/channeloptions/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.tcp.client.channeloptions;
 
-import io.netty.channel.ChannelOption;
+import io.netty5.channel.ChannelOption;
 import reactor.netty.Connection;
 import reactor.netty.tcp.TcpClient;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/lifecycle/Application.java
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.documentation.tcp.client.lifecycle;
 
-import io.netty.handler.logging.LoggingHandler;
-import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty5.handler.logging.LoggingHandler;
+import io.netty5.handler.timeout.ReadTimeoutHandler;
 import reactor.netty.Connection;
 import reactor.netty.tcp.TcpClient;
 import java.util.concurrent.TimeUnit;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/resolver/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/resolver/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.tcp.client.resolver.custom;
 
-import io.netty.resolver.DefaultAddressResolverGroup;
+import io.netty5.resolver.DefaultAddressResolverGroup;
 import reactor.netty.Connection;
 import reactor.netty.tcp.TcpClient;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/sni/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/sni/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.documentation.tcp.client.sni;
 
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
+import io.netty5.handler.ssl.SslContext;
+import io.netty5.handler.ssl.SslContextBuilder;
 import reactor.netty.Connection;
 import reactor.netty.tcp.TcpClient;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/uds/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/uds/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.tcp.client.uds;
 
-import io.netty.channel.unix.DomainSocketAddress;
+import io.netty5.channel.unix.DomainSocketAddress;
 import reactor.netty.Connection;
 import reactor.netty.tcp.TcpClient;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client/wiretap/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.tcp.client.wiretap.custom;
 
-import io.netty.handler.logging.LogLevel;
+import io.netty5.handler.logging.LogLevel;
 import reactor.netty.Connection;
 import reactor.netty.tcp.TcpClient;
 import reactor.netty.transport.logging.AdvancedByteBufFormat;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/channeloptions/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/channeloptions/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.tcp.server.channeloptions;
 
-import io.netty.channel.ChannelOption;
+import io.netty5.channel.ChannelOption;
 import reactor.netty.DisposableServer;
 import reactor.netty.tcp.TcpServer;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/lifecycle/Application.java
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.documentation.tcp.server.lifecycle;
 
-import io.netty.handler.logging.LoggingHandler;
-import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty5.handler.logging.LoggingHandler;
+import io.netty5.handler.timeout.ReadTimeoutHandler;
 import reactor.netty.DisposableServer;
 import reactor.netty.tcp.TcpServer;
 import java.util.concurrent.TimeUnit;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/sni/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/sni/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.documentation.tcp.server.sni;
 
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
+import io.netty5.handler.ssl.SslContext;
+import io.netty5.handler.ssl.SslContextBuilder;
 import reactor.netty.DisposableServer;
 import reactor.netty.tcp.TcpServer;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/uds/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/uds/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.tcp.server.uds;
 
-import io.netty.channel.unix.DomainSocketAddress;
+import io.netty5.channel.unix.DomainSocketAddress;
 import reactor.netty.DisposableServer;
 import reactor.netty.tcp.TcpServer;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server/wiretap/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.tcp.server.wiretap.custom;
 
-import io.netty.handler.logging.LogLevel;
+import io.netty5.handler.logging.LogLevel;
 import reactor.netty.DisposableServer;
 import reactor.netty.tcp.TcpServer;
 import reactor.netty.transport.logging.AdvancedByteBufFormat;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/channeloptions/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/channeloptions/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.udp.client.channeloptions;
 
-import io.netty.channel.ChannelOption;
+import io.netty5.channel.ChannelOption;
 import reactor.netty.Connection;
 import reactor.netty.udp.UdpClient;
 import java.time.Duration;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/lifecycle/Application.java
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.documentation.udp.client.lifecycle;
 
-import io.netty.handler.codec.LineBasedFrameDecoder;
-import io.netty.handler.logging.LoggingHandler;
+import io.netty5.handler.codec.LineBasedFrameDecoder;
+import io.netty5.handler.logging.LoggingHandler;
 import reactor.netty.Connection;
 import reactor.netty.udp.UdpClient;
 import java.time.Duration;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/uds/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/uds/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.udp.client.uds;
 
-import io.netty.channel.unix.DomainSocketAddress;
+import io.netty5.channel.unix.DomainSocketAddress;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.udp.UdpClient;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client/wiretap/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.udp.client.wiretap.custom;
 
-import io.netty.handler.logging.LogLevel;
+import io.netty5.handler.logging.LogLevel;
 import reactor.netty.Connection;
 import reactor.netty.transport.logging.AdvancedByteBufFormat;
 import reactor.netty.udp.UdpClient;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/channeloptions/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/channeloptions/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.udp.server.channeloptions;
 
-import io.netty.channel.ChannelOption;
+import io.netty5.channel.ChannelOption;
 import reactor.netty.Connection;
 import reactor.netty.udp.UdpServer;
 import java.time.Duration;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/lifecycle/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/lifecycle/Application.java
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.documentation.udp.server.lifecycle;
 
-import io.netty.handler.codec.LineBasedFrameDecoder;
-import io.netty.handler.logging.LoggingHandler;
+import io.netty5.handler.codec.LineBasedFrameDecoder;
+import io.netty5.handler.logging.LoggingHandler;
 import reactor.netty.Connection;
 import reactor.netty.udp.UdpServer;
 import java.time.Duration;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/read/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/read/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.udp.server.read;
 
-import io.netty.channel.socket.DatagramPacket;
+import io.netty5.channel.socket.DatagramPacket;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.udp.UdpServer;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/send/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/send/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package reactor.netty.examples.documentation.udp.server.send;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.socket.DatagramPacket;
-import io.netty.util.CharsetUtil;
+import io.netty5.channel.socket.DatagramPacket;
+import io.netty5.util.CharsetUtil;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.udp.UdpServer;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/uds/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/uds/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package reactor.netty.examples.documentation.udp.server.uds;
 
-import io.netty.channel.unix.DomainDatagramPacket;
-import io.netty.channel.unix.DomainSocketAddress;
+import io.netty5.channel.unix.DomainDatagramPacket;
+import io.netty5.channel.unix.DomainSocketAddress;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.udp.UdpServer;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/warmup/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/warmup/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.udp.server.warmup;
 
-import io.netty.channel.socket.DatagramPacket;
+import io.netty5.channel.socket.DatagramPacket;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.udp.UdpServer;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/wiretap/custom/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server/wiretap/custom/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.documentation.udp.server.wiretap.custom;
 
-import io.netty.handler.logging.LogLevel;
+import io.netty5.handler.logging.LogLevel;
 import reactor.netty.Connection;
 import reactor.netty.transport.logging.AdvancedByteBufFormat;
 import reactor.netty.udp.UdpServer;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.http.echo;
 
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import reactor.core.publisher.Mono;
 import reactor.netty.ByteBufFlux;
 import reactor.netty.http.Http11SslContextSpec;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package reactor.netty.examples.http.echo;
 
-import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.server.HttpServer;
 
-import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
-import static io.netty.handler.codec.http.HttpHeaderValues.TEXT_PLAIN;
+import static io.netty5.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty5.handler.codec.http.HttpHeaderValues.TEXT_PLAIN;
 
 /**
  * An HTTP server that expects POST request and sends back the content of the received HTTP request.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.http.helloworld;
 
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.client.HttpClient;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 package reactor.netty.examples.http.helloworld;
 
-import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.server.HttpServer;
 
-import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
-import static io.netty.handler.codec.http.HttpHeaderValues.TEXT_PLAIN;
+import static io.netty5.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty5.handler.codec.http.HttpHeaderValues.TEXT_PLAIN;
 
 /**
  * An HTTP server that expects GET request and sends back "Hello World!".

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/discard/DiscardClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/discard/DiscardClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.tcp.discard;
 
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import reactor.core.publisher.Flux;
 import reactor.netty.Connection;
 import reactor.netty.tcp.TcpClient;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/discard/DiscardServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/discard/DiscardServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.tcp.discard;
 
-import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import reactor.netty.tcp.TcpServer;
 import reactor.netty.tcp.TcpSslContextSpec;
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/echo/EchoClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/echo/EchoClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.tcp.echo;
 
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.ByteBufFlux;

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/echo/EchoServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/tcp/echo/EchoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package reactor.netty.examples.tcp.echo;
 
-import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import reactor.netty.tcp.TcpServer;
 import reactor.netty.tcp.TcpSslContextSpec;
 


### PR DESCRIPTION
- `netty-handler-proxy` to `io.netty.contrib`
- `ByteBuf API` is obtain from `Netty 4`

Related to #1873