### PR TITLE
Improving context-propagation tests

### DIFF
--- a/reactor-netty-http/src/contextPropagationTest/java/reactor/netty/ContextPropagationTest.java
+++ b/reactor-netty-http/src/contextPropagationTest/java/reactor/netty/ContextPropagationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -186,7 +186,7 @@ class ContextPropagationTest {
 				TestThreadLocalHolder.value(threadLocalValue);
 				if (msg instanceof FullHttpRequest) {
 					ByteBuf buffer1;
-					try (ContextSnapshot.Scope scope = ContextSnapshot.captureFrom(ctx.channel()).setThreadLocals()) {
+					try (ContextSnapshot.Scope scope = ContextSnapshot.setAllThreadLocalsFrom(ctx.channel())) {
 						buffer1 = Unpooled.wrappedBuffer(TestThreadLocalHolder.value().getBytes(Charset.defaultCharset()));
 					}
 					ByteBuf buffer2 = Unpooled.wrappedBuffer(TestThreadLocalHolder.value().getBytes(Charset.defaultCharset()));


### PR DESCRIPTION
Recent change in context-propagation library introduced the ability to reset ThreadLocal values not present in the sourceContext.

The `ContextSnapshot#captureFrom()` combined with
`ContextSnapshot#setThreadLocals()` removes all ThreadLocal values not present in the sourceContext.

The method `ContextSnapshot.setAllThreadLocalsFrom()` allows to only set the values from the provided context, avoiding the need for a temporary `ContextSnapshot` copy of the values.

Currently, reactor-netty can't upgrade, as 1.0.1 of context-propagation disallows selective setting of only the interesting values to ThreadLocals without the need to look up existing ThreadLocals.

However, that will be fixed and the `setAllThreadLocalsFrom` is a proper shortcut going forward.