### PR TITLE
Allow H1, H2, and H2C protocol for HttpClient

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -217,15 +217,17 @@ class HttpClientConnect extends HttpClient {
 						_config.sslProvider = HttpClientSecure.defaultSslProvider(_config);
 					}
 
-					if (_config.checkProtocol(HttpClientConfig.h2c) && _config.protocols.length > 1) {
-						removeIncompatibleProtocol(_config, HttpProtocol.H2C);
-					}
-					else if (_config.checkProtocol(HttpClientConfig.h2c)) {
-						sink.error(new IllegalArgumentException(
-								"Configured H2 Clear-Text protocol with TLS. " +
-										"Use the non Clear-Text H2 protocol via HttpClient#protocol or disable TLS " +
-										"via HttpClient#noSSL()"));
-						return;
+					if (_config.checkProtocol(HttpClientConfig.h2c)) {
+						if (_config.protocols.length > 1) {
+							removeIncompatibleProtocol(_config, HttpProtocol.H2C);
+						}
+						else {
+							sink.error(new IllegalArgumentException(
+									"Configured H2 Clear-Text protocol with TLS. " +
+											"Use the non Clear-Text H2 protocol via HttpClient#protocol or disable TLS " +
+											"via HttpClient#noSSL()"));
+							return;
+						}
 					}
 
 					if (_config.sslProvider.getDefaultConfigurationType() == null) {
@@ -245,14 +247,16 @@ class HttpClientConnect extends HttpClient {
 						_config.sslProvider = null;
 					}
 
-					if (_config.checkProtocol(HttpClientConfig.h2) && _config.protocols.length > 1) {
-						removeIncompatibleProtocol(_config, HttpProtocol.H2);
-					}
-					else if (_config.checkProtocol(HttpClientConfig.h2)) {
-						sink.error(new IllegalArgumentException(
-								"Configured H2 protocol without TLS. Use H2 Clear-Text " +
-										"protocol via HttpClient#protocol or configure TLS via HttpClient#secure"));
-						return;
+					if (_config.checkProtocol(HttpClientConfig.h2)) {
+						if (_config.protocols.length > 1) {
+							removeIncompatibleProtocol(_config, HttpProtocol.H2);
+						}
+						else {
+							sink.error(new IllegalArgumentException(
+									"Configured H2 protocol without TLS. Use H2 Clear-Text " +
+											"protocol via HttpClient#protocol or configure TLS via HttpClient#secure"));
+							return;
+						}
 					}
 				}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -214,13 +214,13 @@ class HttpClientConnect extends HttpClient {
 				if (handler.toURI.isSecure()) {
 					if (_config.sslProvider == null) {
 						_config = new HttpClientConfig(config);
-						if (_config.checkProtocol(HttpClientConfig.h2c) && _config.protocols.length > 1) {
-							removeIncompatibleProtocol(_config, HttpProtocol.H2C);
-						}
 						_config.sslProvider = HttpClientSecure.defaultSslProvider(_config);
 					}
 
-					if (_config.checkProtocol(HttpClientConfig.h2c)) {
+					if (_config.checkProtocol(HttpClientConfig.h2c) && _config.protocols.length > 1) {
+						removeIncompatibleProtocol(_config, HttpProtocol.H2C);
+					}
+					else if (_config.checkProtocol(HttpClientConfig.h2c)) {
 						sink.error(new IllegalArgumentException(
 								"Configured H2 Clear-Text protocol with TLS. " +
 										"Use the non Clear-Text H2 protocol via HttpClient#protocol or disable TLS " +
@@ -242,13 +242,13 @@ class HttpClientConnect extends HttpClient {
 				else {
 					if (_config.sslProvider != null) {
 						_config = new HttpClientConfig(config);
-						if (_config.checkProtocol(HttpClientConfig.h2) && _config.protocols.length > 1) {
-							removeIncompatibleProtocol(_config, HttpProtocol.H2);
-						}
 						_config.sslProvider = null;
 					}
 
-					if (_config.checkProtocol(HttpClientConfig.h2)) {
+					if (_config.checkProtocol(HttpClientConfig.h2) && _config.protocols.length > 1) {
+						removeIncompatibleProtocol(_config, HttpProtocol.H2);
+					}
+					else if (_config.checkProtocol(HttpClientConfig.h2)) {
 						sink.error(new IllegalArgumentException(
 								"Configured H2 protocol without TLS. Use H2 Clear-Text " +
 										"protocol via HttpClient#protocol or configure TLS via HttpClient#secure"));

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Currently a client that's configured for HTTP 1.1, H2, and H2C is unable to make requests to both HTTPS and HTTP urls due to checks in HttpClientConnect.java which can be safely ignored as long as a backup protocol is configured.

The following changes are in line with discussion in this PR [#1403](https://github.com/reactor/reactor-netty/pull/1403#issuecomment-737087183). Specifically the table as follows.

Configured Client Protocols | Server URI scheme | Used Protocol | Current Status
--- | --- | --- | ---
{`H2`} | `http` | _error_ | Works
{`H2`} | `https` | `H2` (pre-known) | Works
{`H2C`} | `http` | `H2C` (pre-known) | Works
{`H2C`} | `https` | _error_ | Works
{`HTTP11`} | `http` | `HTTP11` | Works
{`HTTP11`} | `https` | `HTTP11` | Works
{`H2`, `H2C`} | `http` | `H2C` (pre-known) | Works
{`H2`, `H2C`} | `https` | `H2` (pre-known) | Works
{`H2`, `HTTP11`} | `http` | `HTTP11` | Works
{`H2`, `HTTP11`} | `https` | `H2` (offered via ALPN, fallback to `HTTP11`) | Works
{`H2C`, `HTTP11`} | `http` | `H2C` (offered via `Upgrade` header, fallback to `HTTP11`) | Works
{`H2C`, `HTTP11`} | `https` | `HTTP11` | Works
{`H2`, `H2C`, `HTTP11`} | `http` | `H2C` (offered via `Upgrade` header, fallback to `HTTP11`).  | Fails with "Configured H2 protocol without TLS"
{`H2`, `H2C`, `HTTP11`} | `https` | `H2` (offered via ALPN, fallback to `HTTP11`) | Fails with "Configured H2 Clear-Text protocol with TLS"

This fix will allow clients configured with HTTP 1.1, H2, and H2C to work as expected by ignoring H2C in HTTPS, and by ignoring H2 in HTTP.