### PR TITLE
Use HttpConnectionProvider mutate method (#2463)

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -262,9 +262,8 @@ public interface ConnectionProvider extends Disposable {
 	 * @return a builder to mutate properties of this {@link ConnectionProvider}
 	 * @since 1.0.14
 	 */
-	@Nullable
 	default Builder mutate() {
-		return null;
+		return new Builder("");
 	}
 
 	/**

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpConnectionProvider.java
@@ -57,6 +57,15 @@ final class HttpConnectionProvider implements ConnectionProvider {
 	}
 
 	@Override
+	public Builder mutate() {
+		if (this.http1ConnectionProvider == null) {
+			return ConnectionProvider.super.mutate();
+		}
+
+		return this.http1ConnectionProvider.mutate();
+	}
+
+	@Override
 	public void disposeWhen(SocketAddress address) {
 		http1ConnectionProvider().disposeWhen(address);
 	}


### PR DESCRIPTION
I made mutate method(overriding) in HttpConnectionProvider.
However I can't access `Builder` class directly. 
So I edit mutate method  in ConnectionProvider default method

relates: #2462