### PR TITLE
Adapt to the new ChannelFactory/ServerChannelFactory

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoop.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoop.java
@@ -18,7 +18,9 @@ package reactor.netty.resources;
 import java.util.concurrent.ThreadFactory;
 
 import io.netty5.channel.Channel;
+import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.ServerChannel;
 
 /**
  * An {@link EventLoopGroup} with associated {@link io.netty5.channel.Channel} factory.
@@ -27,11 +29,12 @@ import io.netty5.channel.EventLoopGroup;
  */
 interface DefaultLoop {
 
-	<CHANNEL extends Channel> CHANNEL getChannel(Class<CHANNEL> channelClass);
-
-	<CHANNEL extends Channel> Class<? extends CHANNEL> getChannelClass(Class<CHANNEL> channelClass);
+	<CHANNEL extends Channel> CHANNEL getChannel(Class<CHANNEL> channelClass, EventLoop eventLoop);
 
 	String getName();
+
+	<SERVERCHANNEL extends ServerChannel> SERVERCHANNEL getServerChannel(Class<SERVERCHANNEL> channelClass, EventLoop eventLoop,
+			EventLoopGroup childEventLoopGroup);
 
 	EventLoopGroup newEventLoopGroup(int threads, ThreadFactory factory);
 

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNIO.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNIO.java
@@ -18,7 +18,9 @@ package reactor.netty.resources;
 import java.util.concurrent.ThreadFactory;
 
 import io.netty5.channel.Channel;
+import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.ServerChannel;
 import io.netty5.channel.socket.DatagramChannel;
 import io.netty5.channel.socket.ServerSocketChannel;
 import io.netty5.channel.socket.SocketChannel;
@@ -37,30 +39,12 @@ final class DefaultLoopNIO implements DefaultLoop {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <CHANNEL extends Channel> CHANNEL getChannel(Class<CHANNEL> channelClass) {
+	public <CHANNEL extends Channel> CHANNEL getChannel(Class<CHANNEL> channelClass, EventLoop eventLoop) {
 		if (channelClass.equals(SocketChannel.class)) {
-			return (CHANNEL) new NioSocketChannel();
-		}
-		if (channelClass.equals(ServerSocketChannel.class)) {
-			return (CHANNEL) new NioServerSocketChannel();
+			return (CHANNEL) new NioSocketChannel(eventLoop);
 		}
 		if (channelClass.equals(DatagramChannel.class)) {
-			return (CHANNEL) new NioDatagramChannel();
-		}
-		throw new IllegalArgumentException("Unsupported channel type: " + channelClass.getSimpleName());
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <CHANNEL extends Channel> Class<? extends CHANNEL> getChannelClass(Class<CHANNEL> channelClass) {
-		if (channelClass.equals(SocketChannel.class)) {
-			return (Class<? extends CHANNEL>) NioSocketChannel.class;
-		}
-		if (channelClass.equals(ServerSocketChannel.class)) {
-			return (Class<? extends CHANNEL>) NioServerSocketChannel.class;
-		}
-		if (channelClass.equals(DatagramChannel.class)) {
-			return (Class<? extends CHANNEL>) NioDatagramChannel.class;
+			return (CHANNEL) new NioDatagramChannel(eventLoop);
 		}
 		throw new IllegalArgumentException("Unsupported channel type: " + channelClass.getSimpleName());
 	}
@@ -68,6 +52,16 @@ final class DefaultLoopNIO implements DefaultLoop {
 	@Override
 	public String getName() {
 		return "nio";
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <SERVERCHANNEL extends ServerChannel> SERVERCHANNEL getServerChannel(Class<SERVERCHANNEL> channelClass, EventLoop eventLoop,
+			EventLoopGroup childEventLoopGroup) {
+		if (channelClass.equals(ServerSocketChannel.class)) {
+			return (SERVERCHANNEL) new NioServerSocketChannel(eventLoop, childEventLoopGroup);
+		}
+		throw new IllegalArgumentException("Unsupported channel type: " + channelClass.getSimpleName());
 	}
 
 	@Override

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpResources.java
@@ -23,7 +23,9 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import io.netty5.channel.Channel;
+import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.ServerChannel;
 import io.netty5.resolver.AddressResolverGroup;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
@@ -245,17 +247,10 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 	}
 
 	@Override
-	public <CHANNEL extends Channel> CHANNEL onChannel(Class<CHANNEL> channelType, EventLoopGroup group) {
+	public <CHANNEL extends Channel> CHANNEL onChannel(Class<CHANNEL> channelType, EventLoop eventLoop) {
 		requireNonNull(channelType, "channelType");
-		requireNonNull(group, "group");
-		return defaultLoops.onChannel(channelType, group);
-	}
-
-	@Override
-	public <CHANNEL extends Channel> Class<? extends CHANNEL> onChannelClass(Class<CHANNEL> channelType, EventLoopGroup group) {
-		requireNonNull(channelType, "channelType");
-		requireNonNull(group, "group");
-		return defaultLoops.onChannelClass(channelType, group);
+		requireNonNull(eventLoop, "eventLoop");
+		return defaultLoops.onChannel(channelType, eventLoop);
 	}
 
 	@Override
@@ -266,6 +261,15 @@ public class TcpResources implements ConnectionProvider, LoopResources {
 	@Override
 	public EventLoopGroup onServer(boolean useNative) {
 		return defaultLoops.onServer(useNative);
+	}
+
+	@Override
+	public <SERVERCHANNEL extends ServerChannel> SERVERCHANNEL onServerChannel(Class<SERVERCHANNEL> channelType,
+			EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
+		requireNonNull(channelType, "channelType");
+		requireNonNull(eventLoop, "eventLoop");
+		requireNonNull(childEventLoopGroup, "childEventLoopGroup");
+		return defaultLoops.onServerChannel(channelType, eventLoop, childEventLoopGroup);
 	}
 
 	@Override

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
@@ -27,9 +27,9 @@ import java.util.function.Supplier;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.ServerChannel;
+import io.netty5.channel.ServerChannelFactory;
 import io.netty5.channel.group.ChannelGroup;
-import io.netty5.channel.socket.SocketChannel;
-import io.netty5.channel.unix.DomainSocketChannel;
 import io.netty5.resolver.AddressResolverGroup;
 import io.netty5.resolver.dns.DnsAddressResolverGroup;
 import reactor.netty.ChannelPipelineConfigurer;
@@ -182,11 +182,6 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 		this.resolver = parent.resolver;
 	}
 
-	@Override
-	protected Class<? extends Channel> channelType(boolean isDomainSocket) {
-		return isDomainSocket ? DomainSocketChannel.class : SocketChannel.class;
-	}
-
 	/**
 	 * Provides a global {@link AddressResolverGroup} that is shared amongst all clients.
 	 *
@@ -234,6 +229,16 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 		else {
 			return resolverGroup;
 		}
+	}
+
+	@Override
+	protected Class<? extends ServerChannel> serverChannelType(boolean isDomainSocket) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected ServerChannelFactory<? extends ServerChannel> serverConnectionFactory(boolean isDomainSocket) {
+		throw new UnsupportedOperationException();
 	}
 
 	static final ConcurrentMap<Integer, DnsAddressResolverGroup> RESOLVERS_CACHE = new ConcurrentHashMap<>();

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
@@ -487,8 +487,8 @@ public final class NameResolverProvider {
 				.ndots(ndots)
 				.queryTimeoutMillis(queryTimeout.toMillis())
 				.eventLoop(group.next())
-				.channelFactory(() -> loop.onChannel(DatagramChannel.class, group))
-				.socketChannelFactory(() -> loop.onChannel(SocketChannel.class, group));
+				.channelFactory(el -> loop.onChannel(DatagramChannel.class, el))
+				.socketChannelFactory(el -> loop.onChannel(SocketChannel.class, el));
 		if (hostsFileEntriesResolver != null) {
 			builder.hostsFileEntriesResolver(hostsFileEntriesResolver);
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransportConfig.java
@@ -23,11 +23,10 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelFactory;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.group.ChannelGroup;
-import io.netty5.channel.socket.ServerSocketChannel;
-import io.netty5.channel.unix.ServerDomainSocketChannel;
 import io.netty5.util.AttributeKey;
 import reactor.netty.ChannelPipelineConfigurer;
 import reactor.netty.Connection;
@@ -161,7 +160,12 @@ public abstract class ServerTransportConfig<CONF extends TransportConfig> extend
 
 	@Override
 	protected Class<? extends Channel> channelType(boolean isDomainSocket) {
-		return isDomainSocket ? ServerDomainSocketChannel.class : ServerSocketChannel.class;
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected ChannelFactory<? extends Channel> connectionFactory(boolean isDomainSocket) {
+		throw new UnsupportedOperationException();
 	}
 
 	/**

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConfig.java
@@ -18,7 +18,8 @@ package reactor.netty.udp;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelFactory;
 import io.netty5.channel.ChannelOption;
-import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.ServerChannel;
+import io.netty5.channel.ServerChannelFactory;
 import io.netty5.channel.socket.DatagramChannel;
 import io.netty5.channel.socket.InternetProtocolFamily;
 import io.netty5.channel.socket.nio.NioDatagramChannel;
@@ -84,12 +85,12 @@ public final class UdpClientConfig extends ClientTransportConfig<UdpClientConfig
 	}
 
 	@Override
-	protected ChannelFactory<? extends Channel> connectionFactory(EventLoopGroup elg, boolean isDomainSocket) {
+	protected ChannelFactory<? extends Channel> connectionFactory(boolean isDomainSocket) {
 		if (isPreferNative()) {
-			return super.connectionFactory(elg, isDomainSocket);
+			return super.connectionFactory(isDomainSocket);
 		}
 		else {
-			return () -> new NioDatagramChannel(family());
+			return el -> new NioDatagramChannel(el, family());
 		}
 	}
 
@@ -118,6 +119,16 @@ public final class UdpClientConfig extends ClientTransportConfig<UdpClientConfig
 	@Override
 	protected ChannelMetricsRecorder defaultMetricsRecorder() {
 		return MicrometerUdpClientMetricsRecorder.INSTANCE;
+	}
+
+	@Override
+	protected Class<? extends ServerChannel> serverChannelType(boolean isDomainSocket) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected ServerChannelFactory<? extends ServerChannel> serverConnectionFactory(boolean isDomainSocket) {
+		throw new UnsupportedOperationException();
 	}
 
 	static final ChannelOperations.OnSetup DEFAULT_OPS = (ch, c, msg) -> new UdpOperations(ch, c);

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpResources.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import io.netty5.channel.Channel;
+import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.resolver.AddressResolverGroup;
 import reactor.core.publisher.Mono;
@@ -176,17 +177,10 @@ public class UdpResources implements LoopResources {
 	}
 
 	@Override
-	public <CHANNEL extends Channel> CHANNEL onChannel(Class<CHANNEL> channelType, EventLoopGroup group) {
+	public <CHANNEL extends Channel> CHANNEL onChannel(Class<CHANNEL> channelType, EventLoop eventLoop) {
 		requireNonNull(channelType, "channelType");
-		requireNonNull(group, "group");
-		return defaultLoops.onChannel(channelType, group);
-	}
-
-	@Override
-	public <CHANNEL extends Channel> Class<? extends CHANNEL> onChannelClass(Class<CHANNEL> channelType, EventLoopGroup group) {
-		requireNonNull(channelType, "channelType");
-		requireNonNull(group, "group");
-		return defaultLoops.onChannelClass(channelType, group);
+		requireNonNull(eventLoop, "eventLoop");
+		return defaultLoops.onChannel(channelType, eventLoop);
 	}
 
 	@Override

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServerConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServerConfig.java
@@ -19,6 +19,8 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelFactory;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.ServerChannel;
+import io.netty5.channel.ServerChannelFactory;
 import io.netty5.channel.group.ChannelGroup;
 import io.netty5.channel.socket.DatagramChannel;
 import io.netty5.channel.socket.InternetProtocolFamily;
@@ -122,12 +124,12 @@ public final class UdpServerConfig extends TransportConfig {
 	}
 
 	@Override
-	protected ChannelFactory<? extends Channel> connectionFactory(EventLoopGroup elg, boolean isDomainSocket) {
+	protected ChannelFactory<? extends Channel> connectionFactory(boolean isDomainSocket) {
 		if (isPreferNative()) {
-			return super.connectionFactory(elg, isDomainSocket);
+			return super.connectionFactory(isDomainSocket);
 		}
 		else {
-			return () -> new NioDatagramChannel(family());
+			return el -> new NioDatagramChannel(el, family());
 		}
 	}
 
@@ -162,6 +164,16 @@ public final class UdpServerConfig extends TransportConfig {
 	@Override
 	protected EventLoopGroup eventLoopGroup() {
 		return loopResources().onClient(isPreferNative());
+	}
+
+	@Override
+	protected Class<? extends ServerChannel> serverChannelType(boolean isDomainSocket) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected ServerChannelFactory<? extends ServerChannel> serverConnectionFactory(boolean isDomainSocket) {
+		throw new UnsupportedOperationException();
 	}
 
 	static final ChannelOperations.OnSetup DEFAULT_OPS = (ch, c, msg) -> new UdpOperations(ch, c);


### PR DESCRIPTION
In Netty 5 we have now

```
/**
 * Creates a new {@link Channel}.
 */
public interface ChannelFactory<T extends Channel> {
    /**
     * Creates a new channel.
     */
    T newChannel(EventLoop eventLoop) throws Exception;
}
```

```
/**
 * Creates a new {@link ServerChannel}.
 */
public interface ServerChannelFactory<T extends ServerChannel> {
    /**
     * Creates a new channel.
     */
    T newChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) throws Exception;
}
```

Related to #1873