### PR TITLE
[test] Fix warnings "unchecked method invocation"/"unchecked conversion"

### DIFF
--- a/reactor-netty-http/src/test/java/reactor/netty/http/observability/ObservabilitySmokeTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/observability/ObservabilitySmokeTest.java
@@ -94,7 +94,7 @@ class ObservabilitySmokeTest extends SampleTestRunner {
 	@Override
 	public BiConsumer<BuildingBlocks, Deque<ObservationHandler<? extends Observation.Context>>> customizeObservationHandlers() {
 		return (bb, timerRecordingHandlers) -> {
-			ObservationHandler defaultHandler = timerRecordingHandlers.removeLast();
+			ObservationHandler<? extends Observation.Context> defaultHandler = timerRecordingHandlers.removeLast();
 			timerRecordingHandlers.addLast(new ReactorNettyTracingObservationHandler(bb.getTracer()));
 			timerRecordingHandlers.addLast(defaultHandler);
 			timerRecordingHandlers.addFirst(new ReactorNettyHttpClientTracingObservationHandler(bb.getTracer(), bb.getHttpClientHandler()));


### PR DESCRIPTION
```
/.../reactor-netty/reactor-netty-http/src/test/java/reactor/netty/http/observability/ObservabilitySmokeTest.java:99:
 warning: [unchecked] unchecked method invocation: method addLast in interface Deque is applied to given types
                        timerRecordingHandlers.addLast(defaultHandler);
                                                      ^
  required: E
  found: ObservationHandler
  where E is a type-variable:
    E extends Object declared in interface Deque
/.../reactor-netty/reactor-netty-http/src/test/java/reactor/netty/http/observability/ObservabilitySmokeTest.java:99:
 warning: [unchecked] unchecked conversion
                        timerRecordingHandlers.addLast(defaultHandler);
                                                       ^
  required: E
  found:    ObservationHandler
  where E is a type-variable:
    E extends Object declared in interface Deque
```