### PR TITLE
Adopt Gradle Toolchain for the JDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,8 +175,12 @@ subprojects {
 	apply from: "${rootDir}/gradle/javadoc.gradle"
 	apply from: "${rootDir}/gradle/errorprone.gradle"
 
-	sourceCompatibility = '1.8'
-	targetCompatibility = '1.8'
+
+	java {
+		toolchain {
+			languageVersion = JavaLanguageVersion.of(8)
+		}
+	}
 
 	jacoco {
 		toolVersion = '0.8.7'
@@ -212,16 +216,6 @@ subprojects {
 															 "-Xlint:fallthrough",
 															 "-Xlint:rawtypes"
 	]
-
-	compileJava {
-		sourceCompatibility = 1.8
-		targetCompatibility = 1.8
-	}
-
-	compileTestJava {
-		sourceCompatibility = 1.8
-		targetCompatibility = 1.8
-	}
 
 	if (JavaVersion.current().isJava8Compatible()) {
 		compileTestJava.options.compilerArgs += "-parameters"


### PR DESCRIPTION
Adopting the Gradle Toolchain for the JDK will make the build _safer_ in machines that have multiple JDKs
installed and that by mistake can build the project using a JDK higher than the intended.

As defined in [Gradle's docs](https://docs.gradle.org/current/userguide/toolchains.html), the toolchains will give us...

> Executing the build (e.g. using gradle check) will now handle several things for you and others running your build
> 1. Setup all compile, test and javadoc tasks to use the defined toolchain which may be different than the one Gradle itself uses
> 2. Gradle detects locally installed JVMs
> 3. Gradle chooses a JRE/JDK matching the requirements of the build (in this case a JVM supporting Java 8)
> 4. If no matching JVM is found, it will automatically download a matching JDK from AdoptOpenJDK