### PR TITLE
Remove from reactor-netty artifact the integration with Brave

### DIFF
--- a/reactor-netty-http-brave/build.gradle
+++ b/reactor-netty-http-brave/build.gradle
@@ -15,7 +15,6 @@ import me.champeau.gradle.japicmp.JapicmpTask
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-apply plugin: 'io.spring.javadoc'
 apply plugin: 'me.champeau.gradle.japicmp'
 apply plugin: 'de.undercouch.download'
 apply plugin: 'biz.aQute.bnd.builder'


### PR DESCRIPTION
Now that `reactor-netty-http-brave` is deprecated in favour of the integration with `Micrometer Tracing`, the dependency that `reactor-netty` has to this artifact is removed.

The integration is still there if one adds a direct dependency to `reactor-netty-http-brave`. It is just removed from the `reactor-netty`.

Remove the plugin for javadoc as it brings  to `reactor-netty` a runtime dependency to `reactor-netty-http-brave`