### PR TITLE
Remove netty5 Unsafe class

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
@@ -437,7 +437,7 @@ public abstract class ServerTransport<T extends ServerTransport<T, CONF>,
 		}
 
 		static void forceClose(Channel child, Throwable t) {
-			child.unsafe().closeForcibly();
+			child.close();
 			log.warn(format(child, "Failed to register an accepted channel: {}"), child, t);
 		}
 	}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConnector.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConnector.java
@@ -323,14 +323,14 @@ public final class TransportConnector {
 								channel.close();
 							}
 							else {
-								channel.unsafe().closeForcibly();
+								channel.close();
 							}
 							monoChannelPromise.setFailure(f.cause());
 						}
 					});
 				}
 				else {
-					channel.unsafe().closeForcibly();
+					channel.close();
 					monoChannelPromise.setFailure(future.cause());
 				}
 			});

--- a/reactor-netty-core/src/test/java/reactor/netty/ReactorNettyTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ReactorNettyTest.java
@@ -22,6 +22,7 @@ import io.netty5.channel.ChannelMetadata;
 import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.ChannelShutdownDirection;
 import io.netty5.channel.embedded.EmbeddedChannel;
+import io.netty5.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
 import reactor.util.annotation.Nullable;
 
@@ -124,11 +125,6 @@ class ReactorNettyTest {
 		}
 
 		@Override
-		protected AbstractUnsafe newUnsafe() {
-			return null;
-		}
-
-		@Override
 		public SocketAddress localAddress() {
 			return localAddress0();
 		}
@@ -170,6 +166,10 @@ class ReactorNettyTest {
 
 		@Override
 		protected void doWrite(ChannelOutboundBuffer in) {
+		}
+
+		@Override
+		protected void connectTransport(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
 		}
 
 		@Override


### PR DESCRIPTION
This PR attempts to remove usage of Usafe (see netty PR from https://github.com/netty/netty/pull/12511).

Looking at the recent changes in the netty PR, it seems that calls like "channel.unsafe().closeForcibly()" are replaced by "channel.close();"

So, I simply did the same in this PR, but ... I'm not sure.
@violetagg , can you help on this please ?
