### PR TITLE
Reintegrate multipart into netty5 branch

### DIFF
--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -71,10 +71,8 @@ jobs:
 #          path: socks-proxy
       - uses: actions/checkout@v3
         with:
-          # TODO temporary https://github.com/netty-contrib/codec-multipart/pull/1
-          repository: pderop/codec-multipart
+          repository: netty-contrib/codec-multipart
           path: codec-multipart
-          ref: httpcontent-used-as-raw-type
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -69,6 +69,10 @@ jobs:
 #        with:
 #          repository: netty-contrib/socks-proxy
 #          path: socks-proxy
+      - uses: actions/checkout@v3
+        with:
+          repository: netty-contrib/codec-multipart
+          path: codec-multipart
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -87,3 +91,6 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew clean check --no-daemon -PforceTransport=${{ matrix.transport }} -x spotlessCheck
 #        working-directory: ./reactor-netty
+      - name: Build codec-multipart
+        run: ./mvnw install -DskipTests=true
+        working-directory: ./codec-multipart

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -15,6 +15,13 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
+      - uses: actions/checkout@v3
+        with:
+          repository: netty-contrib/codec-multipart
+          path: codec-multipart
+      - name: Build codec-multipart
+        run: ./mvnw install -DskipTests=true "-Dnetty.version=5.0.0.Alpha5"
+        working-directory: ./codec-multipart
       - name: spotless (license header)
         if: always()
         run: ./gradlew clean spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
@@ -54,8 +61,8 @@ jobs:
           #  transport: native
     steps:
       - uses: actions/checkout@v3
-#        with:
-#          path: reactor-netty
+        with:
+          path: reactor-netty
 #          fetch-depth: 0 #needed by spotless
 #      - uses: actions/checkout@v3
 #        with:
@@ -88,9 +95,9 @@ jobs:
 #      - name: Build socks-proxy
 #        run: ./mvnw install -DskipTests=true "-Dnetty.version=5.0.0.Alpha5"
 #        working-directory: ./socks-proxy
+      - name: Build codec-multipart
+        run: ./mvnw install -DskipTests=true "-Dnetty.version=5.0.0.Alpha5"
+        working-directory: ./codec-multipart
       - name: Build with Gradle
         run: ./gradlew clean check --no-daemon -PforceTransport=${{ matrix.transport }} -x spotlessCheck
-#        working-directory: ./reactor-netty
-      - name: Build codec-multipart
-        run: ./mvnw install -DskipTests=true
-        working-directory: ./codec-multipart
+        working-directory: ./reactor-netty

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -15,13 +15,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: actions/checkout@v3
-        with:
-          repository: netty-contrib/codec-multipart
-          path: codec-multipart
-      - name: Build codec-multipart
-        run: ./mvnw install -DskipTests=true "-Dnetty.version=5.0.0.Alpha5"
-        working-directory: ./codec-multipart
       - name: spotless (license header)
         if: always()
         run: ./gradlew clean spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
@@ -61,8 +54,8 @@ jobs:
           #  transport: native
     steps:
       - uses: actions/checkout@v3
-        with:
-          path: reactor-netty
+#        with:
+#          path: reactor-netty
 #          fetch-depth: 0 #needed by spotless
 #      - uses: actions/checkout@v3
 #        with:
@@ -76,10 +69,6 @@ jobs:
 #        with:
 #          repository: netty-contrib/socks-proxy
 #          path: socks-proxy
-      - uses: actions/checkout@v3
-        with:
-          repository: netty-contrib/codec-multipart
-          path: codec-multipart
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -95,9 +84,6 @@ jobs:
 #      - name: Build socks-proxy
 #        run: ./mvnw install -DskipTests=true "-Dnetty.version=5.0.0.Alpha5"
 #        working-directory: ./socks-proxy
-      - name: Build codec-multipart
-        run: ./mvnw install -DskipTests=true "-Dnetty.version=5.0.0.Alpha5"
-        working-directory: ./codec-multipart
       - name: Build with Gradle
         run: ./gradlew clean check --no-daemon -PforceTransport=${{ matrix.transport }} -x spotlessCheck
-        working-directory: ./reactor-netty
+#        working-directory: ./reactor-netty

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -71,8 +71,10 @@ jobs:
 #          path: socks-proxy
       - uses: actions/checkout@v3
         with:
-          repository: netty-contrib/codec-multipart
+          # TODO temporary https://github.com/netty-contrib/codec-multipart/pull/1
+          repository: pderop/codec-multipart
           path: codec-multipart
+          ref: httpcontent-used-as-raw-type
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ ext {
 	nettyContribVersion = '5.0.0.Alpha2'
 	//nettyIoUringVersion = '0.0.15.Final'
 	//nettyQuicVersion = '0.0.33.Final'
-	nettyContribMultipartVersion = '5.0.0.Alpha1-SNAPSHOT'
+	nettyContribMultipartVersion = '5.0.0.Alpha1'
 
 	// Testing
 	jacksonDatabindVersion = '2.13.4.2'

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ ext {
 	nettyContribVersion = '5.0.0.Alpha2'
 	//nettyIoUringVersion = '0.0.15.Final'
 	//nettyQuicVersion = '0.0.33.Final'
+	nettyContribMultipartVersion = '5.0.0.Alpha1-SNAPSHOT'
 
 	// Testing
 	jacksonDatabindVersion = '2.13.4.2'

--- a/reactor-netty5-examples/src/main/java/reactor/netty5/examples/documentation/http/server/multipart/Application.java
+++ b/reactor-netty5-examples/src/main/java/reactor/netty5/examples/documentation/http/server/multipart/Application.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty5.examples.documentation.http.server.multipart;
+
+import reactor.core.publisher.Mono;
+import reactor.netty5.DisposableServer;
+import reactor.netty5.http.server.HttpServer;
+
+public class Application {
+
+	public static void main(String[] args) {
+		DisposableServer server =
+				HttpServer.create()
+				          .route(routes ->
+				              routes.post("/multipart", (request, response) -> response.sendString(
+				                      request.receiveForm() //<1>
+				                             .flatMap(data -> Mono.just('[' + data.getName() + ']')))))
+				          .bindNow();
+
+		server.onDispose()
+		      .block();
+	}
+}

--- a/reactor-netty5-examples/src/main/java/reactor/netty5/examples/documentation/http/server/multipart/custom/Application.java
+++ b/reactor-netty5-examples/src/main/java/reactor/netty5/examples/documentation/http/server/multipart/custom/Application.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty5.examples.documentation.http.server.multipart.custom;
+
+import reactor.core.publisher.Mono;
+import reactor.netty5.DisposableServer;
+import reactor.netty5.http.server.HttpServer;
+
+public class Application {
+
+	public static void main(String[] args) {
+		DisposableServer server =
+				HttpServer.create()
+				          .httpFormDecoder(builder -> builder.maxInMemorySize(0))                  //<1>
+				          .route(routes ->
+				              routes.post("/multipart", (request, response) -> response.sendString(
+				                      request.receiveForm(builder -> builder.maxInMemorySize(256)) //<2>
+				                             .flatMap(data -> Mono.just('[' + data.getName() + ']')))))
+				          .bindNow();
+
+		server.onDispose()
+		      .block();
+	}
+}

--- a/reactor-netty5-http/build.gradle
+++ b/reactor-netty5-http/build.gradle
@@ -280,6 +280,8 @@ task japicmp(type: JapicmpTask) {
 			'reactor.netty.http.client.HttpClientResponse#status()',
 			'reactor.netty.http.client.HttpClient$RequestSender#sendForm(java.util.function.BiConsumer)',
 			'reactor.netty.http.client.HttpClient$RequestSender#sendForm(java.util.function.BiConsumer, java.util.function.Consumer)',
+			'reactor.netty.http.client.HttpClientForm#encoding(io.netty.handler.codec.http.multipart.HttpPostRequestEncoder$EncoderMode)',
+			'reactor.netty.http.client.HttpClientForm#factory(io.netty.handler.codec.http.multipart.HttpDataFactory)',
 			'reactor.netty.http.client.WebsocketClientSpec#version()',
 			'reactor.netty.http.client.WebsocketClientSpec$Builder#version(io.netty.handler.codec.http.websocketx.WebSocketVersion)',
 
@@ -312,10 +314,6 @@ task japicmp(type: JapicmpTask) {
 			'reactor.netty.http.client.HttpClient#cookiesWhen(java.lang.String, java.util.function.Function)',
 			'reactor.netty.http.client.HttpClientConfig#cookieEncoder()',
 			'reactor.netty.http.client.HttpClientConfig#cookieDecoder()'
-	]
-	classExcludes = [
-			// Changes related to Netty 5 package change
-			'reactor.netty.http.client.HttpClientForm'
 	]
 }
 

--- a/reactor-netty5-http/build.gradle
+++ b/reactor-netty5-http/build.gradle
@@ -138,7 +138,6 @@ dependencies {
 	testImplementation "io.micrometer:micrometer-test:$micrometerVersion"
 	testImplementation "io.micrometer:micrometer-tracing-integration-test:$micrometerTracingVersion"
 	testImplementation "io.netty.contrib:netty-codec-extras:$nettyContribVersion"
-	testImplementation "io.netty.contrib:netty-codec-multipart:$nettyContribMultipartVersion"
 	testImplementation "org.reflections:reflections:$reflectionsVersion"
 
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"
@@ -279,6 +278,10 @@ task japicmp(type: JapicmpTask) {
 			'reactor.netty.http.client.HttpClientRequest#headers(io.netty.handler.codec.http.HttpHeaders)',
 			'reactor.netty.http.client.HttpClientResponse#responseHeaders()',
 			'reactor.netty.http.client.HttpClientResponse#status()',
+			'reactor.netty.http.client.HttpClient$RequestSender#sendForm(java.util.function.BiConsumer)',
+			'reactor.netty.http.client.HttpClient$RequestSender#sendForm(java.util.function.BiConsumer, java.util.function.Consumer)',
+			'reactor.netty.http.server.HttpServerRequest#receiveForm()',
+			'reactor.netty.http.server.HttpServerRequest#receiveForm(java.util.function.Consumer)',
 			'reactor.netty.http.client.WebsocketClientSpec#version()',
 			'reactor.netty.http.client.WebsocketClientSpec$Builder#version(io.netty.handler.codec.http.websocketx.WebSocketVersion)',
 
@@ -309,6 +312,10 @@ task japicmp(type: JapicmpTask) {
 			'reactor.netty.http.client.HttpClient#cookiesWhen(java.lang.String, java.util.function.Function)',
 			'reactor.netty.http.client.HttpClientConfig#cookieEncoder()',
 			'reactor.netty.http.client.HttpClientConfig#cookieDecoder()'
+	]
+	classExcludes = [
+			// Changes related to Netty 5 package change
+			'reactor.netty.http.client.HttpClientForm'
 	]
 }
 

--- a/reactor-netty5-http/build.gradle
+++ b/reactor-netty5-http/build.gradle
@@ -278,8 +278,6 @@ task japicmp(type: JapicmpTask) {
 			'reactor.netty.http.client.HttpClientRequest#headers(io.netty.handler.codec.http.HttpHeaders)',
 			'reactor.netty.http.client.HttpClientResponse#responseHeaders()',
 			'reactor.netty.http.client.HttpClientResponse#status()',
-			'reactor.netty.http.client.HttpClient$RequestSender#sendForm(java.util.function.BiConsumer)',
-			'reactor.netty.http.client.HttpClient$RequestSender#sendForm(java.util.function.BiConsumer, java.util.function.Consumer)',
 			'reactor.netty.http.client.HttpClientForm#encoding(io.netty.handler.codec.http.multipart.HttpPostRequestEncoder$EncoderMode)',
 			'reactor.netty.http.client.HttpClientForm#factory(io.netty.handler.codec.http.multipart.HttpDataFactory)',
 			'reactor.netty.http.client.WebsocketClientSpec#version()',

--- a/reactor-netty5-http/build.gradle
+++ b/reactor-netty5-http/build.gradle
@@ -62,6 +62,7 @@ dependencies {
 	api "io.netty:netty5-codec-http:$nettyVersion"
 	api "io.netty:netty5-codec-http2:$nettyVersion"
 	api "io.netty:netty5-resolver-dns:$nettyVersion"
+	api "io.netty.contrib:netty-codec-multipart:$nettyContribVersion"
 	// MacOS binaries are not available for Netty SNAPSHOT version
 	if (!"$nettyVersion".endsWithAny("SNAPSHOT")) {
 		if (osdetector.classifier == "osx-x86_64" || osdetector.classifier == "osx-aarch_64") {
@@ -137,6 +138,7 @@ dependencies {
 	testImplementation "io.micrometer:micrometer-test:$micrometerVersion"
 	testImplementation "io.micrometer:micrometer-tracing-integration-test:$micrometerTracingVersion"
 	testImplementation "io.netty.contrib:netty-codec-extras:$nettyContribVersion"
+	testImplementation "io.netty.contrib:netty-codec-multipart:$nettyContribVersion"
 	testImplementation "org.reflections:reflections:$reflectionsVersion"
 
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"
@@ -258,14 +260,6 @@ task japicmp(type: JapicmpTask) {
 			'reactor.netty.http.server.HttpServer#tcpConfiguration(java.util.function.Function)',
 			'reactor.netty.http.server.logging.AccessLogArgProvider#zonedDateTime()',
 
-			// TODO temporary disable multipart on the client
-			'reactor.netty.http.client.HttpClient$RequestSender#sendForm(java.util.function.BiConsumer)',
-			'reactor.netty.http.client.HttpClient$RequestSender#sendForm(java.util.function.BiConsumer, java.util.function.Consumer)',
-
-			// TODO temporary disable multipart on the server
-			'reactor.netty.http.server.HttpServerRequest#receiveForm()',
-			'reactor.netty.http.server.HttpServerRequest#receiveForm(java.util.function.Consumer)',
-
 			// Changes related to Netty 5 package change
 			'reactor.netty.http.HttpInfos#method()',
 			'reactor.netty.http.HttpInfos#version()',
@@ -315,10 +309,6 @@ task japicmp(type: JapicmpTask) {
 			'reactor.netty.http.client.HttpClient#cookiesWhen(java.lang.String, java.util.function.Function)',
 			'reactor.netty.http.client.HttpClientConfig#cookieEncoder()',
 			'reactor.netty.http.client.HttpClientConfig#cookieDecoder()'
-	]
-	classExcludes = [
-			// TODO temporary disable multipart on the client
-			'reactor.netty.http.client.HttpClientForm'
 	]
 }
 

--- a/reactor-netty5-http/build.gradle
+++ b/reactor-netty5-http/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 	api "io.netty:netty5-codec-http:$nettyVersion"
 	api "io.netty:netty5-codec-http2:$nettyVersion"
 	api "io.netty:netty5-resolver-dns:$nettyVersion"
-	api "io.netty.contrib:netty-codec-multipart:$nettyContribVersion"
+	api "io.netty.contrib:netty-codec-multipart:$nettyContribMultipartVersion"
 	// MacOS binaries are not available for Netty SNAPSHOT version
 	if (!"$nettyVersion".endsWithAny("SNAPSHOT")) {
 		if (osdetector.classifier == "osx-x86_64" || osdetector.classifier == "osx-aarch_64") {
@@ -138,7 +138,7 @@ dependencies {
 	testImplementation "io.micrometer:micrometer-test:$micrometerVersion"
 	testImplementation "io.micrometer:micrometer-tracing-integration-test:$micrometerTracingVersion"
 	testImplementation "io.netty.contrib:netty-codec-extras:$nettyContribVersion"
-	testImplementation "io.netty.contrib:netty-codec-multipart:$nettyContribVersion"
+	testImplementation "io.netty.contrib:netty-codec-multipart:$nettyContribMultipartVersion"
 	testImplementation "org.reflections:reflections:$reflectionsVersion"
 
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"

--- a/reactor-netty5-http/build.gradle
+++ b/reactor-netty5-http/build.gradle
@@ -280,8 +280,6 @@ task japicmp(type: JapicmpTask) {
 			'reactor.netty.http.client.HttpClientResponse#status()',
 			'reactor.netty.http.client.HttpClient$RequestSender#sendForm(java.util.function.BiConsumer)',
 			'reactor.netty.http.client.HttpClient$RequestSender#sendForm(java.util.function.BiConsumer, java.util.function.Consumer)',
-			'reactor.netty.http.server.HttpServerRequest#receiveForm()',
-			'reactor.netty.http.server.HttpServerRequest#receiveForm(java.util.function.Consumer)',
 			'reactor.netty.http.client.WebsocketClientSpec#version()',
 			'reactor.netty.http.client.WebsocketClientSpec$Builder#version(io.netty.handler.codec.http.websocketx.WebSocketVersion)',
 
@@ -298,6 +296,8 @@ task japicmp(type: JapicmpTask) {
 			'reactor.netty.http.server.HttpServerResponse#status()',
 			'reactor.netty.http.server.HttpServerResponse#status(io.netty.handler.codec.http.HttpResponseStatus)',
 			'reactor.netty.http.server.ServerCookies#newServerRequestHolder(io.netty.handler.codec.http.HttpHeaders, io.netty.handler.codec.http.cookie.ServerCookieDecoder)',
+			'reactor.netty.http.server.HttpServerRequest#receiveForm()',
+			'reactor.netty.http.server.HttpServerRequest#receiveForm(java.util.function.Consumer)',
 
 			'reactor.netty.http.server.logging.AccessLogHandlerFactory#create(java.util.function.Function)',
 

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClient.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClient.java
@@ -184,6 +184,50 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 * @return a new {@link ResponseReceiver}
 		 */
 		ResponseReceiver<?> send(BiFunction<? super HttpClientRequest, ? super NettyOutbound, ? extends Publisher<Void>> sender);
+
+		/**
+		 * Prepare to send an HTTP Form including Multipart encoded Form which support
+		 * chunked file upload. It will by default be encoded as Multipart but can be
+		 * adapted via {@link HttpClientForm#multipart(boolean)}.
+		 *
+		 * <p><strong>Note:</strong> The HTTP Form passed in will be invoked also for redirect requests
+		 * when {@code followRedirect} is enabled. If you need to control what will be sent when
+		 * {@code followRedirect} is enabled use {@link HttpClientRequest#redirectedFrom()} to check the original
+		 * and any number of subsequent redirect(s), including the one that is in progress.
+		 * <p><strong>Note:</strong> For redirect requests, sensitive headers
+		 * {@link #followRedirect(boolean, Consumer) followRedirect} are removed
+		 * from the initialized request when redirecting to a different domain, they can be re-added globally via
+		 * {@link #followRedirect(boolean, Consumer)}/{@link #followRedirect(BiPredicate, Consumer)}.
+		 *
+		 * @param formCallback called when form generator is created
+		 *
+		 * @return a new {@link ResponseReceiver}
+		 */
+		default ResponseReceiver<?> sendForm(BiConsumer<? super HttpClientRequest, HttpClientForm> formCallback) {
+			return sendForm(formCallback, null);
+		}
+
+		/**
+		 * Prepare to send an HTTP Form including Multipart encoded Form which support
+		 * chunked file upload. It will by default be encoded as Multipart but can be
+		 * adapted via {@link HttpClientForm#multipart(boolean)}.
+		 *
+		 * <p><strong>Note:</strong> The HTTP Form passed in will be invoked also for redirect requests
+		 * when {@code followRedirect} is enabled. If you need to control what will be sent when
+		 * {@code followRedirect} is enabled use {@link HttpClientRequest#redirectedFrom()} to check the original
+		 * and any number of subsequent redirect(s), including the one that is in progress.
+		 * <p><strong>Note:</strong> For redirect requests, sensitive headers
+		 * {@link #followRedirect(boolean, Consumer) followRedirect} are removed
+		 * from the initialized request when redirecting to a different domain, they can be re-added globally via
+		 * {@link #followRedirect(boolean, Consumer)}/{@link #followRedirect(BiPredicate, Consumer)}.
+		 *
+		 * @param formCallback called when form generator is created
+		 * @param progress called after form is being sent and passed with a {@link Flux} of the latest in-flight or uploaded bytes
+		 *
+		 * @return a new {@link ResponseReceiver}
+		 */
+		ResponseReceiver<?> sendForm(BiConsumer<? super HttpClientRequest, HttpClientForm> formCallback,
+				@Nullable Consumer<Flux<Long>> progress);
 	}
 
 	/**

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientFinalizer.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientFinalizer.java
@@ -17,7 +17,9 @@ package reactor.netty5.http.client;
 
 import java.net.URI;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import io.netty5.buffer.Buffer;
@@ -31,7 +33,7 @@ import reactor.netty5.BufferMono;
 import reactor.netty5.Connection;
 import reactor.netty5.NettyOutbound;
 import reactor.netty5.channel.ChannelOperations;
-
+import reactor.util.annotation.Nullable;
 import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 
 /**
@@ -134,6 +136,15 @@ final class HttpClientFinalizer extends HttpClientConnect implements HttpClient.
 	public HttpClientFinalizer send(Publisher<? extends Buffer> requestBody) {
 		Objects.requireNonNull(requestBody, "requestBody");
 		return send((req, out) -> out.send(requestBody));
+	}
+
+	@Override
+	public HttpClientFinalizer sendForm(BiConsumer<? super HttpClientRequest, HttpClientForm> formCallback, @Nullable Consumer<Flux<Long>> progress) {
+		Objects.requireNonNull(formCallback, "formCallback");
+		return send((req, out) -> {
+			HttpClientOperations ops = (HttpClientOperations) out;
+			return new HttpClientOperations.SendForm(ops, formCallback, progress);
+		});
 	}
 
 	@Override

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientFinalizer.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientFinalizer.java
@@ -34,6 +34,7 @@ import reactor.netty5.Connection;
 import reactor.netty5.NettyOutbound;
 import reactor.netty5.channel.ChannelOperations;
 import reactor.util.annotation.Nullable;
+
 import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 
 /**

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientForm.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientForm.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2017-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty5.http.client;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
+import io.netty.contrib.handler.codec.http.multipart.HttpDataFactory;
+import io.netty.contrib.handler.codec.http.multipart.HttpPostRequestEncoder;
+import reactor.util.annotation.Nullable;
+
+/**
+ * An HTTP Form builder
+ */
+public interface HttpClientForm {
+
+	/**
+	 * Add an HTTP Form attribute
+	 *
+	 * @param name Attribute name
+	 * @param value Attribute value
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm attr(String name, String value);
+
+	/**
+	 * Set the Form {@link Charset}
+	 *
+	 * @param charset form charset
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm charset(Charset charset);
+
+	/**
+	 * Should file attributes be cleaned and eventually removed from disk.
+	 * Default to false.
+	 *
+	 * @param clean true if cleaned on termination (successful or failed)
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm cleanOnTerminate(boolean clean);
+
+	/**
+	 * Set Form encoding
+	 *
+	 * @param mode the encoding mode for this form encoding
+	 * @return this builder
+	 */
+	HttpClientForm encoding(HttpPostRequestEncoder.EncoderMode mode);
+
+	/**
+	 * Set Upload factories (allows memory threshold configuration)
+	 *
+	 * @param factory the new {@link HttpDataFactory} to use
+	 * @return this builder
+	 */
+	HttpClientForm factory(HttpDataFactory factory);
+
+	/**
+	 * Add an HTTP File Upload attribute
+	 *
+	 * @param name File name
+	 * @param file File reference
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm file(String name, File file);
+
+	/**
+	 * Add an HTTP File Upload attribute
+	 *
+	 * @param name File name
+	 * @param stream File content as InputStream
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm file(String name, InputStream stream);
+
+	/**
+	 * Add an HTTP File Upload attribute
+	 *
+	 * @param name File name
+	 * @param file File reference
+	 * @param contentType File mime-type
+	 *
+	 * @return this builder
+	 */
+	default HttpClientForm file(String name, File file, @Nullable String contentType) {
+		return file(name, file.getName(), file, contentType);
+	}
+
+	/**
+	 * Add an HTTP File Upload attribute
+	 *
+	 * @param name File name
+	 * @param filename File name to override origin name
+	 * @param file File reference
+	 * @param contentType File mime-type
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm file(String name, String filename, File file, @Nullable String contentType);
+
+	/**
+	 * Add an HTTP File Upload attribute
+	 *
+	 * @param name File name
+	 * @param stream File content as InputStream
+	 * @param contentType File mime-type
+	 *
+	 * @return this builder
+	 */
+	default HttpClientForm file(String name, InputStream stream, @Nullable String contentType) {
+		return file(name, "", stream, contentType);
+	}
+
+	/**
+	 * Add an HTTP File Upload attribute
+	 *
+	 * @param name File name
+	 * @param filename File name to override origin name
+	 * @param stream File content as InputStream
+	 * @param contentType File mime-type
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm file(String name, String filename, InputStream stream, @Nullable String contentType);
+
+	/**
+	 * Add an HTTP File Upload attribute
+	 *
+	 * @param name File name
+	 * @param files File references
+	 * @param contentTypes File mime-types in the same order than file references
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm files(String name, File[] files, String[] contentTypes);
+
+	/**
+	 * Add an HTTP File Upload attribute
+	 *
+	 * @param name File name
+	 * @param files File references
+	 * @param contentTypes File mime-type in the same order than file references
+	 * @param textFiles Plain-Text transmission in the same order than file references
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm files(String name, File[] files, String[] contentTypes, boolean[] textFiles);
+
+	/**
+	 * Define if this request will be encoded as Multipart
+	 *
+	 * @param multipart should this form be encoded as Multipart
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm multipart(boolean multipart);
+
+	/**
+	 * Add an HTTP File Upload attribute for a text file.
+	 *
+	 * @param name Text file name
+	 * @param file Text File reference
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm textFile(String name, File file);
+
+	/**
+	 * Add an HTTP File Upload attribute for a text file.
+	 *
+	 * @param name Text file name
+	 * @param stream Text file content as InputStream
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm textFile(String name, InputStream stream);
+
+	/**
+	 * Add an HTTP File Upload attribute for a text file.
+	 *
+	 * @param name Text file name
+	 * @param file Text File reference
+	 * @param contentType Text file mime-type
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm textFile(String name, File file, @Nullable String contentType);
+
+	/**
+	 * Add an HTTP File Upload attribute for a text file.
+	 *
+	 * @param name Text file name
+	 * @param inputStream Text file content as InputStream
+	 * @param contentType Text file mime-type
+	 *
+	 * @return this builder
+	 */
+	HttpClientForm textFile(String name, InputStream inputStream, @Nullable String contentType);
+}

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientFormEncoder.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientFormEncoder.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.buffer.BufferAllocator;
 import io.netty5.handler.codec.http.HttpContent;
 import io.netty5.handler.codec.http.HttpRequest;
 import io.netty.contrib.handler.codec.http.multipart.DiskAttribute;

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientFormEncoder.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientFormEncoder.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty5.http.client;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.handler.codec.http.HttpContent;
+import io.netty5.handler.codec.http.HttpRequest;
+import io.netty.contrib.handler.codec.http.multipart.DiskAttribute;
+import io.netty.contrib.handler.codec.http.multipart.DiskFileUpload;
+import io.netty.contrib.handler.codec.http.multipart.FileUpload;
+import io.netty.contrib.handler.codec.http.multipart.HttpDataFactory;
+import io.netty.contrib.handler.codec.http.multipart.HttpPostRequestEncoder;
+import io.netty.contrib.handler.codec.http.multipart.MemoryFileUpload;
+import io.netty5.handler.stream.ChunkedInput;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Sinks;
+import reactor.util.annotation.Nullable;
+
+/**
+ * Modified {@link io.netty.contrib.handler.codec.http.multipart.HttpPostRequestEncoder} for
+ * optional filename and builder support
+ * <p>
+ * This encoder will help to encode Request for a FORM as POST.
+ */
+final class HttpClientFormEncoder extends HttpPostRequestEncoder
+		implements ChunkedInput<HttpContent>, Runnable, HttpClientForm {
+
+	final Sinks.Many<Long> progressSink;
+	final HttpRequest request;
+
+	boolean         needNewEncoder;
+	HttpDataFactory newFactory;
+	boolean         cleanOnTerminate;
+	Charset         newCharset;
+	boolean         newMultipart;
+	EncoderMode     newMode;
+
+	/**
+	 * @param factory the factory used to create InterfaceHttpData
+	 * @param request the request to encode
+	 * @param multipart True if the FORM is a ENCTYPE="multipart/form-data"
+	 * @param charset the charset to use as default
+	 * @param encoderMode the mode for the encoder to use. See {@link EncoderMode} for the
+	 * details.
+	 *
+	 * @throws NullPointerException      for request or charset or factory
+	 * @throws ErrorDataEncoderException if the request is not a POST
+	 */
+	HttpClientFormEncoder(HttpDataFactory factory,
+			HttpRequest request,
+			boolean multipart,
+			Charset charset,
+			EncoderMode encoderMode) throws ErrorDataEncoderException {
+		super(factory, request, multipart, charset, encoderMode);
+		this.newCharset = charset;
+		this.request = request;
+		this.cleanOnTerminate = true;
+		this.progressSink = Sinks.many().unicast().onBackpressureError();
+		this.newMode = encoderMode;
+		this.newFactory = factory;
+		this.newMultipart = multipart;
+	}
+
+	@Override
+	public HttpContent readChunk(BufferAllocator allocator) throws Exception {
+		HttpContent c = super.readChunk(allocator);
+		if (c == null) {
+			progressSink.emitComplete(Sinks.EmitFailureHandler.FAIL_FAST);
+		}
+		else {
+			progressSink.emitNext(progress(), Sinks.EmitFailureHandler.FAIL_FAST);
+			if (isEndOfInput()) {
+				progressSink.emitComplete(Sinks.EmitFailureHandler.FAIL_FAST);
+			}
+		}
+		return c;
+	}
+
+	@Override
+	public HttpClientForm attr(String name, String value) {
+		try {
+			addBodyAttribute(name, value);
+		}
+		catch (ErrorDataEncoderException e) {
+			throw Exceptions.propagate(e);
+		}
+		return this;
+	}
+
+	@Override
+	public HttpClientForm charset(Charset charset) {
+		this.newCharset = Objects.requireNonNull(charset, "charset");
+		this.needNewEncoder = true;
+		return this;
+	}
+
+	@Override
+	public HttpClientForm cleanOnTerminate(boolean clean) {
+		this.cleanOnTerminate = clean;
+		return this;
+	}
+
+	@Override
+	public HttpClientForm factory(HttpDataFactory factory) {
+		if (!getBodyListAttributes().isEmpty()) {
+			throw new IllegalStateException("Cannot set a new HttpDataFactory after " +
+					"starting appending Parts, call factory(f) at the earliest occasion" +
+					" offered");
+		}
+		this.newFactory = Objects.requireNonNull(factory, "factory");
+		this.needNewEncoder = true;
+		return this;
+	}
+
+	@Override
+	public HttpClientForm file(String name, File file) {
+		file(name, file, null);
+		return this;
+	}
+
+	@Override
+	public HttpClientForm file(String name, InputStream inputStream) {
+		file(name, inputStream, null);
+		return this;
+	}
+
+	@Override
+	public HttpClientForm file(String name,
+			String filename,
+			File file,
+			@Nullable String contentType) {
+		Objects.requireNonNull(name, "name");
+		Objects.requireNonNull(file, "file");
+		Objects.requireNonNull(filename, "filename");
+		String scontentType = contentType;
+		if (contentType == null) {
+			scontentType = DEFAULT_BINARY_CONTENT_TYPE;
+		}
+		FileUpload fileUpload = newFactory.createFileUpload(request,
+				name,
+				filename,
+				scontentType,
+				DEFAULT_TRANSFER_ENCODING,
+				null,
+				file.length());
+		try {
+			fileUpload.setContent(file);
+			addBodyHttpData(fileUpload);
+		}
+		catch (ErrorDataEncoderException e) {
+			throw Exceptions.propagate(e);
+		}
+		catch (IOException e) {
+			throw Exceptions.propagate(new ErrorDataEncoderException(e));
+		}
+		return this;
+	}
+
+	@Override
+	public HttpClientForm file(String name,
+			String filename,
+			InputStream stream,
+			@Nullable String contentType) {
+		Objects.requireNonNull(name, "name");
+		Objects.requireNonNull(stream, "stream");
+		try {
+			String scontentType = contentType;
+			if (contentType == null) {
+				scontentType = DEFAULT_BINARY_CONTENT_TYPE;
+			}
+			MemoryFileUpload fileUpload = new MemoryFileUpload(name,
+					filename,
+					scontentType,
+					DEFAULT_TRANSFER_ENCODING,
+					newCharset,
+					-1);
+			fileUpload.setMaxSize(-1);
+			fileUpload.setContent(stream);
+			addBodyHttpData(fileUpload);
+		}
+		catch (ErrorDataEncoderException e) {
+			throw Exceptions.propagate(e);
+		}
+		catch (IOException e) {
+			throw Exceptions.propagate(new ErrorDataEncoderException(e));
+		}
+		return this;
+	}
+
+	@Override
+	public HttpClientForm files(String name,
+			File[] files,
+			String[] contentTypes) {
+		for (int i = 0; i < files.length; i++) {
+			file(name, files[i], contentTypes[i]);
+		}
+		return this;
+	}
+
+	@Override
+	public HttpClientForm files(String name,
+			File[] files,
+			String[] contentTypes,
+			boolean[] textFiles) {
+		try {
+			addBodyFileUploads(name, files, contentTypes, textFiles);
+		}
+		catch (ErrorDataEncoderException e) {
+			throw Exceptions.propagate(e);
+		}
+		return this;
+	}
+
+	@Override
+	public HttpClientForm encoding(EncoderMode mode) {
+		this.newMode = Objects.requireNonNull(mode, "mode");
+		this.needNewEncoder = true;
+		return this;
+	}
+
+	@Override
+	public HttpClientForm multipart(boolean isMultipart) {
+		this.needNewEncoder = isChunked() != isMultipart;
+		this.newMultipart = isMultipart;
+		return this;
+	}
+
+	@Override
+	public HttpClientForm textFile(String name, File file) {
+		textFile(name, file, null);
+		return this;
+	}
+
+	@Override
+	public HttpClientForm textFile(String name, File file, @Nullable String contentType) {
+		try {
+			addBodyFileUpload(name, file, contentType, true);
+		}
+		catch (ErrorDataEncoderException e) {
+			throw Exceptions.propagate(e);
+		}
+		return this;
+	}
+
+	@Override
+	public HttpClientForm textFile(String name, InputStream stream) {
+		textFile(name, stream, null);
+		return this;
+	}
+
+	@Override
+	public HttpClientForm textFile(String name,
+			InputStream stream,
+			@Nullable String contentType) {
+		Objects.requireNonNull(name, "name");
+		Objects.requireNonNull(stream, "stream");
+		try {
+			String scontentType = contentType;
+
+			if (contentType == null) {
+				scontentType = DEFAULT_TEXT_CONTENT_TYPE;
+			}
+
+			MemoryFileUpload fileUpload =
+					new MemoryFileUpload(name, "", scontentType, null, newCharset, -1);
+			fileUpload.setMaxSize(-1);
+			fileUpload.setContent(stream);
+			addBodyHttpData(fileUpload);
+		}
+		catch (ErrorDataEncoderException e) {
+			throw Exceptions.propagate(e);
+		}
+		catch (IOException e) {
+			throw Exceptions.propagate(new ErrorDataEncoderException(e));
+		}
+		return this;
+	}
+
+	@Override
+	public void run() {
+		cleanFiles();
+	}
+
+	final HttpClientFormEncoder applyChanges(HttpRequest request) {
+		if (!needNewEncoder) {
+			return this;
+		}
+
+		try {
+			HttpClientFormEncoder encoder = new HttpClientFormEncoder(newFactory,
+					request,
+					newMultipart,
+					newCharset,
+					newMode);
+
+			encoder.setBodyHttpDatas(getBodyListAttributes());
+
+			needNewEncoder = false;
+
+			return encoder;
+		}
+		catch (ErrorDataEncoderException ee) {
+			throw Exceptions.propagate(ee);
+		}
+	}
+
+	static final Map<Pattern, String> percentEncodings            = new HashMap<>();
+	static final String               DEFAULT_BINARY_CONTENT_TYPE =
+			"application/octet-stream";
+	static final String               DEFAULT_TRANSFER_ENCODING   = "binary";
+	static final String               DEFAULT_TEXT_CONTENT_TYPE   = "text/plain";
+
+	static {
+		DiskFileUpload.deleteOnExitTemporaryFile = true; // should delete file
+		// on exit (in normal
+		// exit)
+		DiskFileUpload.baseDirectory = null; // system temp directory
+		DiskAttribute.deleteOnExitTemporaryFile = true; // should delete file on
+		// exit (in normal exit)
+		DiskAttribute.baseDirectory = null; // system temp directory
+
+		percentEncodings.put(Pattern.compile("\\*"), "%2A");
+		percentEncodings.put(Pattern.compile("\\+"), "%20");
+		percentEncodings.put(Pattern.compile("%7E"), "~");
+	}
+}

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientFormEncoder.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientFormEncoder.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
+import io.netty.contrib.handler.codec.http.multipart.InterfaceHttpData;
 import io.netty5.buffer.BufferAllocator;
 import io.netty5.handler.codec.http.HttpContent;
 import io.netty5.handler.codec.http.HttpRequest;
@@ -302,6 +303,12 @@ final class HttpClientFormEncoder extends HttpPostRequestEncoder
 	@Override
 	public void run() {
 		cleanFiles();
+		// Clean list of all InterfaceHttpData from body part
+		for (InterfaceHttpData bodyAttribute : getBodyListAttributes()) {
+			if (bodyAttribute.isAccessible()) {
+				bodyAttribute.close();
+			}
+		}
 	}
 
 	final HttpClientFormEncoder applyChanges(HttpRequest request) {

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientFormEncoder.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientFormEncoder.java
@@ -44,8 +44,9 @@ import reactor.util.annotation.Nullable;
  * <p>
  * This encoder will help to encode Request for a FORM as POST.
  */
+@SuppressWarnings("try")
 final class HttpClientFormEncoder extends HttpPostRequestEncoder
-		implements ChunkedInput<HttpContent>, Runnable, HttpClientForm {
+		implements ChunkedInput<HttpContent<?>>, Runnable, HttpClientForm {
 
 	final Sinks.Many<Long> progressSink;
 	final HttpRequest request;
@@ -84,8 +85,8 @@ final class HttpClientFormEncoder extends HttpPostRequestEncoder
 	}
 
 	@Override
-	public HttpContent readChunk(BufferAllocator allocator) throws Exception {
-		HttpContent c = super.readChunk(allocator);
+	public HttpContent<?> readChunk(BufferAllocator allocator) throws Exception {
+		HttpContent<?> c = super.readChunk(allocator);
 		if (c == null) {
 			progressSink.emitComplete(Sinks.EmitFailureHandler.FAIL_FAST);
 		}

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientOperations.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientOperations.java
@@ -858,9 +858,6 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 					HttpUtil.setContentLength(r, encoder.length());
 				}
 
-				Mono<Void> mono = Mono.fromCompletionStage(parent.channel()
-				                        .writeAndFlush(r).asStage());
-
 				if (encoder.isChunked()) {
 					Flux<Long> tail = encoder.progressSink.asFlux().onBackpressureLatest();
 
@@ -879,6 +876,9 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 					      .writeAndFlush(encoder);
 				}
 				else {
+					Mono<Void> mono = Mono.fromCompletionStage(parent.channel()
+							.writeAndFlush(r).asStage());
+
 					if (encoder.cleanOnTerminate) {
 						mono = mono.doOnCancel(encoder)
 						           .doAfterTerminate(encoder);

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientOperations.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientOperations.java
@@ -828,7 +828,6 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 			}
 		}
 
-		@SuppressWarnings("FutureReturnValueIgnored")
 		void _subscribe(CoreSubscriber<? super Void> s) {
 			HttpDataFactory df = DEFAULT_FACTORY;
 
@@ -848,7 +847,6 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 					parent.requestHeaders.remove(HttpHeaderNames.TRANSFER_ENCODING);
 				}
 
-				// Returned value is deliberately ignored
 				parent.addHandlerFirst(NettyPipeline.ChunkedWriter, new ChunkedWriteHandler());
 
 				boolean chunked = HttpUtil.isTransferEncodingChunked(parent.nettyRequest);
@@ -877,7 +875,6 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 					else {
 						tail.subscribe();
 					}
-					//"FutureReturnValueIgnored" this is deliberate
 					parent.channel()
 					      .writeAndFlush(encoder);
 				}

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerFormDecoderProvider.java
@@ -15,6 +15,15 @@
  */
 package reactor.netty5.http.server;
 
+import io.netty.contrib.handler.codec.http.multipart.HttpDataFactory;
+import io.netty.contrib.handler.codec.http.multipart.HttpPostMultipartRequestDecoder;
+import io.netty.contrib.handler.codec.http.multipart.HttpPostStandardRequestDecoder;
+import io.netty.contrib.handler.codec.http.multipart.InterfaceHttpData;
+import io.netty.contrib.handler.codec.http.multipart.InterfaceHttpPostRequestDecoder;
+import io.netty.contrib.handler.codec.http.multipart.DefaultHttpDataFactory;
+import io.netty.contrib.handler.codec.http.multipart.HttpData;
+import io.netty.contrib.handler.codec.http.multipart.Attribute;
+import io.netty.contrib.handler.codec.http.multipart.FileUpload;
 import io.netty5.handler.codec.http.HttpRequest;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
@@ -25,6 +34,8 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -223,23 +234,51 @@ public final class HttpServerFormDecoderProvider {
 	}
 
 	Mono<ReactorNettyHttpPostRequestDecoder> newHttpPostRequestDecoder(HttpRequest request, boolean isMultipart) {
-		return null;
+		if (maxInMemorySize > -1) {
+			Mono<Path> directoryMono;
+			if (baseDirectory == null) {
+				directoryMono = defaultTempDirectory();
+			}
+			else {
+				directoryMono = Mono.just(baseDirectory);
+			}
+			return directoryMono.map(directory -> createNewHttpPostRequestDecoder(request, isMultipart, directory));
+		}
+		else {
+			return Mono.just(createNewHttpPostRequestDecoder(request, isMultipart, null));
+		}
+	}
+
+	ReactorNettyHttpPostRequestDecoder createNewHttpPostRequestDecoder(HttpRequest request, boolean isMultipart,
+			@Nullable Path baseDirectory) {
+		DefaultHttpDataFactory factory = maxInMemorySize > 0 ?
+				new DefaultHttpDataFactory(maxInMemorySize, charset) :
+				new DefaultHttpDataFactory(maxInMemorySize == 0, charset);
+		factory.setMaxLimit(maxSize);
+		if (baseDirectory != null) {
+			factory.setBaseDir(baseDirectory.toFile().getAbsolutePath());
+		}
+		return isMultipart ?
+				new ReactorNettyHttpPostMultipartRequestDecoder(factory, request) :
+				new ReactorNettyHttpPostStandardRequestDecoder(factory, request);
 	}
 
 	static final HttpServerFormDecoderProvider DEFAULT_FORM_DECODER_SPEC = new HttpServerFormDecoderProvider.Build().build();
 
 	static final String DEFAULT_TEMP_DIRECTORY_PREFIX = "RN_form_";
 
-	interface ReactorNettyHttpPostRequestDecoder {
+	interface ReactorNettyHttpPostRequestDecoder extends InterfaceHttpPostRequestDecoder {
 
 		void cleanCurrentHttpData(boolean onlyCompleted);
+
+		List<HttpData> currentHttpData(boolean onlyCompleted);
 	}
 
 	static final class Build implements Builder {
 
 		static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
-		static final long DEFAULT_MAX_IN_MEMORY_SIZE = 0; // DefaultHttpDataFactory.MINSIZE;
-		static final long DEFAULT_MAX_SIZE = 0; // DefaultHttpDataFactory.MAXSIZE;
+		static final long DEFAULT_MAX_IN_MEMORY_SIZE = DefaultHttpDataFactory.MINSIZE;
+		static final long DEFAULT_MAX_SIZE = DefaultHttpDataFactory.MAXSIZE;
 		static final Scheduler DEFAULT_SCHEDULER = Schedulers.boundedElastic();
 		static final boolean DEFAULT_STREAMING = false;
 
@@ -294,6 +333,122 @@ public final class HttpServerFormDecoderProvider {
 
 		HttpServerFormDecoderProvider build() {
 			return new HttpServerFormDecoderProvider(this);
+		}
+	}
+
+	static final class ReactorNettyHttpPostMultipartRequestDecoder extends HttpPostMultipartRequestDecoder
+			implements ReactorNettyHttpPostRequestDecoder {
+
+		/**
+		 * Current {@link HttpData} from the body (only the completed {@link HttpData}).
+		 */
+		final List<HttpData> currentCompletedHttpData = new ArrayList<>();
+
+		ReactorNettyHttpPostMultipartRequestDecoder(HttpDataFactory factory, HttpRequest request) {
+			super(factory, request);
+		}
+
+		@Override
+		protected void addHttpData(InterfaceHttpData data) {
+			if (data instanceof HttpData) {
+				currentCompletedHttpData.add((HttpData) data);
+			}
+		}
+
+		@Override
+		public void cleanCurrentHttpData(boolean onlyCompleted) {
+			for (HttpData data : currentCompletedHttpData) {
+				removeHttpDataFromClean(data);
+				data.close();
+			}
+			currentCompletedHttpData.clear();
+
+			if (!onlyCompleted) {
+				InterfaceHttpData partial = currentPartialHttpData();
+				if (partial instanceof HttpData) {
+					((HttpData) partial).delete();
+				}
+			}
+		}
+
+		@Override
+		public List<HttpData> currentHttpData(boolean onlyCompleted) {
+			if (!onlyCompleted) {
+				InterfaceHttpData partial = currentPartialHttpData();
+				if (partial instanceof HttpData) {
+					HttpData partialData = (HttpData) partial;
+					currentCompletedHttpData.add(partialData.replace(partialData.content().split()));
+				}
+			}
+
+			return currentCompletedHttpData;
+		}
+
+		@Override
+		public void destroy() {
+			super.destroy();
+			InterfaceHttpData partial = currentPartialHttpData();
+			if (partial != null && partial.isAccessible()) {
+				partial.close();
+			}
+		}
+	}
+
+	static final class ReactorNettyHttpPostStandardRequestDecoder extends HttpPostStandardRequestDecoder
+			implements ReactorNettyHttpPostRequestDecoder {
+
+		/**
+		 * Current {@link HttpData} from the body (only the completed {@link HttpData}).
+		 */
+		final List<HttpData> currentCompletedHttpData = new ArrayList<>();
+
+		ReactorNettyHttpPostStandardRequestDecoder(HttpDataFactory factory, HttpRequest request) {
+			super(factory, request);
+		}
+
+		@Override
+		protected void addHttpData(InterfaceHttpData data) {
+			if (data instanceof HttpData) {
+				currentCompletedHttpData.add((HttpData) data);
+			}
+		}
+
+		@Override
+		public void cleanCurrentHttpData(boolean onlyCompleted) {
+			for (HttpData data : currentCompletedHttpData) {
+				removeHttpDataFromClean(data);
+				data.close();
+			}
+			currentCompletedHttpData.clear();
+
+			if (!onlyCompleted) {
+				InterfaceHttpData partial = currentPartialHttpData();
+				if (partial instanceof HttpData) {
+					((HttpData) partial).delete();
+				}
+			}
+		}
+
+		@Override
+		public List<HttpData> currentHttpData(boolean onlyCompleted) {
+			if (!onlyCompleted) {
+				InterfaceHttpData partial = currentPartialHttpData();
+				if (partial instanceof HttpData) {
+					HttpData partialData = (HttpData) partial;
+					currentCompletedHttpData.add(partialData.replace(partialData.content().split()));
+				}
+			}
+
+			return currentCompletedHttpData;
+		}
+
+		@Override
+		public void destroy() {
+			super.destroy();
+			InterfaceHttpData partial = currentPartialHttpData();
+			if (partial != null && partial.isAccessible()) {
+				partial.close();
+			}
 		}
 	}
 }

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerFormDecoderProvider.java
@@ -376,8 +376,7 @@ public final class HttpServerFormDecoderProvider {
 			if (!onlyCompleted) {
 				InterfaceHttpData partial = currentPartialHttpData();
 				if (partial instanceof HttpData partialData) {
-					partialData.usingContent(partialContent ->
-							currentCompletedHttpData.add(partialData.replace(partialContent.split())));
+					currentCompletedHttpData.add(partialData.copy());
 				}
 			}
 
@@ -434,8 +433,7 @@ public final class HttpServerFormDecoderProvider {
 			if (!onlyCompleted) {
 				InterfaceHttpData partial = currentPartialHttpData();
 				if (partial instanceof HttpData partialData) {
-					partialData.usingContent(partialContent ->
-							currentCompletedHttpData.add(partialData.replace(partialContent.split())));
+					currentCompletedHttpData.add(partialData.copy());
 				}
 			}
 

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerFormDecoderProvider.java
@@ -388,7 +388,7 @@ public final class HttpServerFormDecoderProvider {
 		public void destroy() {
 			super.destroy();
 			InterfaceHttpData partial = currentPartialHttpData();
-			if (partial != null && partial.isAccessible()) {
+			if (partial != null) {
 				partial.close();
 			}
 		}
@@ -446,7 +446,7 @@ public final class HttpServerFormDecoderProvider {
 		public void destroy() {
 			super.destroy();
 			InterfaceHttpData partial = currentPartialHttpData();
-			if (partial != null && partial.isAccessible()) {
+			if (partial != null) {
 				partial.close();
 			}
 		}

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerFormDecoderProvider.java
@@ -376,7 +376,8 @@ public final class HttpServerFormDecoderProvider {
 			if (!onlyCompleted) {
 				InterfaceHttpData partial = currentPartialHttpData();
 				if (partial instanceof HttpData partialData) {
-					currentCompletedHttpData.add(partialData.replace(partialData.content().split()));
+					partialData.usingContent(partialContent ->
+							currentCompletedHttpData.add(partialData.replace(partialContent.split())));
 				}
 			}
 
@@ -433,7 +434,8 @@ public final class HttpServerFormDecoderProvider {
 			if (!onlyCompleted) {
 				InterfaceHttpData partial = currentPartialHttpData();
 				if (partial instanceof HttpData partialData) {
-					currentCompletedHttpData.add(partialData.replace(partialData.content().split()));
+					partialData.usingContent(partialContent ->
+							currentCompletedHttpData.add(partialData.replace(partialContent.split())));
 				}
 			}
 

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerFormDecoderProvider.java
@@ -350,8 +350,8 @@ public final class HttpServerFormDecoderProvider {
 
 		@Override
 		protected void addHttpData(InterfaceHttpData data) {
-			if (data instanceof HttpData) {
-				currentCompletedHttpData.add((HttpData) data);
+			if (data instanceof HttpData httpData) {
+				currentCompletedHttpData.add(httpData);
 			}
 		}
 
@@ -365,8 +365,8 @@ public final class HttpServerFormDecoderProvider {
 
 			if (!onlyCompleted) {
 				InterfaceHttpData partial = currentPartialHttpData();
-				if (partial instanceof HttpData) {
-					((HttpData) partial).delete();
+				if (partial instanceof HttpData partialData) {
+					partialData.delete();
 				}
 			}
 		}
@@ -375,8 +375,7 @@ public final class HttpServerFormDecoderProvider {
 		public List<HttpData> currentHttpData(boolean onlyCompleted) {
 			if (!onlyCompleted) {
 				InterfaceHttpData partial = currentPartialHttpData();
-				if (partial instanceof HttpData) {
-					HttpData partialData = (HttpData) partial;
+				if (partial instanceof HttpData partialData) {
 					currentCompletedHttpData.add(partialData.replace(partialData.content().split()));
 				}
 			}
@@ -408,8 +407,8 @@ public final class HttpServerFormDecoderProvider {
 
 		@Override
 		protected void addHttpData(InterfaceHttpData data) {
-			if (data instanceof HttpData) {
-				currentCompletedHttpData.add((HttpData) data);
+			if (data instanceof HttpData httpData) {
+				currentCompletedHttpData.add(httpData);
 			}
 		}
 
@@ -423,8 +422,8 @@ public final class HttpServerFormDecoderProvider {
 
 			if (!onlyCompleted) {
 				InterfaceHttpData partial = currentPartialHttpData();
-				if (partial instanceof HttpData) {
-					((HttpData) partial).delete();
+				if (partial instanceof HttpData partialData) {
+					partialData.delete();
 				}
 			}
 		}
@@ -433,8 +432,7 @@ public final class HttpServerFormDecoderProvider {
 		public List<HttpData> currentHttpData(boolean onlyCompleted) {
 			if (!onlyCompleted) {
 				InterfaceHttpData partial = currentPartialHttpData();
-				if (partial instanceof HttpData) {
-					HttpData partialData = (HttpData) partial;
+				if (partial instanceof HttpData partialData) {
 					currentCompletedHttpData.add(partialData.replace(partialData.content().split()));
 				}
 			}

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerOperations.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerOperations.java
@@ -819,11 +819,11 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 				config.newHttpPostRequestDecoder(nettyRequest, isMultipart).flatMapMany(decoder ->
 						receiveObject() // receiveContent uses filter operator, this operator buffers, but we don't want it
 								.concatMap(object -> {
-									if (!(object instanceof HttpContent)) {
+									if (!(object instanceof HttpContent<?> objHttpContent)) {
 										return Mono.empty();
 									}
-									HttpContent httpContent = config.maxInMemorySize > -1 ?
-											(HttpContent) (((HttpContent) object).send().receive()) : (HttpContent) object;
+									HttpContent<?> httpContent = config.maxInMemorySize > -1 ?
+											objHttpContent.send().receive() : objHttpContent;
 
 									return config.maxInMemorySize == -1 ?
 											Flux.using(

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerRequest.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerRequest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import io.netty.contrib.handler.codec.http.multipart.HttpData;
 import io.netty5.handler.codec.http.HttpContent;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
 import reactor.core.publisher.Flux;
@@ -91,6 +92,38 @@ public interface HttpServerRequest extends NettyInbound, HttpServerInfos {
 	 * @since 1.0.11
 	 */
 	boolean isMultipart();
+
+	/**
+	 * When the request is {@code POST} and have {@code Content-Type} with value
+	 * {@code application/x-www-form-urlencoded} or {@code multipart/form-data},
+	 * returns a {@link Flux} of {@link HttpData} containing received {@link Attribute}/{@link FileUpload}.
+	 * When the request is not {@code POST} or does not have {@code Content-Type}
+	 * with value {@code application/x-www-form-urlencoded} or {@code multipart/form-data},
+	 * a {@link Flux#error(Throwable)} will be returned.
+	 * <p>Uses HTTP form decoder configuration specified on server level or the default one if nothing is configured.
+	 * <p>{@link HttpData#retain()} disables auto memory release on each {@link HttpData} published,
+	 * retaining in order to prevent premature recycling when {@link HttpData} is accumulated downstream.
+	 *
+	 * @return a {@link Flux} of {@link HttpData} containing received {@link Attribute}/{@link FileUpload}
+	 * @since 1.0.11
+	 */
+	Flux<HttpData> receiveForm();
+
+	/**
+	 * When the request is {@code POST} and have {@code Content-Type} with value
+	 * {@code application/x-www-form-urlencoded} or {@code multipart/form-data},
+	 * returns a {@link Flux} of {@link HttpData} containing received {@link Attribute}/{@link FileUpload}.
+	 * When the request is not {@code POST} or does not have {@code Content-Type}
+	 * with value {@code application/x-www-form-urlencoded} or {@code multipart/form-data},
+	 * a {@link Flux#error(Throwable)} will be returned.
+	 * <p>{@link HttpData#retain()} disables auto memory release on each {@link HttpData} published,
+	 * retaining in order to prevent premature recycling when {@link HttpData} is accumulated downstream.
+	 *
+	 * @param formDecoderBuilder {@link HttpServerFormDecoderProvider.Builder} for HTTP form decoder configuration
+	 * @return a {@link Flux} of {@link HttpData} containing received {@link Attribute}/{@link FileUpload}
+	 * @since 1.0.11
+	 */
+	Flux<HttpData> receiveForm(Consumer<HttpServerFormDecoderProvider.Builder> formDecoderBuilder);
 
 	/**
 	 * Returns the address of the host peer or {@code null} in case of Unix Domain Sockets.

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/client/HttpClientTest.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/client/HttpClientTest.java
@@ -1495,6 +1495,32 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@Test
+	void testIssue614() {
+		disposableServer =
+				createServer()
+				          .route(routes ->
+				              routes.post("/dump", (req, res) -> {
+				                  if (req.requestHeaders().contains("Transfer-Encoding")) {
+				                      return Mono.error(new Exception("Transfer-Encoding is not expected"));
+				                  }
+				                  return res.sendString(Mono.just("OK"));
+				              }))
+				          .bindNow();
+
+		StepVerifier.create(
+				createHttpClientForContextWithAddress()
+				        .post()
+				        .uri("/dump")
+				        .sendForm((req, form) -> form.attr("attribute", "value"))
+				        .responseContent()
+				        .aggregate()
+				        .asString())
+				    .expectNext("OK")
+				    .expectComplete()
+				    .verify(Duration.ofSeconds(30));
+	}
+
+	@Test
 	void testIssue632() throws Exception {
 		disposableServer =
 				createServer()

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/client/HttpClientWithTomcatTest.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/client/HttpClientWithTomcatTest.java
@@ -20,7 +20,10 @@ import io.netty5.handler.codec.http.HttpHeaderNames;
 import io.netty5.handler.codec.http.HttpHeaderValues;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
 import io.netty5.handler.codec.http.HttpMethod;
+import io.netty5.handler.codec.http.HttpRequest;
 import io.netty5.handler.codec.http.HttpResponseStatus;
+import io.netty.contrib.handler.codec.http.multipart.DefaultHttpDataFactory;
+import io.netty.contrib.handler.codec.http.multipart.HttpData;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -30,14 +33,24 @@ import reactor.netty5.BufferFlux;
 import reactor.netty5.TomcatServer;
 import reactor.netty5.resources.ConnectionProvider;
 import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.netty5.http.client.HttpClientOperations.SendForm.DEFAULT_FACTORY;
 
 /**
  * @author Violeta Georgieva
@@ -78,6 +91,58 @@ class HttpClientWithTomcatTest {
 		assertThat(response)
 				.isNotNull()
 				.contains("q=test%20d%20dq");
+	}
+
+	@Test
+	void postUploadWithMultipart() throws Exception {
+		Path file = Paths.get(getClass().getResource("/smallFile.txt").toURI());
+		try (InputStream f = Files.newInputStream(file)) {
+			doTestPostUpload((req, form) -> form.multipart(true)
+							.file("test", f)
+							.attr("attr1", "attr2")
+							.file("test2", f),
+					"test attr1 test2 ");
+		}
+	}
+
+	@Test
+	void postUploadNoMultipart() throws Exception {
+		doTestPostUpload((req, form) -> form.multipart(false).attr("attr1", "attr2"), "attr1=attr2");
+	}
+
+	@Test
+	void postUploadNoMultipartWithCustomFactory() throws Exception {
+		doTestPostUpload((req, form) -> {
+			DefaultHttpDataFactory customFactory = new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE);
+			form.factory(customFactory)
+			    .multipart(false)
+			    .attr("attr1", "attr2");
+		}, "attr1=attr2");
+	}
+
+	@SuppressWarnings("unchecked")
+	private void doTestPostUpload(BiConsumer<? super HttpClientRequest, HttpClientForm> formCallback,
+			String expectedResponse) throws Exception {
+		HttpClient client =
+				HttpClient.create()
+				          .host("localhost")
+				          .port(getPort())
+				          .wiretap(true);
+
+		Tuple2<Integer, String> res;
+		res = client.post()
+		            .uri("/multipart")
+		            .sendForm(formCallback)
+		            .responseSingle((r, buf) -> buf.asString().map(s -> Tuples.of(r.status().code(), s)))
+		            .block(Duration.ofSeconds(30));
+
+		assertThat(res).as("response").isNotNull();
+		assertThat(res.getT1()).as("status code").isEqualTo(200);
+		assertThat(res.getT2()).as("response body reflecting request").contains(expectedResponse);
+
+		Field field = DEFAULT_FACTORY.getClass().getDeclaredField("requestFileDeleteMap");
+		field.setAccessible(true);
+		assertThat((Map<HttpRequest, List<HttpData>>) field.get(DEFAULT_FACTORY)).isEmpty();
 	}
 
 	@Test

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerFormDecoderProviderTests.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerFormDecoderProviderTests.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty5.http.server;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.scheduler.Schedulers;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static reactor.netty5.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_CHARSET;
+import static reactor.netty5.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_MAX_IN_MEMORY_SIZE;
+import static reactor.netty5.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_MAX_SIZE;
+import static reactor.netty5.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_SCHEDULER;
+import static reactor.netty5.http.server.HttpServerFormDecoderProvider.Build.DEFAULT_STREAMING;
+
+/**
+ * @author Violeta Georgieva
+ * @since 1.0.11
+ */
+class HttpServerFormDecoderProviderTests {
+
+	private HttpServerFormDecoderProvider.Build builder;
+
+	@BeforeEach
+	void setUp() {
+		builder = new HttpServerFormDecoderProvider.Build();
+	}
+
+	@Test
+	void baseDirectory() {
+		checkDefaultBaseDirectory(builder);
+
+		Path path = Paths.get("/tmp");
+		builder.baseDirectory(path);
+
+		assertThat(builder.baseDirectory).as("base directory").isSameAs(path);
+
+		checkDefaultCharset(builder);
+		checkDefaultMaxInMemorySize(builder);
+		checkDefaultMaxSize(builder);
+		checkDefaultScheduler(builder);
+		checkDefaultStreaming(builder);
+	}
+
+	@Test
+	void baseDirectoryBadValue() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> builder.baseDirectory(null));
+	}
+
+	@Test
+	void charset() {
+		checkDefaultCharset(builder);
+
+		builder.charset(Charset.defaultCharset());
+
+		assertThat(builder.charset).as("charset").isSameAs(Charset.defaultCharset());
+
+		checkDefaultBaseDirectory(builder);
+		checkDefaultMaxInMemorySize(builder);
+		checkDefaultMaxSize(builder);
+		checkDefaultScheduler(builder);
+		checkDefaultStreaming(builder);
+	}
+
+	@Test
+	void charsetBadValue() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> builder.charset(null));
+	}
+
+	@Test
+	void maxInMemorySize() {
+		checkDefaultMaxInMemorySize(builder);
+
+		builder.maxInMemorySize(-1);
+
+		assertThat(builder.maxInMemorySize).as("max in-memory size").isEqualTo(-1);
+
+		checkDefaultBaseDirectory(builder);
+		checkDefaultCharset(builder);
+		checkDefaultMaxSize(builder);
+		checkDefaultScheduler(builder);
+		checkDefaultStreaming(builder);
+	}
+
+	@Test
+	void maxInMemorySizeBadValue() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> builder.maxInMemorySize(-2))
+				.withMessage("Maximum in-memory size must be greater or equal to -1");
+	}
+
+	@Test
+	void maxSize() {
+		checkDefaultMaxSize(builder);
+
+		builder.maxSize(256);
+
+		assertThat(builder.maxSize).as("max size").isEqualTo(256);
+
+		checkDefaultBaseDirectory(builder);
+		checkDefaultCharset(builder);
+		checkDefaultMaxInMemorySize(builder);
+		checkDefaultScheduler(builder);
+		checkDefaultStreaming(builder);
+	}
+
+	@Test
+	void maxSizeBadValue() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> builder.maxSize(-2))
+				.withMessage("Maximum size must be be greater or equal to -1");
+	}
+
+	@Test
+	void scheduler() {
+		checkDefaultScheduler(builder);
+
+		builder.scheduler(Schedulers.immediate());
+
+		assertThat(builder.scheduler).as("scheduler").isSameAs(Schedulers.immediate());
+
+		checkDefaultBaseDirectory(builder);
+		checkDefaultCharset(builder);
+		checkDefaultMaxInMemorySize(builder);
+		checkDefaultMaxSize(builder);
+		checkDefaultStreaming(builder);
+	}
+
+	@Test
+	void schedulerBadValue() {
+		assertThatExceptionOfType(NullPointerException.class)
+				.isThrownBy(() -> builder.scheduler(null));
+	}
+
+	@Test
+	void streaming() {
+		checkDefaultStreaming(builder);
+
+		builder.streaming(true);
+
+		assertThat(builder.streaming).as("streaming").isTrue();
+
+		checkDefaultBaseDirectory(builder);
+		checkDefaultCharset(builder);
+		checkDefaultMaxInMemorySize(builder);
+		checkDefaultMaxSize(builder);
+		checkDefaultScheduler(builder);
+	}
+
+	private static void checkDefaultBaseDirectory(HttpServerFormDecoderProvider.Build builder) {
+		assertThat(builder.baseDirectory).as("default base directory").isNull();
+	}
+
+	private static void checkDefaultCharset(HttpServerFormDecoderProvider.Build builder) {
+		assertThat(builder.charset).as("default charset")
+				.isSameAs(DEFAULT_CHARSET)
+				.isSameAs(StandardCharsets.UTF_8);
+	}
+
+	private static void checkDefaultMaxInMemorySize(HttpServerFormDecoderProvider.Build builder) {
+		assertThat(builder.maxInMemorySize).as("default max in-memory size")
+				.isEqualTo(DEFAULT_MAX_IN_MEMORY_SIZE)
+				.isEqualTo(16 * 1024);
+	}
+
+	private static void checkDefaultMaxSize(HttpServerFormDecoderProvider.Build builder) {
+		assertThat(builder.maxSize).as("default max size")
+				.isEqualTo(DEFAULT_MAX_SIZE)
+				.isEqualTo(-1);
+	}
+
+	private static void checkDefaultScheduler(HttpServerFormDecoderProvider.Build builder) {
+		assertThat(builder.scheduler).as("default scheduler")
+				.isSameAs(DEFAULT_SCHEDULER)
+				.isSameAs(Schedulers.boundedElastic());
+	}
+
+	private static void checkDefaultStreaming(HttpServerFormDecoderProvider.Build builder) {
+		assertThat(builder.streaming).as("default streaming")
+				.isEqualTo(DEFAULT_STREAMING)
+				.isFalse();
+	}
+}

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerPostFormTests.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerPostFormTests.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty5.http.server;
+
+import io.netty.contrib.handler.codec.http.multipart.HttpData;
+import io.netty5.buffer.api.CompositeBuffer;
+import io.netty5.buffer.api.DefaultBufferAllocators;
+import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty5.handler.ssl.util.SelfSignedCertificate;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.netty5.BaseHttpTest;
+import reactor.netty5.http.Http2SslContextSpec;
+import reactor.netty5.http.HttpProtocol;
+import reactor.netty5.http.client.HttpClient;
+import reactor.util.annotation.Nullable;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Violeta Georgieva
+ * @since 1.0.11
+ */
+class HttpServerPostFormTests extends BaseHttpTest {
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.METHOD)
+	@ParameterizedTest(name = "{displayName}({0}, {1})")
+	@MethodSource("data")
+	@interface ParameterizedPostFormTest {
+	}
+
+	static Object[][] data() throws Exception {
+		SelfSignedCertificate cert = new SelfSignedCertificate();
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(cert.certificate(), cert.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+						.configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+
+		HttpServer server = HttpServer.create().httpRequestDecoder(spec -> spec.h2cMaxContentLength(32 * 1024));
+
+		HttpServer h2Server = server.protocol(HttpProtocol.H2)
+				.secure(spec -> spec.sslContext(serverCtx));
+
+		HttpServer h2Http1Server = server.protocol(HttpProtocol.H2, HttpProtocol.HTTP11)
+				.secure(spec -> spec.sslContext(serverCtx));
+
+		HttpClient client = HttpClient.create();
+
+		HttpClient h2Client = client.protocol(HttpProtocol.H2)
+				.secure(spec -> spec.sslContext(clientCtx));
+
+		HttpClient h2Http1Client = client.protocol(HttpProtocol.H2, HttpProtocol.HTTP11)
+				.secure(spec -> spec.sslContext(clientCtx));
+
+		return new Object[][] {{server, client},
+				{server.protocol(HttpProtocol.H2C), client.protocol(HttpProtocol.H2C)},
+				{server.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11), client.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11)},
+				{h2Server, h2Client},
+				{h2Http1Server, h2Http1Client}};
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartExceedsMaxSizeInMemoryConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(-1).maxSize(4 * 1024), false, true, false,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartExceedsMaxSizeInMemoryConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(-1).maxSize(4 * 1024), true, true, false,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartExceedsMaxSizeMixedConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(256).maxSize(4 * 1024), false, true, false,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartExceedsMaxSizeMixedConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(256).maxSize(4 * 1024), true, true, false,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartExceedsMaxSizeOnDiskConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(0).maxSize(4 * 1024), false, true, false,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartExceedsMaxSizeOnDiskConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(0).maxSize(4 * 1024), true, true, false,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartExceedsMaxSizeStreamingConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.streaming(true).maxSize(4 * 1024), false, true, true,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartExceedsMaxSizeStreamingConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.streaming(true).maxSize(4 * 1024), true, true, true,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartInMemoryConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(-1), false, true, false,
+				"[test1 MemoryFileUpload true] [attr1 MemoryAttribute true] [test2 MemoryFileUpload true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartInMemoryConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(-1), true, true, false,
+				"[test1 MemoryFileUpload true] [attr1 MemoryAttribute true] [test2 MemoryFileUpload true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartMixedConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(256), false, true, false,
+				"[test1 MixedFileUpload true] [attr1 MixedAttribute true] [test2 MixedFileUpload true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartMixedConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(256), true, true, false,
+				"[test1 MixedFileUpload true] [attr1 MixedAttribute true] [test2 MixedFileUpload true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartOnDiskConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(0), false, true, false,
+				"[test1 DiskFileUpload true] [attr1 DiskAttribute true] [test2 DiskFileUpload true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartOnDiskConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(0), true, true, false,
+				"[test1 DiskFileUpload true] [attr1 DiskAttribute true] [test2 DiskFileUpload true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartStreamingConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.streaming(true), false, true, true, null);
+	}
+
+	@ParameterizedPostFormTest
+	void testMultipartStreamingConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.streaming(true), true, true, true, null);
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedExceedsMaxSizeInMemoryConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(-1).maxSize(10), false, false, false,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedExceedsMaxSizeInMemoryConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(-1).maxSize(10), true, false, false,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedExceedsMaxSizeMixedConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(256).maxSize(10), false, false, false,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedExceedsMaxSizeMixedConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(256).maxSize(10), true, false, false,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedExceedsMaxSizeOnDiskConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(0).maxSize(10), false, false, false,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedExceedsMaxSizeOnDiskConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(0).maxSize(10), true, false, false,
+				"Size exceed allowed maximum capacity");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedInMemoryConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(-1), false, false, false,
+				"[test1 MemoryAttribute true] [attr1 MemoryAttribute true] [test2 MemoryAttribute true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedInMemoryConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(-1), true, false, false,
+				"[test1 MemoryAttribute true] [attr1 MemoryAttribute true] [test2 MemoryAttribute true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedMixedConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(256), false, false, false,
+				"[test1 MixedAttribute true] [attr1 MixedAttribute true] [test2 MixedAttribute true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedMixedConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(256), true, false, false,
+				"[test1 MixedAttribute true] [attr1 MixedAttribute true] [test2 MixedAttribute true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedOnDiskConfigOnRequest(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(0), false, false, false,
+				"[test1 DiskAttribute true] [attr1 DiskAttribute true] [test2 DiskAttribute true] ");
+	}
+
+	@ParameterizedPostFormTest
+	void testUrlencodedOnDiskConfigOnServer(HttpServer server, HttpClient client) throws Exception {
+		doTestPostForm(server, client, spec -> spec.maxInMemorySize(0), true, false, false,
+				"[test1 DiskAttribute true] [attr1 DiskAttribute true] [test2 DiskAttribute true] ");
+	}
+
+	private void doTestPostForm(HttpServer server, HttpClient client,
+			Consumer<HttpServerFormDecoderProvider.Builder> provider, boolean configOnServer,
+			boolean multipart, boolean streaming, @Nullable String expectedResponse) throws Exception {
+		AtomicReference<List<HttpData>> originalHttpData1 = new AtomicReference<>(new ArrayList<>());
+		AtomicReference<List<HttpData>> originalHttpData2 = new AtomicReference<>(new ArrayList<>());
+		AtomicReference<Map<String, CompositeBuffer>> copiedHttpData = new AtomicReference<>(new HashMap<>());
+		server = (configOnServer ? server.httpFormDecoder(provider) : server)
+		        .handle((req, res) ->
+		            res.sendString((configOnServer ? req.receiveForm() : req.receiveForm(provider))
+		                    .flatMap(data -> {
+		                        if ("0".equals(req.path())) {
+		                            originalHttpData1.get().add(data);
+
+		                            if (streaming) {
+		                                CompositeBuffer copy = copiedHttpData.get()
+		                                        .computeIfAbsent(data.getName(), k -> DefaultBufferAllocators.preferredAllocator().compose());
+		                                try {
+		                                    // In case of streaming this is not a blocking call
+		                                    copy.writeBytes(data.get());
+		                                }
+		                                catch (IOException e) {
+		                                    return Mono.error(e);
+		                                }
+		                            }
+		                        }
+		                        else {
+		                            originalHttpData2.get().add(data);
+		                        }
+		                        return Mono.just('[' + data.getName() + ' ' +
+		                                data.getClass().getSimpleName() + ' ' +
+		                                data.isCompleted() + "] ");
+		                    })
+		                    .onErrorResume(t -> Mono.just(t.getCause().getMessage()))
+		                    .log()));
+
+		disposableServer = server.bindNow();
+
+		List<Tuple2<Integer, String>> responses;
+		Path file = Paths.get(getClass().getResource("/largeFile1.txt").toURI());
+		responses =
+				Flux.range(0, 2)
+				    .flatMap(i ->
+				            client.port(disposableServer.port())
+				                  .post()
+				                  .uri("/" + i)
+				                  .sendForm((req, form) -> form.multipart(multipart)
+				                                               .file("test1", "largeFile1.txt", file.toFile(), null)
+				                                               .attr("attr1", "attr2")
+				                                               .file("test2", "largeFile1.txt", file.toFile(), null))
+				                  .responseSingle((r, buf) -> buf.asString().map(s -> Tuples.of(r.status().code(), s))))
+				    .collectList()
+				    .block(Duration.ofSeconds(30));
+
+		assertThat(responses).as("response").isNotNull();
+
+		for (Tuple2<Integer, String> response : responses) {
+			assertThat(response.getT1()).as("status code").isEqualTo(200);
+
+			if (expectedResponse != null) {
+				assertThat(response.getT2()).as("response body reflecting request").contains(expectedResponse);
+			}
+		}
+
+		assertThat(originalHttpData1.get()).allMatch(data -> !data.isAccessible());
+		assertThat(originalHttpData2.get()).allMatch(data -> !data.isAccessible());
+
+		if (streaming) {
+			if (expectedResponse == null) {
+				assertThat(copiedHttpData.get()).hasSize(3);
+
+				byte[] fileBytes = Files.readAllBytes(file);
+				testContent(copiedHttpData.get().get("test1"), fileBytes);
+				testContent(copiedHttpData.get().get("test2"), fileBytes);
+
+				copiedHttpData.get().forEach((s, buffer) -> buffer.close());
+			}
+			else {
+				List<HttpProtocol> serverProtocols = Arrays.asList(server.configuration().protocols());
+				if (serverProtocols.size() == 1 && serverProtocols.get(0).equals(HttpProtocol.HTTP11)) {
+					assertThat(copiedHttpData.get()).hasSize(1);
+					copiedHttpData.get().forEach((s, buffer) -> buffer.close());
+				}
+				else {
+					assertThat(copiedHttpData.get()).hasSize(0);
+				}
+			}
+		}
+	}
+
+	private void testContent(CompositeBuffer file, byte[] expectedBytes) {
+		byte[] fileBytes = new byte[file.readableBytes()];
+		file.readBytes(fileBytes, 0, file.readableBytes());
+		assertThat(fileBytes).isEqualTo(expectedBytes);
+	}
+}

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerPostFormTests.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerPostFormTests.java
@@ -16,8 +16,8 @@
 package reactor.netty5.http.server;
 
 import io.netty.contrib.handler.codec.http.multipart.HttpData;
-import io.netty5.buffer.api.CompositeBuffer;
-import io.netty5.buffer.api.DefaultBufferAllocators;
+import io.netty5.buffer.CompositeBuffer;
+import io.netty5.buffer.DefaultBufferAllocators;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerTests.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerTests.java
@@ -66,6 +66,7 @@ import io.netty5.handler.codec.http.HttpClientCodec;
 import io.netty5.handler.codec.http.HttpContent;
 import io.netty5.handler.codec.http.HttpContentDecompressor;
 import io.netty5.handler.codec.http.HttpHeaderNames;
+import io.netty5.handler.codec.http.HttpHeaderValues;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
 import io.netty5.handler.codec.http.HttpMessage;
 import io.netty5.handler.codec.http.HttpMethod;
@@ -2256,7 +2257,6 @@ class HttpServerTests extends BaseHttpTest {
 			Function<HttpClient, HttpClient> clientCustomizer,
 			boolean connectionClose, boolean throwException) throws Exception {
 		CountDownLatch latch = new CountDownLatch(1);
-		AtomicReference<List<ByteBuf>> byteBufReplay = new AtomicReference<>(new ArrayList<>());
 		AtomicReference<List<Buffer>> bufReplay = new AtomicReference<>(new ArrayList<>());
 		HttpServer server = serverCustomizer.apply(createServer());
 		disposableServer =
@@ -2298,7 +2298,6 @@ class HttpServerTests extends BaseHttpTest {
 		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 		Mono.delay(Duration.ofMillis(500))
 		    .block();
-		assertThat(byteBufReplay.get()).allMatch(buf -> buf.refCnt() == 0);
 		assertThat(bufReplay.get()).allMatch(buf -> !buf.isAccessible());
 	}
 

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerTests.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerTests.java
@@ -2267,11 +2267,8 @@ class HttpServerTests extends BaseHttpTest {
 				                  if (msg instanceof ByteBufHolder byteBuf) {
 				                      byteBufReplay.get().add(byteBuf.content());
 				                  }
-				                  else if (msg instanceof ByteBuf byteBuf) {
-				                      byteBufReplay.get().add(byteBuf);
-				                  }
-								  else if (msg instanceof Buffer buf) {
-									  bufReplay.get().add(buf);
+				                  else if (msg instanceof Buffer buf) {
+				                      bufReplay.get().add(buf);
 				                  }
 				                  ctx.fireChannelRead(msg);
 				              }

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerTests.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerTests.java
@@ -2264,10 +2264,7 @@ class HttpServerTests extends BaseHttpTest {
 
 				              @Override
 				              public void channelRead(ChannelHandlerContext ctx, Object msg) {
-				                  if (msg instanceof ByteBufHolder byteBuf) {
-				                      byteBufReplay.get().add(byteBuf.content());
-				                  }
-				                  else if (msg instanceof Buffer buf) {
+				                  if (msg instanceof Buffer buf) {
 				                      bufReplay.get().add(buf);
 				                  }
 				                  ctx.fireChannelRead(msg);

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerTests.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerTests.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
 
@@ -1984,6 +1985,327 @@ class HttpServerTests extends BaseHttpTest {
 
 		assertThat(hostname.get()).isNotNull();
 		assertThat(hostname.get()).isEqualTo("test.com");
+	}
+
+	@Test
+	void testIssue1286_HTTP11() throws Exception {
+		doTestIssue1286(Function.identity(), Function.identity(), false, false);
+	}
+
+	@Test
+	void testIssue1286_H2C() throws Exception {
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2C),
+				client -> client.protocol(HttpProtocol.H2C),
+				false, false);
+	}
+
+	@Test
+	void testIssue1286_ServerHTTP11AndH2CClientH2C() throws Exception {
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11),
+				client -> client.protocol(HttpProtocol.H2C),
+				false, false);
+	}
+
+	@Test
+	void testIssue1286_ServerHTTP11AndH2CClientHTTP11AndH2C() throws Exception {
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11)
+				                .httpRequestDecoder(spec -> spec.h2cMaxContentLength(256)),
+				client -> client.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11),
+				false, false);
+	}
+
+	@Test
+	void testIssue1286_H2() throws Exception {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(serverCtx)),
+				client -> client.protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(clientCtx)),
+				false, false);
+	}
+
+	@Test
+	void testIssue1286_ServerHTTP11AndH2ClientH2() throws Exception {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2, HttpProtocol.HTTP11).secure(spec -> spec.sslContext(serverCtx)),
+				client -> client.protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(clientCtx)),
+				false, false);
+	}
+
+	@Test
+	void testIssue1286_ServerHTTP11AndH2ClientHTTP11AndH2() throws Exception {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2, HttpProtocol.HTTP11).secure(spec -> spec.sslContext(serverCtx)),
+				client -> client.protocol(HttpProtocol.H2, HttpProtocol.HTTP11).secure(spec -> spec.sslContext(clientCtx)),
+				false, false);
+	}
+
+	@Test
+	void testIssue1286ErrorResponse_HTTP11() throws Exception {
+		doTestIssue1286(Function.identity(), Function.identity(), false, true);
+	}
+
+	@Test
+	void testIssue1286ErrorResponse_H2C() throws Exception {
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2C),
+				client -> client.protocol(HttpProtocol.H2C),
+				false, true);
+	}
+
+	@Test
+	void testIssue1286ErrorResponse_ServerHTTP11AndH2CAndClientH2C() throws Exception {
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11),
+				client -> client.protocol(HttpProtocol.H2C),
+				false, true);
+	}
+
+	@Test
+	void testIssue1286ErrorResponse_ServerHTTP11AndH2CClientHTTP11AndH2C() throws Exception {
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11)
+				                .httpRequestDecoder(spec -> spec.h2cMaxContentLength(256)),
+				client -> client.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11),
+				false, true);
+	}
+
+	@Test
+	void testIssue1286ErrorResponse_H2() throws Exception {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(serverCtx)),
+				client -> client.protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(clientCtx)),
+				false, true);
+	}
+
+	@Test
+	void testIssue1286ErrorResponse_ServerHTTP11AndH2ClientH2() throws Exception {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2, HttpProtocol.HTTP11).secure(spec -> spec.sslContext(serverCtx)),
+				client -> client.protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(clientCtx)),
+				false, true);
+	}
+
+	@Test
+	void testIssue1286ErrorResponse_ServerHTTP11AndH2ClientHTTP11AndH2() throws Exception {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2, HttpProtocol.HTTP11).secure(spec -> spec.sslContext(serverCtx)),
+				client -> client.protocol(HttpProtocol.H2, HttpProtocol.HTTP11).secure(spec -> spec.sslContext(clientCtx)),
+				false, true);
+	}
+
+	@Test
+	void testIssue1286ConnectionClose_HTTP11() throws Exception {
+		doTestIssue1286(Function.identity(), Function.identity(), true, false);
+	}
+
+	@Test
+	void testIssue1286ConnectionClose_H2C() throws Exception {
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2C),
+				client -> client.protocol(HttpProtocol.H2C),
+				true, false);
+	}
+
+	@Test
+	void testIssue1286ConnectionClose_ServerHTTP11AndH2CClientH2C() throws Exception {
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11),
+				client -> client.protocol(HttpProtocol.H2C),
+				true, false);
+	}
+
+	@Test
+	void testIssue1286ConnectionClose_ServerHTTP11AndH2CClientHTTP11AndH2C() throws Exception {
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11)
+				                .httpRequestDecoder(spec -> spec.h2cMaxContentLength(256)),
+				client -> client.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11),
+				true, false);
+	}
+
+	@Test
+	void testIssue1286ConnectionClose_H2() throws Exception {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(serverCtx)),
+				client -> client.protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(clientCtx)),
+				true, false);
+	}
+
+	@Test
+	void testIssue1286ConnectionClose_ServerHTTP11AndH2ClientH2() throws Exception {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2, HttpProtocol.HTTP11).secure(spec -> spec.sslContext(serverCtx)),
+				client -> client.protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(clientCtx)),
+				true, false);
+	}
+
+	@Test
+	void testIssue1286ConnectionClose_ServerHTTP11AndH2ClientHTTP11AndH2() throws Exception {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2, HttpProtocol.HTTP11).secure(spec -> spec.sslContext(serverCtx)),
+				client -> client.protocol(HttpProtocol.H2, HttpProtocol.HTTP11).secure(spec -> spec.sslContext(clientCtx)),
+				true, false);
+	}
+
+	@Test
+	void testIssue1286ConnectionCloseErrorResponse_HTTP11() throws Exception {
+		doTestIssue1286(Function.identity(), Function.identity(), true, true);
+	}
+
+	@Test
+	void testIssue1286ConnectionCloseErrorResponse_H2C() throws Exception {
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2C),
+				client -> client.protocol(HttpProtocol.H2C),
+				true, true);
+	}
+
+	@Test
+	void testIssue1286ConnectionCloseErrorResponse_ServerHTTP11AndH2CClientH2C() throws Exception {
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11),
+				client -> client.protocol(HttpProtocol.H2C),
+				true, true);
+	}
+
+	@Test
+	void testIssue1286ConnectionCloseErrorResponse_ServerHTTP11AndH2CClientHTTP11AndH2C() throws Exception {
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11)
+				                .httpRequestDecoder(spec -> spec.h2cMaxContentLength(256)),
+				client -> client.protocol(HttpProtocol.H2C, HttpProtocol.HTTP11),
+				true, true);
+	}
+
+	@Test
+	void testIssue1286ConnectionCloseErrorResponse_H2() throws Exception {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(serverCtx)),
+				client -> client.protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(clientCtx)),
+				true, true);
+	}
+
+	@Test
+	void testIssue1286ConnectionCloseErrorResponse_ServerHTTP11AndH2ClientH2() throws Exception {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2, HttpProtocol.HTTP11).secure(spec -> spec.sslContext(serverCtx)),
+				client -> client.protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(clientCtx)),
+				true, true);
+	}
+
+	@Test
+	void testIssue1286ConnectionCloseErrorResponse_ServerHTTP11AndH2ClientHTTP11AndH2() throws Exception {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestIssue1286(
+				server -> server.protocol(HttpProtocol.H2, HttpProtocol.HTTP11).secure(spec -> spec.sslContext(serverCtx)),
+				client -> client.protocol(HttpProtocol.H2, HttpProtocol.HTTP11).secure(spec -> spec.sslContext(clientCtx)),
+				true, true);
+	}
+
+	private void doTestIssue1286(
+			Function<HttpServer, HttpServer> serverCustomizer,
+			Function<HttpClient, HttpClient> clientCustomizer,
+			boolean connectionClose, boolean throwException) throws Exception {
+		CountDownLatch latch = new CountDownLatch(1);
+		AtomicReference<List<ByteBuf>> byteBufReplay = new AtomicReference<>(new ArrayList<>());
+		AtomicReference<List<Buffer>> bufReplay = new AtomicReference<>(new ArrayList<>());
+		HttpServer server = serverCustomizer.apply(createServer());
+		disposableServer =
+				server.doOnConnection(conn -> conn.addHandlerLast(new ChannelHandlerAdapter() {
+
+				              @Override
+				              public void channelRead(ChannelHandlerContext ctx, Object msg) {
+				                  if (msg instanceof ByteBufHolder byteBuf) {
+				                      byteBufReplay.get().add(byteBuf.content());
+				                  }
+				                  else if (msg instanceof ByteBuf byteBuf) {
+				                      byteBufReplay.get().add(byteBuf);
+				                  }
+								  else if (msg instanceof Buffer buf) {
+									  bufReplay.get().add(buf);
+				                  }
+				                  ctx.fireChannelRead(msg);
+				              }
+				      }))
+				      .handle((req, res) -> {
+				          res.withConnection(conn -> conn.onTerminate()
+				                                         .subscribe(null, t -> latch.countDown(), latch::countDown));
+				          if (throwException) {
+				              return Mono.delay(Duration.ofMillis(100))
+				                         .flatMap(l -> Mono.error(new RuntimeException("testIssue1286")));
+				          }
+				          return res.sendString(Mono.delay(Duration.ofMillis(100))
+				                                    .flatMap(l -> Mono.just("OK")));
+				      })
+				      .bindNow();
+
+		HttpClient client = clientCustomizer.apply(createClient(disposableServer.port()));
+
+		if (connectionClose) {
+			client = client.headers(h -> h.add(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE));
+		}
+
+		client.post()
+		      .uri("/")
+		      .sendForm((req, form) -> form.attr("testIssue1286", "testIssue1286"))
+		      .responseContent()
+		      .aggregate()
+		      .subscribe();
+
+		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+		Mono.delay(Duration.ofMillis(500))
+		    .block();
+		assertThat(byteBufReplay.get()).allMatch(buf -> buf.refCnt() == 0);
+		assertThat(bufReplay.get()).allMatch(buf -> !buf.isAccessible());
 	}
 
 	@Test


### PR DESCRIPTION
Related to #2221

This PR is an attempt to reintegrate the Multipart feature into netty5 branch using new netty-contrib multipart codec.
The old multipart code that has bee reintegrated comes from the latest 1.0.x branch.
