### PR TITLE
Leak detection properties are added for the test execution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -273,11 +273,8 @@ subprojects {
 
 		onOutput { descriptor, event ->
 			def evMsg = event.message
-			if (evMsg.contains("ResourceLeakDetector")) {
-				if (!evMsg.contains(" -Dio.netty.leakDetection")
-						&& !evMsg.contains("DEBUG io.netty.util.ResourceLeakDetectorFactory")) {
-					logger.error("ERROR: Test: " + descriptor + " produced resource leak: " + event.message)
-				}
+			if (evMsg.contains("LoggingLeakCallback")) {
+				logger.error("ERROR: Test: " + descriptor + " produced resource leak: " + event.message)
 			}
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -244,7 +244,10 @@ subprojects {
 		systemProperty("reactor.trace.cancel", "true")
 		systemProperty("reactor.trace.nocapacity", "true")
 		systemProperty("testGroups", project.properties.get("testGroups"))
-		systemProperty("io.netty.leakDetection.level", "paranoid")
+		systemProperty("io.netty5.leakDetectionLevel", "paranoid")
+		systemProperty("io.netty5.leakDetection.targetRecords", "32")
+		systemProperty("io.netty5.buffer.lifecycleTracingEnabled", "true")
+		systemProperty("io.netty5.buffer.leakDetectionEnabled", "true")
 		systemProperty("reactor.netty5.pool.getPermitsSamplingRate", "0.5")
 		systemProperty("reactor.netty5.pool.returnPermitsSamplingRate", "0.5")
 		if (project.hasProperty("forceTransport")) {

--- a/reactor-netty5-core/src/main/java/reactor/netty5/NettyOutbound.java
+++ b/reactor-netty5-core/src/main/java/reactor/netty5/NettyOutbound.java
@@ -42,7 +42,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import static reactor.netty5.ReactorNetty.PREDICATE_GROUP_BOUNDARY;
-import static reactor.netty5.ReactorNetty.PREDICATE_GROUP_FLUSH;
 
 /**
  * An outbound-traffic API delegating to an underlying {@link Channel}.
@@ -237,13 +236,7 @@ public interface NettyOutbound extends Publisher<Void> {
 				    .concatMap(p -> Flux.<Buffer>from(p)
 				                        .concatWith(Mono.just(BOUNDARY.copy(0, BOUNDARY.readableBytes(), true))), 32)
 				    .doFinally(sig -> BOUNDARY.close()),
-				buf -> {
-					boolean flush = PREDICATE_GROUP_FLUSH.test(buf);
-					if (flush) {
-						buf.close();
-					}
-					return flush;
-				});
+				ReactorNetty.PREDICATE_GROUP_FLUSH);
 	}
 
 	/**

--- a/reactor-netty5-core/src/main/java/reactor/netty5/ReactorNetty.java
+++ b/reactor-netty5-core/src/main/java/reactor/netty5/ReactorNetty.java
@@ -17,7 +17,6 @@ package reactor.netty5;
 
 import java.net.SocketAddress;
 import java.nio.channels.FileChannel;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.ZoneId;
 import java.util.List;
@@ -35,6 +34,7 @@ import io.netty5.buffer.BufferUtil;
 import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferAllocator;
 import io.netty5.buffer.BufferHolder;
+import io.netty5.buffer.MemoryManager;
 import io.netty5.channel.nio.AbstractNioChannel;
 import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
@@ -999,6 +999,8 @@ public final class ReactorNetty {
 
 	static final Predicate<Object>         PREDICATE_FLUSH        = o -> false;
 
+	static final Buffer                    BOUNDARY               = MemoryManager.unsafeWrap(new byte[0]).makeReadOnly();
+
 	static final char CHANNEL_ID_PREFIX = '[';
 	static final String CHANNEL_ID_SUFFIX_1 = "] ";
 	static final char CHANNEL_ID_SUFFIX_2 = ' ';
@@ -1006,8 +1008,8 @@ public final class ReactorNetty {
 	static final int ORIGINAL_CHANNEL_ID_PREFIX_LENGTH = ORIGINAL_CHANNEL_ID_PREFIX.length();
 	static final char TRACE_ID_PREFIX = '(';
 
-	public static final String PREDICATE_GROUP_BOUNDARY = "ReactorNettyBoundary";
-	public static final Predicate<Buffer> PREDICATE_GROUP_FLUSH =
-			b -> PREDICATE_GROUP_BOUNDARY.equals(b.toString(StandardCharsets.UTF_8));
+	@SuppressWarnings("ReferenceEquality")
+	//Design to use reference comparison here
+	public static final Predicate<Buffer> PREDICATE_GROUP_FLUSH = b -> b == BOUNDARY;
 
 }

--- a/reactor-netty5-core/src/test/java/reactor/netty5/NettyOutboundTest.java
+++ b/reactor-netty5-core/src/test/java/reactor/netty5/NettyOutboundTest.java
@@ -159,11 +159,10 @@ class NettyOutboundTest {
 				//capture the chunks unencrypted, transform as Strings:
 				new MessageToMessageEncoder<Buffer>() {
 					@Override
-					protected void encodeAndClose(ChannelHandlerContext ctx, Buffer msg,
+					protected void encode(ChannelHandlerContext ctx, Buffer msg,
 							List<Object> out) {
 						clearMessages.add(msg.readCharSequence(msg.readableBytes(), StandardCharsets.UTF_8));
 						out.add(msg.split());
-						msg.close();
 					}
 				},
 				//transform the ChunkedFile into Buffer chunks:
@@ -253,10 +252,9 @@ class NettyOutboundTest {
 				//transform the Buffer chunks into Strings:
 				new MessageToMessageEncoder<Buffer>() {
 					@Override
-					protected void encodeAndClose(ChannelHandlerContext ctx, Buffer msg,
+					protected void encode(ChannelHandlerContext ctx, Buffer msg,
 							List<Object> out) {
 						out.add(msg.readCharSequence(msg.readableBytes(), StandardCharsets.UTF_8));
-						msg.close();
 					}
 				},
 				//transform the ChunkedFile into Buffer chunks:

--- a/reactor-netty5-core/src/test/java/reactor/netty5/NettyOutboundTest.java
+++ b/reactor-netty5-core/src/test/java/reactor/netty5/NettyOutboundTest.java
@@ -163,6 +163,7 @@ class NettyOutboundTest {
 							List<Object> out) {
 						clearMessages.add(msg.readCharSequence(msg.readableBytes(), StandardCharsets.UTF_8));
 						out.add(msg.split());
+						msg.close();
 					}
 				},
 				//transform the ChunkedFile into Buffer chunks:
@@ -255,6 +256,7 @@ class NettyOutboundTest {
 					protected void encodeAndClose(ChannelHandlerContext ctx, Buffer msg,
 							List<Object> out) {
 						out.add(msg.readCharSequence(msg.readableBytes(), StandardCharsets.UTF_8));
+						msg.close();
 					}
 				},
 				//transform the ChunkedFile into Buffer chunks:

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientOperations.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientOperations.java
@@ -637,13 +637,16 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 			if (log.isDebugEnabled()) {
 				log.debug(format(channel(), "Received last HTTP packet"));
 			}
-			if (!(msg instanceof EmptyLastHttpContent)) {
+			if (!(msg instanceof EmptyLastHttpContent emptyLastHttpContent)) {
 				if (redirecting != null) {
 					Resource.dispose(msg);
 				}
 				else {
 					super.onInboundNext(ctx, msg);
 				}
+			}
+			else {
+				emptyLastHttpContent.close();
 			}
 
 			if (redirecting == null) {

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/server/Http2StreamBridgeServerHandler.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/server/Http2StreamBridgeServerHandler.java
@@ -29,7 +29,7 @@ import io.netty5.handler.codec.http.HttpRequest;
 import io.netty5.handler.codec.http.LastHttpContent;
 import io.netty5.handler.codec.http2.Http2StreamFrameToHttpObjectCodec;
 import io.netty5.handler.ssl.SslHandler;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureContextListener;
 import reactor.core.publisher.Mono;
@@ -125,7 +125,7 @@ final class Http2StreamBridgeServerHandler extends ChannelHandlerAdapter impleme
 				HttpServerOperations.log.debug(format(ctx.channel(), "Dropped HTTP content, " +
 						"since response has been sent already: {}"), msg);
 			}
-			ReferenceCountUtil.release(msg);
+			Resource.dispose(msg);
 			ctx.read();
 			return;
 		}

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerOperations.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerOperations.java
@@ -520,8 +520,8 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		                  .get(NettyPipeline.CompressionHandler) == null) {
 			SimpleCompressionHandler handler = new SimpleCompressionHandler();
 			try {
-				// decodeAndClose(...) is needed only to initialize the acceptEncodingQueue
-				handler.decodeAndClose(channel().pipeline().context(NettyPipeline.ReactiveBridge), nettyRequest);
+				// decode(...) is needed only to initialize the acceptEncodingQueue
+				handler.decode(channel().pipeline().context(NettyPipeline.ReactiveBridge), nettyRequest, false);
 
 				addHandlerFirst(NettyPipeline.CompressionHandler, handler);
 			}

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerOperations.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/server/HttpServerOperations.java
@@ -559,8 +559,11 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 			return;
 		}
 		if (msg instanceof HttpContent) {
-			if (!(msg instanceof EmptyLastHttpContent)) {
+			if (!(msg instanceof EmptyLastHttpContent emptyLastHttpContent)) {
 				super.onInboundNext(ctx, msg);
+			}
+			else {
+				emptyLastHttpContent.close();
 			}
 			if (msg instanceof LastHttpContent) {
 				//force auto read to enable more accurate close selection now inbound is done

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/server/WebsocketServerOperations.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/server/WebsocketServerOperations.java
@@ -33,6 +33,7 @@ import io.netty5.handler.codec.http.websocketx.WebSocketCloseStatus;
 import io.netty5.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.netty5.handler.codec.http.websocketx.WebSocketServerHandshakerFactory;
 import io.netty5.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureListener;
 import org.reactivestreams.Publisher;
@@ -115,6 +116,7 @@ final class WebsocketServerOperations extends HttpServerOperations
 					                     request,
 					                     responseHeaders)
 					          .addListener(f -> {
+					              Resource.dispose(request);
 					              if (replaced.rebind(this)) {
 					                  markPersistent(false);
 					                  // This change is needed after the Netty change https://github.com/netty/netty/pull/11966

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/server/WebsocketServerOperations.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/server/WebsocketServerOperations.java
@@ -25,7 +25,7 @@ import io.netty5.handler.codec.http.DefaultFullHttpRequest;
 import io.netty5.handler.codec.http.EmptyLastHttpContent;
 import io.netty5.handler.codec.http.HttpHeaderNames;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
-import io.netty5.handler.codec.http.HttpRequest;
+import io.netty5.handler.codec.http.FullHttpRequest;
 import io.netty5.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty5.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty5.handler.codec.http.websocketx.PongWebSocketFrame;
@@ -33,7 +33,6 @@ import io.netty5.handler.codec.http.websocketx.WebSocketCloseStatus;
 import io.netty5.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.netty5.handler.codec.http.websocketx.WebSocketServerHandshakerFactory;
 import io.netty5.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
-import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureListener;
 import org.reactivestreams.Publisher;
@@ -86,7 +85,7 @@ final class WebsocketServerOperations extends HttpServerOperations
 			removeHandler(NettyPipeline.AccessLogHandler);
 			removeHandler(NettyPipeline.HttpMetricsHandler);
 
-			HttpRequest request = new DefaultFullHttpRequest(replaced.version(), replaced.method(), replaced.uri(),
+			FullHttpRequest request = new DefaultFullHttpRequest(replaced.version(), replaced.method(), replaced.uri(),
 					channel.bufferAllocator().allocate(0));
 
 			request.headers()
@@ -116,7 +115,7 @@ final class WebsocketServerOperations extends HttpServerOperations
 					                     request,
 					                     responseHeaders)
 					          .addListener(f -> {
-					              Resource.dispose(request);
+					              request.close();
 					              if (replaced.rebind(this)) {
 					                  markPersistent(false);
 					                  // This change is needed after the Netty change https://github.com/netty/netty/pull/11966

--- a/reactor-netty5-http/src/main/resources/META-INF/native-image/io.projectreactor.netty/reactor-netty5-http/reflect-config.json
+++ b/reactor-netty5-http/src/main/resources/META-INF/native-image/io.projectreactor.netty/reactor-netty5-http/reflect-config.json
@@ -64,6 +64,13 @@
 	},
 	{
 		"condition": {
+			"typeReachable": "reactor.netty5.http.client.HttpClientConfig$ReactorNettyHttpClientUpgradeHandler"
+		},
+		"name": "reactor.netty5.http.client.HttpClientConfig$ReactorNettyHttpClientUpgradeHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"condition": {
 			"typeReachable": "reactor.netty5.http.server.AbstractHttpServerMetricsHandler"
 		},
 		"name": "reactor.netty5.http.server.AbstractHttpServerMetricsHandler",

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/client/HttpClientOperationsTest.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/client/HttpClientOperationsTest.java
@@ -165,7 +165,10 @@ class HttpClientOperationsTest {
 		EmbeddedChannel channel = new EmbeddedChannel();
 		HttpClientOperations ops = new HttpClientOperations(() -> channel,
 				ConnectionObserver.emptyListener());
-		ops.setNettyResponse(new DefaultFullHttpResponse(HTTP_1_1, status, channel.bufferAllocator().allocate(0)));
-		assertThat(ops.status().reasonPhrase()).isEqualTo(status.reasonPhrase());
+		try (DefaultFullHttpResponse response =
+				new DefaultFullHttpResponse(HTTP_1_1, status, channel.bufferAllocator().allocate(0))) {
+			ops.setNettyResponse(response);
+			assertThat(ops.status().reasonPhrase()).isEqualTo(status.reasonPhrase());
+		}
 	}
 }

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerTests.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerTests.java
@@ -1850,8 +1850,10 @@ class HttpServerTests extends BaseHttpTest {
 				null,
 				false);
 		ops.status(status);
-		HttpMessage response = ops.newFullBodyMessage(channel.bufferAllocator().allocate(0));
-		assertThat(((FullHttpResponse) response).status().reasonPhrase()).isEqualTo(status.reasonPhrase());
+		try (Buffer buffer = channel.bufferAllocator().allocate(0)) {
+			HttpMessage response = ops.newFullBodyMessage(buffer);
+			assertThat(((FullHttpResponse) response).status().reasonPhrase()).isEqualTo(status.reasonPhrase());
+		}
 		channel.close();
 	}
 

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/server/logging/AccessLogHandlerH1Tests.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/server/logging/AccessLogHandlerH1Tests.java
@@ -59,6 +59,8 @@ class AccessLogHandlerH1Tests {
 		channel.writeOutbound(newHttpResponse(false));
 
 		channel.writeOutbound(new DefaultLastHttpContent(channel.bufferAllocator().allocate(0)));
+
+		assertThat(channel.finishAndReleaseAll()).isTrue();
 	}
 
 	@Test

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/server/logging/AccessLogHandlerH2Tests.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/server/logging/AccessLogHandlerH2Tests.java
@@ -61,6 +61,8 @@ class AccessLogHandlerH2Tests {
 		Buffer buffer = channel.bufferAllocator().allocate(RESPONSE_CONTENT.length);
 		buffer.writeBytes(RESPONSE_CONTENT).makeReadOnly();
 		channel.writeOutbound(new DefaultHttp2DataFrame(buffer.send(), true));
+
+		assertThat(channel.finishAndReleaseAll()).isTrue();
 	}
 
 	private void assertAccessLogArgProvider(AccessLogArgProvider args, SocketAddress remoteAddress) {


### PR DESCRIPTION
- Fix memory leaks when processing `EmptyLastHttpContent`
- Avoid buffer leak by closing the `HttpRequest` passed to the `WebSocketServerHandshaker.handshake` method
- Declare `ReactorNetty#BOUNDARY` as on-heap non-releasable buffer
- Do not close the empty full message when invoking `SimpleCompressionHandler` out of the pipeline
- `Http2StreamBridgeServerHandler.channelRead` method should use `Resource.dispose()` method
- [HttpServer] Ensure `Http2FrameCodec` is created only when there is a need for protocol upgrade
- [HttpClient] Ensure `Http2FrameCodec.Encoder` is closed when upgrade is rejected. Ensure `Http2FrameCodec.Encoder` is closed when `Exception` happened before decoding the server response
- Fix memory leaks in tests

