### PR TITLE
onInboundCancel does not close channel when inbound udpclient receiver is cancelled

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConfig.java
@@ -157,7 +157,7 @@ public final class UdpClientConfig extends ClientTransportConfig<UdpClientConfig
 				UdpClient.log.debug(format(channel(), INBOUND_CANCEL_LOG));
 			}
 			//"FutureReturnValueIgnored" this is deliberate
-			channel().close();
+			connection().dispose();
 		}
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpOperations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import static reactor.netty.ReactorNetty.format;
 /**
  * @author Stephane Maldini
  */
-final class UdpOperations extends ChannelOperations<UdpInbound, UdpOutbound>
+class UdpOperations extends ChannelOperations<UdpInbound, UdpOutbound>
 		implements UdpInbound, UdpOutbound {
 
 	UdpOperations(Connection c, ConnectionObserver listener) {

--- a/reactor-netty-core/src/test/java/reactor/netty/LogTracker.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/LogTracker.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Helper class used to track occurrences of string from logs.
+ */
+public class LogTracker extends AppenderBase<ILoggingEvent>  implements AutoCloseable {
+
+	public static final String LOG_FLUXRECEIVE = "reactor.netty.channel.FluxReceive";
+	public static final String MSG_FLUXRECEIVE_DROPPED = "FluxReceive{pending=0, cancelled=true, inboundDone=false, inboundError=null}: dropping frame";
+
+	public final CountDownLatch latch;
+	private final Logger logger;
+	private final String message;
+
+	public LogTracker(String loggerName, String message, int occurrences) {
+		this.logger = (Logger) LoggerFactory.getLogger(loggerName);
+		this.message = message;
+		this.latch = new CountDownLatch(occurrences);
+
+		start();
+		this.logger.addAppender(this);
+	}
+
+	public LogTracker(String loggerName, String message) {
+		this(loggerName, message, 1);
+	}
+
+	public LogTracker(Class<?> loggerName, String message) {
+		this(loggerName.getName(), message, 1);
+	}
+
+	@Override
+	protected void append(ILoggingEvent eventObject) {
+		if (eventObject.getFormattedMessage().contains(message)) {
+			latch.countDown();
+		}
+	}
+	@Override
+	public void close() {
+		logger.detachAppender(this);
+		stop();
+	}
+
+}

--- a/reactor-netty-core/src/test/java/reactor/netty/udp/UdpClientTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/udp/UdpClientTest.java
@@ -323,13 +323,13 @@ class UdpClientTest {
 						Mono<Void> receive = in.receive()
 								.asString()
 								.log("receive")
-								.doOnCancel(() -> cancelled.countDown())
+								.doOnCancel(cancelled::countDown)
 								.then();
 
 						// When the empty mono is cancelled, the Flux.zip operator will cancel other publisher parameters,
 						return Flux.zip(receive, empty.asMono())
 								.log("zip")
-								.then();
+								.then(Mono.never());
 					})
 					.wiretap(true)
 					.connect()


### PR DESCRIPTION
While working on #2585, it has been observed that when an UdpClient inbound receiver is cancelled, then unlike the HttpClient, the udp channel is not closed. in other words, the `onInboundCancel` method is not implemented by UdpOperations class.

I'm not sure, but this PR is to start a discussion whether or not the udp **client** channel should be closed when the inbound receiver is cancelled.

The `UdpClientTest.testUdpClientCancelled` test shows an example usecase.

The `UdpServerTest.testUdpServerCancelled` test also verifies that an udp server will drop any incoming messages in case the server inbound receiver is cancelled.

If it is not making sense to close the udp client channel on inbound receiver cancellation, then I will cancel this PR, but will change the UdpClientTest.testUdpClientCancelled to just check if buffers are dropped when the client inbound receiver is cancelled, and I'll add it to the other #2585 PR.
 
Partially Fixes #2583