### PR TITLE
Defer the creation of the request/response object

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -772,13 +772,9 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 		if (!channel().isActive()) {
 			return Mono.error(AbortedException.beforeSend());
 		}
-		if (markSentHeaderAndBody()) {
-			HttpMessage request = newFullBodyMessage(Unpooled.EMPTY_BUFFER);
-			return FutureMono.deferFuture(() -> channel().writeAndFlush(request));
-		}
-		else {
-			return Mono.empty();
-		}
+		return FutureMono.deferFuture(() -> markSentHeaderAndBody() ?
+				channel().writeAndFlush(newFullBodyMessage(Unpooled.EMPTY_BUFFER)) :
+				channel().newSucceededFuture());
 	}
 
 	final void setNettyResponse(HttpResponse nettyResponse) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -445,13 +445,9 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 
 	@Override
 	public Mono<Void> send() {
-		if (markSentHeaderAndBody()) {
-			HttpMessage response = newFullBodyMessage(EMPTY_BUFFER);
-			return FutureMono.deferFuture(() -> channel().writeAndFlush(response));
-		}
-		else {
-			return Mono.empty();
-		}
+		return FutureMono.deferFuture(() -> markSentHeaderAndBody() ?
+				channel().writeAndFlush(newFullBodyMessage(EMPTY_BUFFER)) :
+				channel().newSucceededFuture());
 	}
 
 	@Override


### PR DESCRIPTION
If there is no subscription we may not need this object.