### PR TITLE
SimpleCompressionHandler must invoke super.decodeAndClose(...) only with request meta data when no payload/not accessible

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -536,7 +536,7 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		                  .get(NettyPipeline.CompressionHandler) == null) {
 			SimpleCompressionHandler handler = new SimpleCompressionHandler();
 			try {
-				//Do not invoke handler.channelRead as it will trigger ctx.fireChannelRead
+				// decodeAndClose(...) is needed only to initialize the acceptEncodingQueue
 				handler.decodeAndClose(channel().pipeline().context(NettyPipeline.ReactiveBridge), nettyRequest);
 
 				addHandlerFirst(NettyPipeline.CompressionHandler, handler);

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
@@ -28,7 +28,6 @@ import java.util.zip.GZIPInputStream;
 import io.netty5.handler.codec.http.HttpHeaders;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -217,7 +216,6 @@ class HttpCompressionClientServerTests extends BaseHttpTest {
 	}
 
 	@ParameterizedCompressionTest
-	@Disabled
 	void serverCompressionPredicateTrue(HttpServer server, HttpClient client) throws Exception {
 		testServerCompressionPredicateTrue(server, client, false);
 	}
@@ -297,7 +295,6 @@ class HttpCompressionClientServerTests extends BaseHttpTest {
 	}
 
 	@ParameterizedCompressionTest
-	@Disabled
 	void serverCompressionEnabledBigResponse(HttpServer server, HttpClient client) throws Exception {
 		disposableServer =
 				server.compress(4)
@@ -393,7 +390,6 @@ class HttpCompressionClientServerTests extends BaseHttpTest {
 	}
 
 	@ParameterizedCompressionTest
-	@Disabled
 	void testIssue282(HttpServer server, HttpClient client) {
 		disposableServer =
 				server.compress(2048)
@@ -415,7 +411,6 @@ class HttpCompressionClientServerTests extends BaseHttpTest {
 	}
 
 	@ParameterizedCompressionTest
-	@Disabled
 	void testIssue292(HttpServer server, HttpClient client) {
 		disposableServer =
 				server.compress(10)


### PR DESCRIPTION
`super.decodeAndClose(...)` is needed only for initialising `acceptEncodingQueue`

Related to #1873