### PR TITLE
Ensure HttpClientConfig#connectionProvider returns the original provider used to create HttpClient

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
@@ -60,7 +60,7 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 	 *
 	 * @return the {@link ConnectionProvider}
 	 */
-	public final ConnectionProvider connectionProvider() {
+	public ConnectionProvider connectionProvider() {
 		return connectionProvider;
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -115,6 +115,11 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		return (ch, c, msg) -> new HttpClientOperations(ch, c, cookieEncoder, cookieDecoder);
 	}
 
+	@Override
+	public ConnectionProvider connectionProvider() {
+		return httpConnectionProvider().http1ConnectionProvider();
+	}
+
 	/**
 	 * Return the configured {@link ClientCookieDecoder} or the default {@link ClientCookieDecoder#STRICT}.
 	 *
@@ -321,7 +326,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 	Function<String, String> uriTagValue;
 	WebsocketClientSpec websocketClientSpec;
 
-	HttpClientConfig(ConnectionProvider connectionProvider, Map<ChannelOption<?>, ?> options,
+	HttpClientConfig(HttpConnectionProvider connectionProvider, Map<ChannelOption<?>, ?> options,
 			Supplier<? extends SocketAddress> remoteAddress) {
 		super(connectionProvider, options, remoteAddress);
 		this.acceptGzip = false;
@@ -442,6 +447,10 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		else {
 			deferredConf = deferredConf -> deferredConf.flatMap(deferrer);
 		}
+	}
+
+	HttpConnectionProvider httpConnectionProvider() {
+		return (HttpConnectionProvider) super.connectionProvider();
 	}
 
 	void protocols(HttpProtocol... protocols) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -57,7 +57,6 @@ import reactor.netty.NettyOutbound;
 import reactor.netty.channel.AbortedException;
 import reactor.netty.http.HttpOperations;
 import reactor.netty.http.HttpProtocol;
-import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.tcp.TcpClientConfig;
 import reactor.netty.transport.AddressUtils;
 import reactor.netty.transport.ProxyProvider;
@@ -81,7 +80,7 @@ class HttpClientConnect extends HttpClient {
 
 	final HttpClientConfig config;
 
-	HttpClientConnect(ConnectionProvider provider) {
+	HttpClientConnect(HttpConnectionProvider provider) {
 		this.config = new HttpClientConfig(
 				provider,
 				Collections.singletonMap(ChannelOption.AUTO_READ, false),
@@ -265,7 +264,7 @@ class HttpClientConnect extends HttpClient {
 
 				AddressResolverGroup<?> resolver = _config.resolverInternal();
 
-				_config.connectionProvider()
+				_config.httpConnectionProvider()
 						.acquire(_config, observer, handler, resolver)
 						.subscribe(new ClientTransportSubscriber(sink));
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -3165,7 +3165,7 @@ class HttpClientTest extends BaseHttpTest {
 		HttpClientConfig config = client.configuration();
 
 		LoopResources loopResources1 = config.loopResources();
-		ConnectionProvider provider1 = ((HttpConnectionProvider) config.connectionProvider()).http1ConnectionProvider();
+		ConnectionProvider provider1 = config.connectionProvider();
 		AddressResolverGroup<?> resolverGroup1 = config.defaultAddressResolverGroup();
 
 		try {
@@ -3182,7 +3182,7 @@ class HttpClientTest extends BaseHttpTest {
 		HttpResources.reset();
 
 		LoopResources loopResources2 = config.loopResources();
-		ConnectionProvider provider2 = ((HttpConnectionProvider) config.connectionProvider()).http1ConnectionProvider();
+		ConnectionProvider provider2 = config.connectionProvider();
 		AddressResolverGroup<?> resolverGroup2 = config.defaultAddressResolverGroup();
 
 		assertThat(loopResources1).isNotSameAs(loopResources2);


### PR DESCRIPTION
Fixes #2462