### PR TITLE
Allow configurable connection provider eviction predicate

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -387,6 +387,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 		final Duration disposeTimeout;
 		final BiFunction<Runnable, Duration, Disposable> pendingAcquireTimer;
 		final AllocationStrategy<?> allocationStrategy;
+		final BiPredicate<Connection, ConnectionMetadata> evictionPredicate;
 
 		PoolFactory(ConnectionPoolSpec<?> conf, Duration disposeTimeout) {
 			this(conf, disposeTimeout, null);
@@ -408,6 +409,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 			this.disposeTimeout = disposeTimeout;
 			this.pendingAcquireTimer = conf.pendingAcquireTimer;
 			this.allocationStrategy = conf.allocationStrategy;
+			this.evictionPredicate = conf.evictionPredicate;
 		}
 
 		public InstrumentedPool<T> newPool(
@@ -426,27 +428,34 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 				Publisher<T> allocator,
 				@Nullable reactor.pool.AllocationStrategy allocationStrategy, // this is not used but kept for backwards compatibility
 				Function<T, Publisher<Void>> destroyHandler,
-				BiPredicate<T, PooledRefMetadata> evictionPredicate,
+				BiPredicate<T, PooledRefMetadata> defaultEvictionPredicate,
 				Function<PoolConfig<T>, InstrumentedPool<T>> poolFactory) {
 			if (disposeTimeout != null) {
-				return newPoolInternal(allocator, destroyHandler, evictionPredicate)
+				return newPoolInternal(allocator, destroyHandler, defaultEvictionPredicate)
 						.build(poolFactory.andThen(InstrumentedPoolDecorators::gracefulShutdown));
 			}
-			return newPoolInternal(allocator, destroyHandler, evictionPredicate).build(poolFactory);
+			return newPoolInternal(allocator, destroyHandler, defaultEvictionPredicate).build(poolFactory);
 		}
 
 		PoolBuilder<T, PoolConfig<T>> newPoolInternal(
 				Publisher<T> allocator,
 				Function<T, Publisher<Void>> destroyHandler,
-				BiPredicate<T, PooledRefMetadata> evictionPredicate) {
+				BiPredicate<T, PooledRefMetadata> defaultEvictionPredicate) {
 			PoolBuilder<T, PoolConfig<T>> poolBuilder =
 					PoolBuilder.from(allocator)
 					           .destroyHandler(destroyHandler)
-					           .evictionPredicate(evictionPredicate
-					                   .or((poolable, meta) -> (maxIdleTime != -1 && meta.idleTime() >= maxIdleTime)
-					                           || (maxLifeTime != -1 && meta.lifeTime() >= maxLifeTime)))
 					           .maxPendingAcquire(pendingAcquireMaxCount)
 					           .evictInBackground(evictionInterval);
+
+			if (this.evictionPredicate != null) {
+				poolBuilder = poolBuilder.evictionPredicate(
+						(poolable, meta) -> this.evictionPredicate.test(poolable, new PooledConnectionMetadata(meta)));
+			}
+			else {
+				poolBuilder = poolBuilder.evictionPredicate(defaultEvictionPredicate.or((poolable, meta) ->
+						(maxIdleTime != -1 && meta.idleTime() >= maxIdleTime)
+								|| (maxLifeTime != -1 && meta.lifeTime() >= maxLifeTime)));
+			}
 
 			if (DEFAULT_POOL_GET_PERMITS_SAMPLING_RATE > 0d && DEFAULT_POOL_GET_PERMITS_SAMPLING_RATE <= 1d
 					&& DEFAULT_POOL_RETURN_PERMITS_SAMPLING_RATE > 0d && DEFAULT_POOL_RETURN_PERMITS_SAMPLING_RATE <= 1d) {
@@ -547,6 +556,40 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 			public void returnPermits(int returned) {
 				delegate.returnPermits(returned);
 			}
+		}
+	}
+
+	static final class PooledConnectionMetadata implements ConnectionMetadata {
+
+		final PooledRefMetadata delegate;
+
+		PooledConnectionMetadata(PooledRefMetadata delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public int acquireCount() {
+			return delegate.acquireCount();
+		}
+
+		@Override
+		public long idleTime() {
+			return delegate.idleTime();
+		}
+
+		@Override
+		public long lifeTime() {
+			return delegate.lifeTime();
+		}
+
+		@Override
+		public long releaseTimestamp() {
+			return delegate.releaseTimestamp();
+		}
+
+		@Override
+		public long allocationTimestamp() {
+			return delegate.allocationTimestamp();
 		}
 	}
 

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/ConnectionProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/ConnectionProviderTest.java
@@ -17,6 +17,7 @@ package reactor.netty.resources;
 
 import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
+import reactor.netty.Connection;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -24,6 +25,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +36,7 @@ class ConnectionProviderTest {
 	static final String TEST_STRING = "";
 	static final Supplier<ConnectionProvider.MeterRegistrar> TEST_SUPPLIER = () -> (a, b, c, d) -> {};
 	static final BiFunction<Runnable, Duration, Disposable> TEST_BI_FUNCTION = (r, duration) -> () -> {};
+	static final BiPredicate<Connection, ConnectionProvider.ConnectionMetadata> TEST_BI_PREDICATE = (conn, meta) -> true;
 
 	@Test
 	void testBuilderCopyConstructor() throws IllegalAccessException {
@@ -79,6 +82,9 @@ class ConnectionProviderTest {
 		}
 		else if (BiFunction.class == clazz) {
 			field.set(builder, TEST_BI_FUNCTION);
+		}
+		else if (BiPredicate.class == clazz) {
+			field.set(builder, TEST_BI_PREDICATE);
 		}
 		else {
 			throw new IllegalArgumentException("Unknown field type " + clazz);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
@@ -494,7 +494,7 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 			this.remoteAddress = remoteAddress;
 			this.resolver = resolver;
 			this.pool = poolFactory.newPool(connectChannel(), null, DEFAULT_DESTROY_HANDLER, DEFAULT_EVICTION_PREDICATE,
-					poolConFig -> new Http2Pool(poolConFig, poolFactory.allocationStrategy(), poolFactory.maxIdleTime(), poolFactory.maxLifeTime()));
+					poolConfig -> new Http2Pool(poolConfig, poolFactory.allocationStrategy()));
 		}
 
 		Publisher<Connection> connectChannel() {


### PR DESCRIPTION
Add support for a custom eviction predicate in the ConnectionProvider.