### PR TITLE
Do not add io.netty:netty5-resolver-dns-native-macos:osx-x86_64 as required dependency

### DIFF
--- a/reactor-netty5-core/build.gradle
+++ b/reactor-netty5-core/build.gradle
@@ -63,15 +63,15 @@ dependencies {
 	api "io.netty:netty5-resolver-dns:$nettyVersion"
 	if (!"$nettyVersion".endsWithAny("SNAPSHOT")) {
 		if (osdetector.classifier == "osx-x86_64" || osdetector.classifier == "osx-aarch_64") {
-			api "io.netty:netty5-resolver-dns-native-macos:$nettyVersion$os_suffix"
+			testImplementation "io.netty:netty5-resolver-dns-native-macos:$nettyVersion$os_suffix"
 		}
 		else {
-			api "io.netty:netty5-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
+			testImplementation "io.netty:netty5-resolver-dns-classes-macos:$nettyVersion"
 		}
 	}
 	else {
 		// MacOS binaries are not available for Netty SNAPSHOT version
-		api "io.netty:netty5-resolver-dns-classes-macos:$nettyVersion"
+		testImplementation "io.netty:netty5-resolver-dns-classes-macos:$nettyVersion"
 	}
 	//transport resolution: typical build forces epoll but not kqueue transitively
 	//on the other hand, if we want to make transport-specific tests, we'll make all

--- a/reactor-netty5-http/build.gradle
+++ b/reactor-netty5-http/build.gradle
@@ -66,15 +66,15 @@ dependencies {
 	// MacOS binaries are not available for Netty SNAPSHOT version
 	if (!"$nettyVersion".endsWithAny("SNAPSHOT")) {
 		if (osdetector.classifier == "osx-x86_64" || osdetector.classifier == "osx-aarch_64") {
-			api "io.netty:netty5-resolver-dns-native-macos:$nettyVersion$os_suffix"
+			testImplementation "io.netty:netty5-resolver-dns-native-macos:$nettyVersion$os_suffix"
 		}
 		else {
-			api "io.netty:netty5-resolver-dns-native-macos:$nettyVersion:osx-x86_64"
+			testImplementation "io.netty:netty5-resolver-dns-classes-macos:$nettyVersion"
 		}
 	}
 	else {
 		// MacOS binaries are not available for Netty SNAPSHOT version
-		api "io.netty:netty5-resolver-dns-classes-macos:$nettyVersion"
+		testImplementation "io.netty:netty5-resolver-dns-classes-macos:$nettyVersion"
 	}
 	compileOnly "io.netty.contrib:netty-codec-haproxy:$nettyContribVersion"
 	//transport resolution: typical build forces epoll but not kqueue transitively


### PR DESCRIPTION
Fixes #2440