### PR TITLE
Migrate to the new micrometer-docs-generator

### DIFF
--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -77,21 +77,11 @@ configurations {
 }
 
 dependencies {
-	adoc "io.micrometer:micrometer-docs-generator-spans:$micrometerDocsVersion"
-	adoc "io.micrometer:micrometer-docs-generator-metrics:$micrometerDocsVersion"
+	adoc "io.micrometer:micrometer-docs-generator:$micrometerDocsVersion"
 }
 
-task generateObservabilityDocs(dependsOn: ["generateObservabilityMetricsDocs", "generateObservabilitySpansDocs"]) {
-}
-
-task generateObservabilityMetricsDocs(type: JavaExec) {
-	mainClass = "io.micrometer.docs.metrics.DocsFromSources"
-	classpath configurations.adoc
-	args project.rootDir.getAbsolutePath(), ".*", project.rootProject.buildDir.getAbsolutePath()
-}
-
-task generateObservabilitySpansDocs(type: JavaExec) {
-	mainClass = "io.micrometer.docs.spans.DocsFromSources"
+task generateObservabilityDocs(type: JavaExec) {
+	mainClass = "io.micrometer.docs.DocsGeneratorCommand"
 	classpath configurations.adoc
 	args project.rootDir.getAbsolutePath(), ".*", project.rootProject.buildDir.getAbsolutePath()
 }


### PR DESCRIPTION
As per https://github.com/micrometer-metrics/micrometer-docs-generator/wiki/1.0.0-Migration-Guide 

```
micrometer-docs-generator-metrics and micrometer-docs-generator-spans are deprecated in favor of the new module 
micrometer-docs-generator which generates both metrics and spans (and observation conventions) documents.
```