### PR TITLE
ServerTransport.Acceptor#exceptionCaught should not propagate the event

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
@@ -405,9 +405,6 @@ public abstract class ServerTransport<T extends ServerTransport<T, CONF>,
 				       }
 				   });
 			}
-			// still let the exceptionCaught event flow through the pipeline to give the user
-			// a chance to do something with it
-			ctx.fireExceptionCaught(cause);
 		}
 
 		void enableAutoReadTask(Channel channel) {


### PR DESCRIPTION
There are no other `ChannelHandlers` in the pipeline except `ServerTransport.Acceptor`, thus
it is not needed to propagate the event.