### PR TITLE
With Java toolchain in place AllowRedefinitionToAddDeleteMethods is not needed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,13 +120,7 @@ ext {
 	blockHoundVersion = '1.0.6.RELEASE'
 	bouncycastleVersion = '1.70'
 
-	jdk = JavaVersion.current().majorVersion
-	jdkJavadoc = "https://docs.oracle.com/javase/${jdk}/docs/api/"
-	if (JavaVersion.current().isJava11Compatible()) {
-		jdkJavadoc = "https://docs.oracle.com/en/java/javase/${jdk}/docs/api/"
-	}
-	println "JDK Javadoc link for this build is ${jdkJavadoc}"
-	javadocLinks = [jdkJavadoc,
+	javadocLinks = ["https://docs.oracle.com/javase/8/docs/api/",
 					"https://fasterxml.github.io/jackson-databind/javadoc/2.5/",
 					"https://www.reactive-streams.org/reactive-streams-1.0.4-javadoc/",
 					"https://projectreactor.io/docs/core/release/api/",
@@ -217,12 +211,10 @@ subprojects {
 															 "-Xlint:rawtypes"
 	]
 
-	if (JavaVersion.current().isJava8Compatible()) {
-		compileTestJava.options.compilerArgs += "-parameters"
-		tasks.withType(Javadoc) {
-			options.addStringOption('Xdoclint:none', '-quiet')
-			options.addStringOption('encoding', 'UTF-8')
-		}
+	compileTestJava.options.compilerArgs += "-parameters"
+	tasks.withType(Javadoc) {
+		options.addStringOption('Xdoclint:none', '-quiet')
+		options.addStringOption('encoding', 'UTF-8')
 	}
 
 	[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,6 @@ ext {
 	junitPlatformLauncherVersion = '1.8.2'
 	mockitoVersion = '4.6.1'
 	blockHoundVersion = '1.0.6.RELEASE'
-	bouncycastleVersion = '1.70'
 
 	javadocLinks = ["https://docs.oracle.com/javase/8/docs/api/",
 					"https://fasterxml.github.io/jackson-databind/javadoc/2.5/",

--- a/build.gradle
+++ b/build.gradle
@@ -233,9 +233,6 @@ subprojects {
 	}
 
 	project.tasks.withType(Test).all {
-		if (JavaVersion.current() > JavaVersion.VERSION_12) {
-			jvmArgs += "-XX:+AllowRedefinitionToAddDeleteMethods"
-		}
 		// run tests with IPv4 only when IPv6 is available
 		if (project.hasProperty('preferIPv4Stack')) {
 			systemProperty("java.net.preferIPv4Stack", "true")

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -24,11 +24,9 @@ project.tasks.withType(Javadoc) {
 	description = "Generates aggregated Javadoc API documentation."
 	title = "${project.name} ${version}"
 
-	if (JavaVersion.current().isJava8Compatible()) {
-		compileTestJava.options.compilerArgs += "-parameters"
-		tasks.withType(Javadoc) {
-			options.addStringOption('Xdoclint:none', '-quiet')
-		}
+	compileTestJava.options.compilerArgs += "-parameters"
+	tasks.withType(Javadoc) {
+		options.addStringOption('Xdoclint:none', '-quiet')
 	}
 
 	options.addStringOption('charSet', 'UTF-8')

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -134,13 +134,6 @@ dependencies {
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 	testRuntimeOnly "org.slf4j:jcl-over-slf4j:$slf4jVersion"
 
-	if (JavaVersion.current() > JavaVersion.VERSION_14) {
-		// https://github.com/netty/netty/pull/11487
-		// https://github.com/netty/netty/issues/10317
-		// Necessary for generating SelfSignedCertificate on Java version >= 15
-		testRuntimeOnly "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
-	}
-
 	for (dependency in project.configurations.shaded.dependencies) {
 		compileOnly(dependency)
 		testImplementation(dependency)

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -144,14 +144,6 @@ dependencies {
 	// Needed for HTTP/2 testing
 	testRuntimeOnly "io.netty:netty-tcnative-boringssl-static:$boringSslVersion$os_suffix"
 
-	if (JavaVersion.current() > JavaVersion.VERSION_14) {
-		// https://github.com/netty/netty/pull/11487
-		// https://github.com/netty/netty/issues/10317
-		// Necessary for generating SelfSignedCertificate on Java version >= 15
-		testRuntimeOnly "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
-		noMicrometerTestRuntimeOnly "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
-	}
-
 	// noMicrometerTest sourceSet (must not include Micrometer)
 	noMicrometerTestImplementation "org.assertj:assertj-core:$assertJVersion"
 	noMicrometerTestImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"

--- a/reactor-netty-incubator-quic/build.gradle
+++ b/reactor-netty-incubator-quic/build.gradle
@@ -48,13 +48,6 @@ dependencies {
 
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 	testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
-
-	if (JavaVersion.current() > JavaVersion.VERSION_14) {
-		// https://github.com/netty/netty/pull/11487
-		// https://github.com/netty/netty/issues/10317
-		// Necessary for generating SelfSignedCertificate on Java version >= 15
-		testRuntimeOnly "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
-	}
 }
 
 jar {


### PR DESCRIPTION
The exception below is thrown when Java version specified in the `PATH` is `> 8`

```
Unrecognized VM option 'AllowRedefinitionToAddDeleteMethods'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
Unrecognized VM option 'AllowRedefinitionToAddDeleteMethods'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
Process 'Gradle Test Executor 159' finished with non-zero exit value 1
org.gradle.process.internal.ExecException: Process 'Gradle Test Executor 159' finished with non-zero exit value 1
        at org.gradle.process.internal.DefaultExecHandle$ExecResultImpl.assertNormalExitValue(DefaultExecHandle.java:414)
        at org.gradle.process.internal.worker.DefaultWorkerProcess.onProcessStop(DefaultWorkerProcess.java:141)
        at org.gradle.process.internal.worker.DefaultWorkerProcess.access$000(DefaultWorkerProcess.java:42)
        at org.gradle.process.internal.worker.DefaultWorkerProcess$1.executionFinished(DefaultWorkerProcess.java:94)
```