### PR TITLE
Update faq for connection closed BEFORE error

### DIFF
--- a/docs/asciidoc/faq.adoc
+++ b/docs/asciidoc/faq.adoc
@@ -137,7 +137,6 @@ Issues related to TCP keep-alive configuration on various load balancers were re
 ** multipart exceeds the max file size limit
 ** bad request
 * Check the server.tomcat.max-keep-alive-requests property.
-** Some versions of spring default to 100, instead of unlimited.
 
 Consider checking <<Timeout Configuration>>. The section describes various timeout configuration options that are available for Reactor Netty clients.
 Configuring a proper timeout may improve or solve issues in the communication process.

--- a/docs/asciidoc/faq.adoc
+++ b/docs/asciidoc/faq.adoc
@@ -136,6 +136,8 @@ Issues related to TCP keep-alive configuration on various load balancers were re
 ** limit for buffering data in memory
 ** multipart exceeds the max file size limit
 ** bad request
+* Check the server.tomcat.max-keep-alive-requests property.
+** Some versions of spring default to 100, instead of unlimited.
 
 Consider checking <<Timeout Configuration>>. The section describes various timeout configuration options that are available for Reactor Netty clients.
 Configuring a proper timeout may improve or solve issues in the communication process.


### PR DESCRIPTION
After upgrading spring versions in our stack we started to see `Connection prematurely closed BEFORE response`.
During investigation I found an introduction of max-keep-alive-requests property from Netty. I wanted to mention this as a point to check in the faq.


## Netty introduces max-keep-alive-requests

change: https://github.com/reactor/reactor-netty/pull/1867/files#diff-537f1e33d6e1428b0fcac7e1fe10ba87e6cc7aadc6f240fdb73fbe3103baae74R717

evaluation logic: https://github.com/reactor/reactor-netty/pull/1867/files#diff-d39ea30f5b5b199e58b3fb87763a4d3e303fcbd45e9c360565920c9b81bf950eR290

With default to unlimited.

## Spring adds a default to 100

change: https://github.com/spring-projects/spring-boot/commit/34b94d889826bc0d5075bface8420b79e932f0ad#diff-829ef53f73b35e9544921e277455052df073d15569867a2ee8be29daebf2a19fR388

### documentation references

- [2.7.0](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.server.server.netty.max-keep-alive-requests) Says unlimited default
- [2.5.12](https://docs.spring.io/spring-boot/docs/2.5.12/reference/htmlsingle/#application-properties.server.server.tomcat.max-keep-alive-requests) Says 100 default