### PR TITLE
Configurable request retry

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -83,6 +83,7 @@ import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
+import reactor.util.retry.Retry;
 
 import static reactor.netty.ReactorNetty.format;
 import static reactor.netty.http.client.Http2ConnectionProvider.OWNER;
@@ -314,7 +315,12 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 	BiConsumer<HttpHeaders, HttpClientRequest> redirectRequestBiConsumer;
 	Consumer<HttpClientRequest> redirectRequestConsumer;
 	Duration responseTimeout;
+
+	HttpClient.RequestRetryConfig retryConfig;
+
+	// TODO consolidate this with config concept
 	boolean retryDisabled;
+
 	SslProvider sslProvider;
 	URI uri;
 	String uriStr;
@@ -332,7 +338,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		this.method = HttpMethod.GET;
 		this.protocols = new HttpProtocol[]{HttpProtocol.HTTP11};
 		this._protocols = h11;
-		this.retryDisabled = false;
+		this.retryConfig = HttpClient.RequestRetryConfig.DEFAULT;
 	}
 
 	HttpClientConfig(HttpClientConfig parent) {
@@ -361,6 +367,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		this.redirectRequestBiConsumer = parent.redirectRequestBiConsumer;
 		this.redirectRequestConsumer = parent.redirectRequestConsumer;
 		this.responseTimeout = parent.responseTimeout;
+		this.retryConfig = parent.retryConfig;
 		this.retryDisabled = parent.retryDisabled;
 		this.sslProvider = parent.sslProvider;
 		this.uri = parent.uri;


### PR DESCRIPTION
Allow more configuration when it comes to retrying requests.

This is currently failing at least 1 test for 2 reasons that need to be addressed.  First, `Retry#max` exhaustion generates the retryexhausted wrapper.  I think that's a good thing, but I understand why you'd go a different route from multiple perspectives (IO checked retry, breaking behavior).  Still thinking on that, but feel free to tell me what to do.

Also, in the error case, this fires the `doOnError` hook maxRetry + 1.  The additional 1 comes from the split out retryWhen for URL redirection.  I will try to deal with this

Need to stop for the day, but figured I'd get a draft out there.  I'll clean up all commits/code/etc. before moving out of draft.

#2425