### PR TITLE
Get SslHandler by name for ALPN in HttpClientChannelInitializer

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -867,27 +867,30 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 
 		@Override
 		public void channelActive(ChannelHandlerContext ctx) {
-			SslHandler sslHandler = ctx.pipeline().get(SslHandler.class);
-			if (sslHandler == null) {
+			ChannelHandler handler = ctx.pipeline().get(NettyPipeline.SslHandler);
+			if (handler instanceof SslHandler) {
+				SslHandler sslHandler = (SslHandler) handler;
+
+				String protocol = sslHandler.applicationProtocol() != null ? sslHandler.applicationProtocol() : ApplicationProtocolNames.HTTP_1_1;
+				if (log.isDebugEnabled()) {
+					log.debug(format(ctx.channel(), "Negotiated application-level protocol [" + protocol + "]"));
+				}
+				if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
+					configureHttp2Pipeline(ctx.channel().pipeline(), acceptGzip, decoder, http2Settings, observer);
+				}
+				else if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
+					configureHttp11Pipeline(ctx.channel().pipeline(), acceptGzip, decoder, metricsRecorder, uriTagValue);
+				}
+				else {
+					throw new IllegalStateException("unknown protocol: " + protocol);
+				}
+
+				ctx.fireChannelActive();
+
+				ctx.channel().pipeline().remove(this);
+			} else {
 				throw new IllegalStateException("Cannot determine negotiated application-level protocol.");
 			}
-			String protocol = sslHandler.applicationProtocol() != null ? sslHandler.applicationProtocol() : ApplicationProtocolNames.HTTP_1_1;
-			if (log.isDebugEnabled()) {
-				log.debug(format(ctx.channel(), "Negotiated application-level protocol [" + protocol + "]"));
-			}
-			if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
-				configureHttp2Pipeline(ctx.channel().pipeline(), acceptGzip, decoder, http2Settings, observer);
-			}
-			else if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
-				configureHttp11Pipeline(ctx.channel().pipeline(), acceptGzip, decoder, metricsRecorder, uriTagValue);
-			}
-			else {
-				throw new IllegalStateException("unknown protocol: " + protocol);
-			}
-
-			ctx.fireChannelActive();
-
-			ctx.channel().pipeline().remove(this);
 		}
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -888,7 +888,8 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 				ctx.fireChannelActive();
 
 				ctx.channel().pipeline().remove(this);
-			} else {
+			}
+			else {
 				throw new IllegalStateException("Cannot determine negotiated application-level protocol.");
 			}
 		}


### PR DESCRIPTION
Switch to accessing the SslHandler by name in client ALPN. This should always return the SslHandler for remote endpoint. If we don't do this, the pipeline will always return the first SslHandler in the pipeline. When talking through a TLS enabled forward proxy there may be more than one SslHandler present in the pipeline. This change ensures that we always get the SslHandler for the remote HTTP endpoint and not an intermediary, ensuring we set the correct negotiated protocol.

Fixes reactor/reactor-netty#2480