### PR TITLE
Fix `NullPointerException` when `followRedirect` is true, but there is no `location` header

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -741,11 +741,19 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 
 	final boolean notRedirected(HttpResponse response) {
 		if (isFollowRedirect() && followRedirectPredicate.test(this, this)) {
+			try {
+				redirecting = new RedirectClientException(response.headers(), response.status());
+			}
+			catch (RuntimeException e) {
+				if (log.isDebugEnabled()) {
+					log.debug(format(channel(), "The request cannot be redirected"), e);
+				}
+				return true;
+			}
 			if (log.isDebugEnabled()) {
 				log.debug(format(channel(), "Received redirect location: {}"),
 						httpMessageLogFactory().debug(HttpMessageArgProviderFactory.create(response)));
 			}
-			redirecting = new RedirectClientException(response.headers(), response.status());
 			return false;
 		}
 		return true;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/RedirectClientException.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/RedirectClientException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@ final class RedirectClientException extends RuntimeException {
 	final HttpResponseStatus status;
 
 	RedirectClientException(HttpHeaders headers, HttpResponseStatus status) {
-		location = Objects.requireNonNull(headers.get(HttpHeaderNames.LOCATION));
-		this.status = Objects.requireNonNull(status);
+		location = Objects.requireNonNull(headers.get(HttpHeaderNames.LOCATION), "location");
+		this.status = Objects.requireNonNull(status, "status");
 	}
 
 	@Override

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -797,5 +797,25 @@ class HttpRedirectTest extends BaseHttpTest {
 		assertThat(response).isNotNull();
 		assertThat(response.getT2()).isEqualTo(200);
 		assertThat(response.getT1()).isEqualTo("OK");
+	}
+
+	@Test
+	void testIssue2670() {
+		disposableServer =
+				createServer()
+				        .handle((req, res) -> res.sendString(Mono.just("testIssue2670")))
+				        .bindNow();
+
+		createClient(disposableServer.port())
+		        .followRedirect((req, res) -> true)
+		        .get()
+		        .uri("/")
+		        .responseContent()
+		        .aggregate()
+		        .asString()
+		        .as(StepVerifier::create)
+		        .expectNext("testIssue2670")
+		        .expectComplete()
+		        .verify(Duration.ofSeconds(5));
 	}
 }


### PR DESCRIPTION
Fixes #2670