### PR TITLE
[test] Adapt to Netty change to drop the data when it is unexpected

### DIFF
--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerTests.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/server/HttpServerTests.java
@@ -929,12 +929,7 @@ class HttpServerTests extends BaseHttpTest {
 				(req, res) -> res.header("Content-Length", "0")
 				                 .send(Flux.just(data, data1, data2))
 				                 .then()
-				                 .doOnCancel(() -> {
-				                     data.close();
-				                     data1.close();
-				                     data2.close();
-				                     latch.countDown();
-				                 }),
+				                 .doOnCancel(latch::countDown),
 				(req, out) -> {
 					req.addHeader("Connection", "close");
 					return out;


### PR DESCRIPTION
A response with `Content-Length: 0` is already sent so any other additional data will be dropped.
https://github.com/netty/netty/pull/12836