### PR TITLE
1.0.x improve logging when connection closed after cancel

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -275,6 +275,9 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 			return;
 		}
 		//"FutureReturnValueIgnored" this is deliberate
+		if (log.isDebugEnabled()) {
+			log.debug(format(channel(), "Cancelling inbound stream, closing channel."));
+		}
 		channel().close();
 	}
 


### PR DESCRIPTION
This PR attempts to improve logging in the following two scenario:

1) In a pipeline with multiple client calls, it's possible for a cancel signal to close the connection, e.g. Mono.zip where one publisher completes empty. In this case, you might see a log messages for subscribing to the response stream, immediately followed by channel closing:
```
2022-11-18 08:58:52.678 DEBUG 41948 --- [tor-http-nio-16] reactor.netty.channel.FluxReceive        : FluxReceive{pending=0, cancelled=false, inboundDone=false, inboundError=null}: subscribing inbound receiver
2022-11-18 08:58:52.678 DEBUG 41948 --- [tor-http-nio-16] r.n.resources.PooledConnectionProvider   : Channel closed, now: 9 active connections, 136 inactive connections and 0 pending acquire requests.
```
This PR adds a 3rd log message in between that shows there was a cancel signal:

```
2022-11-18 08:58:52.678 DEBUG 41948 --- [tor-http-nio-16] r.n.http.client.HttpClientOperations - [2ac0945a-1, L:/0:0:0:0:0:0:0:1:50589 - R:/0:0:0:0:0:0:0:1:9999] Cancelling inbound stream, closing channel.
```

2) As an additional point, the Spring Framework WebClient uses onErrorResume, after an application onStatus handler is called, to ensure that response is consumed. It then ignores any errors that may result, if the response was in fact consumed by the onStatus handler. See for example this spring-webflux [WebClientDataBufferAllocatingTests.onStatusWithBodyConsumed](https://github.com/spring-projects/spring-framework/blob/5.0.x/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientDataBufferAllocatingTests.java#L104) test. That means in this scenario, you could also see the following in the logs:

```
2022-11-18 08:58:52.679 ERROR 41948 --- [tor-http-nio-16] reactor.core.publisher.Operators         : Operator called default onErrorDropped

java.lang.IllegalStateException: Only one connection receive subscriber allowed.
	at reactor.netty.channel.FluxReceive.startReceiver(FluxReceive.java:182) ~[reactor-netty-core-1.0.24.jar:1.0.24]
	at reactor.netty.channel.FluxReceive.subscribe(FluxReceive.java:143) ~[reactor-netty-core-1.0.24.jar:1.0.24]
	at reactor.core.publisher.InternalFluxOperator.subscribe(InternalFluxOperator.java:62) ~[reactor-core-3.4.24.jar:3.4.24]
	at reactor.netty.ByteBufFlux.subscribe(ByteBufFlux.java:340) ~[reactor-netty-core-1.0.24.jar:1.0.24]
	at reactor.core.publisher.Mono.subscribe(Mono.java:4455) ~[reactor-core-3.4.24.jar:3.4.24]
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onError(FluxOnErrorResume.java:103) ~[reactor-core-3.4.24.jar:3.4.24]
```

The original github issue associated to this PR (see #2583) is suggesting to improve the error message, with something like `ignoring additional read. Response already consumed (or closed, or whatever the actual state).` to provide a little more context and hopefully guide better as to what happened. 
For the moment, this PR is simply replacing the IllegalStateException `Only one connection receive subscriber allowed` message by `Ignoring additional inbound receiver subscriber`; and some useful informations are also included in the message (the same infos actually provided by the `reactor.netty.channel.FluxReceiver` logger if it is enabled):

- cancelled (true/false): true if the flux has been cancelled, false if not
- terminated (true/false). true when the flux is done because either completed or closed because of an error.
- pending: the number of messages that are still pending and not consumed
- error (true/false): true in case the flux has been terminated because of an error, in the case, the IllegalStateException is constructed with the original root cause exception, so you will then see it in the stacktrace

So, for example, with the spring-webflux [WebClientDataBufferAllocatingTests.onStatusWithBodyConsumed](https://github.com/spring-projects/spring-framework/blob/5.0.x/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientDataBufferAllocatingTests.java#L104) test, we will now get the following IllegalStateException:

```
2022-11-18 08:58:52.679 ERROR 41948 --- [tor-http-nio-16] reactor.core.publisher.Operators         : Operator called default onErrorDropped

java.lang.IllegalStateException: Ignoring additional inbound receiver subscriber. Current flux state=[terminated=false,cancelled=true,pending=0,error=false].
	at reactor.netty.channel.FluxReceive.subscribe(FluxReceive.java:143) ~[reactor-netty-core-1.0.24.jar:1.0.24]
	at reactor.core.publisher.InternalFluxOperator.subscribe(InternalFluxOperator.java:62) ~[reactor-core-3.4.24.jar:3.4.24]
	at reactor.netty.ByteBufFlux.subscribe(ByteBufFlux.java:340) ~[reactor-netty-core-1.0.24.jar:1.0.24]
	at reactor.core.publisher.Mono.subscribe(Mono.java:4455) ~[reactor-core-3.4.24.jar:3.4.24]
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onError(FluxOnErrorResume.java:103) ~[reactor-core-3.4.24.jar:3.4.24]
```

For consistency, the message logged by the _reactor.netty.channel.FluxReceiver_ logger has also been replaced by `Ignoring additional inbound receiver subscriber.` instead of `Only one connection receive subscriber allowed`

Maybe @violetagg will propose some more simple and user friendly informations to provide in the IllegalStateException ?

Fixes #2583 