### PR TITLE
Allow to configure colocation when creating LoopResources

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/LoopResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/LoopResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,6 +144,35 @@ public interface LoopResources extends Disposable {
 			throw new IllegalArgumentException("Must provide a strictly positive selector threads number, was: " + selectCount);
 		}
 		return new DefaultLoopResources(prefix, selectCount, workerCount, daemon);
+	}
+
+	/**
+	 * Create a simple {@link LoopResources} to provide automatically for {@link
+	 * EventLoopGroup} and {@link Channel} factories
+	 *
+	 * @param prefix the event loop thread name prefix
+	 * @param selectCount number of selector threads. When -1 is specified, no selectors threads will be created,
+	 *                    and worker threads will be also used as selector threads.
+	 * @param workerCount number of worker threads
+	 * @param daemon should the thread be released on jvm shutdown
+	 * @param colocate true means that {@link EventLoopGroup} created for clients will reuse current local event loop if already
+	 *                 working inside one.
+	 * @return a new {@link LoopResources} to provide automatically for {@link
+	 * EventLoopGroup} and {@link Channel} factories
+	 *
+	 * @since 1.0.28
+	 */
+	static LoopResources create(String prefix, int selectCount, int workerCount, boolean daemon, boolean colocate) {
+		if (Objects.requireNonNull(prefix, "prefix").isEmpty()) {
+			throw new IllegalArgumentException("Cannot use empty prefix");
+		}
+		if (workerCount < 1) {
+			throw new IllegalArgumentException("Must provide a strictly positive worker threads number, was: " + workerCount);
+		}
+		if (selectCount < 1 && selectCount != -1) {
+			throw new IllegalArgumentException("Must provide a strictly positive selector threads number or -1, was: " + selectCount);
+		}
+		return new DefaultLoopResources(prefix, selectCount, workerCount, daemon, colocate);
 	}
 
 	/**


### PR DESCRIPTION
When a custom event loop group is configured for an H2/H2C http client (i.e using `HttpClient.runOn(LoopResources.create("client", 16, true))` for example), then in  _Forwarder_ kind of scenario when a JVM forwards a received H2/H2C request using the HttpClient to an upstream server, then in this case, it may happen that the custom event loops are unevenly distributed among the http client channels.

what happen is the following:

- One available Slot is being delivered to a borrower from one of the custom event loop [here](https://github.com/reactor/reactor-netty/blob/main/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java#L387-L388), so drain() is called from the custom event loop thread.
- if at this point there are many borrowers but no more streams are available from current acquired connections, then drain will acquire many channels up to the max number of connections in the configuration. And because the current thread is one of the custom eventloop group, then Colocation will take place when connecting (see [here](https://github.com/reactor/reactor-netty/blob/main/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java#L160), nextInternal will return the current loop from the threadlocal). 

This explains why we may have a few (maybe one) custom event loop consuming a lot of CPU, compared to the others. 

We can't disable colocation, because there are scenario where we want to share a custom event loop between, for example, one HttpServer and HttpClient, so both HttpServer and HttpClient may share resources using the same EventLoop.

So, let's add a new `LoopResources.create`  method with colocation choice parameter, allowing the user to explicitly enable or disable colocation:

```java
	/**
	 * Create a simple {@link LoopResources} to provide automatically for {@link
	 * EventLoopGroup} and {@link Channel} factories
	 *
	 * @param prefix the event loop thread name prefix
	 * @param selectCount number of selector threads. When -1 is specified, no selectors threads will be created,
	 *                    and worker threads will be also used as selector threads.
	 * @param workerCount number of worker threads
	 * @param daemon should the thread be released on jvm shutdown
	 * @param colocate true means that {@link EventLoopGroup} created for clients will reuse current local event loop if already
	 *                 working inside one.
	 * @return a new {@link LoopResources} to provide automatically for {@link
	 * EventLoopGroup} and {@link Channel} factories
	 *
	 * @since 1.0.28
	 */
	static LoopResources create(String prefix, int selectCount, int workerCount, boolean daemon, boolean colocate) {
```

Fixes #2604