### PR TITLE
Use BufferAllocator#compose(...) for creating CompositeBuffer

### DIFF
--- a/reactor-netty5-core/src/main/java/reactor/netty5/BufferFlux.java
+++ b/reactor-netty5-core/src/main/java/reactor/netty5/BufferFlux.java
@@ -337,7 +337,7 @@ public class BufferFlux extends FluxOperator<Buffer, Buffer> {
 						Buffer output = null;
 						if (!list.isEmpty()) {
 							output = alloc.compose(list);
-							COMPOSITE_BUFFER.set(this, output);
+							this.compositeBuffer = output;
 						}
 						if (output != null && output.readableBytes() > 0) {
 							sink.next(output);
@@ -347,7 +347,7 @@ public class BufferFlux extends FluxOperator<Buffer, Buffer> {
 						}
 					})
 					.doFinally(signalType -> {
-						Buffer buffer = COMPOSITE_BUFFER.get(this);
+						Buffer buffer = this.compositeBuffer;
 						if (buffer != null) {
 							buffer.close();
 						}

--- a/reactor-netty5-core/src/main/java/reactor/netty5/BufferMono.java
+++ b/reactor-netty5-core/src/main/java/reactor/netty5/BufferMono.java
@@ -18,7 +18,7 @@ package reactor.netty5;
 import io.netty5.buffer.BufferInputStream;
 import io.netty5.buffer.Buffer;
 import io.netty5.buffer.BufferAllocator;
-import io.netty5.buffer.CompositeBuffer;
+import io.netty5.util.Send;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
 import reactor.core.Fuseable;
@@ -28,6 +28,8 @@ import reactor.core.publisher.MonoOperator;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
@@ -130,11 +132,11 @@ public class BufferMono  extends MonoOperator<Buffer, Buffer> {
 						source,
 						s -> allocator.copyOf(s.getBytes(charset)),
 						l -> {
-							CompositeBuffer buffer = CompositeBuffer.compose(allocator);
+							List<Send<Buffer>> sendBufferList = new ArrayList<>(l.size());
 							for (String s : l) {
-								buffer.extendWith(allocator.copyOf(s.getBytes(charset)).send());
+								sendBufferList.add(allocator.copyOf(s.getBytes(charset)).send());
 							}
-							return buffer;
+							return allocator.compose(sendBufferList);
 						})));
 	}
 

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientOperations.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientOperations.java
@@ -33,7 +33,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import io.netty5.buffer.Buffer;
-import io.netty5.buffer.BufferAllocator;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelOption;


### PR DESCRIPTION
When possible use `BufferAllocator#compose(...)` for creating `CompositeBuffer` instead of `CompositeBuffer#extendWith` as the first performs better.
More information https://github.com/netty/netty/issues/12757