### PR TITLE
[doc] Fix javadoc generation

### DIFF
--- a/reactor-netty/build.gradle
+++ b/reactor-netty/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
 
 	compileOnly "io.micrometer:micrometer-core:$micrometerVersion"
+	compileOnly "io.micrometer:context-propagation:$contextPropagationVersion"
 	compileOnly "io.netty:netty-codec-haproxy:$nettyVersion"
 	compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
 	compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"


### PR DESCRIPTION
The following issue is observed when generating javadoc

```
/.../reactor-netty/reactor-netty-core/src/main/java/reactor/netty/contextpropagation/ChannelContextAccessor.java:18: error: package io.micrometer.context does not exist
import io.micrometer.context.ContextAccessor;
                            ^
/.../reactor-netty/reactor-netty-core/src/main/java/reactor/netty/contextpropagation/ChannelContextAccessor.java:39: error: cannot find symbol
public final class ChannelContextAccessor implements ContextAccessor<Channel, Channel> {
                                                     ^
  symbol: class ContextAccessor
```