### PR TITLE
Ensure Reactor Netty follows the requirements for span name and tags

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ConnectObservations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ConnectObservations.java
@@ -53,6 +53,26 @@ enum ConnectObservations implements ObservationDocumentation {
 	enum ConnectTimeHighCardinalityTags implements KeyName {
 
 		/**
+		 * Net peer name.
+		 */
+		NET_PEER_NAME {
+			@Override
+			public String asString() {
+				return "net.peer.name";
+			}
+		},
+
+		/**
+		 * Net peer port.
+		 */
+		NET_PEER_PORT {
+			@Override
+			public String asString() {
+				return "net.peer.port";
+			}
+		},
+
+		/**
 		 * Reactor Netty protocol (tcp/http etc.).
 		 */
 		REACTOR_NETTY_PROTOCOL {

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ConnectSpans.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ConnectSpans.java
@@ -50,6 +50,26 @@ enum ConnectSpans implements SpanDocumentation {
 	enum ConnectTimeHighCardinalityTags implements KeyName {
 
 		/**
+		 * Net peer name.
+		 */
+		NET_PEER_NAME {
+			@Override
+			public String asString() {
+				return "net.peer.name";
+			}
+		},
+
+		/**
+		 * Net peer port.
+		 */
+		NET_PEER_PORT {
+			@Override
+			public String asString() {
+				return "net.peer.port";
+			}
+		},
+
+		/**
 		 * Reactor Netty protocol (tcp/http etc.).
 		 */
 		REACTOR_NETTY_PROTOCOL {
@@ -76,16 +96,6 @@ enum ConnectSpans implements SpanDocumentation {
 			@Override
 			public String asString() {
 				return "reactor.netty.type";
-			}
-		},
-
-		/**
-		 * Remote address.
-		 */
-		REMOTE_ADDRESS {
-			@Override
-			public String asString() {
-				return "remote.address";
 			}
 		}
 	}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsHandler.java
@@ -29,6 +29,7 @@ import reactor.netty.observability.ReactorNettyHandlerContext;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.ContextView;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.function.Supplier;
 
@@ -38,7 +39,8 @@ import static reactor.netty.Metrics.OBSERVATION_KEY;
 import static reactor.netty.Metrics.OBSERVATION_REGISTRY;
 import static reactor.netty.Metrics.SUCCESS;
 import static reactor.netty.Metrics.TLS_HANDSHAKE_TIME;
-import static reactor.netty.Metrics.formatSocketAddress;
+import static reactor.netty.channel.ConnectObservations.ConnectTimeHighCardinalityTags.NET_PEER_NAME;
+import static reactor.netty.channel.ConnectObservations.ConnectTimeHighCardinalityTags.NET_PEER_PORT;
 import static reactor.netty.channel.ConnectObservations.ConnectTimeHighCardinalityTags.REACTOR_NETTY_PROTOCOL;
 import static reactor.netty.channel.ConnectObservations.ConnectTimeHighCardinalityTags.REACTOR_NETTY_STATUS;
 import static reactor.netty.channel.ConnectObservations.ConnectTimeHighCardinalityTags.REACTOR_NETTY_TYPE;
@@ -88,7 +90,8 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 		final MicrometerChannelMetricsRecorder recorder;
 
 		// remote address and status are not known beforehand
-		String remoteAddress;
+		String netPeerName;
+		String netPeerPort;
 		String status;
 
 		ConnectMetricsHandler(MicrometerChannelMetricsRecorder recorder) {
@@ -102,7 +105,7 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 
 		@Override
 		public Timer getTimer() {
-			return recorder.getConnectTimer(getName(), remoteAddress, status);
+			return recorder.getConnectTimer(getName(), netPeerName + ":" + netPeerPort, status);
 		}
 
 		@Override
@@ -128,7 +131,15 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 			// 2. The recorder does not have knowledge about connection establishment lifecycle
 			//
 			// Move the implementation from the recorder here
-			this.remoteAddress = formatSocketAddress(remoteAddress);
+			if (remoteAddress instanceof InetSocketAddress) {
+				InetSocketAddress address = (InetSocketAddress) remoteAddress;
+				this.netPeerName = address.getHostString();
+				this.netPeerPort = address.getPort() + "";
+			}
+			else {
+				this.netPeerName = remoteAddress.toString();
+				this.netPeerPort = "";
+			}
 			Observation observation = Observation.createNotStarted(recorder.name() + CONNECT_TIME, this, OBSERVATION_REGISTRY);
 			if (ctx.channel().hasAttr(CONTEXT_VIEW)) {
 				ContextView contextView = ctx.channel().attr(CONTEXT_VIEW).get();
@@ -179,13 +190,14 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 
 		@Override
 		public KeyValues getHighCardinalityKeyValues() {
-			return KeyValues.of(REACTOR_NETTY_PROTOCOL.asString(), recorder.protocol(),
+			return KeyValues.of(NET_PEER_NAME.asString(), netPeerName, NET_PEER_PORT.asString(), netPeerPort,
+					REACTOR_NETTY_PROTOCOL.asString(), recorder.protocol(),
 					REACTOR_NETTY_STATUS.asString(), status, REACTOR_NETTY_TYPE.asString(), TYPE);
 		}
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues() {
-			return KeyValues.of(REMOTE_ADDRESS.asString(), remoteAddress, STATUS.asString(), status);
+			return KeyValues.of(REMOTE_ADDRESS.asString(), netPeerName + ":" + netPeerPort, STATUS.asString(), status);
 		}
 
 		@Override
@@ -222,7 +234,8 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 		Observation observation;
 
 		// remote address and status are not known beforehand
-		String remoteAddress;
+		String netPeerName;
+		String netPeerPort;
 		String status;
 
 		TlsMetricsHandler(MicrometerChannelMetricsRecorder recorder, boolean onServer) {
@@ -233,7 +246,16 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 		@Override
 		@SuppressWarnings("try")
 		public void channelActive(ChannelHandlerContext ctx) {
-			this.remoteAddress = formatSocketAddress(ctx.channel().remoteAddress());
+			SocketAddress remoteAddress = ctx.channel().remoteAddress();
+			if (remoteAddress instanceof InetSocketAddress) {
+				InetSocketAddress address = (InetSocketAddress) remoteAddress;
+				this.netPeerName = address.getHostString();
+				this.netPeerPort = address.getPort() + "";
+			}
+			else {
+				this.netPeerName = remoteAddress.toString();
+				this.netPeerPort = "";
+			}
 			observation = Observation.createNotStarted(recorder.name() + TLS_HANDSHAKE_TIME, this, OBSERVATION_REGISTRY);
 			if (ctx.channel().hasAttr(CONTEXT_VIEW)) {
 				ContextView contextView = ctx.channel().attr(CONTEXT_VIEW).get();
@@ -301,13 +323,14 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 
 		@Override
 		public KeyValues getHighCardinalityKeyValues() {
-			return KeyValues.of(REACTOR_NETTY_PROTOCOL.asString(), recorder.protocol(),
+			return KeyValues.of(NET_PEER_NAME.asString(), netPeerName, NET_PEER_PORT.asString(), netPeerPort,
+					REACTOR_NETTY_PROTOCOL.asString(), recorder.protocol(),
 					REACTOR_NETTY_STATUS.asString(), status, REACTOR_NETTY_TYPE.asString(), type);
 		}
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues() {
-			return KeyValues.of(REMOTE_ADDRESS.asString(), remoteAddress, STATUS.asString(), status);
+			return KeyValues.of(REMOTE_ADDRESS.asString(), netPeerName + ':' + netPeerPort, STATUS.asString(), status);
 		}
 
 		@Override
@@ -327,7 +350,7 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 
 		@Override
 		public Timer getTimer() {
-			return recorder.getTlsHandshakeTimer(getName(), remoteAddress, status);
+			return recorder.getTlsHandshakeTimer(getName(), netPeerName + ':' + netPeerPort, status);
 		}
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/observability/ReactorNettyTracingObservationHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/observability/ReactorNettyTracingObservationHandler.java
@@ -21,8 +21,6 @@ import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
 
-import static reactor.netty.Metrics.REMOTE_ADDRESS;
-
 /**
  * Abstraction over all Reactor Netty handlers.
  *
@@ -41,18 +39,11 @@ public final class ReactorNettyTracingObservationHandler extends DefaultTracingO
 		for (KeyValue tag : context.getHighCardinalityKeyValues()) {
 			span.tag(tag.getKey(), tag.getValue());
 		}
-		for (KeyValue tag : context.getLowCardinalityKeyValues()) {
-			if (tag.getKey().equals(REMOTE_ADDRESS)) {
-				span.tag(tag.getKey(), tag.getValue());
-				break;
-			}
-		}
 	}
 
 	@Override
 	public String getSpanName(Observation.Context context) {
-		String name = context.getContextualName();
-		return name != null ? name : super.getSpanName(context);
+		return context.getContextualName();
 	}
 
 	@Override

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/HostnameResolutionObservations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/HostnameResolutionObservations.java
@@ -52,6 +52,26 @@ enum HostnameResolutionObservations implements ObservationDocumentation {
 	enum HostnameResolutionTimeHighCardinalityTags implements KeyName {
 
 		/**
+		 * Net peer name.
+		 */
+		NET_PEER_NAME {
+			@Override
+			public String asString() {
+				return "net.peer.name";
+			}
+		},
+
+		/**
+		 * Net peer port.
+		 */
+		NET_PEER_PORT {
+			@Override
+			public String asString() {
+				return "net.peer.port";
+			}
+		},
+
+		/**
 		 * Reactor Netty protocol (tcp/http etc.).
 		 */
 		REACTOR_NETTY_PROTOCOL {

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/HostnameResolutionSpans.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/HostnameResolutionSpans.java
@@ -49,6 +49,26 @@ enum HostnameResolutionSpans implements SpanDocumentation {
 	enum HostnameResolutionTimeHighCardinalityTags implements KeyName {
 
 		/**
+		 * Net peer name.
+		 */
+		NET_PEER_NAME {
+			@Override
+			public String asString() {
+				return "net.peer.name";
+			}
+		},
+
+		/**
+		 * Net peer port.
+		 */
+		NET_PEER_PORT {
+			@Override
+			public String asString() {
+				return "net.peer.port";
+			}
+		},
+
+		/**
 		 * Reactor Netty protocol (tcp/http etc.).
 		 */
 		REACTOR_NETTY_PROTOCOL {
@@ -75,16 +95,6 @@ enum HostnameResolutionSpans implements SpanDocumentation {
 			@Override
 			public String asString() {
 				return "reactor.netty.type";
-			}
-		},
-
-		/**
-		 * Remote address.
-		 */
-		REMOTE_ADDRESS {
-			@Override
-			public String asString() {
-				return "remote.address";
 			}
 		}
 	}

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerAddressResolverGroupMetrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/MicrometerAddressResolverGroupMetrics.java
@@ -27,6 +27,7 @@ import reactor.netty.internal.util.MapUtils;
 import reactor.netty.observability.ReactorNettyHandlerContext;
 import reactor.util.context.ContextView;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.Objects;
@@ -39,7 +40,8 @@ import static reactor.netty.Metrics.ERROR;
 import static reactor.netty.Metrics.OBSERVATION_KEY;
 import static reactor.netty.Metrics.OBSERVATION_REGISTRY;
 import static reactor.netty.Metrics.SUCCESS;
-import static reactor.netty.Metrics.formatSocketAddress;
+import static reactor.netty.transport.HostnameResolutionObservations.HostnameResolutionTimeHighCardinalityTags.NET_PEER_NAME;
+import static reactor.netty.transport.HostnameResolutionObservations.HostnameResolutionTimeHighCardinalityTags.NET_PEER_PORT;
 import static reactor.netty.transport.HostnameResolutionObservations.HostnameResolutionTimeHighCardinalityTags.REACTOR_NETTY_PROTOCOL;
 import static reactor.netty.transport.HostnameResolutionObservations.HostnameResolutionTimeHighCardinalityTags.REACTOR_NETTY_STATUS;
 import static reactor.netty.transport.HostnameResolutionObservations.HostnameResolutionTimeHighCardinalityTags.REACTOR_NETTY_TYPE;
@@ -75,15 +77,24 @@ final class MicrometerAddressResolverGroupMetrics<T extends SocketAddress> exten
 		static final String CONTEXTUAL_NAME = "hostname resolution";
 		static final String TYPE = "client";
 
-		final String remoteAddress;
+		final String netPeerName;
+		final String netPeerPort;
 		final MicrometerChannelMetricsRecorder recorder;
 
 		// status is not known beforehand
 		String status;
 
-		FutureHandlerContext(MicrometerChannelMetricsRecorder recorder, String remoteAddress) {
+		FutureHandlerContext(MicrometerChannelMetricsRecorder recorder, SocketAddress remoteAddress) {
 			this.recorder = recorder;
-			this.remoteAddress = remoteAddress;
+			if (remoteAddress instanceof InetSocketAddress) {
+				InetSocketAddress address = (InetSocketAddress) remoteAddress;
+				this.netPeerName = address.getHostString();
+				this.netPeerPort = address.getPort() + "";
+			}
+			else {
+				this.netPeerName = remoteAddress.toString();
+				this.netPeerPort = "";
+			}
 		}
 
 		@Override
@@ -93,7 +104,7 @@ final class MicrometerAddressResolverGroupMetrics<T extends SocketAddress> exten
 
 		@Override
 		public Timer getTimer() {
-			return recorder.getResolveAddressTimer(getName(), remoteAddress, status);
+			return recorder.getResolveAddressTimer(getName(), netPeerName + ':' + netPeerPort, status);
 		}
 
 		@Override
@@ -103,13 +114,14 @@ final class MicrometerAddressResolverGroupMetrics<T extends SocketAddress> exten
 
 		@Override
 		public KeyValues getHighCardinalityKeyValues() {
-			return KeyValues.of(REACTOR_NETTY_PROTOCOL.asString(), recorder.protocol(),
+			return KeyValues.of(NET_PEER_NAME.asString(), netPeerName, NET_PEER_PORT.asString(), netPeerPort,
+					REACTOR_NETTY_PROTOCOL.asString(), recorder.protocol(),
 					REACTOR_NETTY_STATUS.asString(), status, REACTOR_NETTY_TYPE.asString(), TYPE);
 		}
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues() {
-			return KeyValues.of(REMOTE_ADDRESS.asString(), remoteAddress, STATUS.asString(), status);
+			return KeyValues.of(REMOTE_ADDRESS.asString(), netPeerName + ':' + netPeerPort, STATUS.asString(), status);
 		}
 	}
 
@@ -133,8 +145,7 @@ final class MicrometerAddressResolverGroupMetrics<T extends SocketAddress> exten
 			// 3. There is no connection, so we cannot hold the context information in the Channel
 			//
 			// Move the implementation from the recorder here
-			String remoteAddress = formatSocketAddress(address);
-			FutureHandlerContext handlerContext = new FutureHandlerContext((MicrometerChannelMetricsRecorder) recorder, remoteAddress);
+			FutureHandlerContext handlerContext = new FutureHandlerContext((MicrometerChannelMetricsRecorder) recorder, address);
 			Observation sample = Observation.createNotStarted(name + ADDRESS_RESOLVER, handlerContext, OBSERVATION_REGISTRY);
 			if (contextView.hasKey(OBSERVATION_KEY)) {
 				sample.parentObservation(contextView.get(OBSERVATION_KEY));
@@ -155,8 +166,7 @@ final class MicrometerAddressResolverGroupMetrics<T extends SocketAddress> exten
 			// 3. There is no connection, so we cannot hold the context information in the Channel
 			//
 			// Move the implementation from the recorder here
-			String remoteAddress = formatSocketAddress(address);
-			FutureHandlerContext handlerContext = new FutureHandlerContext((MicrometerChannelMetricsRecorder) recorder, remoteAddress);
+			FutureHandlerContext handlerContext = new FutureHandlerContext((MicrometerChannelMetricsRecorder) recorder, address);
 			Observation observation = Observation.start(name + ADDRESS_RESOLVER, handlerContext, OBSERVATION_REGISTRY);
 			return resolver.get()
 			               .addListener(future -> {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientObservations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientObservations.java
@@ -52,22 +52,42 @@ enum HttpClientObservations implements ObservationDocumentation {
 	enum ResponseTimeHighCardinalityTags implements KeyName {
 
 		/**
-		 * Reactor Netty protocol (always http).
+		 * Status code.
 		 */
-		REACTOR_NETTY_PROTOCOL {
+		HTTP_STATUS_CODE {
 			@Override
 			public String asString() {
-				return "reactor.netty.protocol";
+				return "http.status_code";
 			}
 		},
 
 		/**
-		 * Reactor Netty status.
+		 * URL.
 		 */
-		REACTOR_NETTY_STATUS {
+		HTTP_URL {
 			@Override
 			public String asString() {
-				return "reactor.netty.status";
+				return "http.url";
+			}
+		},
+
+		/**
+		 * Net peer name.
+		 */
+		NET_PEER_NAME {
+			@Override
+			public String asString() {
+				return "net.peer.name";
+			}
+		},
+
+		/**
+		 * Net peer port.
+		 */
+		NET_PEER_PORT {
+			@Override
+			public String asString() {
+				return "net.peer.port";
 			}
 		},
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSpans.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientSpans.java
@@ -49,22 +49,42 @@ enum HttpClientSpans implements SpanDocumentation {
 	enum ResponseTimeHighCardinalityTags implements KeyName {
 
 		/**
-		 * Reactor Netty protocol (always http).
+		 * Status code.
 		 */
-		REACTOR_NETTY_PROTOCOL {
+		HTTP_STATUS_CODE {
 			@Override
 			public String asString() {
-				return "reactor.netty.protocol";
+				return "http.status_code";
 			}
 		},
 
 		/**
-		 * Reactor Netty status.
+		 * URL.
 		 */
-		REACTOR_NETTY_STATUS {
+		HTTP_URL {
 			@Override
 			public String asString() {
-				return "reactor.netty.status";
+				return "http.url";
+			}
+		},
+
+		/**
+		 * Net peer name.
+		 */
+		NET_PEER_NAME {
+			@Override
+			public String asString() {
+				return "net.peer.name";
+			}
+		},
+
+		/**
+		 * Net peer port.
+		 */
+		NET_PEER_PORT {
+			@Override
+			public String asString() {
+				return "net.peer.port";
 			}
 		},
 
@@ -75,16 +95,6 @@ enum HttpClientSpans implements SpanDocumentation {
 			@Override
 			public String asString() {
 				return "reactor.netty.type";
-			}
-		},
-
-		/**
-		 * Remote address.
-		 */
-		REMOTE_ADDRESS {
-			@Override
-			public String asString() {
-				return "remote.address";
 			}
 		}
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
@@ -26,6 +26,7 @@ import reactor.netty.observability.ReactorNettyHandlerContext;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.ContextView;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.Objects;
@@ -35,9 +36,10 @@ import java.util.function.Supplier;
 import static reactor.netty.Metrics.OBSERVATION_KEY;
 import static reactor.netty.Metrics.OBSERVATION_REGISTRY;
 import static reactor.netty.Metrics.RESPONSE_TIME;
-import static reactor.netty.Metrics.formatSocketAddress;
-import static reactor.netty.http.client.HttpClientObservations.ResponseTimeHighCardinalityTags.REACTOR_NETTY_PROTOCOL;
-import static reactor.netty.http.client.HttpClientObservations.ResponseTimeHighCardinalityTags.REACTOR_NETTY_STATUS;
+import static reactor.netty.http.client.HttpClientObservations.ResponseTimeHighCardinalityTags.HTTP_STATUS_CODE;
+import static reactor.netty.http.client.HttpClientObservations.ResponseTimeHighCardinalityTags.HTTP_URL;
+import static reactor.netty.http.client.HttpClientObservations.ResponseTimeHighCardinalityTags.NET_PEER_NAME;
+import static reactor.netty.http.client.HttpClientObservations.ResponseTimeHighCardinalityTags.NET_PEER_PORT;
 import static reactor.netty.http.client.HttpClientObservations.ResponseTimeHighCardinalityTags.REACTOR_NETTY_TYPE;
 import static reactor.netty.http.client.HttpClientObservations.ResponseTimeLowCardinalityTags.METHOD;
 import static reactor.netty.http.client.HttpClientObservations.ResponseTimeLowCardinalityTags.REMOTE_ADDRESS;
@@ -87,7 +89,6 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 		// 2. The recorder does not have knowledge about request lifecycle
 		//
 		// Move the implementation from the recorder here
-		responseTimeHandlerContext.status = status;
 		responseTimeObservation.stop();
 	}
 
@@ -104,11 +105,11 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 		super.startRead(msg);
 
 		responseTimeHandlerContext.setResponse(msg);
+		responseTimeHandlerContext.status = status;
 	}
 
 	// writing the request
 	@Override
-	@SuppressWarnings("try")
 	protected void startWrite(HttpRequest msg, Channel channel, @Nullable ContextView contextView) {
 		super.startWrite(msg, channel, contextView);
 
@@ -120,13 +121,22 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 		responseTimeObservation.start();
 	}
 
+	/**
+	 * Requirements for HTTP clients
+	 * <p>https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name
+	 * The contextual name must be in the format 'HTTP &lt;method&gt;'
+	 * <p>https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes
+	 * <p>https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-client
+	 */
 	static final class ResponseTimeHandlerContext extends RequestReplySenderContext<HttpRequest, HttpResponse>
 			implements ReactorNettyHandlerContext, Supplier<Observation.Context> {
+		static final String HTTP_PREFIX = "http ";
 		static final String TYPE = "client";
 
 		final String method;
+		final String netPeerName;
+		final String netPeerPort;
 		final String path;
-		final String remoteAddress;
 		final MicrometerHttpClientMetricsRecorder recorder;
 
 		// status might not be known beforehand
@@ -136,11 +146,18 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 			super((carrier, key, value) -> Objects.requireNonNull(carrier).headers().set(key, value));
 			this.recorder = recorder;
 			this.method = request.method().name();
+			if (remoteAddress instanceof InetSocketAddress) {
+				InetSocketAddress address = (InetSocketAddress) remoteAddress;
+				this.netPeerName = address.getHostString();
+				this.netPeerPort = address.getPort() + "";
+			}
+			else {
+				this.netPeerName = remoteAddress.toString();
+				this.netPeerPort = "";
+			}
 			this.path = path;
-			this.remoteAddress = formatSocketAddress(remoteAddress);
-			put(HttpClientRequest.class, request);
 			setCarrier(request);
-			setContextualName(this.method);
+			setContextualName(HTTP_PREFIX + this.method);
 		}
 
 		@Override
@@ -150,25 +167,20 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 
 		@Override
 		public Timer getTimer() {
-			return recorder.getResponseTimeTimer(getName(), remoteAddress, path, method, status);
+			return recorder.getResponseTimeTimer(getName(), netPeerName + ":" + netPeerPort, path, method, status);
 		}
 
 		@Override
 		public KeyValues getHighCardinalityKeyValues() {
-			return KeyValues.of(REACTOR_NETTY_PROTOCOL.asString(), recorder.protocol(),
-					REACTOR_NETTY_STATUS.asString(), status, REACTOR_NETTY_TYPE.asString(), TYPE);
+			return KeyValues.of(REACTOR_NETTY_TYPE.asString(), TYPE,
+					HTTP_URL.asString(), path, HTTP_STATUS_CODE.asString(), status,
+					NET_PEER_NAME.asString(), netPeerName, NET_PEER_PORT.asString(), netPeerPort);
 		}
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues() {
-			return KeyValues.of(METHOD.asString(), method, REMOTE_ADDRESS.asString(), remoteAddress,
+			return KeyValues.of(METHOD.asString(), method, REMOTE_ADDRESS.asString(), netPeerName + ":" + netPeerPort,
 					STATUS.asString(), status, URI.asString(), path);
-		}
-
-		@Override
-		public void setResponse(HttpResponse response) {
-			put(HttpClientResponse.class, response);
-			super.setResponse(response);
 		}
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/observability/ReactorNettyPropagatingReceiverTracingObservationHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/observability/ReactorNettyPropagatingReceiverTracingObservationHandler.java
@@ -23,7 +23,6 @@ import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandler;
 import io.micrometer.tracing.propagation.Propagator;
 import io.netty.handler.codec.http.HttpRequest;
-import reactor.netty.http.server.HttpServerRequest;
 import reactor.netty.observability.ReactorNettyHandlerContext;
 
 /**
@@ -55,8 +54,6 @@ public final class ReactorNettyPropagatingReceiverTracingObservationHandler
 
 	@Override
 	public boolean supportsContext(Observation.Context context) {
-		return context instanceof ReactorNettyHandlerContext &&
-				super.supportsContext(context) &&
-				context.get(HttpServerRequest.class) != null;
+		return context instanceof ReactorNettyHandlerContext && super.supportsContext(context);
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/observability/ReactorNettyPropagatingSenderTracingObservationHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/observability/ReactorNettyPropagatingSenderTracingObservationHandler.java
@@ -23,10 +23,7 @@ import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.handler.PropagatingSenderTracingObservationHandler;
 import io.micrometer.tracing.propagation.Propagator;
 import io.netty.handler.codec.http.HttpRequest;
-import reactor.netty.http.client.HttpClientRequest;
 import reactor.netty.observability.ReactorNettyHandlerContext;
-
-import static reactor.netty.Metrics.REMOTE_ADDRESS;
 
 /**
  * Reactor Netty specific {@link PropagatingSenderTracingObservationHandler}
@@ -53,18 +50,10 @@ public final class ReactorNettyPropagatingSenderTracingObservationHandler
 		for (KeyValue tag : context.getHighCardinalityKeyValues()) {
 			span.tag(tag.getKey(), tag.getValue());
 		}
-		for (KeyValue tag : context.getLowCardinalityKeyValues()) {
-			if (tag.getKey().equals(REMOTE_ADDRESS)) {
-				span.tag(tag.getKey(), tag.getValue());
-				break;
-			}
-		}
 	}
 
 	@Override
 	public boolean supportsContext(Observation.Context context) {
-		return context instanceof ReactorNettyHandlerContext &&
-				super.supportsContext(context) &&
-				context.get(HttpClientRequest.class) != null;
+		return context instanceof ReactorNettyHandlerContext && super.supportsContext(context);
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerObservations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerObservations.java
@@ -52,22 +52,42 @@ enum HttpServerObservations implements ObservationDocumentation {
 	enum ResponseTimeHighCardinalityTags implements KeyName {
 
 		/**
-		 * Reactor Netty protocol (always http).
+		 * HTTP scheme.
 		 */
-		REACTOR_NETTY_PROTOCOL {
+		HTTP_SCHEME {
 			@Override
 			public String asString() {
-				return "reactor.netty.protocol";
+				return "http.scheme";
 			}
 		},
 
 		/**
-		 * Reactor Netty status.
+		 * Status code.
 		 */
-		REACTOR_NETTY_STATUS {
+		HTTP_STATUS_CODE {
 			@Override
 			public String asString() {
-				return "reactor.netty.status";
+				return "http.status_code";
+			}
+		},
+
+		/**
+		 * Net host name.
+		 */
+		NET_HOST_NAME {
+			@Override
+			public String asString() {
+				return "net.host.name";
+			}
+		},
+
+		/**
+		 * Net host port.
+		 */
+		NET_HOST_PORT {
+			@Override
+			public String asString() {
+				return "net.host.port";
 			}
 		},
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerSpans.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerSpans.java
@@ -49,22 +49,42 @@ enum HttpServerSpans implements SpanDocumentation {
 	enum ResponseTimeHighCardinalityTags implements KeyName {
 
 		/**
-		 * Reactor Netty protocol (always http).
+		 * HTTP scheme.
 		 */
-		REACTOR_NETTY_PROTOCOL {
+		HTTP_SCHEME {
 			@Override
 			public String asString() {
-				return "reactor.netty.protocol";
+				return "http.scheme";
 			}
 		},
 
 		/**
-		 * Reactor Netty status.
+		 * Status code.
 		 */
-		REACTOR_NETTY_STATUS {
+		HTTP_STATUS_CODE {
 			@Override
 			public String asString() {
-				return "reactor.netty.status";
+				return "http.status_code";
+			}
+		},
+
+		/**
+		 * Net host name.
+		 */
+		NET_HOST_NAME {
+			@Override
+			public String asString() {
+				return "net.host.name";
+			}
+		},
+
+		/**
+		 * Net host port.
+		 */
+		NET_HOST_PORT {
+			@Override
+			public String asString() {
+				return "net.host.port";
 			}
 		},
 


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md

Reactor Netty will publish the following spans

```
SpansAssert.assertThat(bb.getFinishedSpans().stream().filter(f -> f.getTraceId().equals(current.context().traceId()))
           .collect(Collectors.toList()))
           .hasASpanWithName("hostname resolution",
                   spanAssert -> spanAssert.hasTagWithKey("net.peer.name")
                                           .hasTagWithKey("net.peer.port")
                                           .hasTagWithKey("reactor.netty.protocol")
                                           .hasTagWithKey("reactor.netty.status")
                                           .hasTagWithKey("reactor.netty.type"))
           .hasASpanWithName("connect",
                   spanAssert -> spanAssert.hasTagWithKey("net.peer.name")
                                           .hasTagWithKey("net.peer.port")
                                           .hasTagWithKey("reactor.netty.protocol")
                                           .hasTagWithKey("reactor.netty.status")
                                           .hasTagWithKey("reactor.netty.type"))
           .hasASpanWithName("tls handshake",
                   spanAssert -> spanAssert.hasTagWithKey("net.peer.name")
                                           .hasTagWithKey("net.peer.port")
                                           .hasTagWithKey("reactor.netty.protocol")
                                           .hasTagWithKey("reactor.netty.status")
                                           .hasTagWithKey("reactor.netty.type"))
           .hasASpanWithName("http POST",
                   spanAssert -> spanAssert.hasTagWithKey("http.status_code")
                                           .hasTagWithKey("http.url")
                                           .hasTagWithKey("net.peer.name")
                                           .hasTagWithKey("net.peer.port")
                                           .hasTagWithKey("reactor.netty.type"))
           .hasASpanWithName("POST_post/{id}",
                   spanAssert -> spanAssert.hasTagWithKey("http.scheme")
                                           .hasTagWithKey("http.status_code")
                                           .hasTagWithKey("net.host.name")
                                           .hasTagWithKey("net.host.port")
                                           .hasTagWithKey("reactor.netty.type"));
```