### PR TITLE
Handle empty `HOST` header when processing connection information

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ConnectionInfo.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ConnectionInfo.java
@@ -65,10 +65,12 @@ public final class ConnectionInfo {
 		String header = request.headers().get(HttpHeaderNames.HOST);
 		if (header != null) {
 			hostName = header;
-			int portIndex = header.charAt(0) == '[' ? header.indexOf(':', header.indexOf(']')) : header.indexOf(':');
-			if (portIndex != -1) {
-				hostName = header.substring(0, portIndex);
-				hostPort = Integer.parseInt(header.substring(portIndex + 1));
+			if (!header.isEmpty()) {
+				int portIndex = header.charAt(0) == '[' ? header.indexOf(':', header.indexOf(']')) : header.indexOf(':');
+				if (portIndex != -1) {
+					hostName = header.substring(0, portIndex);
+					hostPort = Integer.parseInt(header.substring(portIndex + 1));
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #2723