### PR TITLE
Move from ChannelOutboundHandlerAdapter to ChannelHandlerAdapter

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
@@ -108,7 +108,6 @@ public interface NettyPipeline {
 	String OnChannelReadIdle     = LEFT + "onChannelReadIdle";
 	String OnChannelWriteIdle    = LEFT + "onChannelWriteIdle";
 	String ProxyHandler          = LEFT + "proxyHandler";
-	String UnvoidHandler         = LEFT + "unvoidHandler";
 	String ProxyLoggingHandler   = LEFT + "proxyLoggingHandler";
 	String ProxyProtocolDecoder  = LEFT + "proxyProtocolDecoder";
 	String ProxyProtocolReader   = LEFT + "proxyProtocolReader";


### PR DESCRIPTION
- There is no `VoidPromise` anymore so no need to handle this use case in `ProxyProvider`

Related to #1873