### PR TITLE
Ensure ChannelGroup and associated Executor are closed

### DIFF
--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
@@ -63,7 +63,6 @@ import io.netty.util.NetUtil;
 import io.netty.util.concurrent.DefaultEventExecutor;
 import io.netty.util.concurrent.EventExecutor;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
@@ -811,8 +811,8 @@ class TcpServerTests {
 
 		boundServer.disposeNow();
 
-		FutureMono.from(group.close())
-		          .block(Duration.ofSeconds(30));
+		group.close()
+		          .get(30, TimeUnit.SECONDS);
 
 		assertThat(latch2.await(5, TimeUnit.SECONDS)).as("latch await").isTrue();
 	}
@@ -853,8 +853,8 @@ class TcpServerTests {
 
 		assertThat(configured.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
 
-		FutureMono.from(group.close())
-		          .block(Duration.ofSeconds(30));
+		group.close()
+				.get(30, TimeUnit.SECONDS);
 
 		assertThat(disconnected.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
 
@@ -954,8 +954,8 @@ class TcpServerTests {
 		disposableServer.disposeNow();
 
 		// Dispose the group
-		FutureMono.from(group.close())
-				.block(Duration.ofSeconds(30));
+		group.close()
+				.get(30, TimeUnit.SECONDS);
 
 		// Dispose the event loop
 		loop.disposeLater()

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpServerTests.java
@@ -74,7 +74,6 @@ import reactor.netty.ChannelBindException;
 import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
 import reactor.netty.DisposableServer;
-import reactor.netty.FutureMono;
 import reactor.netty.NettyInbound;
 import reactor.netty.NettyOutbound;
 import reactor.netty.NettyPipeline;

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/ConnectionPoolTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/ConnectionPoolTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,15 @@ package reactor.netty.http.client;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.resolver.DefaultAddressResolverGroup;
 import io.netty.util.AttributeKey;
-import io.netty.util.concurrent.GlobalEventExecutor;
+import io.netty.util.concurrent.DefaultEventExecutor;
+import io.netty.util.concurrent.EventExecutor;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +50,9 @@ import java.nio.charset.Charset;
 import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -65,6 +70,7 @@ class ConnectionPoolTests extends BaseHttpTest {
 	static ConnectionProvider provider;
 	static LoopResources loop;
 	static Supplier<ChannelMetricsRecorder> metricsRecorderSupplier;
+	static final EventExecutor executor = new DefaultEventExecutor();
 
 	HttpClient client;
 
@@ -99,7 +105,7 @@ class ConnectionPoolTests extends BaseHttpTest {
 	}
 
 	@AfterAll
-	static void tearDown() {
+	static void tearDown() throws ExecutionException, InterruptedException, TimeoutException {
 		server1.disposeNow();
 		server2.disposeNow();
 		server3.disposeNow();
@@ -108,6 +114,8 @@ class ConnectionPoolTests extends BaseHttpTest {
 		        .block(Duration.ofSeconds(5));
 		loop.disposeLater()
 		    .block(Duration.ofSeconds(5));
+		executor.shutdownGracefully()
+				.get(5, TimeUnit.SECONDS);
 	}
 
 	@BeforeEach
@@ -151,16 +159,27 @@ class ConnectionPoolTests extends BaseHttpTest {
 	}
 
 	@Test
-	void testClientWithChannelGroup() {
-		HttpClient localClient1 =
-				client.port(server1.port())
-				      .channelGroup(new DefaultChannelGroup(GlobalEventExecutor.INSTANCE));
-		HttpClient localClient2 = localClient1.channelGroup(new DefaultChannelGroup(GlobalEventExecutor.INSTANCE));
-		checkResponsesAndChannelsStates(
-				"server1-ConnectionPoolTests",
-				"server1-ConnectionPoolTests",
-				localClient1,
-				localClient2);
+	void testClientWithChannelGroup() throws ExecutionException, InterruptedException, TimeoutException {
+		ChannelGroup group1 = new DefaultChannelGroup(executor);
+		ChannelGroup group2 = new DefaultChannelGroup(executor);
+
+		try {
+			HttpClient localClient1 =
+					client.port(server1.port())
+							.channelGroup(group1);
+			HttpClient localClient2 = localClient1.channelGroup(group2);
+			checkResponsesAndChannelsStates(
+					"server1-ConnectionPoolTests",
+					"server1-ConnectionPoolTests",
+					localClient1,
+					localClient2);
+		}
+		finally {
+			group1.close()
+					.get(5, TimeUnit.SECONDS);
+			group2.close()
+					.get(5, TimeUnit.SECONDS);
+		}
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/ConnectionPoolTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/ConnectionPoolTests.java
@@ -115,7 +115,7 @@ class ConnectionPoolTests extends BaseHttpTest {
 		loop.disposeLater()
 		    .block(Duration.ofSeconds(5));
 		executor.shutdownGracefully()
-				.get(5, TimeUnit.SECONDS);
+				.get(30, TimeUnit.SECONDS);
 	}
 
 	@BeforeEach
@@ -176,9 +176,9 @@ class ConnectionPoolTests extends BaseHttpTest {
 		}
 		finally {
 			group1.close()
-					.get(5, TimeUnit.SECONDS);
+					.get(30, TimeUnit.SECONDS);
 			group2.close()
-					.get(5, TimeUnit.SECONDS);
+					.get(30, TimeUnit.SECONDS);
 		}
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -89,6 +90,8 @@ import io.netty.resolver.AddressResolverGroup;
 import io.netty.resolver.dns.DnsAddressResolverGroup;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.DefaultEventExecutor;
+import io.netty.util.concurrent.EventExecutor;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -136,10 +139,17 @@ class HttpClientTest extends BaseHttpTest {
 	static final Logger log = Loggers.getLogger(HttpClientTest.class);
 
 	static SelfSignedCertificate ssc;
+	static final EventExecutor executor = new DefaultEventExecutor();
 
 	@BeforeAll
 	static void createSelfSignedCertificate() throws CertificateException {
 		ssc = new SelfSignedCertificate();
+	}
+
+	@AfterAll
+	static void cleanup() throws ExecutionException, InterruptedException, TimeoutException {
+		executor.shutdownGracefully()
+				.get(5, TimeUnit.SECONDS);
 	}
 
 	@Test
@@ -1456,7 +1466,7 @@ class HttpClientTest extends BaseHttpTest {
 		ConnectionProvider connectionProvider =
 				ConnectionProvider.create("testChannelGroupClosesAllConnections", Integer.MAX_VALUE);
 
-		ChannelGroup group = new DefaultChannelGroup(new DefaultEventExecutor());
+		ChannelGroup group = new DefaultChannelGroup(executor);
 
 		CountDownLatch latch1 = new CountDownLatch(3);
 		CountDownLatch latch2 = new CountDownLatch(3);

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -149,7 +149,7 @@ class HttpClientTest extends BaseHttpTest {
 	@AfterAll
 	static void cleanup() throws ExecutionException, InterruptedException, TimeoutException {
 		executor.shutdownGracefully()
-				.get(5, TimeUnit.SECONDS);
+				.get(30, TimeUnit.SECONDS);
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -156,7 +156,7 @@ class HttpServerTests extends BaseHttpTest {
 	@AfterAll
 	static void cleanup() throws ExecutionException, InterruptedException, TimeoutException {
 		executor.shutdownGracefully()
-				.get(5, TimeUnit.SECONDS);
+				.get(30, TimeUnit.SECONDS);
 	}
 
 	@AfterEach
@@ -167,7 +167,7 @@ class HttpServerTests extends BaseHttpTest {
 		}
 		if (group != null) {
 			group.close()
-					.get(5, TimeUnit.SECONDS);
+					.get(30, TimeUnit.SECONDS);
 			group = null;
 		}
 	}


### PR DESCRIPTION
This PR fixes some tests which are not closing some ChannelGroups and their associated Executor.