### PR TITLE
Revise HttpMetricsHandlerTests and fix testServerConnectionsRecorder

### DIFF
--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -31,7 +31,6 @@ import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
 import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -23,10 +23,19 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
 import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +49,7 @@ import reactor.core.publisher.Mono;
 import reactor.netty.BaseHttpTest;
 import reactor.netty.ByteBufFlux;
 import reactor.netty.ConnectionObserver;
+import reactor.netty.NettyPipeline;
 import reactor.netty.http.client.ContextAwareHttpClientMetricsRecorder;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.server.ContextAwareHttpServerMetricsRecorder;
@@ -65,6 +75,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -107,6 +118,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 	@BeforeAll
 	static void createSelfSignedCertificate() throws CertificateException {
+		Assertions.setMaxStackTraceElementsDisplayed(100);
 		ssc = new SelfSignedCertificate();
 		serverCtx11 = Http11SslContextSpec.forServer(ssc.certificate(), ssc.privateKey())
 		                                  .configure(builder -> builder.sslProvider(SslProvider.JDK));
@@ -168,31 +180,34 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testExistingEndpoint(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
-		CountDownLatch latch1 = new CountDownLatch(4); // expect to observe 2 server disconnect + 2 client disconnect events
-		AtomicReference<CountDownLatch> latchRef = new AtomicReference<>(latch1);
-		ConnectionObserver observerDisconnect = observeDisconnect(latchRef);
-
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx, HttpProtocol negotiatedProtocol) throws Exception {
+		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
+		AtomicReference<CountDownLatch> responseSentRef = new AtomicReference<>(responseSent);
+		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
-				.childObserve(observerDisconnect)
+				.doOnConnection(cnx -> responseSentHandler.register(responseSentRef, cnx.channel().pipeline()))
 				.bindNow();
 
 		AtomicReference<SocketAddress> serverAddress = new AtomicReference<>();
-		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols).doAfterRequest((req, conn) ->
-			serverAddress.set(conn.channel().remoteAddress())
-		).observe(observerDisconnect);
+		CountDownLatch clientCompleted = new CountDownLatch(1); // client received full response
+		AtomicReference<CountDownLatch> clientCompletedRef = new AtomicReference<>(clientCompleted);
+		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols)
+				.doAfterRequest((req, conn) -> serverAddress.set(conn.channel().remoteAddress()))
+				.doAfterResponseSuccess((resp, conn) -> clientCompletedRef.get().countDown());
 
-		StepVerifier.create(httpClient.post()
-		                              .uri("/1")
-		                              .send(body)
-		                              .responseContent()
-		                              .aggregate()
-		                              .asString())
-		            .expectNext("Hello World!")
-		            .expectComplete()
-		            .verify(Duration.ofSeconds(30));
+		StepVerifier.create(httpClient
+						.post()
+						.uri("/1")
+						.send(body)
+						.responseContent()
+						.aggregate()
+						.asString())
+				.expectNext("Hello World!")
+				.expectComplete()
+				.verify(Duration.ofSeconds(30));
 
-		assertThat(latch1.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
+		assertThat(responseSentRef.get().await(30, TimeUnit.SECONDS)).as("responseSentRef latch await").isTrue();
+		assertThat(clientCompletedRef.get().await(30, TimeUnit.SECONDS)).as("clientCompletedRef latch await").isTrue();
 
 		InetSocketAddress sa = (InetSocketAddress) serverAddress.get();
 
@@ -213,20 +228,22 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		checkExpectationsExisting("/1", sa.getHostString() + ":" + sa.getPort(), 1, serverCtx != null,
 				numWrites[0], bytesWrite[0]);
 
-		CountDownLatch latch2 = new CountDownLatch(4); // expect to observe 2 server disconnect + 2 client disconnect events
-		latchRef.set(latch2);
+		responseSentRef.set(new CountDownLatch(1));
+		clientCompletedRef.set(new CountDownLatch(1));
 
-		StepVerifier.create(httpClient.post()
-		                              .uri("/2?i=1&j=2")
-		                              .send(body)
-		                              .responseContent()
-		                              .aggregate()
-		                              .asString())
-		            .expectNext("Hello World!")
-		            .expectComplete()
-		            .verify(Duration.ofSeconds(30));
+		StepVerifier.create(httpClient
+						.post()
+						.uri("/2?i=1&j=2")
+						.send(body)
+						.responseContent()
+						.aggregate()
+						.asString())
+				.expectNext("Hello World!")
+				.expectComplete()
+				.verify(Duration.ofSeconds(30));
 
-		assertThat(latch2.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
+		assertThat(responseSentRef.get().await(30, TimeUnit.SECONDS)).as("responseSentRef latch await").isTrue();
+		assertThat(clientCompletedRef.get().await(30, TimeUnit.SECONDS)).as("clientCompletedRef latch await").isTrue();
 
 		sa = (InetSocketAddress) serverAddress.get();
 
@@ -238,7 +255,8 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testRecordingFailsServerSide(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) {
+	                                  @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx,
+	                                  @SuppressWarnings("unused") HttpProtocol negotiatedProtocol) {
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
 				.metrics(true, id -> {
 					throw new IllegalArgumentException("Testcase injected Exception");
@@ -262,7 +280,8 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testRecordingFailsClientSide(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) {
+	                                  @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx,
+	                                  @SuppressWarnings("unused") HttpProtocol negotiatedProtocol) {
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
 				.bindNow();
 
@@ -284,24 +303,27 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testNonExistingEndpoint(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
-		// For HTTP11, we expect to observe 2 DISCONNECTS for client, and 2 DISCONNECT for server.
-		// Else, we expect to observe 2 DISCONNECTS for client, and 1 DISCONNECT for server.
-		boolean isHTTP11 = clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11;
-		int expectedDisconnects = isHTTP11 ? 4 : 3;
+	                             @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx, HttpProtocol negotiatedProtocol) throws Exception {
+		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
+		AtomicReference<CountDownLatch> responseSentRef = new AtomicReference<>(responseSent);
+		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
+		CountDownLatch requestReceived = new CountDownLatch(1); // request fully received by the server
+		AtomicReference<CountDownLatch> requestReceivedRef = new AtomicReference<>(requestReceived);
+		RequestReceivedHandler requestReceivedHandler = RequestReceivedHandler.INSTANCE;
 
-		CountDownLatch latch = new CountDownLatch(expectedDisconnects);
-		AtomicReference<CountDownLatch> latchRef = new AtomicReference<>(latch);
-		ConnectionObserver observerDisconnect = observeDisconnect(latchRef);
-
+		// the serverReceivedHandler is used to detect when the server has received the last client request content
+		// the serverCompletedHandler is used to detect when the server has sent the last response content
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
-				.childObserve(observerDisconnect)
+				.doOnConnection(cnx -> responseSentHandler.register(responseSentRef, cnx.channel().pipeline()))
+				.doOnConnection(cnx -> requestReceivedHandler.register(requestReceivedRef, cnx.channel().pipeline()))
 				.bindNow();
 
 		AtomicReference<SocketAddress> serverAddress = new AtomicReference<>();
-		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols).doAfterRequest((req, conn) ->
-			serverAddress.set(conn.channel().remoteAddress())
-		).observe(observerDisconnect);
+		CountDownLatch clientCompleted = new CountDownLatch(1);
+		AtomicReference<CountDownLatch> clientCompletedRef = new AtomicReference<>(clientCompleted);
+		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols)
+				.doAfterRequest((req, conn) -> serverAddress.set(conn.channel().remoteAddress()))
+				.doAfterResponseSuccess((rsp, conn) -> clientCompletedRef.get().countDown());
 
 		StepVerifier.create(httpClient
 						.headers(h -> h.add("Connection", "close"))
@@ -313,7 +335,9 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.expectComplete()
 				.verify(Duration.ofSeconds(30));
 
-		assertThat(latch.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
+		assertThat(requestReceivedRef.get().await(30, TimeUnit.SECONDS)).as("requestReceivedRef latch await").isTrue();
+		assertThat(responseSentRef.get().await(30, TimeUnit.SECONDS)).as("responseSentRef latch await").isTrue();
+		assertThat(clientCompletedRef.get().await(30, TimeUnit.SECONDS)).as("clientCompletedRef latch await").isTrue();
 
 		InetSocketAddress sa = (InetSocketAddress) serverAddress.get();
 
@@ -343,8 +367,9 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		checkExpectationsNonExisting(sa.getHostString() + ":" + sa.getPort(), 1, 1, serverCtx != null,
 				numWrites[0], numReads[0], bytesWrite[0], bytesRead[0]);
 
-		CountDownLatch latch2 = new CountDownLatch(expectedDisconnects);
-		latchRef.set(latch2);
+		requestReceivedRef.set(new CountDownLatch(1));
+		responseSentRef.set(new CountDownLatch(1));
+		clientCompletedRef.set(new CountDownLatch(1));
 
 		StepVerifier.create(httpClient
 						.headers(h -> h.add("Connection", "close"))
@@ -356,7 +381,9 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.expectComplete()
 				.verify(Duration.ofSeconds(30));
 
-		assertThat(latch2.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
+		assertThat(requestReceivedRef.get().await(30, TimeUnit.SECONDS)).as("requestReceivedRef latch await").isTrue();
+		assertThat(responseSentRef.get().await(30, TimeUnit.SECONDS)).as("responseSentRef latch await").isTrue();
+		assertThat(clientCompletedRef.get().await(30, TimeUnit.SECONDS)).as("clientCompletedRef latch await").isTrue();
 		sa = (InetSocketAddress) serverAddress.get();
 
 		checkExpectationsNonExisting(sa.getHostString() + ":" + sa.getPort(), connIndex, 2, serverCtx != null,
@@ -366,33 +393,35 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testUriTagValueFunction(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
-		CountDownLatch latch1 = new CountDownLatch(4); // expect to observe 2 server disconnect + 2 client disconnect events
-		AtomicReference<CountDownLatch> latchRef = new AtomicReference<>(latch1);
-		ConnectionObserver observerDisconnect = observeDisconnect(latchRef);
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx, HttpProtocol negotiatedProtocol) throws Exception {
+		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
+		CountDownLatch clientCompleted = new CountDownLatch(1); // client received full response
+		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
 
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
+				.doOnConnection(cnx -> responseSentHandler.register(responseSent, cnx.channel().pipeline()))
 				.metrics(true, s -> "testUriTagValueResolver")
-				.childObserve(observerDisconnect)
 				.bindNow();
 
 		AtomicReference<SocketAddress> serverAddress = new AtomicReference<>();
-		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols).doAfterRequest((req, conn) ->
-			serverAddress.set(conn.channel().remoteAddress())
-		).observe(observerDisconnect);
+		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols)
+				.doAfterResponseSuccess((res, conn) -> clientCompleted.countDown())
+				.doAfterRequest((req, conn) -> serverAddress.set(conn.channel().remoteAddress()));
 
-		StepVerifier.create(httpClient.metrics(true, s -> "testUriTagValueResolver")
-		                              .post()
-		                              .uri("/1")
-		                              .send(body)
-		                              .responseContent()
-		                              .aggregate()
-		                              .asString())
-		            .expectNext("Hello World!")
-		            .expectComplete()
-		            .verify(Duration.ofSeconds(30));
+		StepVerifier.create(httpClient
+						.metrics(true, s -> "testUriTagValueResolver")
+						.post()
+						.uri("/1")
+						.send(body)
+						.responseContent()
+						.aggregate()
+						.asString())
+				.expectNext("Hello World!")
+				.expectComplete()
+				.verify(Duration.ofSeconds(30));
 
-		assertThat(latch1.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
+		assertThat(responseSent.await(30, TimeUnit.SECONDS)).as("responseSent latch await").isTrue();
+		assertThat(clientCompleted.await(30, TimeUnit.SECONDS)).as("clientCompleted latch await").isTrue();
 
 		InetSocketAddress sa = (InetSocketAddress) serverAddress.get();
 
@@ -417,30 +446,33 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testUriTagValueFunctionNotSharedForClient(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
-		CountDownLatch latch1 = new CountDownLatch(4); // expect to observe 2 server disconnect + 2 client disconnect events
-		AtomicReference<CountDownLatch> latchRef = new AtomicReference<>(latch1);
-		ConnectionObserver observerDisconnect = observeDisconnect(latchRef);
-
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx, HttpProtocol negotiatedProtocol) throws Exception {
+		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
+		AtomicReference<CountDownLatch> responseSentRef = new AtomicReference<>(responseSent);
+		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
 		disposableServer =
-				customizeServerOptions(httpServer, serverCtx, serverProtocols).metrics(true,
-				                s -> {
-				                    if ("/1".equals(s)) {
-				                        return "testUriTagValueFunctionNotShared_1";
-				                    }
-				                    else {
-				                        return "testUriTagValueFunctionNotShared_2";
-				                    }
-				                })
-						.childObserve(observerDisconnect)
+				customizeServerOptions(httpServer, serverCtx, serverProtocols)
+						.doOnConnection(cnx -> responseSentHandler.register(responseSentRef, cnx.channel().pipeline()))
+						.metrics(true,
+								s -> {
+									if ("/1".equals(s)) {
+										return "testUriTagValueFunctionNotShared_1";
+									}
+									else {
+										return "testUriTagValueFunctionNotShared_2";
+									}
+								})
 						.bindNow();
 
+		CountDownLatch clientCompleted = new CountDownLatch(1); // client received full response
+		AtomicReference<CountDownLatch> clientCompletedRef = new AtomicReference<>(clientCompleted);
 		AtomicReference<SocketAddress> serverAddress = new AtomicReference<>();
-		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols).doAfterRequest((req, conn) ->
-				serverAddress.set(conn.channel().remoteAddress())
-		).observe(observerDisconnect);
+		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols)
+				.doAfterRequest((req, conn) -> serverAddress.set(conn.channel().remoteAddress()))
+				.doAfterResponseSuccess((resp, conn) -> clientCompletedRef.get().countDown());
 
-		httpClient.metrics(true, s -> "testUriTagValueFunctionNotShared_1")
+		httpClient
+				  .metrics(true, s -> "testUriTagValueFunctionNotShared_1")
 		          .post()
 		          .uri("/1")
 		          .send(body)
@@ -452,7 +484,8 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		          .expectComplete()
 		          .verify(Duration.ofSeconds(30));
 
-		assertThat(latch1.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
+		assertThat(responseSentRef.get().await(30, TimeUnit.SECONDS)).as("responseSentRef latch await").isTrue();
+		assertThat(clientCompletedRef.get().await(30, TimeUnit.SECONDS)).as("clientCompletedRef latch await").isTrue();
 
 		InetSocketAddress sa = (InetSocketAddress) serverAddress.get();
 
@@ -470,10 +503,11 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		checkExpectationsExisting("testUriTagValueFunctionNotShared_1", sa.getHostString() + ":" + sa.getPort(),
 				1, serverCtx != null, numWrites[0], bytesWrite[0]);
 
-		CountDownLatch latch2 = new CountDownLatch(4); // expect to observe 2 server disconnect + 2 client disconnect events
-		latchRef.set(latch2);
+		responseSentRef.set(new CountDownLatch(1));
+		clientCompletedRef.set(new CountDownLatch(1));
 
-		httpClient.metrics(true, s -> "testUriTagValueFunctionNotShared_2")
+		httpClient
+				.metrics(true, s -> "testUriTagValueFunctionNotShared_2")
 		          .post()
 		          .uri("/2")
 		          .send(body)
@@ -485,7 +519,8 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		          .expectComplete()
 		          .verify(Duration.ofSeconds(30));
 
-		assertThat(latch2.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
+		assertThat(responseSentRef.get().await(30, TimeUnit.SECONDS)).as("responseSentRef latch await").isTrue();
+		assertThat(clientCompletedRef.get().await(30, TimeUnit.SECONDS)).as("clientCompletedRef await").isTrue();
 
 		sa = (InetSocketAddress) serverAddress.get();
 
@@ -496,16 +531,14 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testContextAwareRecorderOnClient(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
+	                                      @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx,
+	                                      @SuppressWarnings("unused") HttpProtocol negotiatedProtocol) {
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols).bindNow();
 
 		ClientContextAwareRecorder recorder = ClientContextAwareRecorder.INSTANCE;
-		CountDownLatch latch = new CountDownLatch(1);
 		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols);
-		httpClient.doOnResponse((res, conn) -> conn.channel()
-		                                           .closeFuture()
-		                                           .addListener(f -> latch.countDown()))
-		          .metrics(true, () -> recorder)
+
+		httpClient.metrics(true, () -> recorder)
 		          .post()
 		          .uri("/1")
 		          .send(body)
@@ -518,8 +551,6 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		          .expectComplete()
 		          .verify(Duration.ofSeconds(30));
 
-		assertThat(latch.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
-
 		assertThat(recorder.onDataReceivedContextView).isTrue();
 		assertThat(recorder.onDataSentContextView).isTrue();
 	}
@@ -527,19 +558,21 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testContextAwareRecorderOnServer(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
+	                                      @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx,
+	                                      @SuppressWarnings("unused") HttpProtocol negotiatedProtocol) throws Exception {
+		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
 		ServerContextAwareRecorder recorder = ServerContextAwareRecorder.INSTANCE;
+		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
 		disposableServer =
-				customizeServerOptions(httpServer, serverCtx, serverProtocols).metrics(true, () -> recorder)
-				          .mapHandle((mono, conn) -> mono.contextWrite(Context.of("testContextAwareRecorder", "OK")))
-				          .bindNow();
+				customizeServerOptions(httpServer, serverCtx, serverProtocols)
+						.metrics(true, () -> recorder)
+						.doOnConnection(cnx -> responseSentHandler.register(responseSent, cnx.channel().pipeline()))
+						.mapHandle((mono, conn) -> mono.contextWrite(Context.of("testContextAwareRecorder", "OK")))
+						.bindNow();
 
-		CountDownLatch latch = new CountDownLatch(1);
 		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols);
-		httpClient.doOnResponse((res, conn) -> conn.channel()
-		                                           .closeFuture()
-		                                           .addListener(f -> latch.countDown()))
-		          .post()
+
+		httpClient.post()
 		          .uri("/1")
 		          .send(body)
 		          .responseContent()
@@ -550,7 +583,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		          .expectComplete()
 		          .verify(Duration.ofSeconds(30));
 
-		assertThat(latch.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
+		assertThat(responseSent.await(30, TimeUnit.SECONDS)).as("responseSent latch await").isTrue();
 
 		assertThat(recorder.onDataReceivedContextView).isTrue();
 		assertThat(recorder.onDataSentContextView).isTrue();
@@ -559,26 +592,30 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testServerConnectionsMicrometer(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
-		CountDownLatch latch = new CountDownLatch(4); // expect to observe 2 server disconnect + 2 client disconnect events
-		AtomicReference<CountDownLatch> latchRef = new AtomicReference<>(latch);
-		ConnectionObserver observerDisconnect = observeDisconnect(latchRef);
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx, HttpProtocol negotiatedProtocol) throws Exception {
+		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
+		CountDownLatch serverClosed = new CountDownLatch(1); // socket closed on the server side
+		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
+		ServerCloseHandler serverCloseHandler = ServerCloseHandler.INSTANCE;
+		boolean isHttp11 = negotiatedProtocol == HttpProtocol.HTTP11;
 
-		boolean isHttp11 = clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11;
-		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
+		HttpServer server = customizeServerOptions(httpServer, serverCtx, serverProtocols)
 				.metrics(true, Function.identity())
-				.childObserve(observerDisconnect)
-				.bindNow();
+				.doOnConnection(cnx -> responseSentHandler.register(responseSent, cnx.channel().pipeline()));
+
+		server = isHttp11 ?
+				server.doOnChannelInit((cnxObs, ch, sockAddr) -> serverCloseHandler.register(ch, serverClosed, isHttp11)) : server;
+		disposableServer = server.bindNow();
 
 		AtomicReference<SocketAddress> clientAddress = new AtomicReference<>();
-		httpClient = httpClient.doAfterRequest((req, conn) ->
-				clientAddress.set(conn.channel().localAddress())
-		).observe(observerDisconnect);
+		httpClient = httpClient
+				.doAfterRequest((req, conn) -> clientAddress.set(conn.channel().localAddress()));
 
 		String uri = "/4";
 		String address = formatSocketAddress(disposableServer.address());
 
 		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols);
+
 		httpClient
 				.metrics(true, Function.identity())
 				.post()
@@ -592,10 +629,11 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.expectComplete()
 				.verify(Duration.ofSeconds(30));
 
-		assertThat(latch.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
+		assertThat(responseSent.await(30, TimeUnit.SECONDS)).as("responseSent latch await").isTrue();
 
 		// now check the server counters
 		if (isHttp11) {
+			assertThat(serverClosed.await(30, TimeUnit.SECONDS)).as("serverClosed latch await").isTrue();
 			checkGauge(SERVER_CONNECTIONS_TOTAL, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
 			checkGauge(SERVER_CONNECTIONS_ACTIVE, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
 		}
@@ -621,22 +659,18 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		// ServerRecorder.INSTANCE.reset() (AfterEach) and thus leave ServerRecorder.INSTANCE in a bad state
 		ServerRecorder.INSTANCE.reset();
 		boolean isHttp11 = clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11;
+		CountDownLatch serverClosed = new CountDownLatch(1);
+		ServerCloseHandler serverCloseHandler = ServerCloseHandler.INSTANCE;
+
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
-				.metrics(true, () -> {
-							ServerRecorder.INSTANCE.done = isHttp11 ? new CountDownLatch(4) : new CountDownLatch(1);
-							return ServerRecorder.INSTANCE;
-						},
-						Function.identity())
+				.doOnConnection(c -> serverCloseHandler.register(c.channel(), serverClosed, isHttp11))
+				.metrics(true, ServerRecorder.supplier(), Function.identity())
 				.bindNow();
 		String address = formatSocketAddress(disposableServer.address());
 
-		CountDownLatch latch = new CountDownLatch(1);
-
 		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols);
-		httpClient.doOnResponse((res, conn) ->
-						conn.channel()
-								.closeFuture()
-								.addListener(f -> latch.countDown()))
+
+		httpClient
 				.metrics(true, Function.identity())
 				.post()
 				.uri("/5")
@@ -649,8 +683,15 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.expectComplete()
 				.verify(Duration.ofSeconds(30));
 
-		assertThat(latch.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
-		assertThat(ServerRecorder.INSTANCE.done.await(30, TimeUnit.SECONDS)).as("recorder latch await").isTrue();
+		// dispose the client connection provider now, before asserting test expectations.
+		provider.disposeLater()
+				.block(Duration.ofSeconds(30));
+
+		// now the socket is closed, wait for the ServerRecorder to be called in recordServerConnectionClosed before asserting test expectations
+		assertThat(serverClosed.await(30, TimeUnit.SECONDS)).as("serverClosed latch await").isTrue();
+
+		// now we can assert test expectations
+		assertThat(ServerRecorder.INSTANCE.error.get()).isNull();
 		if (isHttp11) {
 			assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(0);
 			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsAmount.get()).isEqualTo(0);
@@ -658,7 +699,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 			assertThat(ServerRecorder.INSTANCE.onInactiveConnectionsLocalAddr.get()).isEqualTo(address);
 		}
 		else {
-			assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(1);
+			assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(0);
 		}
 
 		disposableServer.disposeNow();
@@ -667,7 +708,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@Test
 	void testIssue896() throws Exception {
 		disposableServer = httpServer.noSSL()
-		                             .bindNow();
+				.bindNow();
 
 		// the client will observe three DISCONNECT: one when a NotSSLRecordException is caught,
 		// one when DecoderException is caught, and one when the connection becomes inactive
@@ -695,19 +736,20 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@MethodSource("http11CompatibleProtocols")
 	void testBadRequest(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
 			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
-		CountDownLatch latch1 = new CountDownLatch(4); // expect to observe 2 server disconnect + 2 client disconnect events
-		AtomicReference<CountDownLatch> latchRef = new AtomicReference<>(latch1);
-		ConnectionObserver observerDisconnect = observeDisconnect(latchRef);
+		CountDownLatch serverClosed = new CountDownLatch(1);
+		CountDownLatch clientCompleted = new CountDownLatch(1);
+		boolean isHttp11 = clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11;
+		ServerCloseHandler serverCloseHandler = ServerCloseHandler.INSTANCE;
 
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
+				.doOnChannelInit((obs, c, s) -> serverCloseHandler.register(c, serverClosed, isHttp11))
 				.httpRequestDecoder(spec -> spec.maxHeaderSize(32))
-				.childObserve(observerDisconnect)
 				.bindNow();
 
 		AtomicReference<SocketAddress> serverAddress = new AtomicReference<>();
-		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols).doAfterRequest((req, conn) ->
-				serverAddress.set(conn.channel().remoteAddress())
-		).observe(observerDisconnect);
+		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols)
+				.doAfterRequest((req, conn) -> serverAddress.set(conn.channel().remoteAddress()))
+				.doAfterResponseSuccess((resp, conn) -> clientCompleted.countDown());
 
 		httpClient.get()
 		          .uri("/max_header_size")
@@ -717,8 +759,15 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		          .expectComplete()
 		          .verify(Duration.ofSeconds(30));
 
-		assertThat(latch1.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
+		// dispose the client connection provider now, before asserting test expectations.
+		provider.disposeLater()
+				.block(Duration.ofSeconds(30));
 
+		// now the socket is closed, wait for the ServerRecorder to be called in recordServerConnectionClosed before asserting test expectations
+		assertThat(serverClosed.await(30, TimeUnit.SECONDS)).as("serverClosed latch await").isTrue();
+
+		// Ensure client has fully received the response before asserting test expectations
+		assertThat(clientCompleted.await(30, TimeUnit.SECONDS)).as("clientCompleted latch await").isTrue();
 		InetSocketAddress sa = (InetSocketAddress) serverAddress.get();
 
 		checkExpectationsBadRequest(sa.getHostString() + ":" + sa.getPort(), serverCtx != null);
@@ -745,15 +794,20 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	}
 
 	private void checkServerConnectionsRecorder(HttpServerRequest request) {
-		String address = formatSocketAddress(request.hostAddress());
-		boolean isHttp2 = request.requestHeaders().contains(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text());
-		assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(1);
-		assertThat(ServerRecorder.INSTANCE.onServerConnectionsLocalAddr.get()).isEqualTo(address);
-		if (!isHttp2) {
-			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsAmount.get()).isEqualTo(1);
-			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsLocalAddr.get()).isEqualTo(address);
+		try {
+			String address = formatSocketAddress(request.hostAddress());
+			boolean isHttp2 = request.requestHeaders().contains(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text());
+			assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(1);
+			assertThat(ServerRecorder.INSTANCE.onServerConnectionsLocalAddr.get()).isEqualTo(address);
+			if (!isHttp2) {
+				assertThat(ServerRecorder.INSTANCE.onActiveConnectionsAmount.get()).isEqualTo(1);
+				assertThat(ServerRecorder.INSTANCE.onActiveConnectionsLocalAddr.get()).isEqualTo(address);
+			}
+			assertThat(ServerRecorder.INSTANCE.onInactiveConnectionsLocalAddr.get()).isNull();
 		}
-		assertThat(ServerRecorder.INSTANCE.onInactiveConnectionsLocalAddr.get()).isNull();
+		catch (Throwable error) {
+			ServerRecorder.INSTANCE.error.set(error);
+		}
 	}
 
 	private void checkExpectationsExisting(String uri, String serverAddress, int connIndex, boolean checkTls,
@@ -825,7 +879,6 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		//checkDistributionSummary(CLIENT_DATA_RECEIVED, summaryTags2, numReads, expectedReceivedAmount);
 		checkCounter(CLIENT_ERRORS, summaryTags2, false, 0);
 	}
-
 
 	private void checkExpectationsBadRequest(String serverAddress, boolean checkTls) {
 		String uri = "/max_header_size";
@@ -917,23 +970,23 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 	static Stream<Arguments> httpCompatibleProtocols() {
 		return Stream.of(
-				Arguments.of(new HttpProtocol[]{HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11}, null, null),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11}, null, null, HttpProtocol.HTTP11),
 				Arguments.of(new HttpProtocol[]{HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11},
-						Named.of("Http11SslContextSpec", serverCtx11), Named.of("Http11SslContextSpec", clientCtx11)),
+						Named.of("Http11SslContextSpec", serverCtx11), Named.of("Http11SslContextSpec", clientCtx11), HttpProtocol.HTTP11),
 				Arguments.of(new HttpProtocol[]{HttpProtocol.H2}, new HttpProtocol[]{HttpProtocol.H2},
-						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2)),
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2), HttpProtocol.H2),
 				Arguments.of(new HttpProtocol[]{HttpProtocol.H2}, new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11},
-						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2)),
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2), HttpProtocol.H2),
 				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11},
-						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http11SslContextSpec", clientCtx11)),
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http11SslContextSpec", clientCtx11), HttpProtocol.HTTP11),
 				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2},
-						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2)),
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2), HttpProtocol.H2),
 				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11},
-						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2)),
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C}, new HttpProtocol[]{HttpProtocol.H2C}, null, null),
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11}, null, null),
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C}, null, null),
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, null, null)
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2), HttpProtocol.H2),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C}, new HttpProtocol[]{HttpProtocol.H2C}, null, null, HttpProtocol.H2C),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11}, null, null, HttpProtocol.HTTP11),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C}, null, null, HttpProtocol.H2C),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, null, null, HttpProtocol.H2C)
 		);
 	}
 
@@ -1082,6 +1135,8 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	static final class ServerRecorder implements HttpServerMetricsRecorder {
 
 		static final ServerRecorder INSTANCE = new ServerRecorder();
+		static final Supplier<ServerRecorder> SUPPLIER = () -> INSTANCE;
+		private AtomicReference<Throwable> error = new AtomicReference<>();
 		private final AtomicInteger onServerConnectionsAmount = new AtomicInteger();
 		private final AtomicReference<String> onServerConnectionsLocalAddr = new AtomicReference<>();
 		private final AtomicReference<String> onActiveConnectionsLocalAddr = new AtomicReference<>();
@@ -1089,7 +1144,12 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		private final AtomicInteger onActiveConnectionsAmount = new AtomicInteger();
 		private volatile CountDownLatch done = new CountDownLatch(4);
 
+		static Supplier<ServerRecorder> supplier() {
+			return SUPPLIER;
+		}
+
 		void reset() {
+			error.set(null);
 			onServerConnectionsAmount.set(0);
 			onServerConnectionsLocalAddr.set(null);
 			onActiveConnectionsLocalAddr.set(null);
@@ -1172,6 +1232,112 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 		@Override
 		public void recordResolveAddressTime(SocketAddress socketAddress, Duration duration, String s) {
+		}
+	}
+
+	/**
+	 * Server Handler used to detect when the last http response content has been sent to the client.
+	 * Handler placed before the HttpMetricsHandler on the Server pipeline.
+	 * Metrics are up-to-date when the latch is counted down.
+	 */
+	static final class ResponseSentHandler extends ChannelOutboundHandlerAdapter {
+		final static String HANDLER_NAME = "ServerCompletedHandler.handler";
+		final static ResponseSentHandler INSTANCE = new ResponseSentHandler();
+		AtomicReference<CountDownLatch> latchRef;
+
+		void register(AtomicReference<CountDownLatch> latchRef, ChannelPipeline pipeline) {
+			this.latchRef = latchRef;
+			pipeline.addBefore(NettyPipeline.HttpMetricsHandler, HANDLER_NAME, this);
+		}
+
+		void register(CountDownLatch latch, ChannelPipeline pipeline) {
+			register(new AtomicReference<>(latch), pipeline);
+		}
+
+		@Override
+		public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+			if (msg instanceof LastHttpContent) {
+				promise.addListener(future -> {
+					latchRef.get().countDown();
+				});
+			}
+
+			ctx.write(msg, promise);
+		}
+
+		@Override
+		public boolean isSharable() {
+			return true; // A server may accept multiple connections, hence this handler must be sharable
+		}
+	}
+
+	/**
+	 * Server Handler used to detect when the last http client request content has been received by the server.
+	 * Handler placed after the HttpMetricsHandler on the Server pipeline.
+	 * Metrics are up-to-date when the latch is counted down.
+	 */
+	static final class RequestReceivedHandler extends ChannelInboundHandlerAdapter {
+		final static RequestReceivedHandler INSTANCE = new RequestReceivedHandler();
+		final static String HANDLER_NAME = "ServerReceivedHandler.handler";
+		AtomicReference<CountDownLatch> latchRef;
+
+		void register(AtomicReference<CountDownLatch> latchRef, ChannelPipeline pipeline) {
+			this.latchRef = latchRef;
+			pipeline.addAfter(NettyPipeline.HttpMetricsHandler, HANDLER_NAME, this);
+		}
+
+		void register(CountDownLatch latch, ChannelPipeline pipeline) {
+			register(new AtomicReference<>(latch), pipeline);
+		}
+
+		@Override
+		public void channelRead(ChannelHandlerContext ctx, Object msg) {
+			if (msg instanceof LastHttpContent) {
+				latchRef.get().countDown();
+			}
+			else if (msg instanceof DefaultHttp2DataFrame && ((DefaultHttp2DataFrame) msg).isEndStream()) {
+				latchRef.get().countDown();
+			}
+
+			ctx.fireChannelRead(msg);
+		}
+
+		@Override
+		public boolean isSharable() {
+			return true;
+		}
+	}
+
+	/**
+	 * Server handler used to wait until the client socket is closed on the server side.
+	 * For HTTP1.1, the handler is placed before the ReactorBridge, so all previous handlers will see
+	 * the close before this handler. For HTTP2, the handler is placed lastly on the pipeline.
+	 */
+	static final class ServerCloseHandler extends ChannelInboundHandlerAdapter {
+		static final ServerCloseHandler INSTANCE = new ServerCloseHandler();
+		static final String HANDLER_NAME = "ServerCloseHandler.handler";
+		private CountDownLatch latch;
+
+		void register(Channel channel, CountDownLatch latch, boolean http11) {
+			this.latch = latch;
+
+			if (http11) {
+				channel.pipeline().addBefore(NettyPipeline.ReactiveBridge, HANDLER_NAME, this);
+			}
+			else {
+				channel.parent().pipeline().addLast(HANDLER_NAME, this);
+			}
+		}
+
+		@Override
+		public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+			latch.countDown();
+			ctx.fireChannelInactive();
+		}
+
+		@Override
+		public boolean isSharable() {
+			return true;
 		}
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -195,14 +195,14 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.doAfterResponseSuccess((resp, conn) -> clientCompletedRef.get().countDown());
 
 		StepVerifier.create(httpClient.post()
-						.uri("/1")
-						.send(body)
-						.responseContent()
-						.aggregate()
-						.asString())
-				.expectNext("Hello World!")
-				.expectComplete()
-				.verify(Duration.ofSeconds(30));
+		                              .uri("/1")
+		                              .send(body)
+		                              .responseContent()
+		                              .aggregate()
+		                              .asString())
+		            .expectNext("Hello World!")
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(30));
 
 		assertThat(responseSentRef.get().await(30, TimeUnit.SECONDS)).as("responseSentRef latch await").isTrue();
 		assertThat(clientCompletedRef.get().await(30, TimeUnit.SECONDS)).as("clientCompletedRef latch await").isTrue();
@@ -230,14 +230,14 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		clientCompletedRef.set(new CountDownLatch(1));
 
 		StepVerifier.create(httpClient.post()
-						.uri("/2?i=1&j=2")
-						.send(body)
-						.responseContent()
-						.aggregate()
-						.asString())
-				.expectNext("Hello World!")
-				.expectComplete()
-				.verify(Duration.ofSeconds(30));
+		                              .uri("/2?i=1&j=2")
+		                              .send(body)
+		                              .responseContent()
+		                              .aggregate()
+		                              .asString())
+		            .expectNext("Hello World!")
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(30));
 
 		assertThat(responseSentRef.get().await(30, TimeUnit.SECONDS)).as("responseSentRef latch await").isTrue();
 		assertThat(clientCompletedRef.get().await(30, TimeUnit.SECONDS)).as("clientCompletedRef latch await").isTrue();
@@ -252,7 +252,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testRecordingFailsServerSide(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-	                                  @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) {
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) {
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
 				.metrics(true, id -> {
 					throw new IllegalArgumentException("Testcase injected Exception");
@@ -276,7 +276,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testRecordingFailsClientSide(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-	                                  @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) {
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) {
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
 				.bindNow();
 
@@ -298,7 +298,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testNonExistingEndpoint(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-	                             @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
 		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
 		AtomicReference<CountDownLatch> responseSentRef = new AtomicReference<>(responseSent);
 		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
@@ -306,11 +306,13 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		AtomicReference<CountDownLatch> requestReceivedRef = new AtomicReference<>(requestReceived);
 		RequestReceivedHandler requestReceivedHandler = RequestReceivedHandler.INSTANCE;
 
-		// the serverReceivedHandler is used to detect when the server has received the last client request content
-		// the serverCompletedHandler is used to detect when the server has sent the last response content
+		// the requestReceivedHandler is used to detect when the server has received the last client request content
+		// the responseSentHandler is used to detect when the server has sent the last response content
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
-				.doOnConnection(cnx -> responseSentHandler.register(responseSentRef, cnx.channel().pipeline()))
-				.doOnConnection(cnx -> requestReceivedHandler.register(requestReceivedRef, cnx.channel().pipeline()))
+				.doOnConnection(cnx -> {
+					responseSentHandler.register(responseSentRef, cnx.channel().pipeline());
+					requestReceivedHandler.register(requestReceivedRef, cnx.channel().pipeline());
+				})
 				.bindNow();
 
 		AtomicReference<SocketAddress> serverAddress = new AtomicReference<>();
@@ -404,15 +406,15 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.doAfterRequest((req, conn) -> serverAddress.set(conn.channel().remoteAddress()));
 
 		StepVerifier.create(httpClient.metrics(true, s -> "testUriTagValueResolver")
-						.post()
-						.uri("/1")
-						.send(body)
-						.responseContent()
-						.aggregate()
-						.asString())
-				.expectNext("Hello World!")
-				.expectComplete()
-				.verify(Duration.ofSeconds(30));
+		                              .post()
+		                              .uri("/1")
+		                              .send(body)
+		                              .responseContent()
+		                              .aggregate()
+		                              .asString())
+		            .expectNext("Hello World!")
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(30));
 
 		assertThat(responseSent.await(30, TimeUnit.SECONDS)).as("responseSent latch await").isTrue();
 		assertThat(clientCompleted.await(30, TimeUnit.SECONDS)).as("clientCompleted latch await").isTrue();
@@ -466,16 +468,16 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.doAfterResponseSuccess((resp, conn) -> clientCompletedRef.get().countDown());
 
 		httpClient.metrics(true, s -> "testUriTagValueFunctionNotShared_1")
-				.post()
-				.uri("/1")
-				.send(body)
-				.responseContent()
-				.aggregate()
-				.asString()
-				.as(StepVerifier::create)
-				.expectNext("Hello World!")
-				.expectComplete()
-				.verify(Duration.ofSeconds(30));
+		          .post()
+		          .uri("/1")
+		          .send(body)
+		          .responseContent()
+		          .aggregate()
+		          .asString()
+		          .as(StepVerifier::create)
+		          .expectNext("Hello World!")
+		          .expectComplete()
+		          .verify(Duration.ofSeconds(30));
 
 		assertThat(responseSentRef.get().await(30, TimeUnit.SECONDS)).as("responseSentRef latch await").isTrue();
 		assertThat(clientCompletedRef.get().await(30, TimeUnit.SECONDS)).as("clientCompletedRef latch await").isTrue();
@@ -500,16 +502,16 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		clientCompletedRef.set(new CountDownLatch(1));
 
 		httpClient.metrics(true, s -> "testUriTagValueFunctionNotShared_2")
-				.post()
-				.uri("/2")
-				.send(body)
-				.responseContent()
-				.aggregate()
-				.asString()
-				.as(StepVerifier::create)
-				.expectNext("Hello World!")
-				.expectComplete()
-				.verify(Duration.ofSeconds(30));
+		          .post()
+		          .uri("/2")
+		          .send(body)
+		          .responseContent()
+		          .aggregate()
+		          .asString()
+		          .as(StepVerifier::create)
+		          .expectNext("Hello World!")
+		          .expectComplete()
+		          .verify(Duration.ofSeconds(30));
 
 		assertThat(responseSentRef.get().await(30, TimeUnit.SECONDS)).as("responseSentRef latch await").isTrue();
 		assertThat(clientCompletedRef.get().await(30, TimeUnit.SECONDS)).as("clientCompletedRef await").isTrue();
@@ -523,7 +525,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testContextAwareRecorderOnClient(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-	                                      @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) {
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) {
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols).bindNow();
 
 		ClientContextAwareRecorder recorder = ClientContextAwareRecorder.INSTANCE;
@@ -549,7 +551,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testContextAwareRecorderOnServer(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-	                                      @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
 		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
 		ServerContextAwareRecorder recorder = ServerContextAwareRecorder.INSTANCE;
 		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
@@ -695,7 +697,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@Test
 	void testIssue896() throws Exception {
 		disposableServer = httpServer.noSSL()
-				.bindNow();
+		                             .bindNow();
 
 		// The client should get two errors: NotSSLRecordException, and DecoderException.
 		CountDownLatch latch = new CountDownLatch(2);
@@ -1113,7 +1115,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 		static final ServerRecorder INSTANCE = new ServerRecorder();
 		static final Supplier<ServerRecorder> SUPPLIER = () -> INSTANCE;
-		private AtomicReference<Throwable> error = new AtomicReference<>();
+		private final AtomicReference<Throwable> error = new AtomicReference<>();
 		private final AtomicInteger onServerConnectionsAmount = new AtomicInteger();
 		private final AtomicReference<String> onServerConnectionsLocalAddr = new AtomicReference<>();
 		private final AtomicReference<String> onActiveConnectionsLocalAddr = new AtomicReference<>();
@@ -1235,9 +1237,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		@SuppressWarnings("FutureReturnValueIgnored")
 		public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
 			if (msg instanceof LastHttpContent) {
-				promise.addListener(future -> {
-					latchRef.get().countDown();
-				});
+				promise.addListener(future -> latchRef.get().countDown());
 			}
 
 			ctx.write(msg, promise);
@@ -1262,10 +1262,6 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		void register(AtomicReference<CountDownLatch> latchRef, ChannelPipeline pipeline) {
 			this.latchRef = latchRef;
 			pipeline.addAfter(NettyPipeline.HttpMetricsHandler, HANDLER_NAME, this);
-		}
-
-		void register(CountDownLatch latch, ChannelPipeline pipeline) {
-			register(new AtomicReference<>(latch), pipeline);
 		}
 
 		@Override
@@ -1304,7 +1300,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		}
 
 		@Override
-		public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+		public void channelInactive(ChannelHandlerContext ctx) {
 			latch.countDown();
 			ctx.fireChannelInactive();
 		}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -465,18 +465,17 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.doAfterRequest((req, conn) -> serverAddress.set(conn.channel().remoteAddress()))
 				.doAfterResponseSuccess((resp, conn) -> clientCompletedRef.get().countDown());
 
-		httpClient
-				  .metrics(true, s -> "testUriTagValueFunctionNotShared_1")
-		          .post()
-		          .uri("/1")
-		          .send(body)
-		          .responseContent()
-		          .aggregate()
-		          .asString()
-		          .as(StepVerifier::create)
-		          .expectNext("Hello World!")
-		          .expectComplete()
-		          .verify(Duration.ofSeconds(30));
+		httpClient.metrics(true, s -> "testUriTagValueFunctionNotShared_1")
+				.post()
+				.uri("/1")
+				.send(body)
+				.responseContent()
+				.aggregate()
+				.asString()
+				.as(StepVerifier::create)
+				.expectNext("Hello World!")
+				.expectComplete()
+				.verify(Duration.ofSeconds(30));
 
 		assertThat(responseSentRef.get().await(30, TimeUnit.SECONDS)).as("responseSentRef latch await").isTrue();
 		assertThat(clientCompletedRef.get().await(30, TimeUnit.SECONDS)).as("clientCompletedRef latch await").isTrue();
@@ -604,7 +603,6 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		String address = formatSocketAddress(disposableServer.address());
 
 		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols);
-
 		httpClient
 				.metrics(true, Function.identity())
 				.post()

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -1276,10 +1276,6 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 			if (msg instanceof LastHttpContent) {
 				latchRef.get().countDown();
 			}
-			else if (msg instanceof DefaultHttp2DataFrame && ((DefaultHttp2DataFrame) msg).isEndStream()) {
-				latchRef.get().countDown();
-			}
-
 			ctx.fireChannelRead(msg);
 		}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -180,7 +180,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testExistingEndpoint(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx, HttpProtocol negotiatedProtocol) throws Exception {
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
 		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
 		AtomicReference<CountDownLatch> responseSentRef = new AtomicReference<>(responseSent);
 		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
@@ -195,8 +195,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.doAfterRequest((req, conn) -> serverAddress.set(conn.channel().remoteAddress()))
 				.doAfterResponseSuccess((resp, conn) -> clientCompletedRef.get().countDown());
 
-		StepVerifier.create(httpClient
-						.post()
+		StepVerifier.create(httpClient.post()
 						.uri("/1")
 						.send(body)
 						.responseContent()
@@ -231,8 +230,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		responseSentRef.set(new CountDownLatch(1));
 		clientCompletedRef.set(new CountDownLatch(1));
 
-		StepVerifier.create(httpClient
-						.post()
+		StepVerifier.create(httpClient.post()
 						.uri("/2?i=1&j=2")
 						.send(body)
 						.responseContent()
@@ -255,8 +253,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testRecordingFailsServerSide(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-	                                  @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx,
-	                                  @SuppressWarnings("unused") HttpProtocol negotiatedProtocol) {
+	                                  @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) {
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
 				.metrics(true, id -> {
 					throw new IllegalArgumentException("Testcase injected Exception");
@@ -280,8 +277,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testRecordingFailsClientSide(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-	                                  @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx,
-	                                  @SuppressWarnings("unused") HttpProtocol negotiatedProtocol) {
+	                                  @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) {
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
 				.bindNow();
 
@@ -303,7 +299,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testNonExistingEndpoint(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-	                             @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx, HttpProtocol negotiatedProtocol) throws Exception {
+	                             @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
 		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
 		AtomicReference<CountDownLatch> responseSentRef = new AtomicReference<>(responseSent);
 		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
@@ -393,7 +389,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testUriTagValueFunction(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx, HttpProtocol negotiatedProtocol) throws Exception {
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
 		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
 		CountDownLatch clientCompleted = new CountDownLatch(1); // client received full response
 		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
@@ -408,8 +404,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.doAfterResponseSuccess((res, conn) -> clientCompleted.countDown())
 				.doAfterRequest((req, conn) -> serverAddress.set(conn.channel().remoteAddress()));
 
-		StepVerifier.create(httpClient
-						.metrics(true, s -> "testUriTagValueResolver")
+		StepVerifier.create(httpClient.metrics(true, s -> "testUriTagValueResolver")
 						.post()
 						.uri("/1")
 						.send(body)
@@ -446,7 +441,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testUriTagValueFunctionNotSharedForClient(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx, HttpProtocol negotiatedProtocol) throws Exception {
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
 		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
 		AtomicReference<CountDownLatch> responseSentRef = new AtomicReference<>(responseSent);
 		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
@@ -506,18 +501,17 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		responseSentRef.set(new CountDownLatch(1));
 		clientCompletedRef.set(new CountDownLatch(1));
 
-		httpClient
-				.metrics(true, s -> "testUriTagValueFunctionNotShared_2")
-		          .post()
-		          .uri("/2")
-		          .send(body)
-		          .responseContent()
-		          .aggregate()
-		          .asString()
-		          .as(StepVerifier::create)
-		          .expectNext("Hello World!")
-		          .expectComplete()
-		          .verify(Duration.ofSeconds(30));
+		httpClient.metrics(true, s -> "testUriTagValueFunctionNotShared_2")
+				.post()
+				.uri("/2")
+				.send(body)
+				.responseContent()
+				.aggregate()
+				.asString()
+				.as(StepVerifier::create)
+				.expectNext("Hello World!")
+				.expectComplete()
+				.verify(Duration.ofSeconds(30));
 
 		assertThat(responseSentRef.get().await(30, TimeUnit.SECONDS)).as("responseSentRef latch await").isTrue();
 		assertThat(clientCompletedRef.get().await(30, TimeUnit.SECONDS)).as("clientCompletedRef await").isTrue();
@@ -531,8 +525,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testContextAwareRecorderOnClient(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-	                                      @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx,
-	                                      @SuppressWarnings("unused") HttpProtocol negotiatedProtocol) {
+	                                      @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) {
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols).bindNow();
 
 		ClientContextAwareRecorder recorder = ClientContextAwareRecorder.INSTANCE;
@@ -558,14 +551,12 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testContextAwareRecorderOnServer(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-	                                      @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx,
-	                                      @SuppressWarnings("unused") HttpProtocol negotiatedProtocol) throws Exception {
+	                                      @Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
 		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
 		ServerContextAwareRecorder recorder = ServerContextAwareRecorder.INSTANCE;
 		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
 		disposableServer =
-				customizeServerOptions(httpServer, serverCtx, serverProtocols)
-						.metrics(true, () -> recorder)
+				customizeServerOptions(httpServer, serverCtx, serverProtocols).metrics(true, () -> recorder)
 						.doOnConnection(cnx -> responseSentHandler.register(responseSent, cnx.channel().pipeline()))
 						.mapHandle((mono, conn) -> mono.contextWrite(Context.of("testContextAwareRecorder", "OK")))
 						.bindNow();
@@ -592,13 +583,12 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testServerConnectionsMicrometer(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
-			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx, HttpProtocol negotiatedProtocol) throws Exception {
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
 		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
 		CountDownLatch serverClosed = new CountDownLatch(1); // socket closed on the server side
 		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
 		ServerCloseHandler serverCloseHandler = ServerCloseHandler.INSTANCE;
-		boolean isHttp11 = negotiatedProtocol == HttpProtocol.HTTP11;
-
+		boolean isHttp11 = clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11;
 		HttpServer server = customizeServerOptions(httpServer, serverCtx, serverProtocols)
 				.metrics(true, Function.identity())
 				.doOnConnection(cnx -> responseSentHandler.register(responseSent, cnx.channel().pipeline()));
@@ -960,23 +950,23 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 	static Stream<Arguments> httpCompatibleProtocols() {
 		return Stream.of(
-				Arguments.of(new HttpProtocol[]{HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11}, null, null, HttpProtocol.HTTP11),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11}, null, null),
 				Arguments.of(new HttpProtocol[]{HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11},
-						Named.of("Http11SslContextSpec", serverCtx11), Named.of("Http11SslContextSpec", clientCtx11), HttpProtocol.HTTP11),
+						Named.of("Http11SslContextSpec", serverCtx11), Named.of("Http11SslContextSpec", clientCtx11)),
 				Arguments.of(new HttpProtocol[]{HttpProtocol.H2}, new HttpProtocol[]{HttpProtocol.H2},
-						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2), HttpProtocol.H2),
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2)),
 				Arguments.of(new HttpProtocol[]{HttpProtocol.H2}, new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11},
-						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2), HttpProtocol.H2),
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2)),
 				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11},
-						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http11SslContextSpec", clientCtx11), HttpProtocol.HTTP11),
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http11SslContextSpec", clientCtx11)),
 				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2},
-						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2), HttpProtocol.H2),
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2)),
 				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11},
-						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2), HttpProtocol.H2),
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C}, new HttpProtocol[]{HttpProtocol.H2C}, null, null, HttpProtocol.H2C),
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11}, null, null, HttpProtocol.HTTP11),
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C}, null, null, HttpProtocol.H2C),
-				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, null, null, HttpProtocol.H2C)
+						Named.of("Http2SslContextSpec", serverCtx2), Named.of("Http2SslContextSpec", clientCtx2)),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C}, new HttpProtocol[]{HttpProtocol.H2C}, null, null),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11}, null, null),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C}, null, null),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, null, null)
 		);
 	}
 


### PR DESCRIPTION
This PR is a revamp of the HttpMetricsHandlerTests and also fixes a concurrency issue in testServerConnectionsRecorder, which sometimes fails with this exception:

```
HttpMetricsHandlerTests > testServerConnectionsRecorder(HttpProtocol[], HttpProtocol[], ProtocolSslContextSpec, ProtocolSslContextSpec, HttpProtocol) > reactor.netty.http.HttpMetricsHandlerTests.testServerConnectionsRecorder(HttpProtocol[], HttpProtocol[], ProtocolSslContextSpec, ProtocolSslContextSpec, HttpProtocol)[8] FAILED
    java.lang.AssertionError: expectation "expectNext(Hello World!)" failed (expected: onNext(Hello World!); actual: onError(reactor.netty.http.client.PrematureCloseException: Connection prematurely closed DURING response))
        at reactor.test.MessageFormatter.assertionError(MessageFormatter.java:115)
        at reactor.test.MessageFormatter.failPrefix(MessageFormatter.java:104)
        at reactor.test.MessageFormatter.fail(MessageFormatter.java:73)
        at reactor.test.MessageFormatter.failOptional(MessageFormatter.java:88)
        at reactor.test.DefaultStepVerifierBuilder.lambda$addExpectedValue$10(DefaultStepVerifierBuilder.java:509)
        at reactor.test.DefaultStepVerifierBuilder$SignalEvent.test(DefaultStepVerifierBuilder.java:2288)
        at reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onSignal(DefaultStepVerifierBuilder.java:1528)
        at reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onExpectation(DefaultStepVerifierBuilder.java:1476)
        at reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onError(DefaultStepVerifierBuilder.java:1129)
        at reactor.core.publisher.FluxHandle$HandleSubscriber.onError(FluxHandle.java:210)
        at reactor.core.publisher.FluxMap$MapConditionalSubscriber.onError(FluxMap.java:265)
        at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.onError(FluxDoFinally.java:119)
        at reactor.core.publisher.FluxHandleFuseable$HandleFuseableSubscriber.onError(FluxHandleFuseable.java:226)
        at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.onError(FluxContextWrite.java:121)
        at reactor.core.publisher.MonoCollectList$MonoCollectListSubscriber.onError(MonoCollectList.java:114)
        at reactor.core.publisher.FluxMap$MapSubscriber.onError(FluxMap.java:134)
        at reactor.core.publisher.FluxMap$MapSubscriber.onError(FluxMap.java:134)
        at reactor.core.publisher.MonoFlatMapMany$FlatMapManyInner.onError(MonoFlatMapMany.java:255)
        at reactor.core.publisher.FluxMap$MapSubscriber.onError(FluxMap.java:134)
        at reactor.netty.channel.FluxReceive.onInboundError(FluxReceive.java:450)
        at reactor.netty.channel.ChannelOperations.onInboundError(ChannelOperations.java:492)
        at reactor.netty.http.client.HttpClientOperations.onInboundClose(HttpClientOperations.java:272)
        at reactor.netty.channel.ChannelOperationsHandler.channelInactive(ChannelOperationsHandler.java:70)
        at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelInactive(DefaultChannelHandlerContext.java:284)
        at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelInactive(DefaultChannelHandlerContext.java:278)
        at io.netty5.channel.DefaultChannelHandlerContext.fireChannelInactive(DefaultChannelHandlerContext.java:265)
        at io.netty5.channel.ChannelHandler.channelInactive(ChannelHandler.java:213)
        at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelInactive(DefaultChannelHandlerContext.java:284)
        at io.netty5.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:808)
        at io.netty5.handler.codec.http2.DefaultHttp2StreamChannel.lambda$fireChannelInactiveAndDeregister$2(DefaultHttp2StreamChannel.java:610)
        at io.netty5.util.concurrent.SingleThreadEventExecutor.runTask(SingleThreadEventExecutor.java:338)
        at io.netty5.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:361)
        at io.netty5.channel.SingleThreadEventLoop.run(SingleThreadEventLoop.java:[180](https://github.com/reactor/reactor-netty/runs/7250727386?check_suite_focus=true#step:11:181))
        at io.netty5.util.concurrent.SingleThreadEventExecutor.lambda$doStartThread$4(SingleThreadEventExecutor.java:774)
        at io.netty5.util.internal.ThreadExecutorMap.lambda$apply$1(ThreadExecutorMap.java:68)
        at io.netty5.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:833)
```
Such exception can happen if the checkServerConnectionsRecorder method throws some exceptions.
So, the PR first catches any exceptions thrown from checkServerConnectionsRecorder, and then the testServerConnectionsRecorder asserts if the exception has not been thrown.

So, when doing this, we can then see the root cause exception (this exception comes from netty5 branch, bit it's the same issue in 1.0.x branch):

```
HttpMetricsHandlerTests > testServerConnectionsRecorder(HttpProtocol[], HttpProtocol[], ProtocolSslContextSpec, ProtocolSslContextSpec, HttpProtocol) > reactor.netty.http.HttpMetricsHandlerTests.testServerConnectionsRecorder(HttpProtocol[], HttpProtocol[], ProtocolSslContextSpec, ProtocolSslContextSpec, HttpProtocol)[4] FAILED
    org.opentest4j.AssertionFailedError: 
    expected: 
      null
     but was: 
      org.opentest4j.AssertionFailedError: 
      expected: 1
       but was: 0
      	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
      	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
      	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
      	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
      	at reactor.netty.http.HttpMetricsHandlerTests.checkServerConnectionsRecorder(HttpMetricsHandlerTests.java:768)
      	at reactor.netty.http.HttpMetricsHandlerTests.lambda$setUp$9(HttpMetricsHandlerTests.java:157)
      	at reactor.core.publisher.FluxPeek$PeekSubscriber.onNext(FluxPeek.java:185)
      	at reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:122)
      	at reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:122)
      	at reactor.netty.channel.FluxReceive.drainReceiver(FluxReceive.java:279)
      	at reactor.netty.channel.FluxReceive.onInboundNext(FluxReceive.java:388)
      	at reactor.netty.channel.ChannelOperations.onInboundNext(ChannelOperations.java:408)
      	at reactor.netty.http.server.HttpServerOperations.onInboundNext(HttpServerOperations.java:579)
      	at reactor.netty.channel.ChannelOperationsHandler.channelRead(ChannelOperationsHandler.java:94)
      	at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:437)
      	at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:430)
      	at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:411)
      	at reactor.netty.http.server.AbstractHttpServerMetricsHandler.channelRead(AbstractHttpServerMetricsHandler.java:192)
      	at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:437)
      	at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:430)
      	at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:411)
      	at reactor.netty.http.server.Http2StreamBridgeServerHandler.channelRead(Http2StreamBridgeServerHandler.java:142)
      	at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:437)
      	at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:430)
      	at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:411)
      	at io.netty5.handler.codec.http2.Http2StreamFrameToHttpObjectCodec.decodeAndClose(Http2StreamFrameToHttpObjectCodec.java:125)
      	at io.netty5.handler.codec.http2.Http2StreamFrameToHttpObjectCodec.decodeAndClose(Http2StreamFrameToHttpObjectCodec.java:57)
      	at io.netty5.handler.codec.MessageToMessageCodec$2.decodeAndClose(MessageToMessageCodec.java:83)
      	at io.netty5.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:87)
      	at io.netty5.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:113)
      	at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:437)
      	at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:430)
      	at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:411)
      	at io.netty5.channel.ChannelHandler.channelRead(ChannelHandler.java:234)
      	at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:437)
      	at io.netty5.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:832)
      	at io.netty5.handler.codec.http2.DefaultHttp2StreamChannel.doRead0(DefaultHttp2StreamChannel.java:786)
      	at io.netty5.handler.codec.http2.DefaultHttp2StreamChannel.fireChildRead(DefaultHttp2StreamChannel.java:400)
      	at io.netty5.handler.codec.http2.Http2MultiplexHandler.channelRead(Http2MultiplexHandler.java:173)
      	at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:437)
      	at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:430)
      	at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:411)
      	at io.netty5.channel.internal.DelegatingChannelHandlerContext.fireChannelRead(DelegatingChannelHandlerContext.java:113)
      	at io.netty5.handler.codec.ByteToMessageDecoder$ByteToMessageDecoderContext.fireChannelRead(ByteToMessageDecoder.java:437)
      	at io.netty5.handler.codec.http2.Http2FrameCodec.onHttp2Frame(Http2FrameCodec.java:689)
      	at io.netty5.handler.codec.http2.Http2FrameCodec$FrameListener.onDataRead(Http2FrameCodec.java:632)
      	at io.netty5.handler.codec.http2.Http2FrameListenerDecorator.onDataRead(Http2FrameListenerDecorator.java:37)
      	at io.netty5.handler.codec.http2.Http2EmptyDataFrameListener.onDataRead(Http2EmptyDataFrameListener.java:49)
      	at io.netty5.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onDataRead(DefaultHttp2ConnectionDecoder.java:307)
      	at io.netty5.handler.codec.http2.Http2InboundFrameLogger$1.onDataRead(Http2InboundFrameLogger.java:49)
      	at io.netty5.handler.codec.http2.DefaultHttp2FrameReader.readDataFrame(DefaultHttp2FrameReader.java:411)
      	at io.netty5.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:246)
      	at io.netty5.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:158)
      	at io.netty5.handler.codec.http2.Http2InboundFrameLogger.readFrame(Http2InboundFrameLogger.java:42)
      	at io.netty5.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:173)
      	at io.netty5.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
      	at io.netty5.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:391)
      	at io.netty5.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:451)
      	at io.netty5.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:378)
      	at io.netty5.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:321)
      	at io.netty5.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:202)
      	at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:437)
      	at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:430)
      	at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:411)
      	at reactor.netty.channel.AbstractChannelMetricsHandler.channelRead(AbstractChannelMetricsHandler.java:116)
      	at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:437)
      	at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:430)
      	at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:411)
      	at io.netty5.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)
      	at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:437)
      	at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:430)
      	at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:411)
      	at io.netty5.channel.internal.DelegatingChannelHandlerContext.fireChannelRead(DelegatingChannelHandlerContext.java:113)
      	at io.netty5.handler.codec.ByteToMessageDecoder$ByteToMessageDecoderContext.fireChannelRead(ByteToMessageDecoder.java:437)
      	at io.netty5.handler.ssl.SslHandler.unwrap(SslHandler.java:1205)
      	at io.netty5.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1071)
      	at io.netty5.handler.ssl.SslHandler.decode(SslHandler.java:1118)
      	at io.netty5.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:378)
      	at io.netty5.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:321)
      	at io.netty5.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:202)
      	at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:437)
      	at io.netty5.channel.DefaultChannelHandlerContext.findAndInvokeChannelRead(DefaultChannelHandlerContext.java:430)
      	at io.netty5.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:411)
      	at io.netty5.channel.ChannelHandler.channelRead(ChannelHandler.java:234)
      	at io.netty5.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:437)
      	at io.netty5.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:832)
      	at io.netty5.channel.epoll.AbstractEpollStreamChannel.epollInReady(AbstractEpollStreamChannel.java:485)
      	at io.netty5.channel.epoll.EpollHandler.processReady(EpollHandler.java:445)
      	at io.netty5.channel.epoll.EpollHandler.run(EpollHandler.java:364)
      	at io.netty5.channel.SingleThreadEventLoop.runIO(SingleThreadEventLoop.java:192)
      	at io.netty5.channel.SingleThreadEventLoop.run(SingleThreadEventLoop.java:176)
      	at io.netty5.util.concurrent.SingleThreadEventExecutor.lambda$doStartThread$4(SingleThreadEventExecutor.java:774)
      	at io.netty5.util.internal.ThreadExecutorMap.lambda$apply$1(ThreadExecutorMap.java:68)
      	at io.netty5.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
      	at java.base/java.lang.Thread.run(Thread.java:833)
        at java.base@17.0.3/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base@17.0.3/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base@17.0.3/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base@17.0.3/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
        at app//reactor.netty.http.HttpMetricsHandlerTests.testServerConnectionsRecorder(HttpMetricsHandlerTests.java:668)

```
So, what is failing is this check from checkServerConnectionsRecorder method:

```
    assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(1);
```
when checkServerConnectionsRecorder() is called, the number of connections on the server is surprisingly 0 instead of 1 ! it's a concurrency issue which may happen if CI is slow. Here is the reproducer scenario I can imagine for the moment:

we are testing an HTTP2 test, and the test succeeds, so when tearDown is called, the client connection provider is disposed. But because the system is slow, the server does not immediately see the close, it will see it eventually, but not immediately.

so, the next test is now executing, and then the ServerRecorder.recordServerConnectionOpened() is called: onServerConnectionsAmount is set to 1, but right after, recordServerConnectionClosed is called because the previous server test is still closing -> in this case, onServerConnectionsAmount is decremented and is wrongly set to 0

The PR is an attempt to fix this issue: it first dispose the client connection provider, then it waits for the recordServerConnectionClosed to be called, then it asserts the test expectations.

The PR is also a big refactoring, where all _observeDisconnect_ usage has been removed.

The tests are now based on the following handlers:

- RequestReceivedHandler: this is a Server handler used to detect when the last http client request content has been received by the server. When the RequestReceivedHandler counts down its latch, it means the Server has received the last client request content data. This handler is placed after the _HttpMetricsHandler_, so the RequestReceivedHandler.channelRead method is called after the **AbstractHttpServerMetricsHandler.recordRead** is called. This ensures that all server metrics are up-to-date when the RequestReceivedHandler latch is counted down. The RequestReceivedHandler handler is only used by the testNonExistingEndpoint method, which may receive a 404 before the server has fully received the last client request content.
- ResponseSentHandler: this is a Server handler used to detect when the last http response content has been sent to the client. The handler is placed before the HttpMetricsHandler. It means that the ResponseSentHandler promise listener will be called after the AbstractHttpServerMetricsHandler.write  promise listener. This ensures that the server metrics are up-to-date when the ResponseSentHandler latch is counted down. The ResponseSentHandler is used by various tests which need to ensure that the last response content is sent by the server and that the server metrics are up-to-date
- ServerCloseHandler: it's a Server handler used to wait until the client socket is closed on the server side.
- ClientExceptionHandler: handler used by the _testIssue896_ test. Then handler counts the number of exceptions caught by the client. Metrics are up-to-date when the handler decrements its latch, because the handler is placed after the _HttpClientMetricsHandler_.

Lastly, pay attention to the usage of HttpClient.doAfterResponseSuccess in various tests: this method call is important: it ensures that the AbstractHttpClientMetricsHandler.channelRead method has received the LastHttpContent response, and the recordRead has then been called, so metrics are up-to-date.

Fixes #2368 