### PR TITLE
Include forwarded client IP address in access log

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AbstractAccessLogArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AbstractAccessLogArgProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ abstract class AbstractAccessLogArgProvider<SELF extends AbstractAccessLogArgPro
 			DateTimeFormatter.ofPattern("dd/MMM/yyyy:HH:mm:ss Z");
 	static final String MISSING = "-";
 
-	final SocketAddress remoteAddress;
+	SocketAddress remoteAddress;
 	final String user = MISSING;
 	String zonedDateTime;
 	ZonedDateTime accessDateTime;
@@ -135,6 +135,7 @@ abstract class AbstractAccessLogArgProvider<SELF extends AbstractAccessLogArgPro
 		this.contentLength = -1;
 		this.startTime = 0;
 		this.cookies = null;
+		this.remoteAddress = null;
 	}
 
 	SELF cookies(Map<CharSequence, Set<Cookie>> cookies) {
@@ -154,6 +155,11 @@ abstract class AbstractAccessLogArgProvider<SELF extends AbstractAccessLogArgPro
 			}
 			this.contentLength += contentLength;
 		}
+		return get();
+	}
+
+	SELF remoteAddress(SocketAddress remoteAddress) {
+		this.remoteAddress = remoteAddress;
 		return get();
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogHandlerH1.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogHandlerH1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,10 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import reactor.netty.channel.ChannelOperations;
 import reactor.netty.http.HttpInfos;
+import reactor.netty.http.server.HttpServerRequest;
 import reactor.util.annotation.Nullable;
 
+import java.net.SocketAddress;
 import java.util.function.Function;
 
 /**
@@ -81,6 +83,13 @@ final class AccessLogHandlerH1 extends BaseAccessLogHandler {
 			ChannelOperations<?, ?> ops = ChannelOperations.get(ctx.channel());
 			if (ops instanceof HttpInfos) {
 				accessLogArgProvider.cookies(((HttpInfos) ops).cookies());
+			}
+
+			if (ops instanceof HttpServerRequest) {
+				SocketAddress remoteAddress = ((HttpServerRequest) ops).remoteAddress();
+				if (remoteAddress != null) {
+					accessLogArgProvider.remoteAddress(remoteAddress);
+				}
 			}
 		}
 		if (msg instanceof LastHttpContent) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogHandlerH2.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogHandlerH2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,10 @@ import io.netty.handler.codec.http2.Http2DataFrame;
 import io.netty.handler.codec.http2.Http2HeadersFrame;
 import reactor.netty.channel.ChannelOperations;
 import reactor.netty.http.HttpInfos;
+import reactor.netty.http.server.HttpServerRequest;
 import reactor.util.annotation.Nullable;
 
+import java.net.SocketAddress;
 import java.util.function.Function;
 
 /**
@@ -67,6 +69,13 @@ final class AccessLogHandlerH2 extends BaseAccessLogHandler {
 			ChannelOperations<?, ?> ops = ChannelOperations.get(ctx.channel());
 			if (ops instanceof HttpInfos) {
 				accessLogArgProvider.cookies(((HttpInfos) ops).cookies());
+			}
+
+			if (ops instanceof HttpServerRequest) {
+				SocketAddress remoteAddress = ((HttpServerRequest) ops).remoteAddress();
+				if (remoteAddress != null) {
+					accessLogArgProvider.remoteAddress(remoteAddress);
+				}
 			}
 		}
 		if (msg instanceof Http2DataFrame) {


### PR DESCRIPTION
This PR addresses #2603 issue, and include any Forwarded client ip address in the access log.

Fixes #2603 