### PR TITLE
Adapt the code to the changes in the ChannelHandler/ChannelHandlerContext methods names

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/AbstractChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/AbstractChannelMetricsHandler.java
@@ -112,10 +112,10 @@ public abstract class AbstractChannelMetricsHandler extends ChannelHandlerAdapte
 	}
 
 	@Override
-	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+	public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
 		recordException(ctx, remoteAddress != null ? remoteAddress : ctx.channel().remoteAddress());
 
-		ctx.fireExceptionCaught(cause);
+		ctx.fireChannelExceptionCaught(cause);
 	}
 
 	public abstract ChannelHandler connectMetricsHandler();

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperationsHandler.java
@@ -74,7 +74,7 @@ final class ChannelOperationsHandler extends ChannelHandlerAdapter {
 			}
 		}
 		catch (Throwable err) {
-			exceptionCaught(ctx, err);
+			channelExceptionCaught(ctx, err);
 		}
 	}
 
@@ -115,12 +115,12 @@ final class ChannelOperationsHandler extends ChannelHandlerAdapter {
 					" The connection will be closed."), err);
 			//"FutureReturnValueIgnored" this is deliberate
 			ctx.close();
-			exceptionCaught(ctx, err);
+			channelExceptionCaught(ctx, err);
 		}
 	}
 
 	@Override
-	final public void exceptionCaught(ChannelHandlerContext ctx, Throwable err) {
+	final public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable err) {
 		Connection connection = Connection.from(ctx.channel());
 		ChannelOperations<?, ?> ops = connection.as(ChannelOperations.class);
 		if (ops != null) {

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -644,17 +644,17 @@ public final class SslProvider {
 		}
 
 		@Override
-		public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+		public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
 			if (evt instanceof SslHandshakeCompletionEvent handshake) {
 				handshakeDone = true;
 				if (handshake.isSuccess()) {
 					ctx.fireChannelActive();
 				}
 				else {
-					ctx.fireExceptionCaught(handshake.cause());
+					ctx.fireChannelExceptionCaught(handshake.cause());
 				}
 			}
-			ctx.fireInboundEventTriggered(evt);
+			ctx.fireChannelInboundEvent(evt);
 			if (handshakeDone && ctx.pipeline().context(this) != null) {
 				ctx.pipeline().remove(this);
 			}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
@@ -388,7 +388,7 @@ public abstract class ServerTransport<T extends ServerTransport<T, CONF>,
 		}
 
 		@Override
-		public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+		public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
 			ChannelConfig config = ctx.channel().config();
 			if (config.isAutoRead()) {
 				// stop accept new connections for 1 second to allow the channel to recover
@@ -405,7 +405,7 @@ public abstract class ServerTransport<T extends ServerTransport<T, CONF>,
 			}
 			// still let the exceptionCaught event flow through the pipeline to give the user
 			// a chance to do something with it
-			ctx.fireExceptionCaught(cause);
+			ctx.fireChannelExceptionCaught(cause);
 		}
 
 		void enableAutoReadTask(Channel channel) {

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
@@ -1131,11 +1131,11 @@ class TcpServerTests {
 				             channel.pipeline()
 				                    .addAfter(NettyPipeline.SslHandler, "test", new ChannelHandlerAdapter() {
 				                        @Override
-				                        public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+				                        public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
 				                            if (evt instanceof SniCompletionEvent) {
 				                                hostname.set(((SniCompletionEvent) evt).hostname());
 				                            }
-				                            ctx.fireInboundEventTriggered(evt);
+				                            ctx.fireChannelInboundEvent(evt);
 				                        }
 				                    }))
 				         .handle((in, out) -> out.sendString(Mono.just("testSniSupport")))

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
@@ -126,10 +126,10 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelHandlerAdapter {
 	}
 
 	@Override
-	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+	public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
 		recordException(ctx);
 
-		ctx.fireExceptionCaught(cause);
+		ctx.fireChannelExceptionCaught(cause);
 	}
 
 	protected abstract HttpClientMetricsRecorder recorder();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpTrafficHandler.java
@@ -80,7 +80,7 @@ final class HttpTrafficHandler extends ChannelHandlerAdapter {
 	}
 
 	@Override
-	public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+	public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
 		Channel channel = ctx.channel();
 		if (evt == UPGRADE_ISSUED) {
 			if (log.isDebugEnabled()) {
@@ -100,7 +100,7 @@ final class HttpTrafficHandler extends ChannelHandlerAdapter {
 			}
 			sendNewState(Connection.from(channel), HttpClientState.UPGRADE_REJECTED);
 		}
-		ctx.fireInboundEventTriggered(evt);
+		ctx.fireChannelInboundEvent(evt);
 	}
 
 	void sendNewState(Connection connection, ConnectionObserver.State state) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
@@ -156,14 +156,14 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelHandlerAdapter {
 	}
 
 	@Override
-	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+	public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
 		ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
 		if (channelOps instanceof HttpServerOperations ops) {
 			// Always take the remote address from the operations in order to consider proxy information
 			recordException(ops, uriTagValue == null ? ops.path : uriTagValue.apply(ops.path));
 		}
 
-		ctx.fireExceptionCaught(cause);
+		ctx.fireChannelExceptionCaught(cause);
 	}
 
 	protected abstract HttpServerMetricsRecorder recorder();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -735,8 +735,8 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		}
 
 		@Override
-		public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-			ctx.fireExceptionCaught(cause);
+		public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+			ctx.fireChannelExceptionCaught(cause);
 		}
 
 		@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -282,7 +282,7 @@ final class HttpTrafficHandler extends ChannelHandlerAdapter implements Runnable
 			                  .get();
 		}
 		if (!pipelined.offer(msg)) {
-			ctx.fireExceptionCaught(Exceptions.failWithOverflow());
+			ctx.fireChannelExceptionCaught(Exceptions.failWithOverflow());
 		}
 	}
 
@@ -506,7 +506,7 @@ final class HttpTrafficHandler extends ChannelHandlerAdapter implements Runnable
 				// FutureReturnValueIgnored is deliberate
 				ctx.close();
 			}
-			ctx.fireInboundEventTriggered(evt);
+			ctx.fireChannelInboundEvent(evt);
 		}
 
 		static void addIdleTimeoutHandler(ChannelPipeline pipeline, @Nullable Duration idleTimeout) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1445,9 +1445,9 @@ class HttpServerTests extends BaseHttpTest {
 				                  new ChannelHandlerAdapter() {
 
 				                      @Override
-				                      public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+				                      public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
 				                          error.set(cause);
-				                          ctx.fireExceptionCaught(cause);
+				                          ctx.fireChannelExceptionCaught(cause);
 				                      }
 				          }))
 				          .route(r -> r.put("/1", (req, res) -> req.receive()
@@ -1827,11 +1827,11 @@ class HttpServerTests extends BaseHttpTest {
 				              channel.pipeline()
 				                     .addAfter(NettyPipeline.SslHandler, "test", new ChannelHandlerAdapter() {
 				                         @Override
-				                         public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+				                         public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
 				                             if (evt instanceof SniCompletionEvent) {
 				                                 hostname.set(((SniCompletionEvent) evt).hostname());
 				                             }
-				                             ctx.fireInboundEventTriggered(evt);
+				                             ctx.fireChannelInboundEvent(evt);
 				                         }
 				                     }))
 				          .handle((req, res) -> res.sendString(Mono.just("testSniSupport")))
@@ -1874,11 +1874,11 @@ class HttpServerTests extends BaseHttpTest {
 				              channel.pipeline()
 				                     .addAfter(NettyPipeline.SslHandler, "test", new ChannelHandlerAdapter() {
 				                         @Override
-				                         public void inboundEventTriggered(ChannelHandlerContext ctx, Object evt) {
+				                         public void channelInboundEvent(ChannelHandlerContext ctx, Object evt) {
 				                             if (evt instanceof SniCompletionEvent) {
 				                                 hostname.set(((SniCompletionEvent) evt).hostname());
 				                             }
-				                                 ctx.fireInboundEventTriggered(evt);
+				                                 ctx.fireChannelInboundEvent(evt);
 				                             }
 				                         }))
 				          .handle((req, res) -> res.sendString(Mono.just("testSniSupport")))


### PR DESCRIPTION
Some of the `ChannelHandler`/`ChannelHandlerContext` methods names are changed with
 https://github.com/netty/netty/pull/12505

- `fireExceptionCaught(...)` is now `fireChannelExceptionCaught(...)`
- `exceptionCaught(...)` is now `channelExceptionCaught(...)`
- `fireInboundEventTriggered(...)` is now `fireChannelInboundEvent(...)`
- `inboundEventTriggered(...)` is now  `channelInboundEvent(...)`

Related to #1873