### PR TITLE
Tests need adaptation to work with Netty 5 changes and the new Buffer API

### DIFF
--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/WebsocketTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/WebsocketTest.java
@@ -563,7 +563,7 @@ class WebsocketTest extends BaseHttpTest {
 				createServer()
 				          .handle((req, res) ->
 				                  res.sendWebsocket((in, out) -> out.sendObject(in.receiveFrames()
-				                                                                  .doOnNext(WebSocketFrame::send))))
+				                                                                  .map(frame -> frame.send().receive()))))
 				          .bindNow();
 
 		Flux<WebSocketFrame> response =
@@ -597,7 +597,7 @@ class WebsocketTest extends BaseHttpTest {
 				          .websocket()
 				          .uri("/")
 				          .handle((in, out) -> out.sendObject(in.receiveFrames()
-				                                                .doOnNext(WebSocketFrame::send)
+				                                                .map(frame -> frame.send().receive())
 				                                                .then()))
 				          .next();
 
@@ -910,11 +910,12 @@ class WebsocketTest extends BaseHttpTest {
 
 		HttpClientResponse res =
 				createClient(disposableServer.port())
-				          .headers(h -> {
-				                  h.add(HttpHeaderNames.CONNECTION, "keep-alive, Upgrade");
-				                  h.add(HttpHeaderNames.UPGRADE, "websocket");
-				                  h.add(HttpHeaderNames.ORIGIN, "http://localhost");
-				          })
+				          .headers(h ->
+				                  h.add(HttpHeaderNames.CONNECTION, "keep-alive, Upgrade")
+				                   .add(HttpHeaderNames.UPGRADE, "websocket")
+				                   .add(HttpHeaderNames.ORIGIN, "http://localhost")
+				                   .add(HttpHeaderNames.SEC_WEBSOCKET_VERSION, "13")
+				                   .add(HttpHeaderNames.SEC_WEBSOCKET_KEY, "Ex6C3J0T352QOL9CgUjdUQ"))
 				          .get()
 				          .uri("/ws")
 				          .response()
@@ -972,7 +973,7 @@ class WebsocketTest extends BaseHttpTest {
 				createServer()
 				          .handle((req, res) ->
 				              res.sendWebsocket((in, out) -> out.sendObject(in.receiveFrames()
-				                                                              .doOnNext(WebSocketFrame::send))))
+				                                                              .map(frame -> frame.send().receive()))))
 				          .bindNow();
 
 		CountDownLatch latch = new CountDownLatch(1);
@@ -1041,7 +1042,7 @@ class WebsocketTest extends BaseHttpTest {
 		          .websocket()
 		          .uri("/")
 		          .handle((in, out) -> out.sendObject(in.receiveFrames()
-		                                                .doOnNext(WebSocketFrame::send)))
+		                                                .map(frame -> frame.send().receive())))
 		          .subscribe();
 
 		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogHandlerH1Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogHandlerH1Tests.java
@@ -76,11 +76,12 @@ class AccessLogHandlerH1Tests {
 
 		channel.writeOutbound(newHttpResponse(true));
 
-		Buffer byteBuf = channel.bufferAllocator().allocate(RESPONSE_CONTENT.length);
-		byteBuf.writeBytes(RESPONSE_CONTENT);
-		channel.writeOutbound(byteBuf);
+		Buffer byteBuf1 = channel.bufferAllocator().allocate(RESPONSE_CONTENT.length);
+		byteBuf1.writeBytes(RESPONSE_CONTENT).makeReadOnly();
+		Buffer byteBuf2 = byteBuf1.copy(byteBuf1.readerOffset(), 0, true);
+		channel.writeOutbound(byteBuf1);
 
-		channel.writeOutbound(new DefaultHttpContent(byteBuf));
+		channel.writeOutbound(new DefaultHttpContent(byteBuf2));
 
 		channel.writeOutbound(new DefaultLastHttpContent(channel.bufferAllocator().allocate(0)));
 	}


### PR DESCRIPTION
`WebsocketTest#firefoxConnectionTest`

https://datatracker.ietf.org/doc/html/rfc6455#section-4.1

`The request MUST include a header field with the name Sec-WebSocket-Version.  The value of this header field MUST be 13.`

`The request MUST include a header field with the name Sec-WebSocket-Key.  The value of this header field MUST be a
nonce consisting of a randomly selected 16-byte value that has been base64-encoded (see Section 4 of [RFC4648]).
The nonce MUST be selected randomly for each connection.`