### PR TITLE
Adapt to the changed API for Micrometer's KeyName

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMeters.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMeters.java
@@ -125,7 +125,7 @@ public enum ChannelMeters implements DocumentedMeter {
 		 */
 		REMOTE_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "remote.address";
 			}
 		},
@@ -135,7 +135,7 @@ public enum ChannelMeters implements DocumentedMeter {
 		 */
 		URI {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "uri";
 			}
 		}
@@ -148,7 +148,7 @@ public enum ChannelMeters implements DocumentedMeter {
 		 */
 		LOCAL_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "local.address";
 			}
 		},
@@ -158,7 +158,7 @@ public enum ChannelMeters implements DocumentedMeter {
 		 */
 		URI {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "uri";
 			}
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ConnectObservations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ConnectObservations.java
@@ -57,7 +57,7 @@ enum ConnectObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_PROTOCOL {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.protocol";
 			}
 		},
@@ -67,7 +67,7 @@ enum ConnectObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.status";
 			}
 		},
@@ -77,7 +77,7 @@ enum ConnectObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_TYPE {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.type";
 			}
 		}
@@ -93,7 +93,7 @@ enum ConnectObservations implements DocumentedObservation {
 		 */
 		REMOTE_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "remote.address";
 			}
 		},
@@ -103,7 +103,7 @@ enum ConnectObservations implements DocumentedObservation {
 		 */
 		STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "status";
 			}
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ConnectSpans.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ConnectSpans.java
@@ -54,7 +54,7 @@ enum ConnectSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_PROTOCOL {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.protocol";
 			}
 		},
@@ -64,7 +64,7 @@ enum ConnectSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.status";
 			}
 		},
@@ -74,7 +74,7 @@ enum ConnectSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_TYPE {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.type";
 			}
 		},
@@ -84,7 +84,7 @@ enum ConnectSpans implements DocumentedSpan {
 		 */
 		REMOTE_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "remote.address";
 			}
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsHandler.java
@@ -172,13 +172,13 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 
 		@Override
 		public KeyValues getHighCardinalityKeyValues() {
-			return KeyValues.of(REACTOR_NETTY_PROTOCOL.getKeyName(), recorder.protocol(),
-					REACTOR_NETTY_STATUS.getKeyName(), status, REACTOR_NETTY_TYPE.getKeyName(), TYPE);
+			return KeyValues.of(REACTOR_NETTY_PROTOCOL.asString(), recorder.protocol(),
+					REACTOR_NETTY_STATUS.asString(), status, REACTOR_NETTY_TYPE.asString(), TYPE);
 		}
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues() {
-			return KeyValues.of(REMOTE_ADDRESS.getKeyName(), remoteAddress, STATUS.getKeyName(), status);
+			return KeyValues.of(REMOTE_ADDRESS.asString(), remoteAddress, STATUS.asString(), status);
 		}
 
 		@Override
@@ -288,13 +288,13 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 
 		@Override
 		public KeyValues getHighCardinalityKeyValues() {
-			return KeyValues.of(REACTOR_NETTY_PROTOCOL.getKeyName(), recorder.protocol(),
-					REACTOR_NETTY_STATUS.getKeyName(), status, REACTOR_NETTY_TYPE.getKeyName(), type);
+			return KeyValues.of(REACTOR_NETTY_PROTOCOL.asString(), recorder.protocol(),
+					REACTOR_NETTY_STATUS.asString(), status, REACTOR_NETTY_TYPE.asString(), type);
 		}
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues() {
-			return KeyValues.of(REMOTE_ADDRESS.getKeyName(), remoteAddress, STATUS.getKeyName(), status);
+			return KeyValues.of(REMOTE_ADDRESS.asString(), remoteAddress, STATUS.asString(), status);
 		}
 
 		@Override

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
@@ -78,8 +78,8 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 		DistributionSummary ds = MapUtils.computeIfAbsent(dataReceivedCache, address,
 				key -> filter(DistributionSummary.builder(name + DATA_RECEIVED)
 				                                 .baseUnit(ChannelMeters.DATA_RECEIVED.getBaseUnit())
-				                                 .tags(ChannelMeters.ChannelMetersTags.URI.getKeyName(), protocol,
-				                                       ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.getKeyName(), address)
+				                                 .tags(ChannelMeters.ChannelMetersTags.URI.asString(), protocol,
+				                                       ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address)
 				                                 .register(REGISTRY)));
 		if (ds != null) {
 			ds.record(bytes);
@@ -92,8 +92,8 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 		DistributionSummary ds = MapUtils.computeIfAbsent(dataSentCache, address,
 				key -> filter(DistributionSummary.builder(name + DATA_SENT)
 				                                 .baseUnit(ChannelMeters.DATA_SENT.getBaseUnit())
-				                                 .tags(ChannelMeters.ChannelMetersTags.URI.getKeyName(), protocol,
-				                                       ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.getKeyName(), address)
+				                                 .tags(ChannelMeters.ChannelMetersTags.URI.asString(), protocol,
+				                                       ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address)
 				                                 .register(REGISTRY)));
 		if (ds != null) {
 			ds.record(bytes);
@@ -105,8 +105,8 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 		String address = reactor.netty.Metrics.formatSocketAddress(remoteAddress);
 		Counter c = MapUtils.computeIfAbsent(errorsCache, address,
 				key -> filter(Counter.builder(name + ERRORS)
-				                     .tags(ChannelMeters.ChannelMetersTags.URI.getKeyName(), protocol,
-				                           ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.getKeyName(), address)
+				                     .tags(ChannelMeters.ChannelMetersTags.URI.asString(), protocol,
+				                           ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address)
 				                     .register(REGISTRY)));
 		if (c != null) {
 			c.increment();
@@ -207,8 +207,8 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 		return MapUtils.computeIfAbsent(totalConnectionsCache, address,
 				key -> {
 					Gauge gauge = filter(Gauge.builder(name + CONNECTIONS_TOTAL, totalConnectionsAdder, LongAdder::longValue)
-					                          .tags(ChannelMeters.ConnectionsTotalMeterTags.URI.getKeyName(), protocol,
-					                                ChannelMeters.ConnectionsTotalMeterTags.LOCAL_ADDRESS.getKeyName(), address)
+					                          .tags(ChannelMeters.ConnectionsTotalMeterTags.URI.asString(), protocol,
+					                                ChannelMeters.ConnectionsTotalMeterTags.LOCAL_ADDRESS.asString(), address)
 					                          .register(REGISTRY));
 					return gauge != null ? totalConnectionsAdder : null;
 				});

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProviderMeters.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProviderMeters.java
@@ -154,7 +154,7 @@ enum ConnectionProviderMeters implements DocumentedMeter {
 		 */
 		ID {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "id";
 			}
 		},
@@ -164,7 +164,7 @@ enum ConnectionProviderMeters implements DocumentedMeter {
 		 */
 		NAME {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "name";
 			}
 		},
@@ -174,7 +174,7 @@ enum ConnectionProviderMeters implements DocumentedMeter {
 		 */
 		REMOTE_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "remote.address";
 			}
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/MicrometerPooledConnectionProviderMeterRegistrar.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/MicrometerPooledConnectionProviderMeterRegistrar.java
@@ -51,7 +51,7 @@ final class MicrometerPooledConnectionProviderMeterRegistrar {
 
 	void registerMetrics(String poolName, String id, SocketAddress remoteAddress, InstrumentedPool.PoolMetrics metrics) {
 		String addressAsString = Metrics.formatSocketAddress(remoteAddress);
-		Tags tags = Tags.of(ID.getKeyName(), id, REMOTE_ADDRESS.getKeyName(), addressAsString, NAME.getKeyName(), poolName);
+		Tags tags = Tags.of(ID.asString(), id, REMOTE_ADDRESS.asString(), addressAsString, NAME.asString(), poolName);
 		Gauge.builder(TOTAL_CONNECTIONS.getName(), metrics, InstrumentedPool.PoolMetrics::allocatedSize)
 		     .tags(tags)
 		     .register(REGISTRY);

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TlsHandshakeObservations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TlsHandshakeObservations.java
@@ -56,7 +56,7 @@ enum TlsHandshakeObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_PROTOCOL {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.protocol";
 			}
 		},
@@ -66,7 +66,7 @@ enum TlsHandshakeObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.status";
 			}
 		},
@@ -76,7 +76,7 @@ enum TlsHandshakeObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_TYPE {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.type";
 			}
 		}
@@ -92,7 +92,7 @@ enum TlsHandshakeObservations implements DocumentedObservation {
 		 */
 		REMOTE_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "remote.address";
 			}
 		},
@@ -102,7 +102,7 @@ enum TlsHandshakeObservations implements DocumentedObservation {
 		 */
 		STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "status";
 			}
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TlsHandshakeSpans.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TlsHandshakeSpans.java
@@ -53,7 +53,7 @@ enum TlsHandshakeSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_PROTOCOL {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.protocol";
 			}
 		},
@@ -63,7 +63,7 @@ enum TlsHandshakeSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.status";
 			}
 		},
@@ -73,7 +73,7 @@ enum TlsHandshakeSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_TYPE {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.type";
 			}
 		},
@@ -83,7 +83,7 @@ enum TlsHandshakeSpans implements DocumentedSpan {
 		 */
 		REMOTE_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "remote.address";
 			}
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMeters.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMeters.java
@@ -234,7 +234,7 @@ enum ByteBufAllocatorMeters implements DocumentedMeter {
 		 */
 		ID {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "id";
 			}
 		},
@@ -244,7 +244,7 @@ enum ByteBufAllocatorMeters implements DocumentedMeter {
 		 */
 		TYPE {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "type";
 			}
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ByteBufAllocatorMetrics.java
@@ -55,7 +55,7 @@ final class ByteBufAllocatorMetrics {
 
 	void registerMetrics(String allocType, ByteBufAllocatorMetric metrics, ByteBufAllocator alloc) {
 		MapUtils.computeIfAbsent(cache, metrics.hashCode() + "", key -> {
-			Tags tags = Tags.of(ID.getKeyName(), key, TYPE.getKeyName(), allocType);
+			Tags tags = Tags.of(ID.asString(), key, TYPE.asString(), allocType);
 
 			Gauge.builder(USED_HEAP_MEMORY.getName(), metrics, ByteBufAllocatorMetric::usedHeapMemory)
 			     .tags(tags)

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/EventLoopMeters.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/EventLoopMeters.java
@@ -53,7 +53,7 @@ enum EventLoopMeters implements DocumentedMeter {
 		 */
 		NAME {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "name";
 			}
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/HostnameResolutionObservations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/HostnameResolutionObservations.java
@@ -56,7 +56,7 @@ enum HostnameResolutionObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_PROTOCOL {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.protocol";
 			}
 		},
@@ -66,7 +66,7 @@ enum HostnameResolutionObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.status";
 			}
 		},
@@ -76,7 +76,7 @@ enum HostnameResolutionObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_TYPE {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.type";
 			}
 		}
@@ -92,7 +92,7 @@ enum HostnameResolutionObservations implements DocumentedObservation {
 		 */
 		REMOTE_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "remote.address";
 			}
 		},
@@ -102,7 +102,7 @@ enum HostnameResolutionObservations implements DocumentedObservation {
 		 */
 		STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "status";
 			}
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/HostnameResolutionSpans.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/HostnameResolutionSpans.java
@@ -53,7 +53,7 @@ enum HostnameResolutionSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_PROTOCOL {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.protocol";
 			}
 		},
@@ -63,7 +63,7 @@ enum HostnameResolutionSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.status";
 			}
 		},
@@ -73,7 +73,7 @@ enum HostnameResolutionSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_TYPE {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.type";
 			}
 		},
@@ -83,7 +83,7 @@ enum HostnameResolutionSpans implements DocumentedSpan {
 		 */
 		REMOTE_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "remote.address";
 			}
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerAddressResolverGroupMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerAddressResolverGroupMetrics.java
@@ -97,13 +97,13 @@ final class MicrometerAddressResolverGroupMetrics<T extends SocketAddress> exten
 
 		@Override
 		public KeyValues getHighCardinalityKeyValues() {
-			return KeyValues.of(REACTOR_NETTY_PROTOCOL.getKeyName(), recorder.protocol(),
-					REACTOR_NETTY_STATUS.getKeyName(), status, REACTOR_NETTY_TYPE.getKeyName(), TYPE);
+			return KeyValues.of(REACTOR_NETTY_PROTOCOL.asString(), recorder.protocol(),
+					REACTOR_NETTY_STATUS.asString(), status, REACTOR_NETTY_TYPE.asString(), TYPE);
 		}
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues() {
-			return KeyValues.of(REMOTE_ADDRESS.getKeyName(), remoteAddress, STATUS.getKeyName(), status);
+			return KeyValues.of(REMOTE_ADDRESS.asString(), remoteAddress, STATUS.asString(), status);
 		}
 	}
 

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerEventLoopMeterRegistrar.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerEventLoopMeterRegistrar.java
@@ -51,7 +51,7 @@ final class MicrometerEventLoopMeterRegistrar {
 			String executorName = singleThreadEventExecutor.threadProperties().name();
 			MapUtils.computeIfAbsent(cache, executorName, key -> {
 				Gauge.builder(PENDING_TASKS.getName(), singleThreadEventExecutor::pendingTasks)
-				     .tag(NAME.getKeyName(), executorName)
+				     .tag(NAME.asString(), executorName)
 				     .register(REGISTRY);
 				return eventLoop;
 			});

--- a/reactor-netty-http/src/main/java/reactor/netty/http/MicrometerHttpMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/MicrometerHttpMetricsRecorder.java
@@ -65,7 +65,7 @@ public class MicrometerHttpMetricsRecorder extends MicrometerChannelMetricsRecor
 		DistributionSummary dataReceived = MapUtils.computeIfAbsent(dataReceivedCache, meterKey,
 				key -> filter(DistributionSummary.builder(name() + DATA_RECEIVED)
 				                                 .baseUnit(ChannelMeters.DATA_RECEIVED.getBaseUnit())
-				                                 .tags(REMOTE_ADDRESS.getKeyName(), address, URI.getKeyName(), uri)
+				                                 .tags(REMOTE_ADDRESS.asString(), address, URI.asString(), uri)
 				                                 .register(REGISTRY)));
 		if (dataReceived != null) {
 			dataReceived.record(bytes);
@@ -79,7 +79,7 @@ public class MicrometerHttpMetricsRecorder extends MicrometerChannelMetricsRecor
 		DistributionSummary dataSent = MapUtils.computeIfAbsent(dataSentCache, meterKey,
 				key -> filter(DistributionSummary.builder(name() + DATA_SENT)
 				                                 .baseUnit(ChannelMeters.DATA_SENT.getBaseUnit())
-				                                 .tags(REMOTE_ADDRESS.getKeyName(), address, URI.getKeyName(), uri)
+				                                 .tags(REMOTE_ADDRESS.asString(), address, URI.asString(), uri)
 				                                 .register(REGISTRY)));
 		if (dataSent != null) {
 			dataSent.record(bytes);
@@ -92,7 +92,7 @@ public class MicrometerHttpMetricsRecorder extends MicrometerChannelMetricsRecor
 		MeterKey meterKey = new MeterKey(uri, address, null, null);
 		Counter errors = MapUtils.computeIfAbsent(errorsCache, meterKey,
 				key -> filter(Counter.builder(name() + ERRORS)
-				                     .tags(REMOTE_ADDRESS.getKeyName(), address, URI.getKeyName(), uri)
+				                     .tags(REMOTE_ADDRESS.asString(), address, URI.asString(), uri)
 				                     .register(REGISTRY)));
 		if (errors != null) {
 			errors.increment();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProviderMeters.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProviderMeters.java
@@ -114,7 +114,7 @@ enum Http2ConnectionProviderMeters implements DocumentedMeter {
 		 */
 		ID {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "id";
 			}
 		},
@@ -124,7 +124,7 @@ enum Http2ConnectionProviderMeters implements DocumentedMeter {
 		 */
 		NAME {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "name";
 			}
 		},
@@ -134,7 +134,7 @@ enum Http2ConnectionProviderMeters implements DocumentedMeter {
 		 */
 		REMOTE_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "remote.address";
 			}
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMeters.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMeters.java
@@ -74,7 +74,7 @@ enum HttpClientMeters implements DocumentedMeter {
 		 */
 		METHOD {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "method";
 			}
 		},
@@ -84,7 +84,7 @@ enum HttpClientMeters implements DocumentedMeter {
 		 */
 		REMOTE_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "remote.address";
 			}
 		},
@@ -94,7 +94,7 @@ enum HttpClientMeters implements DocumentedMeter {
 		 */
 		STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "status";
 			}
 		},
@@ -104,7 +104,7 @@ enum HttpClientMeters implements DocumentedMeter {
 		 */
 		URI {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "uri";
 			}
 		}
@@ -117,7 +117,7 @@ enum HttpClientMeters implements DocumentedMeter {
 		 */
 		METHOD {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "method";
 			}
 		},
@@ -127,7 +127,7 @@ enum HttpClientMeters implements DocumentedMeter {
 		 */
 		REMOTE_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "remote.address";
 			}
 		},
@@ -137,7 +137,7 @@ enum HttpClientMeters implements DocumentedMeter {
 		 */
 		URI {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "uri";
 			}
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientObservations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientObservations.java
@@ -56,7 +56,7 @@ enum HttpClientObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_PROTOCOL {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.protocol";
 			}
 		},
@@ -66,7 +66,7 @@ enum HttpClientObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.status";
 			}
 		},
@@ -76,7 +76,7 @@ enum HttpClientObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_TYPE {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.type";
 			}
 		}
@@ -92,7 +92,7 @@ enum HttpClientObservations implements DocumentedObservation {
 		 */
 		METHOD {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "method";
 			}
 		},
@@ -102,7 +102,7 @@ enum HttpClientObservations implements DocumentedObservation {
 		 */
 		REMOTE_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "remote.address";
 			}
 		},
@@ -112,7 +112,7 @@ enum HttpClientObservations implements DocumentedObservation {
 		 */
 		STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "status";
 			}
 		},
@@ -122,7 +122,7 @@ enum HttpClientObservations implements DocumentedObservation {
 		 */
 		URI {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "uri";
 			}
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSpans.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSpans.java
@@ -53,7 +53,7 @@ enum HttpClientSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_PROTOCOL {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.protocol";
 			}
 		},
@@ -63,7 +63,7 @@ enum HttpClientSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.status";
 			}
 		},
@@ -73,7 +73,7 @@ enum HttpClientSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_TYPE {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.type";
 			}
 		},
@@ -83,7 +83,7 @@ enum HttpClientSpans implements DocumentedSpan {
 		 */
 		REMOTE_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "remote.address";
 			}
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttp2ConnectionProviderMeterRegistrar.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttp2ConnectionProviderMeterRegistrar.java
@@ -41,7 +41,7 @@ final class MicrometerHttp2ConnectionProviderMeterRegistrar {
 
 	void registerMetrics(String poolName, String id, SocketAddress remoteAddress, InstrumentedPool.PoolMetrics metrics) {
 		String addressAsString = Metrics.formatSocketAddress(remoteAddress);
-		Tags tags = Tags.of(ID.getKeyName(), id, REMOTE_ADDRESS.getKeyName(), addressAsString, NAME.getKeyName(), poolName);
+		Tags tags = Tags.of(ID.asString(), id, REMOTE_ADDRESS.asString(), addressAsString, NAME.asString(), poolName);
 
 		Gauge.builder(ACTIVE_CONNECTIONS.getName(), metrics, InstrumentedPool.PoolMetrics::acquiredSize)
 		     .tags(tags)

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
@@ -149,14 +149,14 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 
 		@Override
 		public KeyValues getHighCardinalityKeyValues() {
-			return KeyValues.of(REACTOR_NETTY_PROTOCOL.getKeyName(), recorder.protocol(),
-					REACTOR_NETTY_STATUS.getKeyName(), status, REACTOR_NETTY_TYPE.getKeyName(), TYPE);
+			return KeyValues.of(REACTOR_NETTY_PROTOCOL.asString(), recorder.protocol(),
+					REACTOR_NETTY_STATUS.asString(), status, REACTOR_NETTY_TYPE.asString(), TYPE);
 		}
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues() {
-			return KeyValues.of(METHOD.getKeyName(), method, REMOTE_ADDRESS.getKeyName(), remoteAddress,
-					STATUS.getKeyName(), status, URI.getKeyName(), path);
+			return KeyValues.of(METHOD.asString(), method, REMOTE_ADDRESS.asString(), remoteAddress,
+					STATUS.asString(), status, URI.asString(), path);
 		}
 
 		@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
@@ -53,10 +53,10 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 		MeterKey meterKey = new MeterKey(uri, address, method, status);
 		Timer dataReceivedTime = MapUtils.computeIfAbsent(dataReceivedTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_RECEIVED_TIME)
-				                   .tags(HttpClientMeters.DataReceivedTimeTags.REMOTE_ADDRESS.getKeyName(), address,
-				                         HttpClientMeters.DataReceivedTimeTags.URI.getKeyName(), uri,
-				                         HttpClientMeters.DataReceivedTimeTags.METHOD.getKeyName(), method,
-				                         HttpClientMeters.DataReceivedTimeTags.STATUS.getKeyName(), status)
+				                   .tags(HttpClientMeters.DataReceivedTimeTags.REMOTE_ADDRESS.asString(), address,
+				                         HttpClientMeters.DataReceivedTimeTags.URI.asString(), uri,
+				                         HttpClientMeters.DataReceivedTimeTags.METHOD.asString(), method,
+				                         HttpClientMeters.DataReceivedTimeTags.STATUS.asString(), status)
 				                   .register(REGISTRY)));
 		if (dataReceivedTime != null) {
 			dataReceivedTime.record(time);
@@ -69,9 +69,9 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 		MeterKey meterKey = new MeterKey(uri, address, method, null);
 		Timer dataSentTime = MapUtils.computeIfAbsent(dataSentTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_SENT_TIME)
-				                   .tags(HttpClientMeters.DataSentTimeTags.REMOTE_ADDRESS.getKeyName(), address,
-				                         HttpClientMeters.DataSentTimeTags.URI.getKeyName(), uri,
-				                         HttpClientMeters.DataSentTimeTags.METHOD.getKeyName(), method)
+				                   .tags(HttpClientMeters.DataSentTimeTags.REMOTE_ADDRESS.asString(), address,
+				                         HttpClientMeters.DataSentTimeTags.URI.asString(), uri,
+				                         HttpClientMeters.DataSentTimeTags.METHOD.asString(), method)
 				                   .register(REGISTRY)));
 		if (dataSentTime != null) {
 			dataSentTime.record(time);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMeters.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerMeters.java
@@ -184,7 +184,7 @@ enum HttpServerMeters implements DocumentedMeter {
 		 */
 		LOCAL_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "local.address";
 			}
 		},
@@ -194,7 +194,7 @@ enum HttpServerMeters implements DocumentedMeter {
 		 */
 		URI {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "uri";
 			}
 		}
@@ -207,7 +207,7 @@ enum HttpServerMeters implements DocumentedMeter {
 		 */
 		LOCAL_ADDRESS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "local.address";
 			}
 		},
@@ -217,7 +217,7 @@ enum HttpServerMeters implements DocumentedMeter {
 		 */
 		URI {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "uri";
 			}
 		}
@@ -230,7 +230,7 @@ enum HttpServerMeters implements DocumentedMeter {
 		 */
 		METHOD {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "method";
 			}
 		},
@@ -240,7 +240,7 @@ enum HttpServerMeters implements DocumentedMeter {
 		 */
 		URI {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "uri";
 			}
 		}
@@ -253,7 +253,7 @@ enum HttpServerMeters implements DocumentedMeter {
 		 */
 		METHOD {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "method";
 			}
 		},
@@ -263,7 +263,7 @@ enum HttpServerMeters implements DocumentedMeter {
 		 */
 		STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "status";
 			}
 		},
@@ -273,7 +273,7 @@ enum HttpServerMeters implements DocumentedMeter {
 		 */
 		URI {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "uri";
 			}
 		}
@@ -286,7 +286,7 @@ enum HttpServerMeters implements DocumentedMeter {
 		 */
 		URI {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "uri";
 			}
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerObservations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerObservations.java
@@ -56,7 +56,7 @@ enum HttpServerObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_PROTOCOL {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.protocol";
 			}
 		},
@@ -66,7 +66,7 @@ enum HttpServerObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.status";
 			}
 		},
@@ -76,7 +76,7 @@ enum HttpServerObservations implements DocumentedObservation {
 		 */
 		REACTOR_NETTY_TYPE {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.type";
 			}
 		}
@@ -92,7 +92,7 @@ enum HttpServerObservations implements DocumentedObservation {
 		 */
 		METHOD {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "method";
 			}
 		},
@@ -102,7 +102,7 @@ enum HttpServerObservations implements DocumentedObservation {
 		 */
 		STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "status";
 			}
 		},
@@ -112,7 +112,7 @@ enum HttpServerObservations implements DocumentedObservation {
 		 */
 		URI {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "uri";
 			}
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerSpans.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerSpans.java
@@ -53,7 +53,7 @@ enum HttpServerSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_PROTOCOL {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.protocol";
 			}
 		},
@@ -63,7 +63,7 @@ enum HttpServerSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_STATUS {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.status";
 			}
 		},
@@ -73,7 +73,7 @@ enum HttpServerSpans implements DocumentedSpan {
 		 */
 		REACTOR_NETTY_TYPE {
 			@Override
-			public String getKeyName() {
+			public String asString() {
 				return "reactor.netty.type";
 			}
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java
@@ -138,13 +138,13 @@ final class MicrometerHttpServerMetricsHandler extends AbstractHttpServerMetrics
 
 		@Override
 		public KeyValues getHighCardinalityKeyValues() {
-			return KeyValues.of(REACTOR_NETTY_PROTOCOL.getKeyName(), recorder.protocol(),
-					REACTOR_NETTY_STATUS.getKeyName(), status, REACTOR_NETTY_TYPE.getKeyName(), TYPE);
+			return KeyValues.of(REACTOR_NETTY_PROTOCOL.asString(), recorder.protocol(),
+					REACTOR_NETTY_STATUS.asString(), status, REACTOR_NETTY_TYPE.asString(), TYPE);
 		}
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues() {
-			return KeyValues.of(METHOD.getKeyName(), method, STATUS.getKeyName(), status, URI.getKeyName(), path);
+			return KeyValues.of(METHOD.asString(), method, STATUS.asString(), status, URI.asString(), path);
 		}
 
 		@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsRecorder.java
@@ -69,8 +69,8 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 		MeterKey meterKey = new MeterKey(uri, null, method, null);
 		Timer dataReceivedTime = MapUtils.computeIfAbsent(dataReceivedTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_RECEIVED_TIME)
-				                   .tags(HttpServerMeters.DataReceivedTimeTags.URI.getKeyName(), uri,
-				                         HttpServerMeters.DataReceivedTimeTags.METHOD.getKeyName(), method)
+				                   .tags(HttpServerMeters.DataReceivedTimeTags.URI.asString(), uri,
+				                         HttpServerMeters.DataReceivedTimeTags.METHOD.asString(), method)
 				                   .register(REGISTRY)));
 		if (dataReceivedTime != null) {
 			dataReceivedTime.record(time);
@@ -82,9 +82,9 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 		MeterKey meterKey = new MeterKey(uri, null, method, status);
 		Timer dataSentTime = MapUtils.computeIfAbsent(dataSentTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_SENT_TIME)
-				                   .tags(HttpServerMeters.DataSentTimeTags.URI.getKeyName(), uri,
-				                         HttpServerMeters.DataSentTimeTags.METHOD.getKeyName(), method,
-				                         HttpServerMeters.DataSentTimeTags.STATUS.getKeyName(), status)
+				                   .tags(HttpServerMeters.DataSentTimeTags.URI.asString(), uri,
+				                         HttpServerMeters.DataSentTimeTags.METHOD.asString(), method,
+				                         HttpServerMeters.DataSentTimeTags.STATUS.asString(), status)
 				                   .register(REGISTRY)));
 		if (dataSentTime != null) {
 			dataSentTime.record(time);
@@ -113,7 +113,7 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 		DistributionSummary dataReceived = MapUtils.computeIfAbsent(dataReceivedCache, uri,
 				key -> filter(DistributionSummary.builder(name() + DATA_RECEIVED)
 				                                 .baseUnit(HttpServerMeters.HTTP_SERVER_DATA_RECEIVED.getBaseUnit())
-				                                 .tags(HttpServerMeters.HttpServerMetersTags.URI.getKeyName(), uri)
+				                                 .tags(HttpServerMeters.HttpServerMetersTags.URI.asString(), uri)
 				                                 .register(REGISTRY)));
 		if (dataReceived != null) {
 			dataReceived.record(bytes);
@@ -125,7 +125,7 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 		DistributionSummary dataSent = MapUtils.computeIfAbsent(dataSentCache, uri,
 				key -> filter(DistributionSummary.builder(name() + DATA_SENT)
 				                                 .baseUnit(HttpServerMeters.HTTP_SERVER_DATA_SENT.getBaseUnit())
-				                                 .tags(HttpServerMeters.HttpServerMetersTags.URI.getKeyName(), uri)
+				                                 .tags(HttpServerMeters.HttpServerMetersTags.URI.asString(), uri)
 				                                 .register(REGISTRY)));
 		if (dataSent != null) {
 			dataSent.record(bytes);
@@ -136,7 +136,7 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 	public void incrementErrorsCount(SocketAddress remoteAddress, String uri) {
 		Counter errors = MapUtils.computeIfAbsent(errorsCache, uri,
 				key -> filter(Counter.builder(name() + ERRORS)
-				                     .tags(HttpServerMeters.HttpServerMetersTags.URI.getKeyName(), uri)
+				                     .tags(HttpServerMeters.HttpServerMetersTags.URI.asString(), uri)
 				                     .register(REGISTRY)));
 		if (errors != null) {
 			errors.increment();
@@ -212,8 +212,8 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 				key -> {
 					Gauge gauge = filter(
 							Gauge.builder(STREAMS_ACTIVE.getName(), activeStreamsAdder, LongAdder::longValue)
-									.tags(HttpServerMeters.StreamsActiveTags.URI.getKeyName(), PROTOCOL_VALUE_HTTP,
-											HttpServerMeters.StreamsActiveTags.LOCAL_ADDRESS.getKeyName(), address)
+									.tags(HttpServerMeters.StreamsActiveTags.URI.asString(), PROTOCOL_VALUE_HTTP,
+											HttpServerMeters.StreamsActiveTags.LOCAL_ADDRESS.asString(), address)
 									.register(REGISTRY));
 					return gauge != null ? activeStreamsAdder : null;
 				});
@@ -226,8 +226,8 @@ final class MicrometerHttpServerMetricsRecorder extends MicrometerHttpMetricsRec
 				key -> {
 					Gauge gauge = filter(
 							Gauge.builder(CONNECTIONS_ACTIVE.getName(), activeConnectionsAdder, LongAdder::longValue)
-							     .tags(HttpServerMeters.ConnectionsActiveTags.URI.getKeyName(), PROTOCOL_VALUE_HTTP,
-							           HttpServerMeters.ConnectionsActiveTags.LOCAL_ADDRESS.getKeyName(), address)
+							     .tags(HttpServerMeters.ConnectionsActiveTags.URI.asString(), PROTOCOL_VALUE_HTTP,
+							           HttpServerMeters.ConnectionsActiveTags.LOCAL_ADDRESS.asString(), address)
 							     .register(REGISTRY));
 					return gauge != null ? activeConnectionsAdder : null;
 				});


### PR DESCRIPTION
`KeyName.getKeyName` is renamed to `KeyName.asString`