### PR TITLE
Remove the temporary workarounds in CI build

### DIFF
--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -60,17 +60,17 @@ jobs:
           fetch-depth: 0 #needed by spotless
       - uses: actions/checkout@v3
         with:
-          repository: netty/codec-haproxy
+          repository: netty-contrib/codec-haproxy
           path: codec-haproxy
           ref: channel-handler-methods-names
       - uses: actions/checkout@v3
         with:
-          repository: netty/codec-extras
+          repository: netty-contrib/codec-extras
           path: codec-extras
           ref: channel-handler-methods-names
       - uses: actions/checkout@v3
         with:
-          repository: netty/socks-proxy
+          repository: netty-contrib/socks-proxy
           path: socks-proxy
           ref: channel-handler-methods-names
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -60,20 +60,17 @@ jobs:
           fetch-depth: 0 #needed by spotless
       - uses: actions/checkout@v3
         with:
-          # TODO temporary https://github.com/netty-contrib/codec-haproxy/pull/6
-          repository: violetagg/codec-haproxy
+          repository: netty/codec-haproxy
           path: codec-haproxy
           ref: channel-handler-methods-names
       - uses: actions/checkout@v3
         with:
-          # TODO temporary https://github.com/netty-contrib/codec-extras/pull/7
-          repository: violetagg/codec-extras
+          repository: netty/codec-extras
           path: codec-extras
           ref: channel-handler-methods-names
       - uses: actions/checkout@v3
         with:
-          # TODO temporary https://github.com/netty-contrib/socks-proxy/pull/8
-          repository: violetagg/socks-proxy
+          repository: netty/socks-proxy
           path: socks-proxy
           ref: channel-handler-methods-names
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -62,17 +62,14 @@ jobs:
         with:
           repository: netty-contrib/codec-haproxy
           path: codec-haproxy
-          ref: channel-handler-methods-names
       - uses: actions/checkout@v3
         with:
           repository: netty-contrib/codec-extras
           path: codec-extras
-          ref: channel-handler-methods-names
       - uses: actions/checkout@v3
         with:
           repository: netty-contrib/socks-proxy
           path: socks-proxy
-          ref: channel-handler-methods-names
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpTests.java
@@ -26,7 +26,6 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.handler.codec.http.HttpHeaderNames;
 import io.netty5.handler.codec.http.HttpHeaderValues;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -397,8 +396,6 @@ class HttpTests extends BaseHttpTest {
 
 
 	@Test
-	@Disabled
-	// TODO temporary disable https://github.com/netty/netty/pull/12482
 	void streamAndPoolDefaultCompression() {
 		Sinks.Many<String> ep = Sinks.unsafe().many().unicast().onBackpressureBuffer();
 


### PR DESCRIPTION
Enable `HttpTests#streamAndPoolDefaultCompression`