### PR TITLE
Enable the disabled HTTP/2 tests

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -718,7 +718,7 @@ final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.
 				if (!connection.channel().isActive()) {
 					return Mono.empty();
 				}
-				return Mono.fromCompletionStage(connection.channel().closeFuture().asStage());
+				return Mono.fromCompletionStage(connection.channel().close().asStage());
 			};
 
 	static final class Borrower extends AtomicBoolean implements Scannable, Subscription, Runnable {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2StreamBridgeClientHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2StreamBridgeClientHandler.java
@@ -16,6 +16,7 @@
 package reactor.netty.http.client;
 
 import io.netty5.buffer.api.Buffer;
+import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerAdapter;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.http.DefaultHttpContent;
@@ -30,6 +31,7 @@ import io.netty5.util.concurrent.Future;
  * @author Violeta Georgieva
  * @since 1.0.0
  */
+@ChannelHandler.Sharable
 final class Http2StreamBridgeClientHandler extends ChannelHandlerAdapter {
 
 	@Override

--- a/reactor-netty-http/src/noMicrometerTest/java/reactor/netty/http/client/HttpClientNoMicrometerTest.java
+++ b/reactor-netty-http/src/noMicrometerTest/java/reactor/netty/http/client/HttpClientNoMicrometerTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import reactor.core.publisher.Flux;
@@ -74,7 +73,6 @@ class HttpClientNoMicrometerTest {
 	}
 
 	@Test
-	@Disabled
 	void clientCreatedWithMetricsDoesntLoadGaugeHttp2() throws Exception {
 		SelfSignedCertificate ssc = new SelfSignedCertificate();
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
@@ -57,7 +57,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Violeta Georgieva
  * @since 1.0.0
  */
-@Disabled
 class Http2Tests extends BaseHttpTest {
 	private final static String H2_WITHOUT_TLS_SERVER = "Configured H2 protocol without TLS. Use" +
 			" a Clear-Text H2 protocol via HttpServer#protocol or configure TLS" +
@@ -361,6 +360,7 @@ class Http2Tests extends BaseHttpTest {
 	}
 
 	@Test
+	@Disabled
 	void testMonoRequestBodySentAsFullRequest_Mono() {
 		// sends "full" request
 		doTestMonoRequestBodySentAsFullRequest(BufferFlux.fromString(Mono.just("test")), 1);

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
@@ -50,7 +50,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author smaldini
  * @author Violeta Georgieva
  */
-@Disabled
 class HttpCompressionClientServerTests extends BaseHttpTest {
 
 	@Retention(RetentionPolicy.RUNTIME)
@@ -218,6 +217,7 @@ class HttpCompressionClientServerTests extends BaseHttpTest {
 	}
 
 	@ParameterizedCompressionTest
+	@Disabled
 	void serverCompressionPredicateTrue(HttpServer server, HttpClient client) throws Exception {
 		testServerCompressionPredicateTrue(server, client, false);
 	}
@@ -297,6 +297,7 @@ class HttpCompressionClientServerTests extends BaseHttpTest {
 	}
 
 	@ParameterizedCompressionTest
+	@Disabled
 	void serverCompressionEnabledBigResponse(HttpServer server, HttpClient client) throws Exception {
 		disposableServer =
 				server.compress(4)
@@ -392,6 +393,7 @@ class HttpCompressionClientServerTests extends BaseHttpTest {
 	}
 
 	@ParameterizedCompressionTest
+	@Disabled
 	void testIssue282(HttpServer server, HttpClient client) {
 		disposableServer =
 				server.compress(2048)
@@ -413,6 +415,7 @@ class HttpCompressionClientServerTests extends BaseHttpTest {
 	}
 
 	@ParameterizedCompressionTest
+	@Disabled
 	void testIssue292(HttpServer server, HttpClient client) {
 		disposableServer =
 				server.compress(10)

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
@@ -29,7 +29,6 @@ import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.handler.timeout.ReadTimeoutHandler;
 import io.netty5.util.concurrent.DefaultPromise;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
@@ -71,7 +70,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Violeta Georgieva
  * @since 1.0.0
  */
-@Disabled
 class HttpProtocolsTests extends BaseHttpTest {
 	static final ConnectionProvider provider =
 			ConnectionProvider.builder("HttpProtocolsTests")

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/ConnectionPoolTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/ConnectionPoolTests.java
@@ -27,7 +27,6 @@ import io.netty5.util.concurrent.GlobalEventExecutor;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import reactor.core.publisher.Flux;
@@ -341,7 +340,6 @@ class ConnectionPoolTests extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testClientWithProtocols() {
 		Http11SslContextSpec http11SslContextSpec =
 				Http11SslContextSpec.forClient()

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -90,7 +90,6 @@ import io.netty5.resolver.dns.DnsAddressResolverGroup;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.concurrent.SingleThreadEventExecutor;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -1940,7 +1939,6 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testConnectionLifeTimeFixedPoolHttp2_1() throws Exception {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =
@@ -1983,7 +1981,6 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testConnectionLifeTimeElasticPoolHttp2() throws Exception {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =
@@ -2025,7 +2022,6 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testConnectionNoLifeTimeFixedPoolHttp2() throws Exception {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =
@@ -2064,7 +2060,6 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testConnectionNoLifeTimeElasticPoolHttp2() throws Exception {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =
@@ -2111,7 +2106,6 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testConnectionLifeTimeFixedPoolHttp2_2() {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =
@@ -2676,7 +2670,6 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testIssue1478() throws Exception {
 		disposableServer =
 				HttpServer.create()
@@ -2712,7 +2705,6 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testConfigurationSecurityThenProtocols_DefaultHTTP11SslProvider() {
 		HttpClient client = HttpClient.create().secure();
 
@@ -2724,7 +2716,6 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testConfigurationSecurityThenProtocols_DefaultH2SslProvider() {
 		HttpClient client = HttpClient.create().secure();
 
@@ -2742,7 +2733,6 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testConfigurationOnlyProtocols_NoDefaultSslProvider() {
 		HttpClient client = HttpClient.create();
 
@@ -3062,7 +3052,6 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testIssue1943H2C() {
 		doTestIssue1943(HttpProtocol.H2C);
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
@@ -38,7 +38,6 @@ import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -767,7 +766,6 @@ class HttpRedirectTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testHttp2Redirect() {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/Http2ConnectionInfoTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/Http2ConnectionInfoTests.java
@@ -18,7 +18,6 @@ package reactor.netty.http.server;
 import io.netty5.handler.ssl.SslContext;
 import io.netty5.handler.ssl.SslContextBuilder;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
-import org.junit.jupiter.api.Disabled;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.client.HttpClient;
 
@@ -30,7 +29,6 @@ import javax.net.ssl.SSLException;
  * @author Violeta Georgieva
  * @since 1.0.0
  */
-@Disabled
 class Http2ConnectionInfoTests extends ConnectionInfoTests {
 	@Override
 	protected HttpClient customizeClientOptions(HttpClient httpClient) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -80,7 +80,6 @@ import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.util.concurrent.SingleThreadEventExecutor;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1721,7 +1720,6 @@ class HttpServerTests extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testHttpServerWithDomainSockets_HTTP2() {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =
@@ -2386,14 +2384,12 @@ class HttpServerTests extends BaseHttpTest {
 	 */
 	@ParameterizedTest
 	@MethodSource("h2cCompatibleCombinations")
-	@Disabled
 	void testIssue1978H2CNoDelay(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols) throws Exception {
 		doTestIssue1978(serverProtocols, clientProtocols, null, null, 0, 0);
 	}
 
 	@ParameterizedTest
 	@MethodSource("h2cCompatibleCombinations")
-	@Disabled
 	void testIssue1978H2CWithDelay(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols) throws Exception {
 		doTestIssue1978(serverProtocols, clientProtocols, null, null, 50, 20);
 	}
@@ -2403,7 +2399,6 @@ class HttpServerTests extends BaseHttpTest {
 	 */
 	@ParameterizedTest
 	@MethodSource("h2CompatibleCombinations")
-	@Disabled
 	void testIssue1978H2NoDelay(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols) throws Exception {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =
@@ -2414,7 +2409,6 @@ class HttpServerTests extends BaseHttpTest {
 
 	@ParameterizedTest
 	@MethodSource("h2CompatibleCombinations")
-	@Disabled
 	void testIssue1978H2WithDelay(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols) throws Exception {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =

--- a/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
@@ -323,7 +323,6 @@ class DefaultPooledConnectionProviderTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testConnectionIdleWhenNoActiveStreams() throws Exception {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =
@@ -462,14 +461,12 @@ class DefaultPooledConnectionProviderTest extends BaseHttpTest {
 
 	@ParameterizedTest
 	@MethodSource("h2cCompatibleCombinations")
-	@Disabled
 	void testIssue1982H2C(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols) throws Exception {
 		doTestIssue1982(serverProtocols, clientProtocols, null, null);
 	}
 
 	@ParameterizedTest
 	@MethodSource("h2CompatibleCombinations")
-	@Disabled
 	void testIssue1982H2(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols) throws Exception {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =
@@ -552,7 +549,6 @@ class DefaultPooledConnectionProviderTest extends BaseHttpTest {
 
 	//https://github.com/reactor/reactor-netty/issues/1808
 	@Test
-	@Disabled
 	void testMinConnections() throws Exception {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =

--- a/reactor-netty-http/src/test/java/reactor/netty/resources/PooledConnectionProviderDefaultMetricsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/resources/PooledConnectionProviderDefaultMetricsTest.java
@@ -24,7 +24,6 @@ import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -98,7 +97,6 @@ class PooledConnectionProviderDefaultMetricsTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testConnectionProviderMetricsDisabledAndHttpClientMetricsEnabledHttp2() throws Exception {
 		// by default, when the max number of pending acquire is not specified, it will bet set to 2 * max-connection
 		// (see PoolFactory from PoolConnectionProvider.java)
@@ -137,7 +135,6 @@ class PooledConnectionProviderDefaultMetricsTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testConnectionProviderMetricsEnableAndHttpClientMetricsDisabledHttp2() throws Exception {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =
@@ -227,7 +224,6 @@ class PooledConnectionProviderDefaultMetricsTest extends BaseHttpTest {
 	}
 
 	@Test
-	@Disabled
 	void testConnectionPoolPendingAcquireSize() throws Exception {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =


### PR DESCRIPTION
- `Http2StreamBridgeClientHandler` was missing `@Sharable`
- `Http2Pool` when disposing a channel, `close` should be invoked and not `closeFuture`
- When creating channel pipeline for `H2C`, `read` cannot be invoked on `handlerAdded`.
This is related to the changes in channel registration.

Related to #1873