### PR TITLE
Deprecate HttpDecoderSpec#maxChunkSize

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpDecoderSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpDecoderSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,10 @@ public abstract class HttpDecoderSpec<T extends HttpDecoderSpec<T>> implements S
 
 	public static final int DEFAULT_MAX_INITIAL_LINE_LENGTH             = 4096;
 	public static final int DEFAULT_MAX_HEADER_SIZE                     = 8192;
+	/**
+	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as Netty 5 does not support this configuration.
+	 */
+	@Deprecated
 	public static final int DEFAULT_MAX_CHUNK_SIZE                      = 8192;
 	public static final boolean DEFAULT_VALIDATE_HEADERS                = true;
 	public static final int DEFAULT_INITIAL_BUFFER_SIZE                 = 128;
@@ -95,7 +99,9 @@ public abstract class HttpDecoderSpec<T extends HttpDecoderSpec<T>> implements S
 	 *
 	 * @param value the value for the maximum chunk size (strictly positive)
 	 * @return this option builder for further configuration
+	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as Netty 5 does not support this configuration.
 	 */
+	@Deprecated
 	public T maxChunkSize(int value) {
 		if (value <= 0) {
 			throw new IllegalArgumentException("maxChunkSize must be strictly positive");
@@ -108,7 +114,9 @@ public abstract class HttpDecoderSpec<T extends HttpDecoderSpec<T>> implements S
 	 * Return the configured maximum chunk size that can be decoded for the HTTP request.
 	 *
 	 * @return the configured maximum chunk size that can be decoded for the HTTP request
+	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as Netty 5 does not support this configuration.
 	 */
+	@Deprecated
 	public int maxChunkSize() {
 		return maxChunkSize;
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -522,6 +522,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		 .addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.HttpTrafficHandler, new HttpTrafficHandler(observer));
 	}
 
+	@SuppressWarnings("deprecation")
 	static void configureHttp11OrH2CleartextPipeline(
 			ChannelPipeline p,
 			boolean acceptGzip,
@@ -585,6 +586,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 
 	}
 
+	@SuppressWarnings("deprecation")
 	static void configureHttp11Pipeline(ChannelPipeline p,
 			boolean acceptGzip,
 			HttpResponseDecoderSpec decoder,

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -547,6 +547,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	static void configureHttp11OrH2CleartextPipeline(ChannelPipeline p,
 			boolean accessLogEnabled,
 			@Nullable Function<AccessLogArgProvider, AccessLog> accessLog,
@@ -620,6 +621,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	static void configureHttp11Pipeline(ChannelPipeline p,
 			boolean accessLogEnabled,
 			@Nullable Function<AccessLogArgProvider, AccessLog> accessLog,

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpDecoderSpecTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpDecoderSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +87,7 @@ public class HttpDecoderSpecTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	void maxChunkSize() {
 		checkDefaultMaxChunkSize(conf);
 
@@ -102,6 +103,7 @@ public class HttpDecoderSpecTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	void maxChunkSizeBadValues() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
 				.isThrownBy(() -> conf.maxChunkSize(0))
@@ -184,6 +186,7 @@ public class HttpDecoderSpecTest {
 				.isEqualTo(8192);
 	}
 
+	@SuppressWarnings("deprecation")
 	public static void checkDefaultMaxChunkSize(HttpDecoderSpec<?> conf) {
 		assertThat(conf.maxChunkSize()).as("default chunk size")
 				.isEqualTo(HttpDecoderSpec.DEFAULT_MAX_CHUNK_SIZE)

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -1610,6 +1610,7 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	void httpClientResponseConfigInjectAttributes() {
 		AtomicReference<Channel> channelRef = new AtomicReference<>();
 		AtomicBoolean validate = new AtomicBoolean();

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -847,6 +847,7 @@ class HttpServerTests extends BaseHttpTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	void httpServerRequestConfigInjectAttributes() {
 		AtomicReference<Channel> channelRef = new AtomicReference<>();
 		AtomicBoolean validate = new AtomicBoolean();


### PR DESCRIPTION
`Netty 5` does not support this configuration.