### PR TITLE
Support HTTP errors 414 and 431

### DIFF
--- a/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpServerDecoratorTest.java
+++ b/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpServerDecoratorTest.java
@@ -153,6 +153,6 @@ public class ITTracingHttpServerDecoratorTest extends ITHttpServer {
 
 		this.get("/request_line_too_long");
 
-		assertThat(testSpanHandler.takeRemoteSpanWithErrorTag(SERVER, "413").tags()).containsEntry("error", "413");
+		assertThat(testSpanHandler.takeRemoteSpanWithErrorTag(SERVER, "414").tags()).containsEntry("error", "414");
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -766,7 +766,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		          .uri("/max_header_size")
 		          .responseSingle((res, byteBufMono) -> Mono.just(res.status().code()))
 		          .as(StepVerifier::create)
-		          .expectNext(413)
+		          .expectNext(431)
 		          .expectComplete()
 		          .verify(Duration.ofSeconds(30));
 
@@ -881,7 +881,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 	private void checkExpectationsBadRequest(String serverAddress, boolean checkTls) {
 		String uri = "/max_header_size";
-		String[] timerTags1 = new String[] {URI, uri, METHOD, "GET", STATUS, "413"};
+		String[] timerTags1 = new String[] {URI, uri, METHOD, "GET", STATUS, "431"};
 		String[] summaryTags1 = new String[] {URI, uri};
 
 		checkTimer(SERVER_RESPONSE_TIME, timerTags1, 1);
@@ -889,7 +889,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		checkDistributionSummary(SERVER_DATA_SENT, summaryTags1, 1, 0);
 		checkCounter(SERVER_ERRORS, summaryTags1, false, 0);
 
-		timerTags1 = new String[] {REMOTE_ADDRESS, serverAddress, URI, uri, METHOD, "GET", STATUS, "413"};
+		timerTags1 = new String[] {REMOTE_ADDRESS, serverAddress, URI, uri, METHOD, "GET", STATUS, "431"};
 		String[] timerTags2 = new String[] {REMOTE_ADDRESS, serverAddress, URI, uri, METHOD, "GET"};
 		String[] timerTags3 = new String[] {REMOTE_ADDRESS, serverAddress, STATUS, "SUCCESS"};
 		summaryTags1 = new String[] {REMOTE_ADDRESS, serverAddress, URI, uri};

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -923,7 +923,29 @@ class HttpServerTests extends BaseHttpTest {
 				          .responseSingle((res, byteBufMono) -> Mono.just(res.status()));
 
 		StepVerifier.create(status)
-		            .expectNextMatches(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE::equals)
+		            .expectNextMatches(HttpResponseStatus.REQUEST_URI_TOO_LONG::equals)
+		            .expectComplete()
+		            .verify();
+	}
+
+	@Test
+	void httpServerRequestHeadersTooLong() {
+		HttpServer httpServer = HttpServer.create()
+				          .port(0)
+				          .httpRequestDecoder(c -> c.maxHeaderSize(20));
+		disposableServer =
+				httpServer.handle((req, res) -> res.sendString(Mono.just("Should not be reached")))
+				          .bindNow();
+
+		Mono<HttpResponseStatus> status =
+				createClient(disposableServer.port())
+				          .headers(h -> h.set("content-type", "somethingtooolooong"))
+				          .get()
+				          .uri("/path")
+				          .responseSingle((res, byteBufMono) -> Mono.just(res.status()));
+
+		StepVerifier.create(status)
+		            .expectNextMatches(HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE::equals)
 		            .expectComplete()
 		            .verify();
 	}


### PR DESCRIPTION
414 is "uri too long" https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/414 431 is "header too long" https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/431 Old behavior was using 413 "request payload too large" which is specific to the content, not the first line or headers.

I added this upstream to Netty a while ago, https://github.com/netty/netty/pull/12084
vert.x seems to have upgraded their implementation in a [similar manner](https://github.com/eclipse-vertx/vert.x/commit/fdf6fdb443f50407e3d9536ba9c766069bfec315#diff-06e556537e911513a654d243bc7a97baec0b3fc053211d46c6d98a7c62ef59c2L66)