### PR TITLE
HttpMetricsHandlerTests testServerConnectionsMicrometer still unstable

### DIFF
--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -30,11 +30,14 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http2.Http2StreamChannel;
 import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.concurrent.DefaultEventExecutor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -144,6 +147,9 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@BeforeEach
 	void setUp() {
 		httpServer = createServer()
+				// Register a channel group, when invoking disposeNow()
+				// it will close all remaining client sockets on the server, if any.
+				.channelGroup(new DefaultChannelGroup(new DefaultEventExecutor()))
 				.host("127.0.0.1")
 				.metrics(true, Function.identity())
 				.httpRequestDecoder(spec -> spec.h2cMaxContentLength(256))
@@ -167,9 +173,12 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	}
 
 	@AfterEach
-	void tearDown() {
+	void tearDown() throws InterruptedException {
 		provider.disposeLater()
 		        .block(Duration.ofSeconds(30));
+
+		// In case the ServerCloseHandler is registered on the server, make sure client socket is closed on the server side
+		assertThat(ServerCloseHandler.INSTANCE.awaitClientClosedOnServer()).as("awaitClientClosedOnServer timeout").isTrue();
 
 		Metrics.removeRegistry(registry);
 		registry.clear();
@@ -585,15 +594,12 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	void testServerConnectionsMicrometer(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
 			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
 		CountDownLatch responseSent = new CountDownLatch(1); // response fully sent by the server
-		CountDownLatch serverClosed = new CountDownLatch(1); // socket closed on the server side
-		ResponseSentHandler responseSentHandler = ResponseSentHandler.INSTANCE;
-		ServerCloseHandler serverCloseHandler = ServerCloseHandler.INSTANCE;
 		boolean isHttp11 = clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11;
 		HttpServer server = customizeServerOptions(httpServer, serverCtx, serverProtocols)
 				.metrics(true, Function.identity())
 				.doOnConnection(cnx -> {
-					serverCloseHandler.register(cnx.channel(), serverClosed, isHttp11);
-					responseSentHandler.register(responseSent, cnx.channel().pipeline());
+					ResponseSentHandler.INSTANCE.register(responseSent, cnx.channel().pipeline());
+					ServerCloseHandler.INSTANCE.register(cnx.channel());
 				});
 
 		disposableServer = server.bindNow();
@@ -623,18 +629,15 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 		// now check the server counters
 		if (isHttp11) {
-			// the socket on the server should be closed, make sure the client socket is closed on the server side
-			assertThat(serverClosed.await(30, TimeUnit.SECONDS)).as("serverClosed latch await").isTrue();
+			// make sure the client socket is closed on the server side before checking server metrics
+			assertThat(ServerCloseHandler.INSTANCE.awaitClientClosedOnServer()).as("awaitClientClosedOnServer timeout").isTrue();
 			checkGauge(SERVER_CONNECTIONS_TOTAL, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
 			checkGauge(SERVER_CONNECTIONS_ACTIVE, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
 		}
 		else {
 			checkGauge(SERVER_CONNECTIONS_TOTAL, true, 1, URI, HTTP, LOCAL_ADDRESS, address);
 			checkGauge(SERVER_STREAMS_ACTIVE, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
-			// dispose the client connection pool, and make sure the client socket is closed on the server side
-			provider.disposeLater()
-					.block(Duration.ofSeconds(30));
-			assertThat(serverClosed.await(30, TimeUnit.SECONDS)).as("serverClosed latch await").isTrue();
+			// in case of H2, the tearDown method will ensure client socket is closed on the server side
 		}
 
 		// These metrics are meant only for the servers,
@@ -642,8 +645,6 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		address = formatSocketAddress(clientAddress.get());
 		checkGauge(CLIENT_CONNECTIONS_TOTAL, false, 0, URI, HTTP, LOCAL_ADDRESS, address);
 		checkGauge(CLIENT_CONNECTIONS_ACTIVE, false, 0, URI, HTTP, LOCAL_ADDRESS, address);
-
-		disposableServer.disposeNow();
 	}
 
 	@ParameterizedTest
@@ -654,11 +655,9 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		// ServerRecorder.INSTANCE.reset() (AfterEach) and thus leave ServerRecorder.INSTANCE in a bad state
 		ServerRecorder.INSTANCE.reset();
 		boolean isHttp11 = clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11;
-		CountDownLatch serverClosed = new CountDownLatch(1);
-		ServerCloseHandler serverCloseHandler = ServerCloseHandler.INSTANCE;
 
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
-				.doOnConnection(c -> serverCloseHandler.register(c.channel(), serverClosed, isHttp11))
+				.doOnConnection(cnx -> ServerCloseHandler.INSTANCE.register(cnx.channel()))
 				.metrics(true, ServerRecorder.supplier(), Function.identity())
 				.bindNow();
 		String address = formatSocketAddress(disposableServer.address());
@@ -678,26 +677,22 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.expectComplete()
 				.verify(Duration.ofSeconds(30));
 
-		// dispose the client connection provider now, before asserting test expectations.
-		provider.disposeLater()
-				.block(Duration.ofSeconds(30));
-
-		// now the socket is closed, wait for the ServerRecorder to be called in recordServerConnectionClosed before asserting test expectations
-		assertThat(serverClosed.await(30, TimeUnit.SECONDS)).as("serverClosed latch await").isTrue();
-
 		// now we can assert test expectations
 		assertThat(ServerRecorder.INSTANCE.error.get()).isNull();
+
 		if (isHttp11) {
+			// wait for the AbstractHttpServerMetricsHandlerServer to be called in recordServerConnectionClosed before asserting test expectations
+			assertThat(ServerCloseHandler.INSTANCE.awaitClientClosedOnServer()).as("awaitClientClosedOnServer timeout").isTrue();
+
 			assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(0);
 			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsAmount.get()).isEqualTo(0);
 			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsLocalAddr.get()).isEqualTo(address);
 			assertThat(ServerRecorder.INSTANCE.onInactiveConnectionsLocalAddr.get()).isEqualTo(address);
 		}
 		else {
-			assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(0);
+			assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(1);
+			// in case of H2, the tearDown method will ensure client socket is closed on the server side
 		}
-
-		disposableServer.disposeNow();
 	}
 
 	@Test
@@ -729,16 +724,12 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	@MethodSource("http11CompatibleProtocols")
 	void testBadRequest(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
 			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
-		CountDownLatch serverClosed = new CountDownLatch(1);
-		CountDownLatch clientCompleted = new CountDownLatch(1);
-		boolean isHttp11 = clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11;
-		ServerCloseHandler serverCloseHandler = ServerCloseHandler.INSTANCE;
-
 		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
-				.doOnChannelInit((obs, c, s) -> serverCloseHandler.register(c, serverClosed, isHttp11))
+				.doOnChannelInit((cobs, ch, addr) -> ServerCloseHandler.INSTANCE.register(ch))
 				.httpRequestDecoder(spec -> spec.maxHeaderSize(32))
 				.bindNow();
 
+		CountDownLatch clientCompleted = new CountDownLatch(1);
 		AtomicReference<SocketAddress> serverAddress = new AtomicReference<>();
 		httpClient = customizeClientOptions(httpClient, clientCtx, clientProtocols)
 				.doAfterRequest((req, conn) -> serverAddress.set(conn.channel().remoteAddress()))
@@ -752,12 +743,8 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		          .expectComplete()
 		          .verify(Duration.ofSeconds(30));
 
-		// dispose the client connection provider now, before asserting test expectations.
-		provider.disposeLater()
-				.block(Duration.ofSeconds(30));
-
-		// now the socket is closed, wait for the ServerRecorder to be called in recordServerConnectionClosed before asserting test expectations
-		assertThat(serverClosed.await(30, TimeUnit.SECONDS)).as("serverClosed latch await").isTrue();
+		// Ensure client socket is closed on the server, to make sure that server metrics are up-to-date.
+		assertThat(ServerCloseHandler.INSTANCE.awaitClientClosedOnServer()).as("awaitClientClosedOnServer timeout").isTrue();
 
 		// Ensure client has fully received the response before asserting test expectations
 		assertThat(clientCompleted.await(30, TimeUnit.SECONDS)).as("clientCompleted latch await").isTrue();
@@ -1127,7 +1114,6 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		private final AtomicReference<String> onActiveConnectionsLocalAddr = new AtomicReference<>();
 		private final AtomicReference<String> onInactiveConnectionsLocalAddr = new AtomicReference<>();
 		private final AtomicInteger onActiveConnectionsAmount = new AtomicInteger();
-		private volatile CountDownLatch done = new CountDownLatch(4);
 
 		static Supplier<ServerRecorder> supplier() {
 			return SUPPLIER;
@@ -1140,35 +1126,30 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 			onActiveConnectionsLocalAddr.set(null);
 			onInactiveConnectionsLocalAddr.set(null);
 			onActiveConnectionsAmount.set(0);
-			done = new CountDownLatch(4);
 		}
 
 		@Override
 		public void recordServerConnectionOpened(SocketAddress localAddress) {
 			onServerConnectionsLocalAddr.set(formatSocketAddress(localAddress));
 			onServerConnectionsAmount.addAndGet(1);
-			done.countDown();
 		}
 
 		@Override
 		public void recordServerConnectionClosed(SocketAddress localAddress) {
 			onServerConnectionsLocalAddr.set(formatSocketAddress(localAddress));
 			onServerConnectionsAmount.addAndGet(-1);
-			done.countDown();
 		}
 
 		@Override
 		public void recordServerConnectionActive(SocketAddress localAddress) {
 			onActiveConnectionsLocalAddr.set(formatSocketAddress(localAddress));
 			onActiveConnectionsAmount.addAndGet(1);
-			done.countDown();
 		}
 
 		@Override
 		public void recordServerConnectionInactive(SocketAddress localAddress) {
 			onInactiveConnectionsLocalAddr.set(formatSocketAddress(localAddress));
 			onActiveConnectionsAmount.addAndGet(-1);
-			done.countDown();
 		}
 
 		@Override
@@ -1293,16 +1274,19 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		static final ServerCloseHandler INSTANCE = new ServerCloseHandler();
 		static final String HANDLER_NAME = "ServerCloseHandler.handler";
 		private CountDownLatch latch;
+		private boolean registered;
 
-		void register(Channel channel, CountDownLatch latch, boolean http11) {
-			this.latch = latch;
-
-			if (http11) {
-				channel.pipeline().addBefore(NettyPipeline.ReactiveBridge, HANDLER_NAME, this);
+		void register(Channel channel) {
+			this.latch = new CountDownLatch(1);
+			if (channel instanceof Http2StreamChannel) {
+				if (channel.parent().pipeline().get(HANDLER_NAME) == null) {
+					channel.parent().pipeline().addLast(HANDLER_NAME, this);
+				}
 			}
 			else {
-				channel.parent().pipeline().addLast(HANDLER_NAME, this);
+				channel.pipeline().addBefore(NettyPipeline.ReactiveBridge, HANDLER_NAME, this);
 			}
+			registered = true;
 		}
 
 		@Override
@@ -1313,6 +1297,18 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 		@Override
 		public boolean isSharable() {
+			return true;
+		}
+
+		public boolean awaitClientClosedOnServer() throws InterruptedException {
+			if (registered) {
+				try {
+					return latch.await(30, TimeUnit.SECONDS);
+				}
+				finally {
+					registered = false;
+				}
+			}
 			return true;
 		}
 	}


### PR DESCRIPTION
The HttpMetricsHandlerTests testServerConnectionsMicrometer is still unstable. 
Sometimes, the following assertion fails because the SERVER_CONNECTIONS_TOTAL is 1, [see this failing assertion](https://github.com/reactor/reactor-netty/blob/1.0.x/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java#L626) 

Reproduced the problem in github using netty5 branch while validating the multipart porting draft PR.

What I can imagine is the following probable scenario:

1. the testServerConnectionsMicrometer is finishing an HTTP2 test, so the tearDown is in progress, and the client connection pool is disposing, but the server has not yet seen the close, so the SERVER_CONNECTIONS_TOTAL meter is still set to 1
2. now, the testServerConnectionsMicrometer starts a next test using HTTP1.1, but when it waits for the H1 connection to be closed [here](https://github.com/reactor/reactor-netty/blob/1.0.x/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java#L625), then the SERVER_CONNECTIONS_TOTAL is still set to 2, because the connection close done in previous test in not yet seen by the server. 
3. So, when the HTTP1.1 socket is closed and see by the server, the latch is counted down, but the SERVER_CONNECTIONS_TOTAL is now set to 1, because the client socket close from previous test is still in progress, and not yet seen by the server.

So, in testServerConnectionsMicrometer, this problem seems to be fully fixed when we dispose the client connection pool in case protocol is HTT2 and when we also wait for the server to see the H2 connection close.

Fixes #2368 