### PR TITLE
Setup `spotless` for `gradle` files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,13 @@ spotless {
 		target '**/*.java'
 		licenseHeaderFile('codequality/spotless/licenseSlashstarStyle.txt')
 	}
+	format 'gradle', {
+		target '**/*.gradle'
+		//find start of gradle files by looking for either `import`
+		// or start of blocks like `javadoc{` or `configure(rootProject) {`...
+		licenseHeaderFile('codequality/spotless/licenseSlashstarStyle.txt',
+				"^\\w+(\\(\\w+\\))?\\s?\\{\$|import")
+	}
 }
 
 subprojects {

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty/build.gradle
+++ b/reactor-netty/build.gradle
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+* Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Two gradle files were missing year update in the copyright.