### PR TITLE
Adapt to changes made in Future interface

### DIFF
--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -68,10 +68,10 @@ jobs:
           path: codec-extras
       - uses: actions/checkout@v3
         with:
-          # TODO temporary https://github.com/netty-contrib/socks-proxy/pull/10
-          repository: violetagg/socks-proxy
+          # TODO temporary https://github.com/netty-contrib/socks-proxy/pull/11
+          repository: pderop/socks-proxy
           path: socks-proxy
-          ref: pending-write-queue
+          ref: blocking-methods-have-moved-from-future-to-futurecompletablestage
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultLoopResourcesTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultLoopResourcesTest.java
@@ -150,7 +150,7 @@ class DefaultLoopResourcesTest {
 			loop1.disposeLater()
 			     .block(Duration.ofSeconds(5));
 			loop2.shutdownGracefully()
-			     .get(5, TimeUnit.SECONDS);
+			     .asStage().get(5, TimeUnit.SECONDS);
 		}
 	}
 

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
@@ -221,7 +221,7 @@ class DefaultPooledConnectionProviderTest {
 			service.shutdownNow();
 			echoServer.close();
 			group.shutdownGracefully()
-			     .get(5, TimeUnit.SECONDS);
+			     .asStage().get(5, TimeUnit.SECONDS);
 
 			assertThat(f1).isNotNull();
 			assertThat(f1.get()).isNull();
@@ -418,7 +418,7 @@ class DefaultPooledConnectionProviderTest {
 			pool.disposeLater()
 			    .block(Duration.ofSeconds(5));
 			group.shutdownGracefully()
-			     .get(5, TimeUnit.SECONDS);
+			     .asStage().get(5, TimeUnit.SECONDS);
 		}
 	}
 
@@ -463,7 +463,7 @@ class DefaultPooledConnectionProviderTest {
 			pool.disposeLater()
 			    .block(Duration.ofSeconds(5));
 			group.shutdownGracefully()
-			     .get(5, TimeUnit.SECONDS);
+			     .asStage().get(5, TimeUnit.SECONDS);
 		}
 	}
 

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/PooledConnectionProviderCustomMetricsTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/PooledConnectionProviderCustomMetricsTest.java
@@ -63,7 +63,7 @@ class PooledConnectionProviderCustomMetricsTest {
 	@AfterEach
 	void tearDown() throws Exception {
 		group.shutdownGracefully()
-		     .get(10L, TimeUnit.SECONDS);
+		     .asStage().get(10L, TimeUnit.SECONDS);
 		pool.dispose();
 	}
 

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpClientTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpClientTests.java
@@ -1061,7 +1061,7 @@ public class TcpClientTests {
 			loop1.disposeLater()
 			     .block(Duration.ofSeconds(10));
 			loop2.shutdownGracefully()
-			     .get(10, TimeUnit.SECONDS);
+			     .asStage().get(10, TimeUnit.SECONDS);
 		}
 	}
 

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
@@ -110,7 +110,7 @@ class ClientTransportTest {
 			provider.disposeLater()
 			        .block(Duration.ofSeconds(10));
 			loop2.shutdownGracefully()
-			     .get(10, TimeUnit.SECONDS);
+					.asStage().get(10, TimeUnit.SECONDS);
 		}
 	}
 
@@ -309,7 +309,7 @@ class ClientTransportTest {
 			provider.disposeLater()
 			        .block(Duration.ofSeconds(10));
 			loop2.shutdownGracefully()
-			     .get(10, TimeUnit.SECONDS);
+					.asStage().get(10, TimeUnit.SECONDS);
 		}
 	}
 

--- a/reactor-netty-core/src/test/java/reactor/netty/udp/UdpClientTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/udp/UdpClientTest.java
@@ -142,7 +142,7 @@ class UdpClientTest {
 			resources.disposeLater()
 			         .block(Duration.ofSeconds(5));
 			loop.shutdownGracefully()
-			    .get(5, TimeUnit.SECONDS);
+					.asStage().get(5, TimeUnit.SECONDS);
 		}
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -2846,7 +2846,7 @@ class HttpClientTest extends BaseHttpTest {
 		finally {
 			// Closing the executor cleans the AddressResolverGroup internal structures and closes the resolver
 			loop.shutdownGracefully()
-			    .get(500, TimeUnit.SECONDS);
+			    .asStage().get(500, TimeUnit.SECONDS);
 		}
 
 		assertThatExceptionOfType(IllegalStateException.class)


### PR DESCRIPTION
blocking JDK Future methods have moved to FutureCompletableStage interface: see https://github.com/netty/netty/pull/12548
The code needs to be adapted.

Also, we need to use temporary PR for netty-contrib/socks-proxy
