### PR TITLE
Find HttpConnectionProvider in HttpClientConfig (#2468)

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpConnectionProvider.java
@@ -76,7 +76,7 @@ final class HttpConnectionProvider implements ConnectionProvider {
 	final AtomicReference<ConnectionProvider> h2ConnectionProvider = new AtomicReference<>();
 
 	HttpConnectionProvider() {
-		this(null);
+		this(ConnectionProvider.create("default", 1));
 	}
 
 	HttpConnectionProvider(@Nullable ConnectionProvider http1ConnectionProvider) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpConnectionProviderTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpConnectionProviderTest.java
@@ -92,4 +92,38 @@ class HttpConnectionProviderTest {
 				.isEqualTo(HttpResources.get().getOrCreateHttp2ConnectionProvider(HTTP2_CONNECTION_PROVIDER_FACTORY)
 						.maxConnectionsPerHost());
 	}
+
+	@Test
+	void returnOriginalConnectionProvider() {
+		ConnectionProvider provider = HttpClient.create().configuration().connectionProvider();
+		try {
+			assertThat(provider.mutate()).isNotNull();
+		}
+		finally {
+			provider.disposeLater()
+					.block(Duration.ofSeconds(5));
+		}
+	}
+
+	@Test
+	void returnOriginalConnectionProviderUsingBuilder() {
+		ConnectionProvider provider = ConnectionProvider
+				.builder("provider")
+				.maxConnections(1)
+				.disposeTimeout(Duration.ofSeconds(1L))
+				.pendingAcquireTimeout(Duration.ofSeconds(1L))
+				.maxIdleTime(Duration.ofSeconds(1L))
+				.maxLifeTime(Duration.ofSeconds(10L))
+				.lifo()
+				.build();
+
+		try {
+			HttpClient httpClient = HttpClient.create(provider);
+			assertThat(httpClient.configuration().connectionProvider().mutate()).isNotNull();
+		}
+		finally {
+			provider.disposeLater()
+					.block(Duration.ofSeconds(5));
+		}
+	}
 }


### PR DESCRIPTION
@violetagg . I made new PR. 
In https://github.com/reactor/reactor-netty/pull/2463#issuecomment-1239195149, you recommand `the configuration to return the original ConnectionProvider` method.


Fixes #2462