### PR TITLE
Ensure `HttpServer` `minCompressionSize` is respected when `Content-Length` is not explicit and response is `Mono`

### DIFF
--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.GZIPInputStream;
 
+import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -190,29 +191,33 @@ class HttpCompressionClientServerTests extends BaseHttpTest {
 	void serverCompressionEnabledSmallResponse(HttpServer server, HttpClient client) {
 		disposableServer =
 				server.compress(25)
-				      .handle((in, out) -> out.header("content-length", "5")
-				                              .sendString(Mono.just("reply")))
+				      .route(r -> r.get("/1", (in, out) -> out.header("content-length", "5") //explicit 'content-length'
+				                                              .sendString(Mono.just("reply")))
+				                   .get("/2", (in, out) -> out.sendString(Mono.just("reply")))
+				                   .get("/3", (in, out) -> out.header("content-length", "5") //explicit 'content-length'
+				                                              .sendObject(Unpooled.wrappedBuffer("reply".getBytes(Charset.defaultCharset()))))
+				                   .get("/4", (in, out) -> out.sendObject(Unpooled.wrappedBuffer("reply".getBytes(Charset.defaultCharset())))))
 				      .bindNow(Duration.ofSeconds(10));
 
 		//don't activate compression on the client options to avoid auto-handling (which removes the header)
-		Tuple2<String, HttpHeaders> resp =
-				//edit the header manually to attempt to trigger compression on server side
-				client.port(disposableServer.port())
-				      .headers(h -> h.add("Accept-Encoding", "gzip"))
-				      .get()
-				      .uri("/test")
-				      .response((res, byteBufFlux) -> byteBufFlux.asString()
-				                                                 .zipWith(Mono.just(res.responseHeaders())))
-				      .blockFirst(Duration.ofSeconds(10));
-		assertThat(resp).isNotNull();
-
-		//check the server didn't send the gzip header, only transfer-encoding
-		HttpHeaders headers = resp.getT2();
-		assertThat(headers.get("conTENT-encoding")).isNull();
-
-		//check the server sent plain text
-		String reply = resp.getT1();
-		assertThat(reply).isEqualTo("reply");
+		//edit the header manually to attempt to trigger compression on server side
+		Flux.range(1, 4)
+		    .flatMap(i ->
+		            client.port(disposableServer.port())
+		                  .headers(h -> h.add("Accept-Encoding", "gzip"))
+		                  .get()
+		                  .uri("/" + i)
+		                  .responseSingle((res, byteBufFlux) -> byteBufFlux.asString()
+		                                                                   .zipWith(Mono.just(res.responseHeaders()))))
+		    .collectList()
+		    .as(StepVerifier::create)
+		    .assertNext(list -> assertThat(list).allMatch(t ->
+		        //check the server didn't send the gzip header, only 'content-length'
+		        t.getT2().get("conTENT-encoding") == null &&
+		                //check the server sent plain text
+		                "reply".equals(t.getT1())))
+		    .expectComplete()
+		    .verify(Duration.ofSeconds(10));
 	}
 
 	@ParameterizedCompressionTest


### PR DESCRIPTION
When a `Mono` is sent as a response or a single `ByteBuf` is sent as a response, `Reactor Netty` will send `FullHttpResponse` and thus is able to set `Content-Length` if such is not already set. Based on the `Content-Length`, `Reactor Netty` can decide whether or not a compression is needed.