### PR TITLE
testExpectErrorWhenConnectionClosed test is broken when using SSL and netty5

### DIFF
--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1105,13 +1105,17 @@ class HttpServerTests extends BaseHttpTest {
 				          .secure(spec -> spec.sslContext(serverCtx))
 				          .handle((req, res) -> {
 				              // "FutureReturnValueIgnored" is suppressed deliberately
-				              res.withConnection(conn -> conn.channel().close());
-				              return res.sendString(Flux.just("OK").hide())
-				                        .then()
-				                        .doOnError(t -> {
-				                            error.set(t);
-				                            latch.countDown();
-				                        });
+					          res.withConnection(conn -> conn.channel().close().addListener(f -> {
+						          res.sendString(Flux.just("OK").hide())
+								          .then()
+								          .doOnError(t -> {
+									          error.set(t);
+									          latch.countDown();
+								          })
+								          .subscribe();
+					          }));
+
+					          return Mono.never();
 				          })
 				          .bindNow();
 


### PR DESCRIPTION
When using netty5, the _HttpServerTests.testExpectErrorWhenConnectionClosed_ test does not pass anymore.

When it receives a request (using SSL), the test first closes the channel, then it sends a response and at this point it expects to get  an error (because the socket has been closed before sending the response):

```
				          .handle((req, res) -> {
				              // "FutureReturnValueIgnored" is suppressed deliberately
				              res.withConnection(conn -> conn.channel().close());
				              return res.sendString(Flux.just("OK").hide())
				                        .then()
				                        .doOnError(t -> {
				                            error.set(t);
				                            latch.countDown();
				                        });
				          })
```

But in netty5, the above test does not work anymore. Notice that it works when **not** using SSL.

Analysis:

1. When closing the channel, the SslHandler sends a close-notify to the client and flushes [from SslHandler.java, line 1744](https://github.com/netty/netty/blob/main/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java#L1730-L1765)
2. But now, in netty5, the closeNotifyPromise passed as argument (line 1744) is now always completed asynchronously, [see DefaultPromise.java, line 475](https://github.com/netty/netty/blob/main/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java#L475). That was not the case in netty4: the promise listeners were notified synchronously if we were already in the same event loop: [see DefaultPromise, line 491](https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java#L483-L505)
3. And when "safeClosed" is called line [SslHandler.java, 1758](https://github.com/netty/netty/blob/main/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java#L1758), then the flushFuture does not complete synchronously, [see SslHandler.java, line L1986](https://github.com/netty/netty/blob/main/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java#L1978): the listener is not called synchronously because the promise is not yet completed.
4. So, the consequence of all this is that in the test, when we close the channel, the channel is not yet set to "closed" state because the listeners are now completed asynchronously (the listeners are completed by a task that is rescheduled in the event loop queue). So, the code from [HttpOperations.java line 107](https://github.com/reactor/reactor-netty/blob/netty5/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java#L107) is then not called and the test fails.

So, I wonder if there is a problem in the netty5 [DefaultPromise.java, line 475](https://github.com/netty/netty/blob/main/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java#L475). The behavior is now different and the listeners are always scheduled asynchronously.

Now, an attempt to work around this (if it's really a problem) is to apply the following PR in reactor netty test, which sends the response from a channel close promise listener.

@violetagg , WDYT ?
