### PR TITLE
[doc] Javadoc link in reference documentation points to a concrete version

### DIFF
--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -1,6 +1,6 @@
 :sourcedir: ./../../reactor-netty-http/src/main/java
 :examplesdir: ./../../reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client
-:javadoc: https://projectreactor.io/docs/netty/release/api
+:javadoc: https://projectreactor.io/docs/netty/{project-version}/api
 :nettyjavadoc: https://netty.io/4.1/api
 :wirelogger: reactor.netty.http.client.HttpClient
 

--- a/docs/asciidoc/http-server.adoc
+++ b/docs/asciidoc/http-server.adoc
@@ -1,6 +1,6 @@
 :sourcedir: ./../../reactor-netty-http/src/main/java
 :examplesdir: ./../../reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server
-:javadoc: https://projectreactor.io/docs/netty/release/api
+:javadoc: https://projectreactor.io/docs/netty/{project-version}/api
 :wirelogger: reactor.netty.http.server.HttpServer
 
 [[http-server]]

--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -1,6 +1,6 @@
 :sourcedir: ./../../reactor-netty-core/src/main/java
 :examplesdir: ./../../reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/client
-:javadoc: https://projectreactor.io/docs/netty/release/api
+:javadoc: https://projectreactor.io/docs/netty/{project-version}/api
 :nettyjavadoc: https://netty.io/4.1/api
 :wirelogger: reactor.netty.tcp.TcpClient
 

--- a/docs/asciidoc/tcp-server.adoc
+++ b/docs/asciidoc/tcp-server.adoc
@@ -1,6 +1,6 @@
 :sourcedir: ./../../reactor-netty-core/src/main/java
 :examplesdir: ./../../reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/tcp/server
-:javadoc: https://projectreactor.io/docs/netty/release/api
+:javadoc: https://projectreactor.io/docs/netty/{project-version}/api
 :nettyjavadoc: https://netty.io/4.1/api
 :wirelogger: reactor.netty.tcp.TcpServer
 

--- a/docs/asciidoc/udp-client.adoc
+++ b/docs/asciidoc/udp-client.adoc
@@ -1,6 +1,6 @@
 :sourcedir: ./../../reactor-netty-core/src/main/java
 :examplesdir: ./../../reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/client
-:javadoc: https://projectreactor.io/docs/netty/release/api
+:javadoc: https://projectreactor.io/docs/netty/{project-version}/api
 :nettyjavadoc: https://netty.io/4.1/api
 :wirelogger: reactor.netty.udp.UdpClient
 

--- a/docs/asciidoc/udp-server.adoc
+++ b/docs/asciidoc/udp-server.adoc
@@ -1,6 +1,6 @@
 :sourcedir: ./../../reactor-netty-core/src/main/java
 :examplesdir: ./../../reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/udp/server
-:javadoc: https://projectreactor.io/docs/netty/release/api
+:javadoc: https://projectreactor.io/docs/netty/{project-version}/api
 :nettyjavadoc: https://netty.io/4.1/api
 :wirelogger: reactor.netty.udp.UdpServer
 


### PR DESCRIPTION
With 3 parallel versions of Reactor Netty (1.0.x, 1.1.x and 2.0.x), the reference documentation
has to point to the concrete version of Reactor Netty for each it is built