### PR TITLE
Deprecate Cookie encoder/decoder settings

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -561,7 +561,9 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @param cookieBuilder the header {@link Consumer} to invoke before requesting
 	 *
 	 * @return a new {@link HttpClient}
+	 * @deprecated as of 1.1.0. Use {@link #cookie(Cookie)} for configuring cookies. This will be removed in 2.0.0.
 	 */
+	@Deprecated
 	public final HttpClient cookie(String name, Consumer<? super Cookie> cookieBuilder) {
 		Objects.requireNonNull(name, "name");
 		Objects.requireNonNull(cookieBuilder, "cookieBuilder");
@@ -578,7 +580,9 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @param encoder the preferred ClientCookieEncoder
 	 *
 	 * @return a new {@link HttpClient}
+	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as Netty 5 supports only strict validation.
 	 */
+	@Deprecated
 	public final HttpClient cookieCodec(ClientCookieEncoder encoder) {
 		Objects.requireNonNull(encoder, "encoder");
 		ClientCookieDecoder decoder = encoder == ClientCookieEncoder.LAX ?
@@ -594,7 +598,9 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @param decoder the preferred ClientCookieDecoder
 	 *
 	 * @return a new {@link HttpClient}
+	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as Netty 5 supports only strict validation.
 	 */
+	@Deprecated
 	public final HttpClient cookieCodec(ClientCookieEncoder encoder, ClientCookieDecoder decoder) {
 		Objects.requireNonNull(encoder, "encoder");
 		Objects.requireNonNull(decoder, "decoder");

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -126,7 +126,9 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 	 * Return the configured {@link ClientCookieDecoder} or the default {@link ClientCookieDecoder#STRICT}.
 	 *
 	 * @return the configured {@link ClientCookieDecoder} or the default {@link ClientCookieDecoder#STRICT}
+	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as Netty 5 supports only strict validation.
 	 */
+	@Deprecated
 	public ClientCookieDecoder cookieDecoder() {
 		return cookieDecoder;
 	}
@@ -135,7 +137,9 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 	 * Return the configured {@link ClientCookieEncoder} or the default {@link ClientCookieEncoder#STRICT}.
 	 *
 	 * @return the configured {@link ClientCookieEncoder} or the default {@link ClientCookieEncoder#STRICT}
+	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as Netty 5 supports only strict validation.
 	 */
+	@Deprecated
 	public ClientCookieEncoder cookieEncoder() {
 		return cookieEncoder;
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -339,7 +339,9 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 * @param encoder the preferred ServerCookieEncoder
 	 *
 	 * @return a new {@link HttpServer}
+	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as Netty 5 supports only strict validation.
 	 */
+	@Deprecated
 	public final HttpServer cookieCodec(ServerCookieEncoder encoder) {
 		Objects.requireNonNull(encoder, "encoder");
 		ServerCookieDecoder decoder = encoder == ServerCookieEncoder.LAX ?
@@ -358,7 +360,9 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 * @param decoder the preferred ServerCookieDecoder
 	 *
 	 * @return a new {@link HttpServer}
+	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as Netty 5 supports only strict validation.
 	 */
+	@Deprecated
 	public final HttpServer cookieCodec(ServerCookieEncoder encoder, ServerCookieDecoder decoder) {
 		Objects.requireNonNull(encoder, "encoder");
 		Objects.requireNonNull(decoder, "decoder");

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -105,7 +105,9 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 	 * Return the configured {@link ServerCookieDecoder} or the default {@link ServerCookieDecoder#STRICT}.
 	 *
 	 * @return the configured {@link ServerCookieDecoder} or the default {@link ServerCookieDecoder#STRICT}
+	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as Netty 5 supports only strict validation.
 	 */
+	@Deprecated
 	public ServerCookieDecoder cookieDecoder() {
 		return cookieDecoder;
 	}
@@ -114,7 +116,9 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 	 * Return the configured {@link ServerCookieEncoder} or the default {@link ServerCookieEncoder#STRICT}.
 	 *
 	 * @return the configured {@link ServerCookieEncoder} or the default {@link ServerCookieEncoder#STRICT}
+	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as Netty 5 supports only strict validation.
 	 */
+	@Deprecated
 	public ServerCookieEncoder cookieEncoder() {
 		return cookieEncoder;
 	}


### PR DESCRIPTION
Netty 5 supports only strict cookie validation.