### PR TITLE
Ensure junit tests do not have dependency to context-propagation

### DIFF
--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -142,7 +142,6 @@ dependencies {
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 	testRuntimeOnly "org.slf4j:jcl-over-slf4j:$slf4jVersion"
-	testRuntimeOnly "io.micrometer:micrometer-tracing:$micrometerTracingVersion"
 
 	for (dependency in project.configurations.shaded.dependencies) {
 		compileOnly(dependency)

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpMetricsTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpMetricsTests.java
@@ -16,6 +16,7 @@
 package reactor.netty.tcp;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 import static reactor.netty.Metrics.CONNECT_TIME;
 import static reactor.netty.Metrics.CONNECTIONS_TOTAL;
@@ -220,6 +221,12 @@ class TcpMetricsTests {
 
 		assertThat(recorder.onDataReceivedContextView).isTrue();
 		assertThat(recorder.onDataSentContextView).isTrue();
+	}
+
+	@Test
+	void smokeTestNoContextPropagation() {
+		assertThatExceptionOfType(ClassNotFoundException.class)
+				.isThrownBy(() -> Class.forName("io.micrometer.context.ContextRegistry"));
 	}
 
 	private void checkExpectationsPositive() {

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -134,7 +134,9 @@ dependencies {
 	testImplementation "io.projectreactor.tools:blockhound-junit-platform:$blockHoundVersion"
 	testImplementation "io.micrometer:micrometer-core:$micrometerVersion"
 	testImplementation "io.micrometer:micrometer-test:$micrometerVersion"
-	testImplementation "io.micrometer:micrometer-tracing-integration-test:$micrometerTracingVersion"
+	testImplementation("io.micrometer:micrometer-tracing-integration-test:$micrometerTracingVersion") {
+		exclude module: "context-propagation"
+	}
 	testImplementation "org.reflections:reflections:$reflectionsVersion"
 
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"

--- a/reactor-netty-http/src/noMicrometerTest/java/reactor/netty/http/client/HttpClientNoMicrometerTest.java
+++ b/reactor-netty-http/src/noMicrometerTest/java/reactor/netty/http/client/HttpClientNoMicrometerTest.java
@@ -37,6 +37,7 @@ import reactor.netty.resources.ConnectionProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Simon Baslé
@@ -55,6 +56,12 @@ class HttpClientNoMicrometerTest {
 	@Test
 	void smokeTestNoMicrometer() {
 		assertThat(Metrics.isMicrometerAvailable()).as("isMicrometerAvailable").isFalse();
+	}
+
+	@Test
+	void smokeTestNoContextPropagation() {
+		assertThatExceptionOfType(ClassNotFoundException.class)
+				.isThrownBy(() -> Class.forName("io.micrometer.context.ContextRegistry"));
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -88,6 +88,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static reactor.netty.Metrics.CONNECTIONS_ACTIVE;
 import static reactor.netty.Metrics.CONNECTIONS_TOTAL;
 import static reactor.netty.Metrics.CONNECT_TIME;
@@ -778,6 +779,12 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		InetSocketAddress sa = (InetSocketAddress) serverAddress.get();
 
 		checkExpectationsBadRequest(sa.getHostString() + ":" + sa.getPort(), serverCtx != null);
+	}
+
+	@Test
+	void smokeTestNoContextPropagation() {
+		assertThatExceptionOfType(ClassNotFoundException.class)
+				.isThrownBy(() -> Class.forName("io.micrometer.context.ContextRegistry"));
 	}
 
 	private void checkServerConnectionsMicrometer(HttpServerRequest request) {


### PR DESCRIPTION
Ensure that when there is no dependency to micrometer artifacts, there is no dependency to context-propagation also.

Fixes the exception below observed while executing junit tests:

```
java.lang.NoSuchMethodError: io.micrometer.context.ContextSnapshot.setAllThreadLocalsFrom(Ljava/lang/Object;)Lio/micrometer/context/ContextSnapshot$Scope;
	at reactor.core.publisher.ContextPropagation.lambda$contextRestoreForHandle$4(ContextPropagation.java:137)
	at reactor.core.publisher.FluxHandle$HandleSubscriber.onNext(FluxHandle.java:112)
	at reactor.core.publisher.FluxMap$MapConditionalSubscriber.onNext(FluxMap.java:224)
	at reactor.netty.channel.FluxReceive.drainReceiver(FluxReceive.java:292)
```