### PR TITLE
Ensure `IdleTimeoutHandler` receives always `channelRead` events

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -768,8 +768,8 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 				pipeline.addAfter(ctx.name(), NettyPipeline.HttpCodec, upgrader.http2FrameCodec);
 			}
 
-			pipeline.addAfter(ctx.pipeline().context(upgrader.http2FrameCodec).name(),
-					NettyPipeline.H2MultiplexHandler, new Http2MultiplexHandler(upgrader));
+			// Add this handler at the end of the pipeline as it does not forward all channelRead events
+			pipeline.addLast(NettyPipeline.H2MultiplexHandler, new Http2MultiplexHandler(upgrader));
 
 			pipeline.remove(this);
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -1004,6 +1004,11 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 				configureHttp11Pipeline(p, accessLogEnabled, accessLog, compressPredicate, cookieDecoder, cookieEncoder,
 						decoder, formDecoderProvider, forwardedHeaderHandler, httpMessageLogFactory, idleTimeout, listener,
 						mapHandle, maxKeepAliveRequests, metricsRecorder, minCompressionSize, uriTagValue);
+
+				// When the server is configured with HTTP/1.1 and H2 and HTTP/1.1 is negotiated,
+				// when channelActive event happens, this HttpTrafficHandler is still not in the pipeline,
+				// and will not be able to add IdleTimeoutHandler. So in this use case add IdleTimeoutHandler here.
+				IdleTimeoutHandler.addIdleTimeoutHandler(ctx.pipeline(), idleTimeout);
 				return;
 			}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -121,6 +121,12 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 	public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
 		super.handlerAdded(ctx);
 		this.ctx = ctx;
+
+		// When the server is configured with HTTP/1.1 and H2 and the client is HTTP/1.1,
+		// when channelActive event happens, this handler is still not in the pipeline.
+		// In this use case add IdleTimeoutHandler when this handler is added to the pipeline.
+		IdleTimeoutHandler.addIdleTimeoutHandler(ctx.pipeline(), idleTimeout);
+
 		if (HttpServerOperations.log.isDebugEnabled()) {
 			HttpServerOperations.log.debug(format(ctx.channel(), "New http connection, requesting read"));
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -121,12 +121,6 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 	public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
 		super.handlerAdded(ctx);
 		this.ctx = ctx;
-
-		// When the server is configured with HTTP/1.1 and H2 and the client is HTTP/1.1,
-		// when channelActive event happens, this handler is still not in the pipeline.
-		// In this use case add IdleTimeoutHandler when this handler is added to the pipeline.
-		IdleTimeoutHandler.addIdleTimeoutHandler(ctx.pipeline(), idleTimeout);
-
 		if (HttpServerOperations.log.isDebugEnabled()) {
 			HttpServerOperations.log.debug(format(ctx.channel(), "New http connection, requesting read"));
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/IdleTimeoutHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/IdleTimeoutHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ final class IdleTimeoutHandler extends IdleStateHandler {
 	}
 
 	static void addIdleTimeoutHandler(ChannelPipeline pipeline, @Nullable Duration idleTimeout) {
-		if (idleTimeout != null) {
+		if (pipeline.get(NettyPipeline.IdleTimeoutHandler) == null && idleTimeout != null) {
 			String baseName = null;
 			if (pipeline.get(NettyPipeline.HttpCodec) != null) {
 				baseName = NettyPipeline.HttpCodec;


### PR DESCRIPTION
- When the server is configured with `HTTP/1.1` and `H2C` ensure `Http2MultiplexHandler` is at the end of the pipeline because this handler doesn't forward all `channelRead` events.
- When the server is configured with `HTTP/1.1` and `H2` and the client sends `HTTP/1.1`, when `channelActive` event happens, `HttpTrafficHandler` is still not in the pipeline. In this use case add `IdleTimeoutHandler` when `HttpTrafficHandler` is added to the pipeline.

Fixes #2649