### PR TITLE
When the scheme is `https`/`wss`, the https default port is used as a fallback option

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
@@ -69,9 +69,11 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 		if (protoMatcher.find()) {
 			connectionInfo = connectionInfo.withScheme(protoMatcher.group(1).trim());
 		}
-		int port = connectionInfo.getScheme().equalsIgnoreCase("https") ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
 		Matcher hostMatcher = FORWARDED_HOST_PATTERN.matcher(forwarded);
 		if (hostMatcher.find()) {
+			String scheme = connectionInfo.getScheme();
+			int port = scheme.equalsIgnoreCase("https") || scheme.equalsIgnoreCase("wss") ?
+					DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
 			connectionInfo = connectionInfo.withHostAddress(
 					AddressUtils.parseAddress(hostMatcher.group(1), port, DEFAULT_FORWARDED_HEADER_VALIDATION));
 		}
@@ -96,7 +98,9 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 		}
 		String hostHeader = request.headers().get(X_FORWARDED_HOST_HEADER);
 		if (hostHeader != null) {
-			int port = connectionInfo.getScheme().equalsIgnoreCase("https") ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
+			String scheme = connectionInfo.getScheme();
+			int port = scheme.equalsIgnoreCase("https") || scheme.equalsIgnoreCase("wss") ?
+					DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
 			connectionInfo = connectionInfo.withHostAddress(
 					AddressUtils.parseAddress(hostHeader.split(",", 2)[0].trim(), port, DEFAULT_FORWARDED_HEADER_VALIDATION));
 			String portHeader = request.headers().get(X_FORWARDED_PORT_HEADER);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -490,7 +490,7 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 	public int hostPort() {
 		return connectionInfo != null ?
 				connectionInfo.getHostPort() :
-				scheme().equalsIgnoreCase("https") ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
+				scheme().equalsIgnoreCase("https") || scheme().equalsIgnoreCase("wss") ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
 	}
 
 	@Override


### PR DESCRIPTION
This change is in addition to PR #2714