### PR TITLE
Add `ConnectionInformation#hostName/hostPort`

### DIFF
--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -235,6 +235,8 @@ task japicmp(type: JapicmpTask) {
 
 	compatibilityChangeExcludes = [ "METHOD_NEW_DEFAULT" ]
 	methodExcludes = [
+			'reactor.netty.http.server.ConnectionInformation#hostName()',
+			'reactor.netty.http.server.ConnectionInformation#hostPort()'
 	]
 }
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ConnectionInformation.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ConnectionInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,4 +74,24 @@ public interface ConnectionInformation {
 	 * @return the protocol scheme
 	 */
 	String connectionScheme();
+
+	/**
+	 * Returns the host name derived from the {@code Host}/{@code X-Forwarded-Host}/{@code Forwarded} header
+	 * associated with this request.
+	 *
+	 * @return the host name derived from the {@code Host}/{@code X-Forwarded-Host}/{@code Forwarded} header
+	 * associated with this request.
+	 * @since 1.0.29
+	 */
+	String hostName();
+
+	/**
+	 * Returns the host port derived from the {@code Host}/{@code X-Forwarded-*}/{@code Forwarded} header
+	 * associated with this request.
+	 *
+	 * @return the host port derived from the {@code Host}/{@code X-Forwarded-*}/{@code Forwarded} header
+	 * associated with this request.
+	 * @since 1.0.29
+	 */
+	int hostPort();
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -96,6 +96,9 @@ import reactor.util.context.Context;
 import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 import static io.netty.handler.codec.http.HttpUtil.isTransferEncodingChunked;
 import static reactor.netty.ReactorNetty.format;
+import static reactor.netty.http.server.ConnectionInfo.DEFAULT_HOST_NAME;
+import static reactor.netty.http.server.ConnectionInfo.DEFAULT_HTTPS_PORT;
+import static reactor.netty.http.server.ConnectionInfo.DEFAULT_HTTP_PORT;
 import static reactor.netty.http.server.HttpServerFormDecoderProvider.DEFAULT_FORM_DECODER_SPEC;
 import static reactor.netty.http.server.HttpServerState.REQUEST_DECODING_FAILED;
 
@@ -476,6 +479,18 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 	@Override
 	public String connectionScheme() {
 		return scheme;
+	}
+
+	@Override
+	public String hostName() {
+		return connectionInfo != null ? connectionInfo.getHostName() : DEFAULT_HOST_NAME;
+	}
+
+	@Override
+	public int hostPort() {
+		return connectionInfo != null ?
+				connectionInfo.getHostPort() :
+				scheme().equalsIgnoreCase("https") ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
 	}
 
 	@Override


### PR DESCRIPTION
- The host name and port are derived from the `Host`/`X-Forwarded-*`/`Forwarded` header associated with this request.
- When `X-Forwarded-*`/`Forwarded` header does not specify a port, add a port as per the scheme