### PR TITLE
Ensure `HttpServer` `Active Connections` metric is correct when connection closure before response write

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,8 @@ import static reactor.netty.ReactorNetty.format;
 abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 
 	private static final Logger log = Loggers.getLogger(AbstractHttpServerMetricsHandler.class);
+
+	boolean channelActivated;
 
 	long dataReceived;
 
@@ -97,6 +99,10 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 				// Allow request-response exchange to continue, unaffected by metrics problem
 			}
 		}
+		ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+		if (channelOps instanceof HttpServerOperations) {
+			recordInactiveConnectionOrStream((HttpServerOperations) channelOps);
+		}
 		ctx.fireChannelInactive();
 	}
 
@@ -129,24 +135,7 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 							}
 							// Allow request-response exchange to continue, unaffected by metrics problem
 						}
-						// ops.hostAddress() == null when request decoding failed, in this case
-						// we do not report active connection, so we do not report inactive connection
-						if (ops.hostAddress() != null) {
-							try {
-								if (ops.isHttp2()) {
-									recordClosedStream(ops);
-								}
-								else {
-									recordInactiveConnection(ops);
-								}
-							}
-							catch (RuntimeException e) {
-								if (log.isWarnEnabled()) {
-									log.warn(format(ctx.channel(), "Exception caught while recording metrics."), e);
-								}
-								// Allow request-response exchange to continue, unaffected by metrics problem
-							}
-						}
+						recordInactiveConnectionOrStream(ops);
 					}
 
 					dataSent = 0;
@@ -172,6 +161,7 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 				dataReceivedTime = System.nanoTime();
 				ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
 				if (channelOps instanceof HttpServerOperations) {
+					channelActivated = true;
 					HttpServerOperations ops = (HttpServerOperations) channelOps;
 					if (ops.isHttp2()) {
 						recordOpenStream(ops);
@@ -277,5 +267,27 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 
 	protected void recordClosedStream(HttpServerOperations ops) {
 		recorder().recordStreamClosed(ops.hostAddress());
+	}
+
+	void recordInactiveConnectionOrStream(HttpServerOperations ops) {
+		// ops.hostAddress() == null when request decoding failed, in this case
+		// we do not report active connection, so we do not report inactive connection
+		if (ops.hostAddress() != null && channelActivated) {
+			channelActivated = false;
+			try {
+				if (ops.isHttp2()) {
+					recordClosedStream(ops);
+				}
+				else {
+					recordInactiveConnection(ops);
+				}
+			}
+			catch (RuntimeException e) {
+				if (log.isWarnEnabled()) {
+					log.warn(format(ops.channel(), "Exception caught while recording metrics."), e);
+				}
+				// Allow request-response exchange to continue, unaffected by metrics problem
+			}
+		}
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -183,11 +183,11 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 										checkServerConnectionsRecorder(req))))
 						.get("/6", (req, res) -> {
 							checkServerConnectionsMicrometer(req);
-							return Mono.delay(Duration.ofMillis(100)).then(res.send());
+							return Mono.delay(Duration.ofMillis(200)).then(res.send());
 						})
 						.get("/7", (req, res) -> {
 							checkServerConnectionsRecorder(req);
-							return Mono.delay(Duration.ofMillis(100)).then(res.send());
+							return Mono.delay(Duration.ofMillis(200)).then(res.send());
 						}));
 
 		provider = ConnectionProvider.create("HttpMetricsHandlerTests", 1);

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.handler.timeout.ReadTimeoutException;
 import io.netty.util.concurrent.DefaultEventExecutor;
 import io.netty.util.concurrent.EventExecutor;
 import org.assertj.core.api.Assertions;
@@ -156,6 +157,8 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	 *  <li> /3 does not exists but is used by testNonExistingEndpoint, checkExpectationsNonExisting tests</li>
 	 *  <li> /4 is used by testServerConnectionsMicrometer test</li>
 	 *  <li> /5 is used by testServerConnectionsRecorder test</li>
+	 *  <li> /6 is used by testServerConnectionsMicrometerConnectionClose test</li>
+	 *  <li> /7 is used by testServerConnectionsRecorderConnectionClose test</li>
 	 * </ul>
 	 */
 	@BeforeEach
@@ -177,7 +180,15 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 										checkServerConnectionsMicrometer(req))))
 						.post("/5", (req, res) -> res.header("Connection", "close")
 								.send(req.receive().retain().doOnNext(b ->
-										checkServerConnectionsRecorder(req)))));
+										checkServerConnectionsRecorder(req))))
+						.get("/6", (req, res) -> {
+							checkServerConnectionsMicrometer(req);
+							return Mono.delay(Duration.ofMillis(100)).then(res.send());
+						})
+						.get("/7", (req, res) -> {
+							checkServerConnectionsRecorder(req);
+							return Mono.delay(Duration.ofMillis(100)).then(res.send());
+						}));
 
 		provider = ConnectionProvider.create("HttpMetricsHandlerTests", 1);
 		httpClient = createClient(provider, () -> disposableServer.address())
@@ -674,6 +685,48 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
+	void testServerConnectionsMicrometerConnectionClose(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
+		boolean isHttp11 = clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11;
+
+		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
+				.metrics(true, Function.identity())
+				.doOnConnection(cnx -> {
+					ServerCloseHandler.INSTANCE.register(cnx.channel());
+					if (!isHttp11) {
+						StreamCloseHandler.INSTANCE.register(cnx.channel());
+					}
+				})
+				.bindNow();
+
+		customizeClientOptions(httpClient, clientCtx, clientProtocols)
+		        .metrics(true, Function.identity())
+		        .responseTimeout(Duration.ofMillis(50))
+		        .get()
+		        .uri("/6")
+		        .responseContent()
+		        .as(StepVerifier::create)
+		        .expectError(ReadTimeoutException.class)
+		        .verify(Duration.ofSeconds(30));
+
+		String address = formatSocketAddress(disposableServer.address());
+		if (isHttp11) {
+			// make sure the client socket is closed on the server side before checking server metrics
+			assertThat(ServerCloseHandler.INSTANCE.awaitClientClosedOnServer()).as("awaitClientClosedOnServer timeout").isTrue();
+			checkGauge(SERVER_CONNECTIONS_TOTAL, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
+			checkGauge(SERVER_CONNECTIONS_ACTIVE, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
+		}
+		else {
+			// make sure the client stream is closed on the server side before checking server metrics
+			assertThat(StreamCloseHandler.INSTANCE.awaitClientClosedOnServer()).as("awaitClientClosedOnServer timeout").isTrue();
+			checkGauge(SERVER_CONNECTIONS_TOTAL, true, 1, URI, HTTP, LOCAL_ADDRESS, address);
+			checkGauge(SERVER_STREAMS_ACTIVE, true, 0, URI, HTTP, LOCAL_ADDRESS, address);
+			// in case of H2, the tearDown method will ensure client socket is closed on the server side
+		}
+	}
+
+	@ParameterizedTest
+	@MethodSource("httpCompatibleProtocols")
 	void testServerConnectionsRecorder(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
 			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
 		// Invoke ServerRecorder.INSTANCE.reset() here as disposableServer.dispose (AfterEach) might be invoked after
@@ -716,6 +769,57 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		}
 		else {
 			assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(1);
+			// in case of H2, the tearDown method will ensure client socket is closed on the server side
+		}
+	}
+
+	@ParameterizedTest
+	@MethodSource("httpCompatibleProtocols")
+	void testServerConnectionsRecorderConnectionClose(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,
+			@Nullable ProtocolSslContextSpec serverCtx, @Nullable ProtocolSslContextSpec clientCtx) throws Exception {
+		// Invoke ServerRecorder.INSTANCE.reset() here as disposableServer.dispose (AfterEach) might be invoked after
+		// ServerRecorder.INSTANCE.reset() (AfterEach) and thus leave ServerRecorder.INSTANCE in a bad state
+		ServerRecorder.INSTANCE.reset();
+		boolean isHttp11 = clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11;
+
+		disposableServer = customizeServerOptions(httpServer, serverCtx, serverProtocols)
+				.metrics(true, ServerRecorder.supplier(), Function.identity())
+				.doOnConnection(cnx -> {
+					ServerCloseHandler.INSTANCE.register(cnx.channel());
+					if (!isHttp11) {
+						StreamCloseHandler.INSTANCE.register(cnx.channel());
+					}
+				})
+				.bindNow();
+
+		customizeClientOptions(httpClient, clientCtx, clientProtocols)
+		        .metrics(true, Function.identity())
+		        .responseTimeout(Duration.ofMillis(50))
+		        .get()
+		        .uri("/7")
+		        .responseContent()
+		        .as(StepVerifier::create)
+		        .expectError(ReadTimeoutException.class)
+		        .verify(Duration.ofSeconds(30));
+
+		// now we can assert test expectations
+		assertThat(ServerRecorder.INSTANCE.error.get()).isNull();
+
+		String address = formatSocketAddress(disposableServer.address());
+		if (isHttp11) {
+			// wait for the AbstractHttpServerMetricsHandlerServer to be called in recordServerConnectionClosed before asserting test expectations
+			assertThat(ServerCloseHandler.INSTANCE.awaitClientClosedOnServer()).as("awaitClientClosedOnServer timeout").isTrue();
+			assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(0);
+			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsAmount.get()).isEqualTo(0);
+			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsLocalAddr.get()).isEqualTo(address);
+			assertThat(ServerRecorder.INSTANCE.onInactiveConnectionsLocalAddr.get()).isEqualTo(address);
+		}
+		else {
+			assertThat(StreamCloseHandler.INSTANCE.awaitClientClosedOnServer()).as("awaitClientClosedOnServer timeout").isTrue();
+			assertThat(ServerRecorder.INSTANCE.onServerConnectionsAmount.get()).isEqualTo(1);
+			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsAmount.get()).isEqualTo(0);
+			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsLocalAddr.get()).isEqualTo(address);
+			assertThat(ServerRecorder.INSTANCE.onInactiveConnectionsLocalAddr.get()).isEqualTo(address);
 			// in case of H2, the tearDown method will ensure client socket is closed on the server side
 		}
 	}
@@ -1178,6 +1282,18 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		}
 
 		@Override
+		public void recordStreamOpened(SocketAddress localAddress) {
+			onActiveConnectionsLocalAddr.set(formatSocketAddress(localAddress));
+			onActiveConnectionsAmount.addAndGet(1);
+		}
+
+		@Override
+		public void recordStreamClosed(SocketAddress localAddress) {
+			onInactiveConnectionsLocalAddr.set(formatSocketAddress(localAddress));
+			onActiveConnectionsAmount.addAndGet(-1);
+		}
+
+		@Override
 		public void recordDataReceived(SocketAddress remoteAddress, String uri, long bytes) {
 		}
 
@@ -1295,7 +1411,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 	 * For HTTP1.1, the handler is placed before the ReactorBridge, so all previous handlers will see
 	 * the close before this handler. For HTTP2, the handler is placed lastly on the pipeline.
 	 */
-	static final class ServerCloseHandler extends ChannelInboundHandlerAdapter {
+	static class ServerCloseHandler extends ChannelInboundHandlerAdapter {
 		static final ServerCloseHandler INSTANCE = new ServerCloseHandler();
 		static final String HANDLER_NAME = "ServerCloseHandler.handler";
 		private CountDownLatch latch;
@@ -1303,6 +1419,11 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 		void register(Channel channel) {
 			this.latch = new CountDownLatch(1);
+			registerInternal(channel);
+			registered = true;
+		}
+
+		void registerInternal(Channel channel) {
 			if (channel instanceof Http2StreamChannel) {
 				if (channel.parent().pipeline().get(HANDLER_NAME) == null) {
 					channel.parent().pipeline().addLast(HANDLER_NAME, this);
@@ -1311,7 +1432,6 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 			else {
 				channel.pipeline().addBefore(NettyPipeline.ReactiveBridge, HANDLER_NAME, this);
 			}
-			registered = true;
 		}
 
 		@Override
@@ -1335,6 +1455,17 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				}
 			}
 			return true;
+		}
+	}
+
+	static final class StreamCloseHandler extends ServerCloseHandler {
+		static final StreamCloseHandler INSTANCE = new StreamCloseHandler();
+
+		@Override
+		void registerInternal(Channel channel) {
+			if (channel.pipeline().get(HANDLER_NAME) == null) {
+				channel.pipeline().addBefore(NettyPipeline.ReactiveBridge, HANDLER_NAME, this);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #2619