### PR TITLE
Suppress NarrowingCompoundAssignment warnings

### DIFF
--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/AbstractHttpClientMetricsHandler.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/AbstractHttpClientMetricsHandler.java
@@ -88,6 +88,7 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelHandlerAdapter {
 	}
 
 	@Override
+	@SuppressWarnings("NarrowingCompoundAssignment")
 	public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
 		try {
 			if (msg instanceof HttpRequest request) {
@@ -134,6 +135,7 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelHandlerAdapter {
 	}
 
 	@Override
+	@SuppressWarnings("NarrowingCompoundAssignment")
 	public void channelRead(ChannelHandlerContext ctx, Object msg) {
 		try {
 			if (msg instanceof HttpResponse response) {

--- a/reactor-netty5-http/src/main/java/reactor/netty5/http/client/AbstractHttpClientMetricsHandler.java
+++ b/reactor-netty5-http/src/main/java/reactor/netty5/http/client/AbstractHttpClientMetricsHandler.java
@@ -64,7 +64,7 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelHandlerAdapter {
 
 	final Function<String, String> uriTagValue;
 
-	byte flags;
+	int flags;
 
 	final static int REQUEST_SENT = 0x01;
 
@@ -88,7 +88,6 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelHandlerAdapter {
 	}
 
 	@Override
-	@SuppressWarnings("NarrowingCompoundAssignment")
 	public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
 		try {
 			if (msg instanceof HttpRequest request) {
@@ -135,7 +134,6 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelHandlerAdapter {
 	}
 
 	@Override
-	@SuppressWarnings("NarrowingCompoundAssignment")
 	public void channelRead(ChannelHandlerContext ctx, Object msg) {
 		try {
 			if (msg instanceof HttpResponse response) {


### PR DESCRIPTION
This PR removes the following compilation warnings introduced by PR #2539:

``
reactor-netty5-http/src/main/java/reactor/netty5/http/client/AbstractHttpClientMetricsHandler.java:108: warning: [NarrowingCompoundAssignment] Compound assignments from int to byte hide lossy casts
                                                                flags |= REQUEST_SENT;
                                                                      ^
    (see https://errorprone.info/bugpattern/NarrowingCompoundAssignment)
  Did you mean 'flags = (byte) (flags | REQUEST_SENT);'?
reactor-netty5-http/src/main/java/reactor/netty5/http/client/AbstractHttpClientMetricsHandler.java:151: warning: [NarrowingCompoundAssignment] Compound assignments from int to byte hide lossy casts
                                flags |= RESPONSE_RECEIVED;
``