### PR TITLE
Add reflection hints for better native-image support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,7 @@ ext {
 	junitPlatformLauncherVersion = '1.9.0'
 	mockitoVersion = '4.7.0'
 	blockHoundVersion = '1.0.6.RELEASE'
+	reflectionsVersion = '0.10.2'
 
 	javadocLinks = ["https://docs.oracle.com/javase/8/docs/api/",
 					"https://fasterxml.github.io/jackson-databind/javadoc/2.5/",

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -137,10 +137,12 @@ dependencies {
 	testImplementation "io.projectreactor.tools:blockhound-junit-platform:$blockHoundVersion"
 	testImplementation "io.micrometer:micrometer-core:$micrometerVersion"
 	testImplementation "io.micrometer:micrometer-test:$micrometerVersion"
+	testImplementation "org.reflections:reflections:$reflectionsVersion"
 
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 	testRuntimeOnly "org.slf4j:jcl-over-slf4j:$slf4jVersion"
+	testRuntimeOnly "io.micrometer:micrometer-tracing:$micrometerTracingVersion"
 
 	for (dependency in project.configurations.shaded.dependencies) {
 		compileOnly(dependency)

--- a/reactor-netty-core/src/main/resources/META-INF/native-image/io.projectreactor.netty/reactor-netty-core/reflect-config.json
+++ b/reactor-netty-core/src/main/resources/META-INF/native-image/io.projectreactor.netty/reactor-netty-core/reflect-config.json
@@ -1,0 +1,90 @@
+[
+	{
+		"name": "reactor.netty.ReactorNetty$ExtractorHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.ReactorNetty$InboundIdleStateHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.ReactorNetty$OutboundIdleStateHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.channel.AbstractChannelMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.channel.ChannelMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.channel.ChannelMetricsHandler$ConnectMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.channel.ChannelMetricsHandler$TlsMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.channel.ChannelOperationsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.channel.ContextAwareChannelMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.channel.ContextAwareChannelMetricsHandler$ContextAwareConnectMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.channel.ContextAwareChannelMetricsHandler$TlsMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.channel.MicrometerChannelMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.channel.MicrometerChannelMetricsHandler$ConnectMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.channel.MicrometerChannelMetricsHandler$TlsMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.resources.DefaultPooledConnectionProvider$PooledConnectionAllocator$PooledConnectionInitializer",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.tcp.SniProvider$SniHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.tcp.SslProvider$SslReadHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.transport.ProxyProvider$UnvoidHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.transport.ServerTransport$Acceptor",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.transport.ServerTransport$AcceptorInitializer",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.transport.TransportConfig$TransportChannelInitializer",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.transport.logging.ReactorNettyLoggingHandler",
+		"queryAllPublicMethods": true
+	}
+]

--- a/reactor-netty-core/src/test/java/reactor/netty/NativeConfigTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/NativeConfigTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelOutboundHandler;
+import org.junit.jupiter.api.Test;
+import org.reflections.Reflections;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.reflections.scanners.Scanners.SubTypes;
+
+class NativeConfigTest {
+
+	@Test
+	void testChannelInboundHandler() throws Exception {
+		Set<Pojo> classes = new HashSet<>();
+		classes.addAll(findAllClassesUsingReflectionsLibrary("reactor.netty", ChannelInboundHandler.class));
+		classes.addAll(findAllClassesUsingReflectionsLibrary("reactor.netty", ChannelOutboundHandler.class));
+
+		try (InputStream is = getClass()
+				.getResourceAsStream("/META-INF/native-image/io.projectreactor.netty/reactor-netty-core/reflect-config.json")) {
+
+			ObjectMapper mapper = new ObjectMapper();
+			Set<Pojo> classesFromFile = new HashSet<>(Arrays.asList(mapper.readValue(is, Pojo[].class)));
+
+			assertThat(classesFromFile).isEqualTo(classes);
+		}
+	}
+
+	Set<Pojo> findAllClassesUsingReflectionsLibrary(String packageName, Class<?> subtype) {
+		Reflections reflections = new Reflections(
+				new ConfigurationBuilder()
+						.forPackage(packageName)
+						.filterInputsBy(s -> !s.contains("Test")));
+		return reflections.get(SubTypes.of(subtype).asClass())
+				.stream()
+				.filter(aClass -> aClass.getName().startsWith(packageName))
+				.map(aClass -> new Pojo(aClass.getName()))
+				.collect(Collectors.toSet());
+	}
+
+	public static final class Pojo {
+		private String name;
+		private boolean queryAllPublicMethods;
+
+		private Pojo() {
+		}
+
+		private Pojo(String name) {
+			this(name, true);
+		}
+
+		private Pojo(String name, boolean queryAllPublicMethods) {
+			this.name = name;
+			this.queryAllPublicMethods = queryAllPublicMethods;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public boolean isQueryAllPublicMethods() {
+			return queryAllPublicMethods;
+		}
+
+		public void setQueryAllPublicMethods(boolean queryAllPublicMethods) {
+			this.queryAllPublicMethods = queryAllPublicMethods;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (!(o instanceof Pojo)) {
+				return false;
+			}
+			Pojo myObject = (Pojo) o;
+			return name.equals(myObject.name);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(name);
+		}
+
+		@Override
+		public String toString() {
+			return "Pojo{" +
+					"name='" + name + '\'' +
+					", queryAllPublicMethods='" + queryAllPublicMethods + '\'' +
+					'}';
+		}
+	}
+}

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -135,6 +135,7 @@ dependencies {
 	testImplementation "io.micrometer:micrometer-core:$micrometerVersion"
 	testImplementation "io.micrometer:micrometer-test:$micrometerVersion"
 	testImplementation "io.micrometer:micrometer-tracing-integration-test:$micrometerTracingVersion"
+	testImplementation "org.reflections:reflections:$reflectionsVersion"
 
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/reactor-netty-http/src/main/resources/META-INF/native-image/io.projectreactor.netty/reactor-netty-http/reflect-config.json
+++ b/reactor-netty-http/src/main/resources/META-INF/native-image/io.projectreactor.netty/reactor-netty-http/reflect-config.json
@@ -1,0 +1,110 @@
+[
+	{
+		"name": "reactor.netty.http.client.AbstractHttpClientMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.client.ContextAwareHttpClientMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.client.Http2StreamBridgeClientHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.client.HttpClientConfig$H2Codec",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.client.HttpClientConfig$H2OrHttp11Codec",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.client.HttpClientMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.client.HttpTrafficHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.client.MicrometerHttpClientMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.AbstractHttpServerMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.ContextAwareHttpServerMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.HAProxyMessageDetector",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.HAProxyMessageReader",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.Http2StreamBridgeServerHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.HttpServerConfig$H2ChannelMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.HttpServerConfig$H2Codec",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.HttpServerConfig$H2OrHttp11Codec",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.HttpServerConfig$Http11OrH2CleartextCodec",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.HttpServerMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.HttpTrafficHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.IdleTimeoutHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.MicrometerHttpServerMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.NonSslRedirectDetector",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.NonSslRedirectHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.SimpleCompressionHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.logging.AccessLogHandlerH1",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.logging.AccessLogHandlerH2",
+		"queryAllPublicMethods": true
+	},
+	{
+		"name": "reactor.netty.http.server.logging.BaseAccessLogHandler",
+		"queryAllPublicMethods": true
+	}
+]

--- a/reactor-netty-http/src/test/java/reactor/netty/NativeConfigTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/NativeConfigTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelOutboundHandler;
+import org.junit.jupiter.api.Test;
+import org.reflections.Reflections;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.reflections.scanners.Scanners.SubTypes;
+
+class NativeConfigTest {
+
+	@Test
+	void testChannelInboundHandler() throws Exception {
+		Set<Pojo> classes = new HashSet<>();
+		classes.addAll(findAllClassesUsingReflectionsLibrary("reactor.netty.http", ChannelInboundHandler.class));
+		classes.addAll(findAllClassesUsingReflectionsLibrary("reactor.netty.http", ChannelOutboundHandler.class));
+
+		try (InputStream is = getClass()
+				.getResourceAsStream("/META-INF/native-image/io.projectreactor.netty/reactor-netty-http/reflect-config.json")) {
+
+			ObjectMapper mapper = new ObjectMapper();
+			Set<Pojo> classesFromFile = new HashSet<>(Arrays.asList(mapper.readValue(is, Pojo[].class)));
+
+			assertThat(classesFromFile).isEqualTo(classes);
+		}
+	}
+
+	Set<Pojo> findAllClassesUsingReflectionsLibrary(String packageName, Class<?> subtype) {
+		Reflections reflections = new Reflections(
+				new ConfigurationBuilder()
+						.forPackage(packageName)
+						.filterInputsBy(s -> !s.contains("Test")));
+		return reflections.get(SubTypes.of(subtype).asClass())
+				.stream()
+				.filter(aClass -> aClass.getName().startsWith(packageName))
+				.map(aClass -> new Pojo(aClass.getName()))
+				.collect(Collectors.toSet());
+	}
+
+	public static final class Pojo {
+		private String name;
+		private boolean queryAllPublicMethods;
+
+		private Pojo() {
+		}
+
+		private Pojo(String name) {
+			this(name, true);
+		}
+
+		private Pojo(String name, boolean queryAllPublicMethods) {
+			this.name = name;
+			this.queryAllPublicMethods = queryAllPublicMethods;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public boolean isQueryAllPublicMethods() {
+			return queryAllPublicMethods;
+		}
+
+		public void setQueryAllPublicMethods(boolean queryAllPublicMethods) {
+			this.queryAllPublicMethods = queryAllPublicMethods;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (!(o instanceof Pojo)) {
+				return false;
+			}
+			Pojo myObject = (Pojo) o;
+			return name.equals(myObject.name);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(name);
+		}
+
+		@Override
+		public String toString() {
+			return "Pojo{" +
+					"name='" + name + '\'' +
+					", queryAllPublicMethods='" + queryAllPublicMethods + '\'' +
+					'}';
+		}
+	}
+}


### PR DESCRIPTION
When a `ChannelHandler` is added to the `Netty` channel pipeline and if the `ChannelHandler`
implements `ChannelInboundHandler`/`ChannelOutboundHandler`,
`io.netty.channel.ChannelHandlerMask#mask0` will inspect the `ChannelHandler's` methods for
`io.netty.channel.ChannelHandlerMask.Skip` annotation.
When there are no reflection hints, `NoSuchMethodException` is thrown when trying to query the methods with reflection.
This will lead to methods marked as not skippable, although the program will be able to run
without any problems, when all methods are marked as not skippable, one might observe performance issues.

Fixes #2419