### PR TITLE
[test] Ensure HTTP/2 tests comply with RFC requirements for HTTP/2 headers

### DIFF
--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderH2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderH2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,8 @@ import java.net.InetSocketAddress;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static reactor.netty.http.server.logging.LoggingTests.HEADER_CONNECTION_NAME;
-import static reactor.netty.http.server.logging.LoggingTests.HEADER_CONNECTION_VALUE;
+import static reactor.netty.http.server.logging.LoggingTests.HEADER_TEST_NAME;
+import static reactor.netty.http.server.logging.LoggingTests.HEADER_TEST_VALUE;
 import static reactor.netty.http.server.logging.LoggingTests.URI;
 
 
@@ -45,7 +45,7 @@ class AccessLogArgProviderH2Tests {
 
 	static {
 		Http2Headers requestHttpHeaders = new DefaultHttp2Headers();
-		requestHttpHeaders.add(HEADER_CONNECTION_NAME, HEADER_CONNECTION_VALUE);
+		requestHttpHeaders.add(HEADER_TEST_NAME, HEADER_TEST_VALUE);
 		requestHttpHeaders.method(HttpMethod.GET.name());
 		requestHttpHeaders.path(URI);
 		requestHeaders = new DefaultHttp2HeadersFrame(requestHttpHeaders);
@@ -94,10 +94,10 @@ class AccessLogArgProviderH2Tests {
 	@Test
 	void requestHeader() {
 		assertThatNullPointerException().isThrownBy(() -> accessLogArgProvider.requestHeader(null));
-		assertThat(accessLogArgProvider.requestHeader(HEADER_CONNECTION_NAME)).isNull();
+		assertThat(accessLogArgProvider.requestHeader(HEADER_TEST_NAME)).isNull();
 		accessLogArgProvider.requestHeaders(requestHeaders);
-		assertThat(accessLogArgProvider.requestHeader(HEADER_CONNECTION_NAME))
-				.isEqualTo(HEADER_CONNECTION_VALUE);
+		assertThat(accessLogArgProvider.requestHeader(HEADER_TEST_NAME))
+				.isEqualTo(HEADER_TEST_VALUE);
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogHandlerH2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogHandlerH2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@ import org.junit.jupiter.api.Test;
 import java.net.SocketAddress;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static reactor.netty.http.server.logging.LoggingTests.HEADER_CONNECTION_NAME;
-import static reactor.netty.http.server.logging.LoggingTests.HEADER_CONNECTION_VALUE;
+import static reactor.netty.http.server.logging.LoggingTests.HEADER_TEST_NAME;
+import static reactor.netty.http.server.logging.LoggingTests.HEADER_TEST_VALUE;
 import static reactor.netty.http.server.logging.LoggingTests.RESPONSE_CONTENT;
 import static reactor.netty.http.server.logging.LoggingTests.URI;
 
@@ -45,14 +45,14 @@ class AccessLogHandlerH2Tests {
 		channel.pipeline().addLast(new AccessLogHandlerH2(
 				args -> {
 					assertAccessLogArgProvider(args, channel.remoteAddress());
-					return AccessLog.create("{}={}", HEADER_CONNECTION_NAME,
-							args.requestHeader(HEADER_CONNECTION_NAME));
+					return AccessLog.create("{}={}", HEADER_TEST_NAME,
+							args.requestHeader(HEADER_TEST_NAME));
 				}));
 
 		Http2Headers requestHeaders = new DefaultHttp2Headers();
 		requestHeaders.method(HttpMethod.GET.name());
 		requestHeaders.path(URI);
-		requestHeaders.add(HEADER_CONNECTION_NAME, HEADER_CONNECTION_VALUE);
+		requestHeaders.add(HEADER_TEST_NAME, HEADER_TEST_VALUE);
 		channel.writeInbound(new DefaultHttp2HeadersFrame(requestHeaders));
 
 		Http2Headers responseHeaders = new DefaultHttp2Headers();
@@ -75,7 +75,7 @@ class AccessLogHandlerH2Tests {
 		assertThat(args.protocol()).isEqualTo(AccessLogArgProviderH2.H2_PROTOCOL_NAME);
 		assertThat(args.status()).isEqualTo(HttpResponseStatus.OK.codeAsText());
 		assertThat(args.contentLength()).isEqualTo(RESPONSE_CONTENT.length);
-		assertThat(args.requestHeader(HEADER_CONNECTION_NAME)).isEqualTo(HEADER_CONNECTION_VALUE);
+		assertThat(args.requestHeader(HEADER_TEST_NAME)).isEqualTo(HEADER_TEST_VALUE);
 	}
 
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/LoggingTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/LoggingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ class LoggingTests {
 
 	static final CharSequence HEADER_CONNECTION_NAME = HttpHeaderNames.CONNECTION;
 	static final String HEADER_CONNECTION_VALUE = "keep-alive";
+	static final CharSequence HEADER_TEST_NAME = "test";
+	static final String HEADER_TEST_VALUE = "test";
 	static final String URI = "/hello";
 	static final byte[] RESPONSE_CONTENT = "Hello".getBytes(StandardCharsets.UTF_8);
 


### PR DESCRIPTION
Netty fixed the checks for HTTP/2 headers' compliance with RFC: https://github.com/netty/netty/pull/12760

This fixes the CI build against Netty 4.1 SNAPSHOT
https://github.com/reactor/reactor-netty/actions/runs/3106167960