### PR TITLE
Remove transitive dependency netty5-codec-http from reactor-netty5-core

### DIFF
--- a/reactor-netty5-core/build.gradle
+++ b/reactor-netty5-core/build.gradle
@@ -58,7 +58,9 @@ dependencies {
 	compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
 
 	api "io.netty:netty5-handler:$nettyVersion"
-	api "io.netty.contrib:netty-handler-proxy:$nettyContribVersion"
+	api("io.netty.contrib:netty-handler-proxy:$nettyContribVersion") {
+		exclude module: "netty5-codec-http"
+	}
 	api "io.netty:netty5-resolver-dns:$nettyVersion"
 	if (!"$nettyVersion".endsWithAny("SNAPSHOT")) {
 		if (osdetector.classifier == "osx-x86_64" || osdetector.classifier == "osx-aarch_64") {

--- a/reactor-netty5-core/src/test/java/reactor/netty5/ConnectionTest.java
+++ b/reactor-netty5-core/src/test/java/reactor/netty5/ConnectionTest.java
@@ -26,8 +26,8 @@ import io.netty5.channel.ChannelHandlerAdapter;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.LineBasedFrameDecoder;
-import io.netty5.handler.codec.http.HttpServerCodec;
-import io.netty5.handler.codec.http.websocketx.Utf8FrameValidator;
+import io.netty5.handler.codec.string.StringDecoder;
+import io.netty5.handler.codec.string.StringEncoder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
@@ -53,6 +53,7 @@ class ConnectionTest {
 	EmbeddedChannel channel;
 	ChannelHandler decoder;
 	ChannelHandler encoder;
+	ChannelHandler httpServerCodecMock;
 	ChannelHandler httpTrafficHandlerMock;
 	ChannelHandler reactiveBridgeMock;
 	Connection testContext;
@@ -63,6 +64,7 @@ class ConnectionTest {
 		channel = new EmbeddedChannel();
 		decoder = new LineBasedFrameDecoder(12);
 		encoder = new LineBasedFrameDecoder(12);
+		httpServerCodecMock = new ChannelHandlerAdapter(){};
 		httpTrafficHandlerMock = new ChannelHandlerAdapter(){};
 		reactiveBridgeMock = new ChannelHandlerAdapter(){};
 		testContext = () -> channel;
@@ -96,7 +98,7 @@ class ConnectionTest {
 	@Test
 	void addByteDecoderWhenNoRight() {
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec());
+		       .addLast(NettyPipeline.HttpCodec, httpServerCodecMock);
 
 		testContext.addHandlerLast(DECODER_NAME, decoder)
 		           .addHandlerFirst(DECODER_EXTRACT_NAME, NettyPipeline.inboundHandler(ADD_EXTRACTOR));
@@ -116,7 +118,7 @@ class ConnectionTest {
 	@Test
 	void addByteDecoderWhenFullReactorPipeline() {
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec())
+		       .addLast(NettyPipeline.HttpCodec, httpServerCodecMock)
 		       .addLast(NettyPipeline.HttpTrafficHandler, httpTrafficHandlerMock)
 		       .addLast(NettyPipeline.ReactiveBridge, reactiveBridgeMock);
 
@@ -154,7 +156,7 @@ class ConnectionTest {
 	@Test
 	void addNonByteDecoderWhenNoRight() {
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec());
+		       .addLast(NettyPipeline.HttpCodec, httpServerCodecMock);
 
 		testContext.addHandlerLast(DECODER_NAME, decoder);
 
@@ -171,7 +173,7 @@ class ConnectionTest {
 	@Test
 	void addNonByteDecoderWhenFullReactorPipeline() {
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec())
+		       .addLast(NettyPipeline.HttpCodec, httpServerCodecMock)
 		       .addLast(NettyPipeline.HttpTrafficHandler, httpTrafficHandlerMock)
 		       .addLast(NettyPipeline.ReactiveBridge, reactiveBridgeMock);
 
@@ -188,7 +190,7 @@ class ConnectionTest {
 		ChannelHandler decoder2 = new LineBasedFrameDecoder(13);
 
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec())
+		       .addLast(NettyPipeline.HttpCodec, httpServerCodecMock)
 		       .addLast(NettyPipeline.HttpTrafficHandler, httpTrafficHandlerMock)
 		       .addLast(NettyPipeline.ReactiveBridge, reactiveBridgeMock);
 
@@ -217,7 +219,7 @@ class ConnectionTest {
 	@Test
 	void addByteEncoderWhenNoRight() {
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec());
+		       .addLast(NettyPipeline.HttpCodec, httpServerCodecMock);
 
 		testContext.addHandlerFirst(ENCODER_NAME, encoder);
 
@@ -234,7 +236,7 @@ class ConnectionTest {
 	@Test
 	void addByteEncoderWhenFullReactorPipeline() {
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec())
+		       .addLast(NettyPipeline.HttpCodec, httpServerCodecMock)
 		       .addLast(NettyPipeline.HttpTrafficHandler, httpTrafficHandlerMock)
 		       .addLast(NettyPipeline.ReactiveBridge, reactiveBridgeMock);
 		ChannelHandler encoder = new LineBasedFrameDecoder(12);
@@ -260,7 +262,7 @@ class ConnectionTest {
 	@Test
 	void addNonByteEncoderWhenNoRight() {
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec());
+		       .addLast(NettyPipeline.HttpCodec, httpServerCodecMock);
 
 		testContext.addHandlerFirst(ENCODER_NAME, encoder);
 
@@ -277,7 +279,7 @@ class ConnectionTest {
 	@Test
 	void addNonByteEncoderWhenFullReactorPipeline() {
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec())
+		       .addLast(NettyPipeline.HttpCodec, httpServerCodecMock)
 		       .addLast(NettyPipeline.HttpTrafficHandler, httpTrafficHandlerMock)
 		       .addLast(NettyPipeline.ReactiveBridge, reactiveBridgeMock);
 
@@ -294,7 +296,7 @@ class ConnectionTest {
 		ChannelHandler encoder2 = new LineBasedFrameDecoder(13);
 
 		channel.pipeline()
-		       .addLast(NettyPipeline.HttpCodec, new HttpServerCodec())
+		       .addLast(NettyPipeline.HttpCodec, httpServerCodecMock)
 		       .addLast(NettyPipeline.HttpTrafficHandler, httpTrafficHandlerMock)
 		       .addLast(NettyPipeline.ReactiveBridge, reactiveBridgeMock);
 
@@ -328,7 +330,7 @@ class ConnectionTest {
 		};
 
 		c.markPersistent(false)
-		 .addHandlerFirst("byteEncoder", new Utf8FrameValidator())
+		 .addHandlerFirst("byteEncoder", new StringEncoder())
 		 .addHandlerFirst(ENCODER_NAME, encoder);
 
 		assertThat(c.isPersistent()).isFalse();
@@ -357,7 +359,7 @@ class ConnectionTest {
 		};
 
 		c.markPersistent(false)
-		 .addHandlerLast("byteDecoder", new Utf8FrameValidator())
+		 .addHandlerLast("byteDecoder", new StringDecoder())
 		 .addHandlerLast(DECODER_NAME, decoder);
 
 		assertThat(c.isPersistent()).isFalse();
@@ -367,23 +369,23 @@ class ConnectionTest {
 	@Test
 	void addDecoderSkipsIfExist() {
 		channel.pipeline()
-		       .addFirst(DECODER_NAME, new Utf8FrameValidator());
+		       .addFirst(DECODER_NAME, new StringDecoder());
 
 		testContext.addHandlerFirst(DECODER_NAME, decoder);
 
 		assertThat(channel.pipeline().names()).containsExactly(DECODER_NAME);
-		assertThat(channel.pipeline().get(DECODER_NAME)).isInstanceOf(Utf8FrameValidator.class);
+		assertThat(channel.pipeline().get(DECODER_NAME)).isInstanceOf(StringDecoder.class);
 	}
 
 	@Test
 	void addEncoderSkipsIfExist() {
 		channel.pipeline()
-		       .addFirst(ENCODER_NAME, new Utf8FrameValidator());
+		       .addFirst(ENCODER_NAME, new StringEncoder());
 
 		testContext.addHandlerFirst(ENCODER_NAME, new LineBasedFrameDecoder(10));
 
 		assertThat(channel.pipeline().names()).containsExactly(ENCODER_NAME);
-		assertThat(channel.pipeline().get(ENCODER_NAME)).isInstanceOf(Utf8FrameValidator.class);
+		assertThat(channel.pipeline().get(ENCODER_NAME)).isInstanceOf(StringEncoder.class);
 	}
 
 	@Test

--- a/reactor-netty5-core/src/test/java/reactor/netty5/transport/ClientTransportTest.java
+++ b/reactor-netty5-core/src/test/java/reactor/netty5/transport/ClientTransportTest.java
@@ -144,34 +144,6 @@ class ClientTransportTest {
 	}
 
 	@Test
-	void testCreateClientWithHttpProxy() {
-		Properties properties = new Properties();
-		properties.setProperty(ProxyProvider.HTTP_PROXY_HOST, "host");
-
-		TestClientTransport transport = createTestTransportForProxy()
-				.proxyWithSystemProperties(properties);
-
-		TestClientTransportConfig config = transport.configuration();
-		assertThat(config.proxyProvider()).isNotNull();
-		assertThat(config.proxyProvider().getType()).isEqualTo(ProxyProvider.Proxy.HTTP);
-		assertThat(config.resolver()).isSameAs(NoopAddressResolverGroup.INSTANCE);
-	}
-
-	@Test
-	void testCreateClientWithHttpsProxy() {
-		Properties properties = new Properties();
-		properties.setProperty(ProxyProvider.HTTPS_PROXY_HOST, "host");
-
-		TestClientTransport transport = createTestTransportForProxy()
-				.proxyWithSystemProperties(properties);
-
-		TestClientTransportConfig config = transport.configuration();
-		assertThat(config.proxyProvider()).isNotNull();
-		assertThat(config.proxyProvider().getType()).isEqualTo(ProxyProvider.Proxy.HTTP);
-		assertThat(config.resolver()).isSameAs(NoopAddressResolverGroup.INSTANCE);
-	}
-
-	@Test
 	void testCreateClientWithSock5Proxy() {
 		Properties properties = new Properties();
 		properties.setProperty(ProxyProvider.SOCKS_PROXY_HOST, "host");

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClient.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClient.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
@@ -1139,14 +1140,6 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		return dup;
 	}
 
-	@Override
-	public final HttpClient proxy(Consumer<? super ProxyProvider.TypeSpec> proxyOptions) {
-		Objects.requireNonNull(proxyOptions, "proxyOptions");
-		HttpClientProxyProvider.Build builder = new HttpClientProxyProvider.Build();
-		proxyOptions.accept(builder);
-		return proxyWithProxyProvider(builder.build());
-	}
-
 	/**
 	 * HTTP PUT to connect the {@link HttpClient}.
 	 *
@@ -1327,6 +1320,19 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	@Override
 	public final HttpClient wiretap(boolean enable) {
 		return super.wiretap(enable);
+	}
+
+	@Override
+	protected ProxyProvider proxyProviderFrom(Consumer<? super ProxyProvider.TypeSpec> proxyOptions) {
+		HttpClientProxyProvider.Build builder = new HttpClientProxyProvider.Build();
+		proxyOptions.accept(builder);
+		return builder.build();
+	}
+
+	@Override
+	protected ProxyProvider proxyProviderFrom(Properties properties) {
+		ProxyProvider provider = HttpClientProxyProvider.createFrom(properties);
+		return provider != null ? provider : super.proxyProviderFrom(properties);
 	}
 
 	static boolean isCompressing(HttpHeaders h) {

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientProxyProvider.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/HttpClientProxyProvider.java
@@ -19,8 +19,10 @@ import io.netty.contrib.handler.proxy.HttpProxyHandler;
 import io.netty.contrib.handler.proxy.ProxyHandler;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
 import reactor.netty5.transport.ProxyProvider;
+import reactor.util.annotation.Nullable;
 
 import java.util.Objects;
+import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -42,6 +44,17 @@ public final class HttpClientProxyProvider extends ProxyProvider {
 		 */
 		T httpHeaders(Consumer<HttpHeaders> headers);
 	}
+
+	static final String HTTP_PROXY_HOST = "http.proxyHost";
+	static final String HTTP_PROXY_PORT = "http.proxyPort";
+	static final String HTTP_PROXY_USER = "http.proxyUser";
+	static final String HTTP_PROXY_PASSWORD = "http.proxyPassword";
+	static final String HTTPS_PROXY_HOST = "https.proxyHost";
+	static final String HTTPS_PROXY_PORT = "https.proxyPort";
+	static final String HTTPS_PROXY_USER = "https.proxyUser";
+	static final String HTTPS_PROXY_PASSWORD = "https.proxyPassword";
+	static final String HTTP_NON_PROXY_HOSTS = "http.nonProxyHosts";
+	static final String DEFAULT_NON_PROXY_HOSTS = "localhost|127.*|[::1]";
 
 	final Supplier<? extends HttpHeaders> httpHeaders;
 
@@ -81,6 +94,67 @@ public final class HttpClientProxyProvider extends ProxyProvider {
 	@Override
 	public int hashCode() {
 		return Objects.hash(super.hashCode(), httpHeaders.get());
+	}
+
+	@Nullable
+	static HttpClientProxyProvider createFrom(Properties properties) {
+		Objects.requireNonNull(properties, "properties");
+
+		if (properties.containsKey(HTTP_PROXY_HOST) || properties.containsKey(HTTPS_PROXY_HOST)) {
+			return createHttpProxyFrom(properties);
+		}
+
+		return null;
+	}
+
+	/*
+		assumes properties has either http.proxyHost or https.proxyHost
+	 */
+	static HttpClientProxyProvider createHttpProxyFrom(Properties properties) {
+		String hostProperty;
+		String portProperty;
+		String userProperty;
+		String passwordProperty;
+		String defaultPort;
+		if (properties.containsKey(HTTPS_PROXY_HOST)) {
+			hostProperty = HTTPS_PROXY_HOST;
+			portProperty = HTTPS_PROXY_PORT;
+			userProperty = HTTPS_PROXY_USER;
+			passwordProperty = HTTPS_PROXY_PASSWORD;
+			defaultPort = "443";
+		}
+		else {
+			hostProperty = HTTP_PROXY_HOST;
+			portProperty = HTTP_PROXY_PORT;
+			userProperty = HTTP_PROXY_USER;
+			passwordProperty = HTTP_PROXY_PASSWORD;
+			defaultPort = "80";
+		}
+
+		String hostname = Objects.requireNonNull(properties.getProperty(hostProperty), hostProperty);
+		int port = parsePort(properties.getProperty(portProperty, defaultPort), portProperty);
+
+		String nonProxyHosts = properties.getProperty(HTTP_NON_PROXY_HOSTS, DEFAULT_NON_PROXY_HOSTS);
+		RegexShouldProxyPredicate transformedNonProxyHosts = RegexShouldProxyPredicate.fromWildcardedPattern(nonProxyHosts);
+
+		Build proxy = new Build()
+				.type(Proxy.HTTP)
+				.host(hostname)
+				.port(port)
+				.nonProxyHostsPredicate(transformedNonProxyHosts);
+
+		if (properties.containsKey(userProperty)) {
+			proxy = proxy.username(properties.getProperty(userProperty));
+
+			if (properties.containsKey(passwordProperty)) {
+				proxy = proxy.password(u -> properties.getProperty(passwordProperty));
+			}
+			else {
+				throw new NullPointerException("Proxy username is set via '" + userProperty + "', but '" + passwordProperty + "' is not set.");
+			}
+		}
+
+		return proxy.build();
 	}
 
 	static final class Build extends AbstractBuild<Build> implements Builder<Build> {

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/client/ClientTransportTest.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/client/ClientTransportTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty5.http.client;
+
+import io.netty5.channel.ChannelOption;
+import io.netty5.handler.logging.LoggingHandler;
+import io.netty5.resolver.AddressResolverGroup;
+import io.netty5.resolver.NoopAddressResolverGroup;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.netty5.Connection;
+import reactor.netty5.channel.ChannelMetricsRecorder;
+import reactor.netty5.resources.ConnectionProvider;
+import reactor.netty5.resources.LoopResources;
+import reactor.netty5.transport.ClientTransport;
+import reactor.netty5.transport.ClientTransportConfig;
+import reactor.netty5.transport.NameResolverProvider;
+import reactor.netty5.transport.ProxyProvider;
+
+import java.net.SocketAddress;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Violeta Georgieva
+ */
+class ClientTransportTest {
+
+	@Test
+	void testCreateClientWithHttpProxy() {
+		Properties properties = new Properties();
+		properties.setProperty("http.proxyHost", "host");
+
+		TestClientTransport transport = createTestTransportForProxy(properties)
+				.proxyWithSystemProperties();
+
+		TestClientTransportConfig config = transport.configuration();
+		assertThat(config.proxyProvider()).isNotNull();
+		assertThat(config.proxyProvider().getType()).isEqualTo(ProxyProvider.Proxy.HTTP);
+		assertThat(config.resolver()).isSameAs(NoopAddressResolverGroup.INSTANCE);
+	}
+
+	@Test
+	void testCreateClientWithHttpsProxy() {
+		Properties properties = new Properties();
+		properties.setProperty("https.proxyHost", "host");
+
+		TestClientTransport transport = createTestTransportForProxy(properties)
+				.proxyWithSystemProperties();
+
+		TestClientTransportConfig config = transport.configuration();
+		assertThat(config.proxyProvider()).isNotNull();
+		assertThat(config.proxyProvider().getType()).isEqualTo(ProxyProvider.Proxy.HTTP);
+		assertThat(config.resolver()).isSameAs(NoopAddressResolverGroup.INSTANCE);
+	}
+
+	static TestClientTransport createTestTransportForProxy(Properties properties) {
+		ConnectionProvider provider = ConnectionProvider.create("test");
+		return new TestClientTransport(Mono.empty(),
+				new TestClientTransportConfig(provider, Collections.emptyMap(), () -> null),
+				properties
+		);
+	}
+
+	static final class TestClientTransport extends ClientTransport<TestClientTransport, TestClientTransportConfig> {
+
+		final Mono<? extends Connection> connect;
+		final TestClientTransportConfig config;
+		final Properties properties;
+
+		TestClientTransport(Mono<? extends Connection> connect, TestClientTransportConfig config, Properties properties) {
+			this.connect = connect;
+			this.config = config;
+			this.properties = properties;
+		}
+
+		@Override
+		public TestClientTransportConfig configuration() {
+			return config;
+		}
+
+		@Override
+		protected Mono<? extends Connection> connect() {
+			return connect;
+		}
+
+		@Override
+		protected TestClientTransport duplicate() {
+			return new TestClientTransport(this.connect, this.config, this.properties);
+		}
+
+		@Override
+		protected ProxyProvider proxyProviderFrom(Properties systemProperties) {
+			return HttpClientProxyProvider.createFrom(properties);
+		}
+	}
+
+	static final class TestClientTransportConfig extends ClientTransportConfig<TestClientTransportConfig> {
+
+		final AtomicReference<AddressResolverGroup<?>> defaultResolver = new AtomicReference<>();
+
+		TestClientTransportConfig(ConnectionProvider connectionProvider, Map<ChannelOption<?>, ?> options,
+		                          Supplier<? extends SocketAddress> remoteAddress) {
+			super(connectionProvider, options, remoteAddress);
+		}
+
+		@Override
+		protected AddressResolverGroup<?> defaultAddressResolverGroup() {
+			return NameResolverProvider.builder().build().newNameResolverGroup(loopResources(), true);
+		}
+
+		@Override
+		protected LoggingHandler defaultLoggingHandler() {
+			return null;
+		}
+
+		@Override
+		protected LoopResources defaultLoopResources() {
+			return null;
+		}
+
+		@Override
+		protected ChannelMetricsRecorder defaultMetricsRecorder() {
+			return null;
+		}
+
+		@Override
+		protected AddressResolverGroup<?> resolverInternal() {
+			defaultResolver.compareAndSet(null, defaultAddressResolverGroup());
+			return defaultResolver.get();
+		}
+	}
+}

--- a/reactor-netty5-http/src/test/java/reactor/netty5/http/client/HttpClientProxyProviderTest.java
+++ b/reactor-netty5-http/src/test/java/reactor/netty5/http/client/HttpClientProxyProviderTest.java
@@ -15,22 +15,44 @@
  */
 package reactor.netty5.http.client;
 
+import io.netty.contrib.handler.proxy.HttpProxyHandler;
+import io.netty.contrib.handler.proxy.ProxyHandler;
 import io.netty5.handler.codec.http.headers.HttpHeaders;
 import org.junit.jupiter.api.Test;
 import reactor.netty5.transport.ProxyProvider;
 
 import java.net.InetSocketAddress;
+import java.util.Properties;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static reactor.netty5.http.client.HttpClientProxyProvider.HTTPS_PROXY_HOST;
+import static reactor.netty5.http.client.HttpClientProxyProvider.HTTPS_PROXY_PASSWORD;
+import static reactor.netty5.http.client.HttpClientProxyProvider.HTTPS_PROXY_PORT;
+import static reactor.netty5.http.client.HttpClientProxyProvider.HTTPS_PROXY_USER;
+import static reactor.netty5.http.client.HttpClientProxyProvider.HTTP_NON_PROXY_HOSTS;
+import static reactor.netty5.http.client.HttpClientProxyProvider.HTTP_PROXY_HOST;
+import static reactor.netty5.http.client.HttpClientProxyProvider.HTTP_PROXY_PASSWORD;
+import static reactor.netty5.http.client.HttpClientProxyProvider.HTTP_PROXY_PORT;
+import static reactor.netty5.http.client.HttpClientProxyProvider.HTTP_PROXY_USER;
+import static reactor.netty5.http.client.HttpClientProxyProvider.createFrom;
 
 class HttpClientProxyProviderTest {
 
 	private static final InetSocketAddress ADDRESS_1 = InetSocketAddress.createUnresolved("localhost", 80);
+	private static final String DEFAULT_NON_PROXY_HOSTS_TRANSFORMED_TO_REGEX = "\\Qlocalhost\\E|\\Q127.\\E.*|\\Q[::1]\\E";
 	@SuppressWarnings("UnnecessaryLambda")
 	private static final Consumer<HttpHeaders> HEADER_1 = list -> list.add("Authorization", "Bearer 123");
 	@SuppressWarnings("UnnecessaryLambda")
 	private static final Consumer<HttpHeaders> HEADER_2 = list -> list.add("Authorization", "Bearer 456");
+
+	@Test
+	void differentAuthHeaders() {
+		assertThat(createHeaderProxy(ADDRESS_1, HEADER_1)).isNotEqualTo(createHeaderProxy(ADDRESS_1, HEADER_2));
+		assertThat(createHeaderProxy(ADDRESS_1, HEADER_1).hashCode()).isNotEqualTo(createHeaderProxy(ADDRESS_1, HEADER_2).hashCode());
+	}
 
 	@Test
 	void equalProxyProvidersAuthHeader() {
@@ -39,9 +61,259 @@ class HttpClientProxyProviderTest {
 	}
 
 	@Test
-	void differentAuthHeaders() {
-		assertThat(createHeaderProxy(ADDRESS_1, HEADER_1)).isNotEqualTo(createHeaderProxy(ADDRESS_1, HEADER_2));
-		assertThat(createHeaderProxy(ADDRESS_1, HEADER_1).hashCode()).isNotEqualTo(createHeaderProxy(ADDRESS_1, HEADER_2).hashCode());
+	void proxyFromSystemProperties_basicAuthSetFromHttpProxy() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTP_PROXY_HOST, "host");
+		properties.setProperty(HTTP_PROXY_USER, "user");
+		properties.setProperty(HTTP_PROXY_PASSWORD, "password");
+
+		ProxyProvider provider = createFrom(properties);
+		assertThat(provider).isNotNull();
+
+		ProxyHandler handler = provider.newProxyHandler();
+		assertThat(handler.getClass()).isEqualTo(HttpProxyHandler.class);
+
+		HttpProxyHandler httpHandler = (HttpProxyHandler) handler;
+		assertThat(httpHandler.username()).isEqualTo("user");
+		assertThat(httpHandler.password()).isEqualTo("password");
+	}
+
+	@Test
+	void proxyFromSystemProperties_basicAuthSetFromHttpsProxy() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTPS_PROXY_HOST, "host");
+		properties.setProperty(HTTPS_PROXY_USER, "user");
+		properties.setProperty(HTTPS_PROXY_PASSWORD, "password");
+
+		ProxyProvider provider = createFrom(properties);
+		assertThat(provider).isNotNull();
+
+		ProxyHandler handler = provider.newProxyHandler();
+		assertThat(handler.getClass()).isEqualTo(HttpProxyHandler.class);
+
+		HttpProxyHandler httpHandler = (HttpProxyHandler) handler;
+		assertThat(httpHandler.username()).isEqualTo("user");
+		assertThat(httpHandler.password()).isEqualTo("password");
+	}
+
+	@Test
+	void proxyFromSystemProperties_customNonProxyHostsSetForHttpProxy() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTP_PROXY_HOST, "host");
+		properties.setProperty(HTTP_NON_PROXY_HOSTS, "non-host");
+
+		ProxyProvider provider = createFrom(properties);
+
+		assertThat(provider).isNotNull();
+		assertThat(provider.getNonProxyHostsPredicate().toString()).isEqualTo("\\Qnon-host\\E");
+	}
+
+	@Test
+	void proxyFromSystemProperties_customNonProxyHostsSetForHttpsProxy() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTPS_PROXY_HOST, "host");
+		properties.setProperty(HTTP_NON_PROXY_HOSTS, "non-host");
+
+		ProxyProvider provider = createFrom(properties);
+
+		assertThat(provider).isNotNull();
+		assertThat(provider.getNonProxyHostsPredicate().toString()).isEqualTo("\\Qnon-host\\E");
+	}
+
+	@Test
+	void proxyFromSystemProperties_customNonProxyHostsWithWildcardSetForHttpProxy() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTP_PROXY_HOST, "host");
+		properties.setProperty(HTTP_NON_PROXY_HOSTS, "*.non-host");
+
+		ProxyProvider provider = createFrom(properties);
+
+		assertThat(provider).isNotNull();
+		assertThat(provider.getNonProxyHostsPredicate().toString()).isEqualTo(".*\\Q.non-host\\E");
+	}
+
+	@Test
+	void proxyFromSystemProperties_customNonProxyHostsWithWildcardSetForHttpsProxy() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTPS_PROXY_HOST, "host");
+		properties.setProperty(HTTP_NON_PROXY_HOSTS, "*.non-host");
+
+		ProxyProvider provider = createFrom(properties);
+
+		assertThat(provider).isNotNull();
+		assertThat(provider.getNonProxyHostsPredicate().toString()).isEqualTo(".*\\Q.non-host\\E");
+	}
+
+	@Test
+	void proxyFromSystemProperties_defaultNonHttpHostsSetForHttpProxy() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTP_PROXY_HOST, "host");
+
+		ProxyProvider provider = createFrom(properties);
+
+		assertThat(provider).isNotNull();
+		assertThat(provider.getNonProxyHostsPredicate().toString()).isEqualTo(DEFAULT_NON_PROXY_HOSTS_TRANSFORMED_TO_REGEX);
+	}
+
+	@Test
+	void proxyFromSystemProperties_defaultNonHttpHostsSetForHttpsProxy() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTPS_PROXY_HOST, "host");
+
+		ProxyProvider provider = createFrom(properties);
+
+		assertThat(provider).isNotNull();
+		assertThat(provider.getNonProxyHostsPredicate().toString()).isEqualTo(DEFAULT_NON_PROXY_HOSTS_TRANSFORMED_TO_REGEX);
+	}
+
+	@Test
+	void proxyFromSystemProperties_errorWhenHttpPortIsEmptyString() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTP_PROXY_HOST, "host");
+		properties.setProperty(HTTP_PROXY_PORT, "");
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> createFrom(properties))
+				.withMessage("expected system property http.proxyPort to be a number but got empty string");
+	}
+
+	@Test
+	void proxyFromSystemProperties_errorWhenHttpPortIsNotANumber() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTP_PROXY_HOST, "host");
+		properties.setProperty(HTTP_PROXY_PORT, "8080Hello");
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> createFrom(properties))
+				.withMessage("expected system property http.proxyPort to be a number but got 8080Hello");
+	}
+
+	@Test
+	void proxyFromSystemProperties_errorWhenHttpsPortIsEmptyString() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTPS_PROXY_HOST, "host");
+		properties.setProperty(HTTPS_PROXY_PORT, "");
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> createFrom(properties))
+				.withMessage("expected system property https.proxyPort to be a number but got empty string");
+	}
+
+	@Test
+	void proxyFromSystemProperties_errorWhenHttpsPortIsNotANumber() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTPS_PROXY_HOST, "host");
+		properties.setProperty(HTTPS_PROXY_PORT, "8080Hello");
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> createFrom(properties))
+				.withMessage("expected system property https.proxyPort to be a number but got 8080Hello");
+	}
+
+	@Test
+	void proxyFromSystemProperties_httpsProxyOverHttpProxy() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTPS_PROXY_HOST, "https");
+		properties.setProperty(HTTP_PROXY_HOST, "http");
+
+		ProxyProvider provider = createFrom(properties);
+
+		assertThat(provider).isNotNull();
+		assertThat(provider.getAddress().get().getHostString()).isEqualTo("https");
+	}
+
+	@Test
+	void proxyFromSystemProperties_npeWhenHttpProxyUsernameIsSetButNotPassword() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTP_PROXY_HOST, "host");
+		properties.setProperty(HTTP_PROXY_USER, "user");
+
+		Throwable throwable = catchThrowable(() -> createFrom(properties));
+		assertThat(throwable)
+				.isInstanceOf(NullPointerException.class)
+				.hasMessage("Proxy username is set via 'http.proxyUser', but 'http.proxyPassword' is not set.");
+	}
+
+	@Test
+	void proxyFromSystemProperties_npeWhenHttpsProxyUsernameIsSetButNotPassword() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTPS_PROXY_HOST, "host");
+		properties.setProperty(HTTPS_PROXY_USER, "user");
+
+		Throwable throwable = catchThrowable(() -> createFrom(properties));
+		assertThat(throwable)
+				.isInstanceOf(NullPointerException.class)
+				.hasMessage("Proxy username is set via 'https.proxyUser', but 'https.proxyPassword' is not set.");
+	}
+
+	@Test
+	void proxyFromSystemProperties_parseHttpPortFromSystemProperties() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTP_PROXY_HOST, "host");
+		properties.setProperty(HTTP_PROXY_PORT, "8080");
+
+		ProxyProvider provider = createFrom(properties);
+
+		assertThat(provider).isNotNull();
+		assertThat(provider.getAddress().get().getPort()).isEqualTo(8080);
+	}
+
+	@Test
+	void proxyFromSystemProperties_parseHttpsPortFromSystemProperties() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTPS_PROXY_HOST, "host");
+		properties.setProperty(HTTPS_PROXY_PORT, "8443");
+
+		ProxyProvider provider = createFrom(properties);
+
+		assertThat(provider).isNotNull();
+		assertThat(provider.getAddress().get().getPort()).isEqualTo(8443);
+	}
+
+	@Test
+	void proxyFromSystemProperties_port80SetByDefaultForHttpProxy() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTP_PROXY_HOST, "host");
+
+		ProxyProvider provider = createFrom(properties);
+
+		assertThat(provider).isNotNull();
+		assertThat(provider.getAddress().get().getPort()).isEqualTo(80);
+	}
+
+	@Test
+	void proxyFromSystemProperties_port443SetByDefaultForHttpProxy() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTPS_PROXY_HOST, "host");
+
+		ProxyProvider provider = createFrom(properties);
+
+		assertThat(provider).isNotNull();
+		assertThat(provider.getAddress().get().getPort()).isEqualTo(443);
+	}
+
+	@Test
+	void proxyFromSystemProperties_proxyProviderIsNotNullWhenHttpHostSet() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTP_PROXY_HOST, "host");
+
+		ProxyProvider provider = createFrom(properties);
+
+		assertThat(provider).isNotNull();
+		assertThat(provider.getType()).isEqualTo(ProxyProvider.Proxy.HTTP);
+		assertThat(provider.getAddress().get().getHostString()).isEqualTo("host");
+	}
+
+	@Test
+	void proxyFromSystemProperties_proxySettingsIsNotNullWhenHttpSHostSet() {
+		Properties properties = new Properties();
+		properties.setProperty(HTTPS_PROXY_HOST, "host");
+
+		ProxyProvider provider = createFrom(properties);
+
+		assertThat(provider).isNotNull();
+		assertThat(provider.getType()).isEqualTo(ProxyProvider.Proxy.HTTP);
+		assertThat(provider.getAddress().get().getHostString()).isEqualTo("host");
 	}
 
 	private ProxyProvider createHeaderProxy(InetSocketAddress address, Consumer<HttpHeaders> authHeader) {


### PR DESCRIPTION
Move HTTP proxy functionality from `ProxyProvider` to `HttpClientProxyProvider`.

Fixes #1953