### PR TITLE
Ensure correct access log handling for HTTP/1.1 pipelining

### DIFF
--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -235,6 +235,8 @@ task japicmp(type: JapicmpTask) {
 
 	compatibilityChangeExcludes = [ "METHOD_NEW_DEFAULT" ]
 	methodExcludes = [
+			'reactor.netty.http.server.HttpServerRequest#protocol()',
+			'reactor.netty.http.server.HttpServerRequest#timestamp()'
 	]
 }
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -588,7 +588,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		                    forwardedHeaderHandler, httpMessageLogFactory, idleTimeout, listener, mapHandle, maxKeepAliveRequests));
 
 		if (accessLogEnabled) {
-			p.addBefore(NettyPipeline.HttpTrafficHandler, NettyPipeline.AccessLogHandler, AccessLogHandlerFactory.H1.create(accessLog));
+			p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.AccessLogHandler, AccessLogHandlerFactory.H1.create(accessLog));
 		}
 
 		boolean alwaysCompress = compressPredicate == null && minCompressionSize == 0;
@@ -640,7 +640,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		                    forwardedHeaderHandler, httpMessageLogFactory, idleTimeout, listener, mapHandle, maxKeepAliveRequests));
 
 		if (accessLogEnabled) {
-			p.addAfter(NettyPipeline.HttpCodec, NettyPipeline.AccessLogHandler, AccessLogHandlerFactory.H1.create(accessLog));
+			p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.AccessLogHandler, AccessLogHandlerFactory.H1.create(accessLog));
 		}
 
 		boolean alwaysCompress = compressPredicate == null && minCompressionSize == 0;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package reactor.netty.http.server;
 
 import java.net.InetSocketAddress;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -142,4 +143,19 @@ public interface HttpServerRequest extends NettyInbound, HttpServerInfos {
 	 */
 	HttpHeaders requestHeaders();
 
+	/**
+	 * Returns the inbound protocol and version.
+	 *
+	 * @return the inbound protocol and version
+	 * @since 1.0.28
+	 */
+	String protocol();
+
+	/**
+	 * Returns the time when the request was received.
+	 *
+	 * @return the time when the request was received
+	 * @since 1.0.28
+	 */
+	ZonedDateTime timestamp();
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -17,6 +17,7 @@ package reactor.netty.http.server;
 
 import java.net.SocketAddress;
 import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.function.BiFunction;
@@ -45,6 +46,7 @@ import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
+import reactor.netty.ReactorNetty;
 import reactor.netty.http.logging.HttpMessageArgProviderFactory;
 import reactor.netty.http.logging.HttpMessageLogFactory;
 import reactor.util.annotation.Nullable;
@@ -182,7 +184,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 							pipelined != null ? pipelined.size() : 0);
 				}
 				overflow = true;
-				doPipeline(ctx, msg);
+				doPipeline(ctx, new HttpRequestHolder(request));
 				return;
 			}
 			else {
@@ -195,6 +197,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 				}
 
 				HttpServerOperations ops;
+				ZonedDateTime timestamp = ZonedDateTime.now(ReactorNetty.ZONE_ID_SYSTEM);
 				try {
 					ops = new HttpServerOperations(Connection.from(ctx.channel()),
 							listener,
@@ -210,11 +213,12 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 							formDecoderProvider,
 							httpMessageLogFactory,
 							mapHandle,
-							secure);
+							secure,
+							timestamp);
 				}
 				catch (RuntimeException e) {
 					request.setDecoderResult(DecoderResult.failure(e.getCause() != null ? e.getCause() : e));
-					sendDecodingFailures(e, msg);
+					sendDecodingFailures(e, msg, timestamp);
 					return;
 				}
 				ops.bind();
@@ -270,8 +274,12 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 	}
 
 	void sendDecodingFailures(Throwable t, Object msg) {
+		sendDecodingFailures(t, msg, null);
+	}
+
+	void sendDecodingFailures(Throwable t, Object msg, @Nullable ZonedDateTime timestamp) {
 		persistentConnection = false;
-		HttpServerOperations.sendDecodingFailures(ctx, listener, secure, t, msg, httpMessageLogFactory);
+		HttpServerOperations.sendDecodingFailures(ctx, listener, secure, t, msg, httpMessageLogFactory, timestamp);
 	}
 
 	void doPipeline(ChannelHandlerContext ctx, Object msg) {
@@ -372,7 +380,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 		Object next;
 		HttpRequest nextRequest = null;
 		while ((next = pipelined.peek()) != null) {
-			if (next instanceof HttpRequest) {
+			if (next instanceof HttpRequestHolder) {
 				if (nextRequest != null) {
 					return;
 				}
@@ -381,34 +389,49 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 					return;
 				}
 
-				nextRequest = (HttpRequest) next;
+				HttpRequestHolder holder = (HttpRequestHolder) next;
+				nextRequest = holder.request;
 
 				DecoderResult decoderResult = nextRequest.decoderResult();
 				if (decoderResult.isFailure()) {
-					sendDecodingFailures(decoderResult.cause(), nextRequest);
+					sendDecodingFailures(decoderResult.cause(), nextRequest, holder.timestamp);
 					discard();
 					return;
 				}
 
-				HttpServerOperations ops = new HttpServerOperations(Connection.from(ctx.channel()),
-						listener,
-						nextRequest,
-						compress,
-						ConnectionInfo.from(ctx.channel(),
-						                    nextRequest,
-						                    secure,
-						                    remoteAddress,
-						                    forwardedHeaderHandler),
-						cookieDecoder,
-						cookieEncoder,
-						formDecoderProvider,
-						httpMessageLogFactory,
-						mapHandle,
-						secure);
+				HttpServerOperations ops;
+				try {
+					ops = new HttpServerOperations(Connection.from(ctx.channel()),
+							listener,
+							nextRequest,
+							compress,
+							ConnectionInfo.from(ctx.channel(),
+							                    nextRequest,
+							                    secure,
+							                    remoteAddress,
+							                    forwardedHeaderHandler),
+							cookieDecoder,
+							cookieEncoder,
+							formDecoderProvider,
+							httpMessageLogFactory,
+							mapHandle,
+							secure,
+							holder.timestamp);
+				}
+				catch (RuntimeException e) {
+					holder.request.setDecoderResult(DecoderResult.failure(e.getCause() != null ? e.getCause() : e));
+					sendDecodingFailures(e, holder.request, holder.timestamp);
+					return;
+				}
 				ops.bind();
 				listener.onStateChange(ops, ConnectionObserver.State.CONFIGURED);
+
+				pipelined.poll();
+				ctx.fireChannelRead(holder.request);
 			}
-			ctx.fireChannelRead(pipelined.poll());
+			else {
+				ctx.fireChannelRead(pipelined.poll());
+			}
 		}
 		overflow = false;
 	}
@@ -492,4 +515,13 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 				MULTIPART_PREFIX.length());
 	}
 
+	static final class HttpRequestHolder {
+		final HttpRequest request;
+		final ZonedDateTime timestamp;
+
+		HttpRequestHolder(HttpRequest request) {
+			this.request = request;
+			this.timestamp = ZonedDateTime.now(ReactorNetty.ZONE_ID_SYSTEM);
+		}
+	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
@@ -56,6 +56,7 @@ import reactor.netty.LogTracker;
 import reactor.netty.NettyPipeline;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientConfig;
+import reactor.netty.http.client.HttpClientResponse;
 import reactor.netty.http.server.HttpServer;
 import reactor.netty.http.server.HttpServerConfig;
 import reactor.netty.http.server.logging.AccessLog;
@@ -355,13 +356,13 @@ class HttpProtocolsTests extends BaseHttpTest {
 	@ParameterizedCompatibleCombinationsTest
 	void testAccessLog(HttpServer server, HttpClient client) throws Exception {
 		disposableServer =
-				server.handle((req, resp) -> {
+				server.route(r -> r.get("/", (req, resp) -> {
 				          resp.withConnection(conn -> {
 				              ChannelHandler handler = conn.channel().pipeline().get(NettyPipeline.AccessLogHandler);
 				              resp.header(NettyPipeline.AccessLogHandler, handler != null ? "FOUND" : "NOT FOUND");
 				          });
 				          return resp.send();
-				      })
+				      }))
 				      .accessLog(true)
 				      .bindNow();
 
@@ -369,21 +370,32 @@ class HttpProtocolsTests extends BaseHttpTest {
 		HttpProtocol[] clientProtocols = client.configuration().protocols();
 		boolean isHttp11 = (serverProtocols.length == 1 && serverProtocols[0] == HttpProtocol.HTTP11) ||
 				(clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11);
-		String expectedLogRecord = "GET / HTTP/" + (isHttp11 ? "1.1" : "2.0") + "\" 200";
-		try (LogTracker logTracker = new LogTracker("reactor.netty.http.server.AccessLog", expectedLogRecord)) {
-			client.port(disposableServer.port())
-			      .get()
-			      .uri("/")
-			      .responseSingle((res, bytes) -> {
-			          return Mono.just(res.responseHeaders().get(NettyPipeline.AccessLogHandler));
-			      })
-			      .as(StepVerifier::create)
-			      .expectNext("FOUND")
-			      .expectComplete()
-			      .verify(Duration.ofSeconds(5));
+		String okMessage = "GET / HTTP/" + (isHttp11 ? "1.1" : "2.0") + "\" 200";
+		String notFoundMessage = "GET /not_found HTTP/" + (isHttp11 ? "1.1" : "2.0") + "\" 404";
+		try (LogTracker logTracker = new LogTracker("reactor.netty.http.server.AccessLog", okMessage, notFoundMessage)) {
+			doTestAccessLog(client, "/",
+					res -> Mono.just(res.responseHeaders().get(NettyPipeline.AccessLogHandler)), "FOUND");
+
+			doTestAccessLog(client, "/not_found", res -> Mono.just(res.status().toString()), "404 Not Found");
 
 			assertThat(logTracker.latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+			assertThat(logTracker.actualMessages).hasSize(2);
+			assertThat(logTracker.actualMessages.get(0).getFormattedMessage()).contains(okMessage);
+			assertThat(logTracker.actualMessages.get(1).getFormattedMessage()).contains(notFoundMessage);
 		}
+	}
+
+	private void doTestAccessLog(HttpClient client, String uri,
+			Function<HttpClientResponse, Mono<String>> response, String expectation) {
+		client.port(disposableServer.port())
+		      .get()
+		      .uri(uri)
+		      .responseSingle((res, bytes) -> response.apply(res))
+		      .as(StepVerifier::create)
+		      .expectNext(expectation)
+		      .expectComplete()
+		      .verify(Duration.ofSeconds(5));
 	}
 
 	@ParameterizedCompatibleCombinationsTest

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.cert.CertificateException;
 import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -121,6 +122,7 @@ import reactor.netty.FutureMono;
 import reactor.netty.LogTracker;
 import reactor.netty.NettyOutbound;
 import reactor.netty.NettyPipeline;
+import reactor.netty.ReactorNetty;
 import reactor.netty.channel.AbortedException;
 import reactor.netty.channel.ChannelOperations;
 import reactor.netty.http.Http11SslContextSpec;
@@ -356,56 +358,80 @@ class HttpServerTests extends BaseHttpTest {
 		assertThat(code).isEqualTo(500);
 	}
 
-	@Test
-	void httpPipelining() throws Exception {
-
+	@ParameterizedTest
+	@ValueSource(booleans = {false, true})
+	void httpPipelining(boolean enableAccessLog) throws Exception {
 		AtomicInteger i = new AtomicInteger();
 
 		disposableServer = createServer()
-		                             .handle((req, resp) ->
+		                             .accessLog(enableAccessLog)
+		                             .route(r -> r.get("/plaintext", (req, resp) ->
 		                                     resp.header(HttpHeaderNames.CONTENT_LENGTH, "1")
 		                                         .sendString(Mono.just(i.incrementAndGet())
 		                                                         .flatMap(d ->
 		                                                                 Mono.delay(Duration.ofSeconds(4 - d))
-		                                                                     .map(x -> d + "\n"))))
+		                                                                     .map(x -> d + "\n")))))
 		                             .bindNow();
 
 		DefaultFullHttpRequest request =
-				new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
-				                           HttpMethod.GET,
-				                           "/plaintext");
+				new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/plaintext");
 
-		CountDownLatch latch = new CountDownLatch(6);
+		DefaultFullHttpRequest requestNotFound =
+				new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/not_found");
 
-		Connection client =
-				TcpClient.create()
-				         .port(disposableServer.port())
-				         .handle((in, out) -> {
-				                 in.withConnection(x ->
-				                         x.addHandlerFirst(new HttpClientCodec()))
-				                   .receiveObject()
-				                   .ofType(DefaultHttpContent.class)
-				                   .as(ByteBufFlux::fromInbound)
-				                   .asString()
-				                   .log()
-				                   .map(Integer::parseInt)
-				                   .subscribe(d -> {
-				                       for (int x = 0; x < d; x++) {
-				                           latch.countDown();
-				                       }
-				                   });
+		CountDownLatch latch = new CountDownLatch(10);
 
-				                 return out.sendObject(Flux.just(request.retain(),
-				                                                 request.retain(),
-				                                                 request.retain()))
-				                           .neverComplete();
-				         })
-				         .wiretap(true)
-				         .connectNow();
+		String okMessage = "GET /plaintext HTTP/1.1\" 200";
+		String notFoundMessage = "GET /not_found HTTP/1.1\" 404";
+		try (LogTracker logTracker = new LogTracker("reactor.netty.http.server.AccessLog", 4, okMessage, notFoundMessage)) {
+			Connection client =
+					TcpClient.create()
+					         .port(disposableServer.port())
+					         .handle((in, out) -> {
+					                 in.withConnection(x ->
+					                         x.addHandlerFirst(new HttpClientCodec()))
+					                   .receiveObject()
+					                   .map(o -> {
+					                       if (o == LastHttpContent.EMPTY_LAST_CONTENT) {
+					                           return new DefaultHttpContent(
+					                               Unpooled.wrappedBuffer((i.incrementAndGet() + "").getBytes(Charset.defaultCharset())));
+					                       }
+					                       return o;
+					                   })
+					                   .ofType(DefaultHttpContent.class)
+					                   .as(ByteBufFlux::fromInbound)
+					                   .asString()
+					                   .log()
+					                   .map(Integer::parseInt)
+					                   .subscribe(d -> {
+					                       for (int x = 0; x < d; x++) {
+					                           latch.countDown();
+					                       }
+					                   });
 
-		assertThat(latch.await(45, TimeUnit.SECONDS)).as("latch await").isTrue();
+					                 return out.sendObject(Flux.just(request.retain(),
+					                                                 request.retain(),
+					                                                 request.retain(),
+					                                                 requestNotFound))
+					                           .neverComplete();
+					         })
+					         .wiretap(true)
+					         .connectNow();
 
-		client.disposeNow();
+			assertThat(latch.await(45, TimeUnit.SECONDS)).as("latch await").isTrue();
+
+			client.disposeNow();
+
+			if (enableAccessLog) {
+				assertThat(logTracker.latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+				assertThat(logTracker.actualMessages).hasSize(4);
+				assertThat(logTracker.actualMessages.get(0).getFormattedMessage()).contains(okMessage);
+				assertThat(logTracker.actualMessages.get(1).getFormattedMessage()).contains(okMessage);
+				assertThat(logTracker.actualMessages.get(2).getFormattedMessage()).contains(okMessage);
+				assertThat(logTracker.actualMessages.get(3).getFormattedMessage()).contains(notFoundMessage);
+			}
+		}
 	}
 
 	@Test
@@ -1993,7 +2019,8 @@ class HttpServerTests extends BaseHttpTest {
 				DEFAULT_FORM_DECODER_SPEC,
 				ReactorNettyHttpMessageLogFactory.INSTANCE,
 				null,
-				false);
+				false,
+				ZonedDateTime.now(ReactorNetty.ZONE_ID_SYSTEM));
 		ops.status(status);
 		HttpMessage response = ops.newFullBodyMessage(Unpooled.EMPTY_BUFFER);
 		assertThat(((FullHttpResponse) response).status().reasonPhrase()).isEqualTo(status.reasonPhrase());
@@ -2901,7 +2928,8 @@ class HttpServerTests extends BaseHttpTest {
 				DEFAULT_FORM_DECODER_SPEC,
 				ReactorNettyHttpMessageLogFactory.INSTANCE,
 				null,
-				false);
+				false,
+				ZonedDateTime.now(ReactorNetty.ZONE_ID_SYSTEM));
 		assertThat(ops.isFormUrlencoded()).isEqualTo(expectation);
 		// "FutureReturnValueIgnored" is suppressed deliberately
 		channel.close();

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogHandlerH1Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogHandlerH1Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,92 +15,58 @@
  */
 package reactor.netty.http.server.logging;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.http.DefaultHttpContent;
-import io.netty.handler.codec.http.DefaultHttpHeaders;
-import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.DefaultHttpResponse;
-import io.netty.handler.codec.http.DefaultLastHttpContent;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.netty.BaseHttpTest;
+import reactor.test.StepVerifier;
 
 import java.net.SocketAddress;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.netty.http.server.logging.LoggingTests.HEADER_CONNECTION_NAME;
 import static reactor.netty.http.server.logging.LoggingTests.HEADER_CONNECTION_VALUE;
-import static reactor.netty.http.server.logging.LoggingTests.RESPONSE_CONTENT;
+import static reactor.netty.http.server.logging.LoggingTests.RESPONSE_CONTENT_STRING;
 import static reactor.netty.http.server.logging.LoggingTests.URI;
 
 /**
  * @author limaoning
  */
-class AccessLogHandlerH1Tests {
+class AccessLogHandlerH1Tests extends BaseHttpTest {
 
-	@Test
-	void responseNonChunked() {
-		EmbeddedChannel channel = new EmbeddedChannel();
-		channel.pipeline().addLast(new AccessLogHandlerH1(
-				args -> {
-					assertAccessLogArgProvider(args, channel.remoteAddress(), false);
-					return AccessLog.create("{}={}", HEADER_CONNECTION_NAME,
-							args.requestHeader(HEADER_CONNECTION_NAME));
-				}));
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void responseChunked(boolean chunked) {
+		disposableServer =
+				createServer()
+				        .handle((req, res) ->
+				                res.withConnection(conn ->
+				                        conn.addHandlerLast(new AccessLogHandlerH1(
+				                                args -> {
+				                                    assertAccessLogArgProvider(args, conn.channel().remoteAddress(), chunked);
+				                                    return AccessLog.create("{}={}", HEADER_CONNECTION_NAME,
+				                                            args.requestHeader(HEADER_CONNECTION_NAME));
+				                                })))
+				                   .chunkedTransfer(chunked)
+				                   .sendString(chunked ? Flux.just(RESPONSE_CONTENT_STRING, "") :
+				                           Mono.just(RESPONSE_CONTENT_STRING)))
+				        .bindNow();
 
-		channel.writeInbound(newHttpRequest());
-
-		channel.writeOutbound(newHttpResponse(false));
-
-		channel.writeOutbound(new DefaultLastHttpContent());
-	}
-
-	@Test
-	void responseChunked() {
-		EmbeddedChannel channel = new EmbeddedChannel();
-		channel.pipeline().addLast(new AccessLogHandlerH1(
-				args -> {
-					assertAccessLogArgProvider(args, channel.remoteAddress(), true);
-					return AccessLog.create("{}={}", HEADER_CONNECTION_NAME,
-							args.requestHeader(HEADER_CONNECTION_NAME));
-				}));
-
-		channel.writeInbound(newHttpRequest());
-
-		channel.writeOutbound(newHttpResponse(true));
-
-		ByteBuf byteBuf = Unpooled.buffer(RESPONSE_CONTENT.length);
-		byteBuf.writeBytes(RESPONSE_CONTENT);
-		channel.writeOutbound(byteBuf);
-
-		channel.writeOutbound(new DefaultHttpContent(byteBuf));
-
-		channel.writeOutbound(new DefaultLastHttpContent());
-	}
-
-	private HttpRequest newHttpRequest() {
-		HttpHeaders requestHeaders = new DefaultHttpHeaders();
-		requestHeaders.add(HEADER_CONNECTION_NAME, HEADER_CONNECTION_VALUE);
-		return new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, URI, requestHeaders);
-	}
-
-	private HttpResponse newHttpResponse(boolean chunked) {
-		HttpHeaders responseHeaders = new DefaultHttpHeaders();
-		if (chunked) {
-			responseHeaders.add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
-		}
-		else {
-			responseHeaders.add(HttpHeaderNames.CONTENT_LENGTH, RESPONSE_CONTENT.length);
-		}
-		return new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, responseHeaders);
+		createClient(disposableServer.port())
+		        .get()
+		        .uri("/")
+		        .responseContent()
+		        .aggregate()
+		        .asString()
+		        .as(StepVerifier::create)
+		        .expectNext(RESPONSE_CONTENT_STRING)
+		        .expectComplete()
+		        .verify(Duration.ofSeconds(5));
 	}
 
 	@SuppressWarnings("deprecation")
@@ -114,10 +80,10 @@ class AccessLogHandlerH1Tests {
 		assertThat(args.protocol()).isEqualTo(HttpVersion.HTTP_1_1.text());
 		assertThat(args.status()).isEqualTo(HttpResponseStatus.OK.codeAsText());
 		if (chunked) {
-			assertThat(args.contentLength()).isEqualTo(RESPONSE_CONTENT.length << 1);
+			assertThat(args.contentLength()).isEqualTo(RESPONSE_CONTENT_STRING.length() << 1);
 		}
 		else {
-			assertThat(args.contentLength()).isEqualTo(RESPONSE_CONTENT.length);
+			assertThat(args.contentLength()).isEqualTo(RESPONSE_CONTENT_STRING.length());
 		}
 		assertThat(args.requestHeader(HEADER_CONNECTION_NAME)).isEqualTo(HEADER_CONNECTION_VALUE);
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/LoggingTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/LoggingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ class LoggingTests {
 	static final CharSequence HEADER_TEST_NAME = "test";
 	static final String HEADER_TEST_VALUE = "test";
 	static final String URI = "/hello";
-	static final byte[] RESPONSE_CONTENT = "Hello".getBytes(StandardCharsets.UTF_8);
+	static final String RESPONSE_CONTENT_STRING = "Hello";
+	static final byte[] RESPONSE_CONTENT = RESPONSE_CONTENT_STRING.getBytes(StandardCharsets.UTF_8);
 
 }


### PR DESCRIPTION
- Move `AccessLogHandler` after `HttpTrafficHandler`, as the latter handles HTTP/1.1 pipelining
- When draining cached requests ensure exceptions are handled as decoding failures
- `AccessLogArgProviderH1` now depends on `HttpServerRequest`, as the latter holds information for the time when the requests were received on the server

Fixes #2628