### PR TITLE
Ensure a custom factory can be used with HttpClient#sendForm

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFormEncoder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFormEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,7 @@ final class HttpClientFormEncoder extends HttpPostRequestEncoder
 		}
 		this.newFactory = Objects.requireNonNull(factory, "factory");
 		this.needNewEncoder = true;
-		return applyChanges(request);
+		return this;
 	}
 
 	@Override
@@ -316,6 +316,8 @@ final class HttpClientFormEncoder extends HttpPostRequestEncoder
 					newMode);
 
 			encoder.setBodyHttpDatas(getBodyListAttributes());
+
+			needNewEncoder = false;
 
 			return encoder;
 		}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientWithTomcatTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientWithTomcatTest.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory;
 import io.netty.handler.codec.http.multipart.HttpData;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -107,6 +108,16 @@ class HttpClientWithTomcatTest {
 	@Test
 	void postUploadNoMultipart() throws Exception {
 		doTestPostUpload((req, form) -> form.multipart(false).attr("attr1", "attr2"), "attr1=attr2");
+	}
+
+	@Test
+	void postUploadNoMultipartWithCustomFactory() throws Exception {
+		doTestPostUpload((req, form) -> {
+			DefaultHttpDataFactory customFactory = new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE);
+			form.factory(customFactory)
+			    .multipart(false)
+			    .attr("attr1", "attr2");
+		}, "attr1=attr2");
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
`HttpClient#sendForm` API uses `BiConsumer` and not `BiFunction`.
The user cannot change the encoder in the callback.
When a custom factory is provided, apply the changes when the control is again in Reactor Netty.

Fixes #2259