### PR TITLE
Ensure `CL`/`TE` headers are handled correctly for `204`/`205`/`304` status codes when server configured with `HTTP/2`

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
@@ -125,10 +125,11 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 								ReferenceCountUtil.release(b);
 								return Mono.error(e);
 							}
-							if (HttpUtil.getContentLength(outboundHttpMessage(), -1) == 0) {
+							if (HttpUtil.getContentLength(outboundHttpMessage(), -1) == 0 ||
+									isContentAlwaysEmpty()) {
 								if (log.isDebugEnabled()) {
-									log.debug(format(channel(), "Dropped HTTP content, " +
-											"since response has Content-Length: 0 {}"), b);
+									log.debug(format(channel(), "Dropped HTTP content, since response has " +
+											"1. [Content-Length: 0] or 2. there must be no content: {}"), b);
 								}
 								b.release();
 								return FutureMono.from(channel().writeAndFlush(newFullBodyMessage(Unpooled.EMPTY_BUFFER)));
@@ -200,6 +201,10 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 						msg = outboundHttpMessage();
 					}
 				}
+				else if (isContentAlwaysEmpty()) {
+					markSentBody();
+					msg = newFullBodyMessage(Unpooled.EMPTY_BUFFER);
+				}
 				else {
 					msg = outboundHttpMessage();
 				}
@@ -235,6 +240,8 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 	protected abstract void beforeMarkSentHeaders();
 
 	protected abstract void afterMarkSentHeaders();
+
+	protected abstract boolean isContentAlwaysEmpty();
 
 	protected abstract void onHeadersSent();
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -538,6 +538,11 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 	}
 
 	@Override
+	protected boolean isContentAlwaysEmpty() {
+		return false;
+	}
+
+	@Override
 	protected void onHeadersSent() {
 		channel().read();
 		if (channel().parent() != null) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -466,7 +466,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 	 */
 	static boolean isSelfDefinedMessageLength(HttpResponse response) {
 		return isContentLengthSet(response) || isTransferEncodingChunked(response) || isMultipart(
-				response) || isInformational(response) || isNotModified(response);
+				response) || isInformational(response) || isNotModified(response) || isNoContent(response);
 	}
 
 	static boolean isInformational(HttpResponse response) {
@@ -474,8 +474,12 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 		               .codeClass() == HttpStatusClass.INFORMATIONAL;
 	}
 
+	static boolean isNoContent(HttpResponse response) {
+		return HttpResponseStatus.NO_CONTENT.code() == response.status().code();
+	}
+
 	static boolean isNotModified(HttpResponse response) {
-		return HttpResponseStatus.NOT_MODIFIED.equals(response.status());
+		return HttpResponseStatus.NOT_MODIFIED.code() == response.status().code();
 	}
 
 	static boolean isMultipart(HttpResponse response) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpResponseStatusCodesHandlingTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpResponseStatusCodesHandlingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpResponseStatusCodesHandlingTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpResponseStatusCodesHandlingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,27 @@
  */
 package reactor.netty.http;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.BaseHttpTest;
 import reactor.netty.ByteBufFlux;
 import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.server.HttpServer;
 import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.stream.Stream;
 
 /**
  * @author Violeta Georgieva
@@ -50,5 +63,117 @@ class HttpResponseStatusCodesHandlingTests extends BaseHttpTest {
 		StepVerifier.create(content)
 				    .expectNext(404)
 				    .verifyComplete();
+	}
+
+	@ParameterizedTest
+	@MethodSource("httpCompatibleCombinations")
+	void noContentStatusCodes(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols) throws Exception {
+		SelfSignedCertificate ssc = new SelfSignedCertificate();
+
+		HttpServer server = createServer().protocol(serverProtocols);
+		if (Arrays.asList(serverProtocols).contains(HttpProtocol.H2)) {
+			Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+			server = server.secure(spec -> spec.sslContext(serverCtx));
+		}
+
+		disposableServer =
+				server.host("localhost")
+				      .route(r -> r.get("/204-1", (req, res) -> res.status(HttpResponseStatus.NO_CONTENT)
+				                                                        .sendHeaders())
+				                   .get("/204-2", (req, res) -> res.status(HttpResponseStatus.NO_CONTENT))
+				                   .get("/204-3", (req, res) -> res.status(HttpResponseStatus.NO_CONTENT)
+				                                                        .sendString(Mono.just("/204-3")))
+				                   .get("/204-4", (req, res) -> res.status(HttpResponseStatus.NO_CONTENT)
+				                                                        .sendString(Flux.just("/", "204-4")))
+				                   .get("/204-5", (req, res) -> res.status(HttpResponseStatus.NO_CONTENT)
+				                                                        .send())
+				                   .get("/205-1", (req, res) -> res.status(HttpResponseStatus.RESET_CONTENT)
+				                                                        .sendHeaders())
+				                   .get("/205-2", (req, res) -> res.status(HttpResponseStatus.RESET_CONTENT))
+				                   .get("/205-3", (req, res) -> res.status(HttpResponseStatus.RESET_CONTENT)
+				                                                        .sendString(Mono.just("/205-3")))
+				                   .get("/205-4", (req, res) -> res.status(HttpResponseStatus.RESET_CONTENT)
+				                                                        .sendString(Flux.just("/", "205-4")))
+				                   .get("/205-5", (req, res) -> res.status(HttpResponseStatus.RESET_CONTENT)
+				                                                        .send())
+				                   .get("/304-1", (req, res) -> res.status(HttpResponseStatus.NOT_MODIFIED)
+				                                                        .sendHeaders())
+				                   .get("/304-2", (req, res) -> res.status(HttpResponseStatus.NOT_MODIFIED))
+				                   .get("/304-3", (req, res) -> res.status(HttpResponseStatus.NOT_MODIFIED)
+				                                                        .sendString(Mono.just("/304-3")))
+				                   .get("/304-4", (req, res) -> res.status(HttpResponseStatus.NOT_MODIFIED)
+				                                                        .sendString(Flux.just("/", "304-4")))
+				                   .get("/304-5", (req, res) -> res.status(HttpResponseStatus.NOT_MODIFIED)
+				                                                        .send()))
+				      .bindNow();
+
+		HttpClient client = createClient(disposableServer::address).protocol(clientProtocols);
+		if (Arrays.asList(clientProtocols).contains(HttpProtocol.H2)) {
+			Http2SslContextSpec clientCtx =
+					Http2SslContextSpec.forClient()
+					                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+			client = client.secure(spec -> spec.sslContext(clientCtx));
+		}
+
+		checkResponse("/204-1", client);
+		checkResponse("/204-2", client);
+		checkResponse("/204-3", client);
+		checkResponse("/204-4", client);
+		checkResponse("/204-5", client);
+		checkResponse("/205-1", client);
+		checkResponse("/205-2", client);
+		checkResponse("/205-3", client);
+		checkResponse("/205-4", client);
+		checkResponse("/205-5", client);
+		checkResponse("/304-1", client);
+		checkResponse("/304-2", client);
+		checkResponse("/304-3", client);
+		checkResponse("/304-4", client);
+		checkResponse("/304-5", client);
+	}
+
+	static void checkResponse(String url, HttpClient client) {
+		client.get()
+		      .uri(url)
+		      .responseSingle((r, buf) ->
+		          Mono.zip(Mono.just(r.status().code()),
+		                   Mono.just(r.responseHeaders()),
+		                   buf.asString().defaultIfEmpty("NO BODY")))
+		      .as(StepVerifier::create)
+		      .expectNextMatches(t -> {
+		          int code = t.getT1();
+		          HttpHeaders h = t.getT2();
+		          if (code == HttpResponseStatus.NO_CONTENT.code() ||
+		                  code == HttpResponseStatus.NOT_MODIFIED.code()) {
+		              return !h.contains(HttpHeaderNames.TRANSFER_ENCODING) &&
+		                     !h.contains(HttpHeaderNames.CONTENT_LENGTH) &&
+		                     "NO BODY".equals(t.getT3());
+		          }
+		          else if (code == HttpResponseStatus.RESET_CONTENT.code()) {
+		              return !h.contains(HttpHeaderNames.TRANSFER_ENCODING) &&
+		                     h.getInt(HttpHeaderNames.CONTENT_LENGTH).equals(0) &&
+		                     "NO BODY".equals(t.getT3());
+		          }
+		          else {
+		              return false;
+		          }
+		      })
+		      .expectComplete()
+		      .verify(Duration.ofSeconds(30));
+	}
+
+	static Stream<Arguments> httpCompatibleCombinations() {
+		return Stream.of(
+				Arguments.of(new HttpProtocol[]{HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.HTTP11}),
+
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2}, new HttpProtocol[]{HttpProtocol.H2}),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2}, new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2}),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2, HttpProtocol.HTTP11}),
+
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C}, new HttpProtocol[]{HttpProtocol.H2C}),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C}),
+				Arguments.of(new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11}, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11})
+		);
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -136,7 +136,6 @@ import reactor.test.StepVerifier;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 import reactor.util.function.Tuple2;
-import reactor.util.function.Tuple3;
 
 import javax.net.ssl.SNIHostName;
 
@@ -549,67 +548,6 @@ class HttpServerTests extends BaseHttpTest {
 		ref.get().disposeNow();
 		Thread.sleep(100);
 		assertThat(f.isDone()).isTrue();
-	}
-
-	@Test
-	void nonContentStatusCodes() {
-		disposableServer =
-				createServer()
-				          .host("localhost")
-				          .route(r -> r.get("/204-1", (req, res) -> res.status(HttpResponseStatus.NO_CONTENT)
-				                                                       .sendHeaders())
-				                       .get("/204-2", (req, res) -> res.status(HttpResponseStatus.NO_CONTENT))
-				                       .get("/205-1", (req, res) -> res.status(HttpResponseStatus.RESET_CONTENT)
-				                                                       .sendHeaders())
-				                       .get("/205-2", (req, res) -> res.status(HttpResponseStatus.RESET_CONTENT))
-				                       .get("/304-1", (req, res) -> res.status(HttpResponseStatus.NOT_MODIFIED)
-				                                                       .sendHeaders())
-				                       .get("/304-2", (req, res) -> res.status(HttpResponseStatus.NOT_MODIFIED))
-				                       .get("/304-3", (req, res) -> res.status(HttpResponseStatus.NOT_MODIFIED)
-				                                                       .send()))
-				          .bindNow();
-
-		InetSocketAddress address = (InetSocketAddress) disposableServer.address();
-		checkResponse("/204-1", address);
-		checkResponse("/204-2", address);
-		checkResponse("/205-1", address);
-		checkResponse("/205-2", address);
-		checkResponse("/304-1", address);
-		checkResponse("/304-2", address);
-		checkResponse("/304-3", address);
-	}
-
-	private void checkResponse(String url, InetSocketAddress address) {
-		Mono<Tuple3<Integer, HttpHeaders, String>> response =
-				createClient(() -> address)
-				          .get()
-				          .uri(url)
-				          .responseSingle((r, buf) ->
-				                  Mono.zip(Mono.just(r.status().code()),
-				                           Mono.just(r.responseHeaders()),
-				                           buf.asString().defaultIfEmpty("NO BODY"))
-				          );
-
-		StepVerifier.create(response)
-		            .expectNextMatches(t -> {
-		                int code = t.getT1();
-		                HttpHeaders h = t.getT2();
-		                if (code == 204 || code == 304) {
-		                    return !h.contains("Transfer-Encoding") &&
-		                           !h.contains("Content-Length") &&
-		                           "NO BODY".equals(t.getT3());
-		                }
-		                else if (code == 205) {
-		                    return !h.contains("Transfer-Encoding") &&
-		                           h.getInt("Content-Length").equals(0) &&
-		                           "NO BODY".equals(t.getT3());
-		                }
-		                else {
-		                    return false;
-		                }
-		            })
-		            .expectComplete()
-		            .verify(Duration.ofSeconds(30));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #2620