### PR TITLE
reactor-netty-examples does not need dependency to the old ByteBuf API

### DIFF
--- a/reactor-netty-examples/build.gradle
+++ b/reactor-netty-examples/build.gradle
@@ -20,7 +20,6 @@ dependencies {
 
 	api "io.micrometer:micrometer-core:$micrometerVersion"
 
-	api "io.netty:netty-buffer:$nettyByteBufVersion"
 	// TODO temporary depend on natives from 5.0.0.Alpha2
 	api "io.netty:netty5-transport-native-epoll:5.0.0.Alpha2:linux-x86_64"
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/sse/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/sse/Application.java
@@ -55,7 +55,7 @@ public class Application {
 	}
 
 	/**
-	 * Transforms the Object to ByteBuf following the expected SSE format.
+	 * Transforms the Object to Buffer following the expected SSE format.
 	 */
 	private static Buffer toBuffer(Object obj, BufferAllocator allocator) {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();


### PR DESCRIPTION
Fix comment

Related to #1873