### PR TITLE
Remove maxChunkSize as it was removed from HttpObjectDecoder

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpDecoderSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpDecoderSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,14 +28,12 @@ public abstract class HttpDecoderSpec<T extends HttpDecoderSpec<T>> implements S
 
 	public static final int DEFAULT_MAX_INITIAL_LINE_LENGTH             = 4096;
 	public static final int DEFAULT_MAX_HEADER_SIZE                     = 8192;
-	public static final int DEFAULT_MAX_CHUNK_SIZE                      = 8192;
 	public static final boolean DEFAULT_VALIDATE_HEADERS                = true;
 	public static final int DEFAULT_INITIAL_BUFFER_SIZE                 = 128;
 	public static final boolean DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS = false;
 
 	protected int maxInitialLineLength             = DEFAULT_MAX_INITIAL_LINE_LENGTH;
 	protected int maxHeaderSize                    = DEFAULT_MAX_HEADER_SIZE;
-	protected int maxChunkSize                     = DEFAULT_MAX_CHUNK_SIZE;
 	protected boolean validateHeaders              = DEFAULT_VALIDATE_HEADERS;
 	protected int initialBufferSize                = DEFAULT_INITIAL_BUFFER_SIZE;
 	protected boolean allowDuplicateContentLengths = DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS;
@@ -87,30 +85,6 @@ public abstract class HttpDecoderSpec<T extends HttpDecoderSpec<T>> implements S
 	 */
 	public int maxHeaderSize() {
 		return maxHeaderSize;
-	}
-
-	/**
-	 * Configure the maximum chunk size that can be decoded for the HTTP request.
-	 * Defaults to {@link #DEFAULT_MAX_CHUNK_SIZE}.
-	 *
-	 * @param value the value for the maximum chunk size (strictly positive)
-	 * @return this option builder for further configuration
-	 */
-	public T maxChunkSize(int value) {
-		if (value <= 0) {
-			throw new IllegalArgumentException("maxChunkSize must be strictly positive");
-		}
-		this.maxChunkSize = value;
-		return get();
-	}
-
-	/**
-	 * Return the configured maximum chunk size that can be decoded for the HTTP request.
-	 *
-	 * @return the configured maximum chunk size that can be decoded for the HTTP request
-	 */
-	public int maxChunkSize() {
-		return maxChunkSize;
 	}
 
 	/**
@@ -227,7 +201,6 @@ public abstract class HttpDecoderSpec<T extends HttpDecoderSpec<T>> implements S
 		HttpDecoderSpec<?> that = (HttpDecoderSpec<?>) o;
 		return maxInitialLineLength == that.maxInitialLineLength &&
 				maxHeaderSize == that.maxHeaderSize &&
-				maxChunkSize == that.maxChunkSize &&
 				validateHeaders == that.validateHeaders &&
 				initialBufferSize == that.initialBufferSize &&
 				allowDuplicateContentLengths == that.allowDuplicateContentLengths &&
@@ -236,7 +209,7 @@ public abstract class HttpDecoderSpec<T extends HttpDecoderSpec<T>> implements S
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize,
+		return Objects.hash(maxInitialLineLength, maxHeaderSize, validateHeaders, initialBufferSize,
 				allowDuplicateContentLengths, h2cMaxContentLength);
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -534,7 +534,6 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 				new HttpClientCodec(
 						decoder.maxInitialLineLength(),
 						decoder.maxHeaderSize(),
-						decoder.maxChunkSize(),
 						decoder.failOnMissingResponse,
 						decoder.validateHeaders(),
 						decoder.initialBufferSize(),
@@ -594,7 +593,6 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 				new HttpClientCodec(
 						decoder.maxInitialLineLength(),
 						decoder.maxHeaderSize(),
-						decoder.maxChunkSize(),
 						decoder.failOnMissingResponse,
 						decoder.validateHeaders(),
 						decoder.initialBufferSize(),

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpResponseDecoderSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpResponseDecoderSpec.java
@@ -30,7 +30,6 @@ import java.util.Objects;
  *     <tr><td>{@link #DEFAULT_FAIL_ON_MISSING_RESPONSE}</td><td>false</td></tr>
  *     <tr><td>{@link #DEFAULT_H2C_MAX_CONTENT_LENGTH}</td><td>65536</td></tr>
  *     <tr><td>{@link #DEFAULT_INITIAL_BUFFER_SIZE}</td><td>128</td></tr>
- *     <tr><td>{@link #DEFAULT_MAX_CHUNK_SIZE}</td><td>8192</td></tr>
  *     <tr><td>{@link #DEFAULT_MAX_HEADER_SIZE}</td><td>8192</td></tr>
  *     <tr><td>{@link #DEFAULT_MAX_INITIAL_LINE_LENGTH}</td><td>4096</td></tr>
  *     <tr><td>{@link #DEFAULT_PARSE_HTTP_AFTER_CONNECT_REQUEST}</td><td>false</td></tr>
@@ -114,7 +113,6 @@ public final class HttpResponseDecoderSpec extends HttpDecoderSpec<HttpResponseD
 	HttpResponseDecoderSpec build() {
 		HttpResponseDecoderSpec decoder = new HttpResponseDecoderSpec();
 		decoder.initialBufferSize = initialBufferSize;
-		decoder.maxChunkSize = maxChunkSize;
 		decoder.maxHeaderSize = maxHeaderSize;
 		decoder.maxInitialLineLength = maxInitialLineLength;
 		decoder.validateHeaders = validateHeaders;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRequestDecoderSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpRequestDecoderSpec.java
@@ -27,7 +27,6 @@ import reactor.netty.http.HttpDecoderSpec;
  *     <tr><td>{@link #DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS}</td><td>false</td></tr>
  *     <tr><td>{@link #DEFAULT_H2C_MAX_CONTENT_LENGTH}</td><td>0</td></tr>
  *     <tr><td>{@link #DEFAULT_INITIAL_BUFFER_SIZE}</td><td>128</td></tr>
- *     <tr><td>{@link #DEFAULT_MAX_CHUNK_SIZE}</td><td>8192</td></tr>
  *     <tr><td>{@link #DEFAULT_MAX_HEADER_SIZE}</td><td>8192</td></tr>
  *     <tr><td>{@link #DEFAULT_MAX_INITIAL_LINE_LENGTH}</td><td>4096</td></tr>
  *     <tr><td>{@link #DEFAULT_VALIDATE_HEADERS}</td><td>true</td></tr>
@@ -60,7 +59,6 @@ public final class HttpRequestDecoderSpec extends HttpDecoderSpec<HttpRequestDec
 	HttpRequestDecoderSpec build() {
 		HttpRequestDecoderSpec decoder = new HttpRequestDecoderSpec();
 		decoder.initialBufferSize = initialBufferSize;
-		decoder.maxChunkSize = maxChunkSize;
 		decoder.maxHeaderSize = maxHeaderSize;
 		decoder.maxInitialLineLength = maxInitialLineLength;
 		decoder.validateHeaders = validateHeaders;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -567,7 +567,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 			@Nullable Function<String, String> uriTagValue) {
 		HttpServerCodec httpServerCodec =
 				new HttpServerCodec(decoder.maxInitialLineLength(), decoder.maxHeaderSize(),
-						decoder.maxChunkSize(), decoder.validateHeaders(), decoder.initialBufferSize(),
+						decoder.validateHeaders(), decoder.initialBufferSize(),
 						decoder.allowDuplicateContentLengths());
 
 		Http11OrH2CleartextCodec upgrader = new Http11OrH2CleartextCodec(accessLogEnabled, accessLog, compressPredicate,
@@ -639,7 +639,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		p.addBefore(NettyPipeline.ReactiveBridge,
 		            NettyPipeline.HttpCodec,
 		            new HttpServerCodec(decoder.maxInitialLineLength(), decoder.maxHeaderSize(),
-		                    decoder.maxChunkSize(), decoder.validateHeaders(), decoder.initialBufferSize(),
+		                    decoder.validateHeaders(), decoder.initialBufferSize(),
 		                    decoder.allowDuplicateContentLengths()))
 		 .addBefore(NettyPipeline.ReactiveBridge,
 		            NettyPipeline.HttpTrafficHandler,

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpDecoderSpecTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpDecoderSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ public class HttpDecoderSpecTest {
 		assertThat(conf.maxInitialLineLength()).as("initial line length").isEqualTo(123);
 
 		checkDefaultMaxHeaderSize(conf);
-		checkDefaultMaxChunkSize(conf);
 		checkDefaultValidateHeaders(conf);
 		checkDefaultInitialBufferSize(conf);
 		checkDefaultAllowDuplicateContentLengths(conf);
@@ -67,7 +66,6 @@ public class HttpDecoderSpecTest {
 		assertThat(conf.maxHeaderSize()).as("header size").isEqualTo(123);
 
 		checkDefaultMaxInitialLineLength(conf);
-		checkDefaultMaxChunkSize(conf);
 		checkDefaultValidateHeaders(conf);
 		checkDefaultInitialBufferSize(conf);
 		checkDefaultAllowDuplicateContentLengths(conf);
@@ -87,34 +85,6 @@ public class HttpDecoderSpecTest {
 	}
 
 	@Test
-	void maxChunkSize() {
-		checkDefaultMaxChunkSize(conf);
-
-		conf.maxChunkSize(123);
-
-		assertThat(conf.maxChunkSize()).as("chunk size").isEqualTo(123);
-
-		checkDefaultMaxInitialLineLength(conf);
-		checkDefaultMaxHeaderSize(conf);
-		checkDefaultValidateHeaders(conf);
-		checkDefaultInitialBufferSize(conf);
-		checkDefaultAllowDuplicateContentLengths(conf);
-	}
-
-	@Test
-	void maxChunkSizeBadValues() {
-		assertThatExceptionOfType(IllegalArgumentException.class)
-				.isThrownBy(() -> conf.maxChunkSize(0))
-				.as("rejects 0")
-				.withMessage("maxChunkSize must be strictly positive");
-
-		assertThatExceptionOfType(IllegalArgumentException.class)
-				.isThrownBy(() -> conf.maxChunkSize(-1))
-				.as("rejects negative")
-				.withMessage("maxChunkSize must be strictly positive");
-	}
-
-	@Test
 	void validateHeaders() {
 		checkDefaultValidateHeaders(conf);
 
@@ -124,7 +94,6 @@ public class HttpDecoderSpecTest {
 
 		checkDefaultMaxInitialLineLength(conf);
 		checkDefaultMaxHeaderSize(conf);
-		checkDefaultMaxChunkSize(conf);
 		checkDefaultInitialBufferSize(conf);
 		checkDefaultAllowDuplicateContentLengths(conf);
 	}
@@ -139,7 +108,6 @@ public class HttpDecoderSpecTest {
 
 		checkDefaultMaxInitialLineLength(conf);
 		checkDefaultMaxHeaderSize(conf);
-		checkDefaultMaxChunkSize(conf);
 		checkDefaultValidateHeaders(conf);
 		checkDefaultAllowDuplicateContentLengths(conf);
 	}
@@ -167,7 +135,6 @@ public class HttpDecoderSpecTest {
 
 		checkDefaultMaxInitialLineLength(conf);
 		checkDefaultMaxHeaderSize(conf);
-		checkDefaultMaxChunkSize(conf);
 		checkDefaultValidateHeaders(conf);
 		checkDefaultInitialBufferSize(conf);
 	}
@@ -181,12 +148,6 @@ public class HttpDecoderSpecTest {
 	public static void checkDefaultMaxHeaderSize(HttpDecoderSpec<?> conf) {
 		assertThat(conf.maxHeaderSize()).as("default header size")
 				.isEqualTo(HttpDecoderSpec.DEFAULT_MAX_HEADER_SIZE)
-				.isEqualTo(8192);
-	}
-
-	public static void checkDefaultMaxChunkSize(HttpDecoderSpec<?> conf) {
-		assertThat(conf.maxChunkSize()).as("default chunk size")
-				.isEqualTo(HttpDecoderSpec.DEFAULT_MAX_CHUNK_SIZE)
 				.isEqualTo(8192);
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -1585,7 +1585,6 @@ class HttpClientTest extends BaseHttpTest {
 	void httpClientResponseConfigInjectAttributes() {
 		AtomicReference<Channel> channelRef = new AtomicReference<>();
 		AtomicBoolean validate = new AtomicBoolean();
-		AtomicInteger chunkSize = new AtomicInteger();
 		AtomicBoolean allowDuplicateContentLengths = new AtomicBoolean();
 		disposableServer =
 				createServer()
@@ -1596,7 +1595,6 @@ class HttpClientTest extends BaseHttpTest {
 		createHttpClientForContextWithAddress()
 		        .httpResponseDecoder(opt -> opt.maxInitialLineLength(123)
 		                                       .maxHeaderSize(456)
-		                                       .maxChunkSize(789)
 		                                       .validateHeaders(false)
 		                                       .initialBufferSize(10)
 		                                       .failOnMissingResponse(true)
@@ -1608,7 +1606,6 @@ class HttpClientTest extends BaseHttpTest {
 		                                             .pipeline()
 		                                             .get(HttpClientCodec.class);
 		                    HttpObjectDecoder decoder = (HttpObjectDecoder) getValueReflection(codec, "inboundHandler", 1);
-		                    chunkSize.set((Integer) getValueReflection(decoder, "maxChunkSize", 2));
 		                    validate.set((Boolean) getValueReflection(decoder, "validateHeaders", 2));
 		                    allowDuplicateContentLengths.set((Boolean) getValueReflection(decoder, "allowDuplicateContentLengths", 2));
 		                })
@@ -1621,7 +1618,6 @@ class HttpClientTest extends BaseHttpTest {
 		        .block(Duration.ofSeconds(30));
 
 		assertThat(channelRef.get()).isNotNull();
-		assertThat(chunkSize).as("line length").hasValue(789);
 		assertThat(validate).as("validate headers").isFalse();
 		assertThat(allowDuplicateContentLengths).as("allow duplicate Content-Length").isTrue();
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpResponseDecoderSpecTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpResponseDecoderSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.netty.http.HttpDecoderSpecTest.checkDefaultAllowDuplicateContentLengths;
 import static reactor.netty.http.HttpDecoderSpecTest.checkDefaultInitialBufferSize;
-import static reactor.netty.http.HttpDecoderSpecTest.checkDefaultMaxChunkSize;
 import static reactor.netty.http.HttpDecoderSpecTest.checkDefaultMaxHeaderSize;
 import static reactor.netty.http.HttpDecoderSpecTest.checkDefaultMaxInitialLineLength;
 import static reactor.netty.http.HttpDecoderSpecTest.checkDefaultValidateHeaders;
@@ -48,7 +47,6 @@ class HttpResponseDecoderSpecTest {
 
 		checkDefaultMaxInitialLineLength(conf);
 		checkDefaultMaxHeaderSize(conf);
-		checkDefaultMaxChunkSize(conf);
 		checkDefaultValidateHeaders(conf);
 		checkDefaultInitialBufferSize(conf);
 		checkDefaultAllowDuplicateContentLengths(conf);
@@ -66,7 +64,6 @@ class HttpResponseDecoderSpecTest {
 
 		checkDefaultMaxInitialLineLength(conf);
 		checkDefaultMaxHeaderSize(conf);
-		checkDefaultMaxChunkSize(conf);
 		checkDefaultValidateHeaders(conf);
 		checkDefaultInitialBufferSize(conf);
 		checkDefaultAllowDuplicateContentLengths(conf);
@@ -84,7 +81,6 @@ class HttpResponseDecoderSpecTest {
 
 		checkDefaultMaxInitialLineLength(conf);
 		checkDefaultMaxHeaderSize(conf);
-		checkDefaultMaxChunkSize(conf);
 		checkDefaultValidateHeaders(conf);
 		checkDefaultInitialBufferSize(conf);
 		checkDefaultAllowDuplicateContentLengths(conf);

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpRequestDecoderSpecTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpRequestDecoderSpecTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.netty.http.HttpDecoderSpecTest.checkDefaultAllowDuplicateContentLengths;
 import static reactor.netty.http.HttpDecoderSpecTest.checkDefaultInitialBufferSize;
-import static reactor.netty.http.HttpDecoderSpecTest.checkDefaultMaxChunkSize;
 import static reactor.netty.http.HttpDecoderSpecTest.checkDefaultMaxHeaderSize;
 import static reactor.netty.http.HttpDecoderSpecTest.checkDefaultMaxInitialLineLength;
 import static reactor.netty.http.HttpDecoderSpecTest.checkDefaultValidateHeaders;
@@ -47,7 +46,6 @@ class HttpRequestDecoderSpecTests {
 
 		checkDefaultMaxInitialLineLength(conf);
 		checkDefaultMaxHeaderSize(conf);
-		checkDefaultMaxChunkSize(conf);
 		checkDefaultValidateHeaders(conf);
 		checkDefaultInitialBufferSize(conf);
 		checkDefaultAllowDuplicateContentLengths(conf);

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -840,13 +840,11 @@ class HttpServerTests extends BaseHttpTest {
 	void httpServerRequestConfigInjectAttributes() {
 		AtomicReference<Channel> channelRef = new AtomicReference<>();
 		AtomicBoolean validate = new AtomicBoolean();
-		AtomicInteger chunkSize = new AtomicInteger();
 		AtomicBoolean allowDuplicateContentLengths = new AtomicBoolean();
 		disposableServer =
 				createServer()
 				          .httpRequestDecoder(opt -> opt.maxInitialLineLength(123)
 				                                        .maxHeaderSize(456)
-				                                        .maxChunkSize(789)
 				                                        .validateHeaders(false)
 				                                        .initialBufferSize(10)
 				                                        .allowDuplicateContentLengths(true))
@@ -857,7 +855,6 @@ class HttpServerTests extends BaseHttpTest {
 				                                               .pipeline()
 				                                               .get(HttpServerCodec.class);
 				                      HttpObjectDecoder decoder = (HttpObjectDecoder) getValueReflection(codec, "inboundHandler", 1);
-				                      chunkSize.set((Integer) getValueReflection(decoder, "maxChunkSize", 2));
 				                      validate.set((Boolean) getValueReflection(decoder, "validateHeaders", 2));
 				                      allowDuplicateContentLengths.set((Boolean) getValueReflection(decoder, "allowDuplicateContentLengths", 2));
 				                  })
@@ -873,7 +870,6 @@ class HttpServerTests extends BaseHttpTest {
 		          .block();
 
 		assertThat(channelRef.get()).isNotNull();
-		assertThat(chunkSize).as("line length").hasValue(789);
 		assertThat(validate).as("validate headers").isFalse();
 		assertThat(allowDuplicateContentLengths).as("allow duplicate Content-Length").isTrue();
 	}


### PR DESCRIPTION
Related to #1873