### PR TITLE
Do not open a stream on a connection that received GOAWAY

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
@@ -338,6 +338,7 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 				Http2StreamChannel ch = future.getNow();
 
 				if (!channel.isActive() || frameCodec == null ||
+						((Http2FrameCodec) frameCodec.handler()).connection().goAwayReceived() ||
 						!((Http2FrameCodec) frameCodec.handler()).connection().local().canOpenStream()) {
 					invalidate(this);
 					if (!retried) {


### PR DESCRIPTION
According to the specification
https://www.rfc-editor.org/rfc/rfc9113.html#section-6.8

`Receivers of a GOAWAY frame MUST NOT open additional streams on the connection`

Reactor Netty by default is running with graceful shutdown which means that `GOAWAY`
might be received and the connection to be still alive.

`Http2Pool` should consider this use case and stop offering a connection that received `GOAWAY`.

Fixes #2396