### PR TITLE
Updates to latest netty5 changes: userEventTriggered/half close/sync

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -644,7 +644,7 @@ public final class SslProvider {
 		}
 
 		@Override
-		public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+		public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
 			if (evt instanceof SslHandshakeCompletionEvent handshake) {
 				handshakeDone = true;
 				if (handshake.isSuccess()) {
@@ -654,7 +654,7 @@ public final class SslProvider {
 					ctx.fireExceptionCaught(handshake.cause());
 				}
 			}
-			ctx.fireUserEventTriggered(evt);
+			ctx.fireInboundEventTriggered(evt);
 			if (handshakeDone && ctx.pipeline().context(this) != null) {
 				ctx.pipeline().remove(this);
 			}

--- a/reactor-netty-core/src/test/java/reactor/netty/ReactorNettyTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ReactorNettyTest.java
@@ -20,6 +20,7 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelMetadata;
 import io.netty5.channel.ChannelOutboundBuffer;
+import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 import reactor.util.annotation.Nullable;
@@ -160,6 +161,10 @@ class ReactorNettyTest {
 		}
 
 		@Override
+		protected void doShutdown(ChannelShutdownDirection direction) throws Exception {
+		}
+
+		@Override
 		protected void doBeginRead() {
 		}
 
@@ -180,6 +185,11 @@ class ReactorNettyTest {
 		@Override
 		public boolean isActive() {
 			return active;
+		}
+
+		@Override
+		public boolean isShutdown(ChannelShutdownDirection direction) {
+			return false;
 		}
 
 		@Override

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/TransportEventLoopMetricsTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/TransportEventLoopMetricsTest.java
@@ -51,7 +51,7 @@ import static reactor.netty.Metrics.PENDING_TASKS;
 class TransportEventLoopMetricsTest {
 
 	private MeterRegistry registry;
-	final Logger log = Loggers.getLogger(TransportEventLoopMetricsTest.class);
+	final static Logger log = Loggers.getLogger(TransportEventLoopMetricsTest.class);
 
 	@BeforeEach
 	void setUp() {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpTrafficHandler.java
@@ -80,7 +80,7 @@ final class HttpTrafficHandler extends ChannelHandlerAdapter {
 	}
 
 	@Override
-	public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+	public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
 		Channel channel = ctx.channel();
 		if (evt == UPGRADE_ISSUED) {
 			if (log.isDebugEnabled()) {
@@ -100,7 +100,7 @@ final class HttpTrafficHandler extends ChannelHandlerAdapter {
 			}
 			sendNewState(Connection.from(channel), HttpClientState.UPGRADE_REJECTED);
 		}
-		ctx.fireUserEventTriggered(evt);
+		ctx.fireInboundEventTriggered(evt);
 	}
 
 	void sendNewState(Connection connection, ConnectionObserver.State state) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -506,7 +506,7 @@ final class HttpTrafficHandler extends ChannelHandlerAdapter implements Runnable
 				// FutureReturnValueIgnored is deliberate
 				ctx.close();
 			}
-			ctx.fireUserEventTriggered(evt);
+			ctx.fireInboundEventTriggered(evt);
 		}
 
 		static void addIdleTimeoutHandler(ChannelPipeline pipeline, @Nullable Duration idleTimeout) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1827,11 +1827,11 @@ class HttpServerTests extends BaseHttpTest {
 				              channel.pipeline()
 				                     .addAfter(NettyPipeline.SslHandler, "test", new ChannelHandlerAdapter() {
 				                         @Override
-				                         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+				                         public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
 				                             if (evt instanceof SniCompletionEvent) {
 				                                 hostname.set(((SniCompletionEvent) evt).hostname());
 				                             }
-				                             ctx.fireUserEventTriggered(evt);
+				                             ctx.fireInboundEventTriggered(evt);
 				                         }
 				                     }))
 				          .handle((req, res) -> res.sendString(Mono.just("testSniSupport")))
@@ -1874,11 +1874,11 @@ class HttpServerTests extends BaseHttpTest {
 				              channel.pipeline()
 				                     .addAfter(NettyPipeline.SslHandler, "test", new ChannelHandlerAdapter() {
 				                         @Override
-				                         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+				                         public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
 				                             if (evt instanceof SniCompletionEvent) {
 				                                 hostname.set(((SniCompletionEvent) evt).hostname());
 				                             }
-				                                 ctx.fireUserEventTriggered(evt);
+				                                 ctx.fireInboundEventTriggered(evt);
 				                             }
 				                         }))
 				          .handle((req, res) -> res.sendString(Mono.just("testSniSupport")))


### PR DESCRIPTION
This change is adapting the code to the changes in Netty 5 snapshot.

Modifications:

- Remove the usage of syncUninterruptibly (https://github.com/netty/netty/pull/12481)
- Adapt to the changes in ChannelHandler: userEventTriggered(...) is renamed to inboundEventTriggered(...) (https://github.com/netty/netty/pull/12497)
- triggerOutboundEvent(...) is added (https://github.com/netty/netty/pull/12497)
- shutdown(...) and channelShutdown(...) are added (https://github.com/netty/netty/pull/12468)