### PR TITLE
Update reference documentation for UDS support

### DIFF
--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -433,7 +433,7 @@ include::{examplesdir}/metrics/custom/Application.java[lines=18..35]
 ====
 
 == Unix Domain Sockets
-The `HTTP` client supports Unix Domain Sockets (UDS) when native transport is in use.
+The `HTTP` client supports Unix Domain Sockets (UDS) for all transports (native and NIO).
 
 The following example shows how to use UDS support:
 

--- a/docs/asciidoc/http-server.adoc
+++ b/docs/asciidoc/http-server.adoc
@@ -615,7 +615,7 @@ include::{examplesdir}/metrics/custom/Application.java[lines=18..41]
 ====
 
 == Unix Domain Sockets
-The `HTTP` server supports Unix Domain Sockets (UDS) when native transport is in use.
+The `HTTP` server supports Unix Domain Sockets (UDS) for all transports (native and NIO).
 
 The following example shows how to use UDS support:
 

--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -323,7 +323,7 @@ include::{examplesdir}/metrics/custom/Application.java[lines=18..37]
 ====
 
 == Unix Domain Sockets
-The `TCP` client supports Unix Domain Sockets (UDS) when native transport is in use.
+The `TCP` client supports Unix Domain Sockets (UDS) for all transports (native and NIO).
 
 The following example shows how to use UDS support:
 

--- a/docs/asciidoc/tcp-server.adoc
+++ b/docs/asciidoc/tcp-server.adoc
@@ -295,7 +295,7 @@ include::{examplesdir}/metrics/custom/Application.java[lines=18..35]
 ====
 
 == Unix Domain Sockets
-The `TCP` server supports Unix Domain Sockets (UDS) when native transport is in use.
+The `TCP` server supports Unix Domain Sockets (UDS) for all transports (native and NIO).
 
 The following example shows how to use UDS support:
 


### PR DESCRIPTION
`TCP`/`HTTP` are now supporting `UDS` for all transports - native and NIO.

Related to #2392