### PR TITLE
Make HttpMetricsHandlerTests stable

### DIFF
--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -46,7 +46,6 @@ import reactor.core.publisher.Mono;
 import reactor.netty.BaseHttpTest;
 import reactor.netty.BufferFlux;
 import reactor.netty.ConnectionObserver;
-import reactor.netty.NettyPipeline;
 import reactor.netty.http.client.ContextAwareHttpClientMetricsRecorder;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.server.ContextAwareHttpServerMetricsRecorder;


### PR DESCRIPTION
This PR is an attempt to sabilise the HttpMetricsHandlerTests, because now in netty5, channel listeners execution is rescheduled at the end of the current event loop queue, see Netty PR [#9489 Always notify FutureListener via the EventExecutor](https://github.com/netty/netty/pull/9489)
So, this is problem for the HttpMetricsHandlerTests tests, because when we receive a response from a server, we start to verify metrics, while the metrics may be not be already up-to-date because they are updated using channel listeners, which may not be executed yet at the time we receive a response.
See for example [AbstractHttpServerMetricsHandler.java](https://github.com/reactor/reactor-netty/blob/netty5/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java#L122-L148)

This PR ensures that no pending tasks are currently enqueued in event loops, before decrementing test latches, see new _scheduleCoundDown_ method.
