### PR TITLE
Update documentation for `ConnectionProvider.Builder#disposeInactivePoolsInBackground`

### DIFF
--- a/docs/asciidoc/http-client-conn-provider.adoc
+++ b/docs/asciidoc/http-client-conn-provider.adoc
@@ -39,8 +39,8 @@ The following listing shows the available configurations:
 |=======
 | Configuration name | Description
 | `disposeInactivePoolsInBackground` | When this option is enabled, connection pools are regularly checked in the background,
-and those that are empty and been inactive for a specified time become eligible for disposal. By default, this background
-disposal of inactive pools is disabled.
+and those that are *empty* and been inactive for a specified time become eligible for disposal. Connection pool is considered
+*empty* when there are no active connections, idle connections and pending acquisitions. By default, this background disposal of inactive pools is disabled.
 | `disposeTimeout` | When `ConnectionProvider#dispose()` or `ConnectionProvider#disposeLater()` is called,
 trigger a graceful shutdown for the connection pools, with this grace period timeout.
 From there on, all calls for acquiring a connection will fail fast with an exception.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -435,8 +435,9 @@ public interface ConnectionProvider extends Disposable {
 
 		/**
 		 * Set the options to use for configuring {@link ConnectionProvider} background disposal for inactive connection pools.
-		 * When this option is enabled, the connection pools are regularly checked whether they are empty and inactive
-		 * for a specified time, thus applicable for disposal.
+		 * When this option is enabled, the connection pools are regularly checked whether they are <strong>empty</strong> and inactive
+		 * for a specified time, thus applicable for disposal. Connection pool is considered
+		 * <strong>empty</strong> when there are no active connections, idle connections and pending acquisitions.
 		 * Default to {@link #DISPOSE_INACTIVE_POOLS_IN_BACKGROUND_DISABLED} - the background disposal is disabled.
 		 * Providing a {@code disposeInterval} of {@link Duration#ZERO zero} means the background disposal is disabled.
 		 *


### PR DESCRIPTION
Clarify that the connection pool can be disposed only when there are no active connections, idle connections and pending acquisitions.