### PR TITLE
Introduce HttpClientProxyProvider with HTTP related configurations

### DIFF
--- a/reactor-netty5-core/src/main/java/reactor/netty5/transport/ClientTransport.java
+++ b/reactor-netty5-core/src/main/java/reactor/netty5/transport/ClientTransport.java
@@ -245,7 +245,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 		return proxyWithProxyProvider(builder.build());
 	}
 
-	final T proxyWithProxyProvider(ProxyProvider proxy) {
+	protected final T proxyWithProxyProvider(ProxyProvider proxy) {
 		T dup = duplicate();
 		CONF conf = dup.configuration();
 		conf.proxyProvider = proxy;

--- a/reactor-netty5-core/src/test/java/reactor/netty5/transport/ProxyProviderTest.java
+++ b/reactor-netty5-core/src/test/java/reactor/netty5/transport/ProxyProviderTest.java
@@ -18,11 +18,9 @@ package reactor.netty5.transport;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Properties;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import io.netty5.handler.codec.http.HttpHeaders;
 import io.netty.contrib.handler.proxy.HttpProxyHandler;
 import io.netty.contrib.handler.proxy.ProxyHandler;
 import io.netty.contrib.handler.proxy.Socks5ProxyHandler;
@@ -44,11 +42,6 @@ class ProxyProviderTest {
 	private static final InetSocketAddress ADDRESS_1 = InetSocketAddress.createUnresolved("localhost", 80);
 	private static final InetSocketAddress ADDRESS_2 = InetSocketAddress.createUnresolved("example.com", 80);
 
-	@SuppressWarnings("UnnecessaryLambda")
-	private static final Consumer<HttpHeaders> HEADER_1 = list -> list.add("Authorization", "Bearer 123");
-	@SuppressWarnings("UnnecessaryLambda")
-	private static final Consumer<HttpHeaders> HEADER_2 = list -> list.add("Authorization", "Bearer 456");
-
 	private static final long CONNECT_TIMEOUT_1 = 100;
 	private static final long CONNECT_TIMEOUT_2 = 200;
 
@@ -67,12 +60,6 @@ class ProxyProviderTest {
 	}
 
 	@Test
-	void equalProxyProvidersAuthHeader() {
-		assertThat(createHeaderProxy(ADDRESS_1, HEADER_1)).isEqualTo(createHeaderProxy(ADDRESS_1, HEADER_1));
-		assertThat(createHeaderProxy(ADDRESS_1, HEADER_1).hashCode()).isEqualTo(createHeaderProxy(ADDRESS_1, HEADER_1).hashCode());
-	}
-
-	@Test
 	void differentAddresses() {
 		assertThat(createProxy(ADDRESS_1, PASSWORD_1)).isNotEqualTo(createProxy(ADDRESS_2, PASSWORD_1));
 		assertThat(createProxy(ADDRESS_1, PASSWORD_1).hashCode()).isNotEqualTo(createProxy(ADDRESS_2, PASSWORD_1).hashCode());
@@ -82,12 +69,6 @@ class ProxyProviderTest {
 	void differentPasswords() {
 		assertThat(createProxy(ADDRESS_1, PASSWORD_1)).isNotEqualTo(createProxy(ADDRESS_1, PASSWORD_2));
 		assertThat(createProxy(ADDRESS_1, PASSWORD_1).hashCode()).isNotEqualTo(createProxy(ADDRESS_1, PASSWORD_2).hashCode());
-	}
-
-	@Test
-	void differentAuthHeaders() {
-		assertThat(createHeaderProxy(ADDRESS_1, HEADER_1)).isNotEqualTo(createHeaderProxy(ADDRESS_1, HEADER_2));
-		assertThat(createHeaderProxy(ADDRESS_1, HEADER_1).hashCode()).isNotEqualTo(createHeaderProxy(ADDRESS_1, HEADER_2).hashCode());
 	}
 
 	@Test
@@ -599,14 +580,6 @@ class ProxyProviderTest {
 		                    .type(ProxyProvider.Proxy.SOCKS5)
 		                    .address(address)
 		                    .nonProxyHosts(NON_PROXY_HOSTS)
-		                    .build();
-	}
-
-	private ProxyProvider createHeaderProxy(InetSocketAddress address, Consumer<HttpHeaders> authHeader) {
-		return ProxyProvider.builder()
-		                    .type(ProxyProvider.Proxy.HTTP)
-		                    .address(address)
-		                    .httpHeaders(authHeader)
 		                    .build();
 	}
 

--- a/reactor-netty5-http/build.gradle
+++ b/reactor-netty5-http/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 	compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
 
 	api "io.netty:netty-buffer:$nettyByteBufVersion"
+	api "io.netty.contrib:netty-handler-proxy:$nettyContribVersion"
 	api "io.netty:netty5-codec-http:$nettyVersion"
 	api "io.netty:netty5-codec-http2:$nettyVersion"
 	api "io.netty:netty5-resolver-dns:$nettyVersion"

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClient.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClient.java
@@ -58,6 +58,7 @@ import reactor.netty5.internal.util.Metrics;
 import reactor.netty5.resources.ConnectionProvider;
 import reactor.netty5.tcp.SslProvider;
 import reactor.netty5.transport.ClientTransport;
+import reactor.netty5.transport.ProxyProvider;
 import reactor.util.annotation.Nullable;
 
 /**
@@ -1164,6 +1165,14 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 			dup.configuration().sslProvider = HttpClientSecure.defaultSslProvider(config);
 		}
 		return dup;
+	}
+
+	@Override
+	public final HttpClient proxy(Consumer<? super ProxyProvider.TypeSpec> proxyOptions) {
+		Objects.requireNonNull(proxyOptions, "proxyOptions");
+		HttpClientProxyProvider.Build builder = new HttpClientProxyProvider.Build();
+		proxyOptions.accept(builder);
+		return proxyWithProxyProvider(builder.build());
 	}
 
 	/**

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientProxyProvider.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientProxyProvider.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty5.http.client;
+
+import io.netty.contrib.handler.proxy.HttpProxyHandler;
+import io.netty.contrib.handler.proxy.ProxyHandler;
+import io.netty5.handler.codec.http.DefaultHttpHeaders;
+import io.netty5.handler.codec.http.HttpHeaders;
+import reactor.netty5.transport.ProxyProvider;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Extended {@link ProxyProvider} that gives ability to configure the request headers for the http proxy.
+ *
+ * @author Violeta Georgieva
+ * @since 2.0.0
+ */
+public final class HttpClientProxyProvider extends ProxyProvider {
+
+	public interface Builder<T extends Builder<T>> extends ProxyProvider.Builder<T> {
+
+		/**
+		 * A consumer to add request headers for the http proxy.
+		 *
+		 * @param headers A consumer to add request headers for the http proxy.
+		 * @return {@code this}
+		 */
+		T httpHeaders(Consumer<HttpHeaders> headers);
+	}
+
+	final Supplier<? extends HttpHeaders> httpHeaders;
+
+	HttpClientProxyProvider(Build builder) {
+		super(builder);
+		this.httpHeaders = builder.httpHeaders;
+	}
+
+	@Override
+	public ProxyHandler newProxyHandler() {
+		if (getType() != Proxy.HTTP) {
+			return super.newProxyHandler();
+		}
+		String username = getUsername();
+		String password = getPasswordValue();
+		ProxyHandler proxyHandler = username != null && password != null ?
+				new HttpProxyHandler(getAddress().get(), username, password, this.httpHeaders.get()) :
+				new HttpProxyHandler(getAddress().get(), this.httpHeaders.get());
+		proxyHandler.setConnectTimeoutMillis(getConnectTimeoutMillis());
+		return proxyHandler;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof HttpClientProxyProvider that)) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		return Objects.equals(httpHeaders.get(), that.httpHeaders.get());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), httpHeaders.get());
+	}
+
+	static final class Build extends AbstractBuild<Build> implements Builder<Build> {
+
+		static final Supplier<? extends HttpHeaders> NO_HTTP_HEADERS = () -> null;
+
+		Supplier<? extends HttpHeaders> httpHeaders = NO_HTTP_HEADERS;
+
+		@Override
+		public HttpClientProxyProvider build() {
+			return new HttpClientProxyProvider(this);
+		}
+
+		@Override
+		public Build get() {
+			return this;
+		}
+
+		@Override
+		public Build httpHeaders(Consumer<HttpHeaders> headers) {
+			if (headers != null) {
+				this.httpHeaders = () -> new DefaultHttpHeaders() {
+					{
+						headers.accept(this);
+					}
+				};
+			}
+			return get();
+		}
+	}
+}

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/client/HttpClientProxyProviderTest.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/client/HttpClientProxyProviderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty5.http.client;
+
+import io.netty5.handler.codec.http.HttpHeaders;
+import org.junit.jupiter.api.Test;
+import reactor.netty5.transport.ProxyProvider;
+
+import java.net.InetSocketAddress;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpClientProxyProviderTest {
+
+	private static final InetSocketAddress ADDRESS_1 = InetSocketAddress.createUnresolved("localhost", 80);
+	@SuppressWarnings("UnnecessaryLambda")
+	private static final Consumer<HttpHeaders> HEADER_1 = list -> list.add("Authorization", "Bearer 123");
+	@SuppressWarnings("UnnecessaryLambda")
+	private static final Consumer<HttpHeaders> HEADER_2 = list -> list.add("Authorization", "Bearer 456");
+
+	@Test
+	void equalProxyProvidersAuthHeader() {
+		assertThat(createHeaderProxy(ADDRESS_1, HEADER_1)).isEqualTo(createHeaderProxy(ADDRESS_1, HEADER_1));
+		assertThat(createHeaderProxy(ADDRESS_1, HEADER_1).hashCode()).isEqualTo(createHeaderProxy(ADDRESS_1, HEADER_1).hashCode());
+	}
+
+	@Test
+	void differentAuthHeaders() {
+		assertThat(createHeaderProxy(ADDRESS_1, HEADER_1)).isNotEqualTo(createHeaderProxy(ADDRESS_1, HEADER_2));
+		assertThat(createHeaderProxy(ADDRESS_1, HEADER_1).hashCode()).isNotEqualTo(createHeaderProxy(ADDRESS_1, HEADER_2).hashCode());
+	}
+
+	private ProxyProvider createHeaderProxy(InetSocketAddress address, Consumer<HttpHeaders> authHeader) {
+		return new HttpClientProxyProvider.Build()
+				.type(ProxyProvider.Proxy.HTTP)
+				.address(address)
+				.httpHeaders(authHeader)
+				.build();
+	}
+}


### PR DESCRIPTION
This is in preparation for removing `netty5-codec-http` dependency from `reactor-netty-core`.
This dependency is transitively available via `netty-handler-proxy` dependency.

Related to #1953