### PR TITLE
Add create method with metrics parameter in ConnectionProvider (#2313)

### DIFF
--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -194,6 +194,9 @@ task japicmp(type: JapicmpTask) {
 	ignoreMissingClasses = true
 	includeSynthetic = true
 	onlyIf { "$compatibleVersion" != "SKIP" }
+	methodExcludes = [
+			"reactor.netty.resources.ConnectionProvider#create(java.lang.String, int, boolean)"
+	]
 }
 
 tasks.japicmp.dependsOn(downloadBaseline)

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -175,6 +175,7 @@ public interface ConnectionProvider extends Disposable {
 	 *
 	 * @return a new {@link ConnectionProvider} to cache and reuse a fixed maximum
 	 * number of {@link Connection}
+	 * @since 1.0.21
 	 */
 	static ConnectionProvider create(String name, int maxConnections, boolean metricsEnabled) {
 		return builder(name).maxConnections(maxConnections)

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -162,6 +162,28 @@ public interface ConnectionProvider extends Disposable {
 	}
 
 	/**
+	 * Create a new {@link ConnectionProvider} to cache and reuse a fixed maximum
+	 * number of {@link Connection}.
+	 * <p>A Fixed {@link ConnectionProvider} will open up to the given max connection value.
+	 * Further connections will be pending acquisition until {@link #DEFAULT_POOL_ACQUIRE_TIMEOUT}
+	 * and the default pending acquisition max count will be 2 * max connections value.
+	 *
+	 * @param name the connection pool name
+	 * @param maxConnections the maximum number of connections before starting pending
+	 * acquisition on existing ones
+	 * @param metricsEnabled true enables metrics collection; false disables it
+	 *
+	 * @return a new {@link ConnectionProvider} to cache and reuse a fixed maximum
+	 * number of {@link Connection}
+	 */
+	static ConnectionProvider create(String name, int maxConnections, boolean metricsEnabled) {
+		return builder(name).maxConnections(maxConnections)
+				.pendingAcquireTimeout(Duration.ofMillis(DEFAULT_POOL_ACQUIRE_TIMEOUT))
+				.metrics(metricsEnabled)
+				.build();
+	}
+
+	/**
 	 * Return an existing or new {@link Connection} on subscribe.
 	 *
 	 * @param config the transport configuration


### PR DESCRIPTION
Add create method with name, maxConnections, metricsEnabled parameters.

Related to https://github.com/reactor/reactor-netty/issues/2313