### PR TITLE
Deprecate ReactorNetty#toPrettyHexDump

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java
@@ -261,8 +261,11 @@ public final class ReactorNetty {
 	}
 
 	/**
-	 * Pretty hex dump will be returned when the object is {@link ByteBuf} or {@link ByteBufHolder}
+	 * Pretty hex dump will be returned when the object is {@link ByteBuf} or {@link ByteBufHolder}.
+	 *
+	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as the functionality is not used anymore.
 	 */
+	@Deprecated
 	public static String toPrettyHexDump(Object msg) {
 		Objects.requireNonNull(msg, "msg");
 		String result;


### PR DESCRIPTION
The functionality is not used and will be removed in Reactor Netty 2.0.0