### PR TITLE
Switch to Micrometer 1.10.0-SNAPSHOT version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,9 +84,9 @@ ext {
 	}
 
 	//Metrics
-	micrometerVersion = '1.10.0-M1' //optional baseline
-	micrometerTracingVersion = '1.0.0-M4' //optional baseline
-	micrometerDocsVersion = '1.0.0-M3' //optional baseline
+	micrometerVersion = '1.10.0-SNAPSHOT' //optional baseline
+	micrometerTracingVersion = '1.0.0-SNAPSHOT' //optional baseline
+	micrometerDocsVersion = '1.0.0-SNAPSHOT' //optional baseline
 
 	contextPropagationVersion = '1.0.0-M2'
 

--- a/reactor-netty-core/src/main/java/reactor/netty/observability/ReactorNettyTimerObservationHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/observability/ReactorNettyTimerObservationHandler.java
@@ -18,7 +18,6 @@ package reactor.netty.observability;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.observation.MeterObservationHandler;
-import io.micrometer.core.instrument.observation.TimerObservationHandler;
 import io.micrometer.observation.Observation;
 
 /**

--- a/reactor-netty-core/src/main/java/reactor/netty/observability/ReactorNettyTimerObservationHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/observability/ReactorNettyTimerObservationHandler.java
@@ -17,6 +17,7 @@ package reactor.netty.observability;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.observation.MeterObservationHandler;
 import io.micrometer.core.instrument.observation.TimerObservationHandler;
 import io.micrometer.observation.Observation;
 
@@ -25,11 +26,20 @@ import io.micrometer.observation.Observation;
  * This timer observation handler is used to reduce memory overhead when creating Timer object instances.
  *
  * @author Pierre De Rop
+ * @author Violeta Georgieva
  * @since 1.1.0
  */
-public final class ReactorNettyTimerObservationHandler extends TimerObservationHandler {
+public final class ReactorNettyTimerObservationHandler implements MeterObservationHandler<Observation.Context> {
+	final MeterRegistry meterRegistry;
+
 	public ReactorNettyTimerObservationHandler(MeterRegistry meterRegistry) {
-		super(meterRegistry);
+		this.meterRegistry = meterRegistry;
+	}
+
+	@Override
+	public void onStart(Observation.Context context) {
+		Timer.Sample sample = Timer.start(meterRegistry);
+		context.put(Timer.Sample.class, sample);
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProviderMeters.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProviderMeters.java
@@ -38,7 +38,7 @@ enum Http2ConnectionProviderMeters implements DocumentedMeter {
 
 		@Override
 		public KeyName[] getKeyNames() {
-			return Http2ConnectionProviderMeters.Http2ConnectionProviderMetersTags.values();
+			return Http2ConnectionProviderMetersTags.values();
 		}
 
 		@Override
@@ -78,7 +78,7 @@ enum Http2ConnectionProviderMeters implements DocumentedMeter {
 
 		@Override
 		public KeyName[] getKeyNames() {
-			return Http2ConnectionProviderMeters.Http2ConnectionProviderMetersTags.values();
+			return Http2ConnectionProviderMetersTags.values();
 		}
 
 		@Override

--- a/reactor-netty-http/src/test/java/reactor/netty/http/observability/ObservabilitySmokeTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/observability/ObservabilitySmokeTest.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.test.SampleTestRunner;
@@ -91,7 +92,7 @@ class ObservabilitySmokeTest extends SampleTestRunner {
 	}
 
 	@Override
-	public BiConsumer<BuildingBlocks, Deque<ObservationHandler>> customizeObservationHandlers() {
+	public BiConsumer<BuildingBlocks, Deque<ObservationHandler<? extends Observation.Context>>> customizeObservationHandlers() {
 		return (bb, timerRecordingHandlers) -> {
 			ObservationHandler defaultHandler = timerRecordingHandlers.removeLast();
 			timerRecordingHandlers.addLast(new ReactorNettyTracingObservationHandler(bb.getTracer()));


### PR DESCRIPTION
Fix exception when generating reference documentation.

```
Jun 22, 2022 10:52:13 AM io.micrometer.docs.metrics.MetricSearchingFileVisitor visitFile
SEVERE: Failed to parse file [/.../reactor-netty/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProviderMeters.java] due to an error
java.lang.IllegalStateException: There's no nested type with name [Http2ConnectionProviderMeters.Http2ConnectionProviderMetersTags]
        at io.micrometer.docs.commons.ParsingUtils.lambda$keyValueEntries$1(ParsingUtils.java:79)
        at java.base/java.util.Optional.orElseThrow(Optional.java:403)
        at io.micrometer.docs.commons.ParsingUtils.lambda$keyValueEntries$2(ParsingUtils.java:78)
        at java.base/java.util.Collections$SingletonList.forEach(Collections.java:4966)
        at io.micrometer.docs.commons.ParsingUtils.keyValueEntries(ParsingUtils.java:75)
        at io.micrometer.docs.metrics.MetricSearchingFileVisitor.parseMetric(MetricSearchingFileVisitor.java:170)
        at io.micrometer.docs.metrics.MetricSearchingFileVisitor.visitFile(MetricSearchingFileVisitor.java:86)
        at io.micrometer.docs.metrics.MetricSearchingFileVisitor.visitFile(MetricSearchingFileVisitor.java:50)
        at java.base/java.nio.file.Files.walkFileTree(Files.java:2811)
        at java.base/java.nio.file.Files.walkFileTree(Files.java:2882)
        at io.micrometer.docs.metrics.DocsFromSources.generate(DocsFromSources.java:62)
        at io.micrometer.docs.metrics.DocsFromSources.main(DocsFromSources.java:53)
```

Adapt to the changes in `TimerObservationHandler` and `SampleTestRunner`
For the time being we don't need `LongTaskTimer`
