### PR TITLE
Use socks-proxy from main branch

### DIFF
--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -68,10 +68,8 @@ jobs:
           path: codec-extras
       - uses: actions/checkout@v3
         with:
-          # TODO temporary https://github.com/netty-contrib/socks-proxy/pull/11
-          repository: pderop/socks-proxy
+          repository: netty-contrib/socks-proxy
           path: socks-proxy
-          ref: blocking-methods-have-moved-from-future-to-futurecompletablestage
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 17
         uses: actions/setup-java@v3


### PR DESCRIPTION
let's use socks-proxy from netty-contrib main branch, because the PR is now merged: https://github.com/netty-contrib/socks-proxy/pull/11

Related to #1873