### PR TITLE
Remove errorproneJavac specific for JDK 8

### DIFF
--- a/gradle/errorprone.gradle
+++ b/gradle/errorprone.gradle
@@ -28,12 +28,10 @@ apply plugin: net.ltgt.gradle.errorprone.ErrorPronePlugin
 
 ext {
 	errorproneCoreVersion = "2.7.1"
-	errorproneJavacVersion = "9+181-r4173-1"
 	guavaVersion = "30.0-jre"
 }
 
 dependencies {
 	errorprone "com.google.errorprone:error_prone_core:$errorproneCoreVersion"
 	errorprone "com.google.guava:guava:$guavaVersion" // prevents conflicts with guava versions of other gradle plugins
-	errorproneJavac "com.google.errorprone:javac:$errorproneJavacVersion"
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -938,6 +938,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	 * @param protocol the protocol used (for HTTP11, we expect to observe 4 disconnect events, and for other (H2/H2C), we expect 3 events)).
 	 * @return number of disconnect events we expect to observe on a given connection
 	 */
+	@SuppressWarnings("UnnecessaryParentheses")
 	int getExpectedDisconnects(HttpProtocol protocol) {
 		return switch (protocol) {
 			case H2, H2C -> 3;


### PR DESCRIPTION
- Remove errorproneJavac specific for JDK 8
https://github.com/tbroyer/gradle-errorprone-plugin#jdk-8-support
- Suppress warning
```
/.../reactor-netty/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java:942: warning: [UnnecessaryParentheses]
These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
                return switch (protocol) {
                              ^
    (see https://errorprone.info/bugpattern/UnnecessaryParentheses)
  Did you mean 'return switch protocol {'?
```