### PR TITLE
Bump MacOs image version to 11

### DIFF
--- a/.github/workflows/check_netty_snapshots.yml
+++ b/.github/workflows/check_netty_snapshots.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-11, windows-2019]
         transport: [native, nio]
         exclude:
           # excludes native on Windows (there's none)

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-11, windows-2019]
         transport: [native, nio]
         exclude:
           # excludes native on Windows (there's none)


### PR DESCRIPTION
GitHub Actions complain with:

```
The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead.
For more details see https://github.com/actions/virtual-environments/issues/5583
```