### PR TITLE
Replace Objects.hash()

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MeterKey.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MeterKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,11 @@ public final class MeterKey {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(uri, remoteAddress, method, status);
+		int result = 1;
+		result = 31 * result + Objects.hashCode(uri);
+		result = 31 * result + Objects.hashCode(remoteAddress);
+		result = 31 * result + Objects.hashCode(method);
+		result = 31 * result + Objects.hashCode(status);
+		return result;
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -654,7 +654,11 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(fqdn, holder, pipelineKey);
+			int result = 1;
+			result = 31 * result + Objects.hashCode(fqdn);
+			result = 31 * result + Objects.hashCode(holder);
+			result = 31 * result + pipelineKey;
+			return result;
 		}
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -613,7 +613,7 @@ public final class SslProvider {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(builderHashCode);
+		return builderHashCode;
 	}
 
 	static void addSslReadHandler(ChannelPipeline pipeline, boolean sslDebug) {
@@ -803,9 +803,18 @@ public final class SslProvider {
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(sslCtxBuilder, type, sslContext, handlerConfigurator,
-					handshakeTimeoutMillis, closeNotifyFlushTimeoutMillis, closeNotifyReadTimeoutMillis,
-					serverNames, confPerDomainName, protocolSslContextSpec);
+			int result = 1;
+			result = 31 * result + Objects.hashCode(sslCtxBuilder);
+			result = 31 * result + Objects.hashCode(type);
+			result = 31 * result + Objects.hashCode(sslContext);
+			result = 31 * result + Objects.hashCode(handlerConfigurator);
+			result = 31 * result + Long.hashCode(handshakeTimeoutMillis);
+			result = 31 * result + Long.hashCode(closeNotifyFlushTimeoutMillis);
+			result = 31 * result + Long.hashCode(closeNotifyReadTimeoutMillis);
+			result = 31 * result + Objects.hashCode(serverNames);
+			result = 31 * result + Objects.hashCode(confPerDomainName);
+			result = 31 * result + Objects.hashCode(protocolSslContextSpec);
+			return result;
 		}
 
 		void addInternal(String domainName, Consumer<? super SslProvider.SslContextSpec> sslProviderBuilder) {

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,9 @@ public final class TcpClientConfig extends ClientTransportConfig<TcpClientConfig
 
 	@Override
 	public int channelHash() {
-		return Objects.hash(super.channelHash(), sslProvider);
+		int result = super.channelHash();
+		result = 31 * result + Objects.hashCode(sslProvider);
+		return result;
 	}
 
 	@Override

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,10 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 
 	@Override
 	public int channelHash() {
-		return Objects.hash(super.channelHash(), proxyProvider, resolver);
+		int result = super.channelHash();
+		result = 31 * result + Objects.hashCode(proxyProvider);
+		result = 31 * result + Objects.hashCode(resolver);
+		return result;
 	}
 
 	/**

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/NameResolverProvider.java
@@ -474,10 +474,26 @@ public final class NameResolverProvider {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(cacheMaxTimeToLive, cacheMinTimeToLive, cacheNegativeTimeToLive, completeOncePreferredResolved,
-				disableRecursionDesired, disableOptionalRecord, loggingFactory, loopResources, maxPayloadSize,
-				maxQueriesPerResolve, ndots, preferNative, queryTimeout, resolvedAddressTypes, resolveCache,
-				bindAddressSupplier, roundRobinSelection, searchDomains);
+		int result = 1;
+		result = 31 * result + Objects.hashCode(cacheMaxTimeToLive);
+		result = 31 * result + Objects.hashCode(cacheMinTimeToLive);
+		result = 31 * result + Objects.hashCode(cacheNegativeTimeToLive);
+		result = 31 * result + Boolean.hashCode(completeOncePreferredResolved);
+		result = 31 * result + Boolean.hashCode(disableRecursionDesired);
+		result = 31 * result + Boolean.hashCode(disableOptionalRecord);
+		result = 31 * result + Objects.hashCode(loggingFactory);
+		result = 31 * result + Objects.hashCode(loopResources);
+		result = 31 * result + maxPayloadSize;
+		result = 31 * result + maxQueriesPerResolve;
+		result = 31 * result + ndots;
+		result = 31 * result + Boolean.hashCode(preferNative);
+		result = 31 * result + Objects.hashCode(queryTimeout);
+		result = 31 * result + Objects.hashCode(resolvedAddressTypes);
+		result = 31 * result + Objects.hashCode(resolveCache);
+		result = 31 * result + Objects.hashCode(bindAddressSupplier);
+		result = 31 * result + Boolean.hashCode(roundRobinSelection);
+		result = 31 * result + Objects.hashCode(searchDomains);
+		return result;
 	}
 
 	/**

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -221,8 +221,15 @@ public final class ProxyProvider {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(
-				username, getPasswordValue(), getAddress().get(), getNonProxyHostsValue(), httpHeaders.get(), getType(), connectTimeoutMillis);
+		int result = 1;
+		result = 31 * result + Objects.hashCode(username);
+		result = 31 * result + Objects.hashCode(getPasswordValue());
+		result = 31 * result + Objects.hashCode(getAddress().get());
+		result = 31 * result + Boolean.hashCode(getNonProxyHostsValue());
+		result = 31 * result + Objects.hashCode(httpHeaders.get());
+		result = 31 * result + Objects.hashCode(getType());
+		result = 31 * result + Long.hashCode(connectTimeoutMillis);
+		return result;
 	}
 
 	private boolean getNonProxyHostsValue() {

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,8 +80,18 @@ public abstract class TransportConfig {
 	}
 
 	public int channelHash() {
-		return Objects.hash(attrs, bindAddress != null ? bindAddress.get() : 0, channelGroup, doOnChannelInit,
-				loggingHandler, loopResources, metricsRecorder, observer, options, preferNative);
+		int result = 1;
+		result = 31 * result + Objects.hashCode(attrs);
+		result = 31 * result + (bindAddress != null ? Objects.hashCode(bindAddress.get()) : 0);
+		result = 31 * result + Objects.hashCode(channelGroup);
+		result = 31 * result + Objects.hashCode(doOnChannelInit);
+		result = 31 * result + Objects.hashCode(loggingHandler);
+		result = 31 * result + Objects.hashCode(loopResources);
+		result = 31 * result + Objects.hashCode(metricsRecorder);
+		result = 31 * result + Objects.hashCode(observer);
+		result = 31 * result + Objects.hashCode(options);
+		result = 31 * result + Boolean.hashCode(preferNative);
+		return result;
 	}
 
 	/**

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/logging/ReactorNettyLoggingHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/logging/ReactorNettyLoggingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,7 +115,12 @@ final class ReactorNettyLoggingHandler extends LoggingHandler {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(byteBufFormat, charset, level(), name);
+		int result = 1;
+		result = 31 * result + Objects.hashCode(byteBufFormat);
+		result = 31 * result + Objects.hashCode(charset);
+		result = 31 * result + Objects.hashCode(level());
+		result = 31 * result + Objects.hashCode(name);
+		return result;
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/Http2SettingsSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/Http2SettingsSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,7 +176,14 @@ public final class Http2SettingsSpec {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(headerTableSize, initialWindowSize, maxConcurrentStreams, maxFrameSize, maxHeaderListSize, pushEnabled);
+		int result = 1;
+		result = 31 * result + Long.hashCode(headerTableSize);
+		result = 31 * result + initialWindowSize;
+		result = 31 * result + Long.hashCode(maxConcurrentStreams);
+		result = 31 * result + maxFrameSize;
+		result = 31 * result + Long.hashCode(maxHeaderListSize);
+		result = 31 * result + Boolean.hashCode(pushEnabled);
+		return result;
 	}
 
 	final Long headerTableSize;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpDecoderSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpDecoderSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package reactor.netty.http;
 
-import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -244,7 +243,14 @@ public abstract class HttpDecoderSpec<T extends HttpDecoderSpec<T>> implements S
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize,
-				allowDuplicateContentLengths, h2cMaxContentLength);
+		int result = 1;
+		result = 31 * result + maxInitialLineLength;
+		result = 31 * result + maxHeaderSize;
+		result = 31 * result + maxChunkSize;
+		result = 31 * result + Boolean.hashCode(validateHeaders);
+		result = 31 * result + initialBufferSize;
+		result = 31 * result + Boolean.hashCode(allowDuplicateContentLengths);
+		result = 31 * result + h2cMaxContentLength;
+		return result;
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -110,7 +110,13 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 
 	@Override
 	public int channelHash() {
-		return Objects.hash(super.channelHash(), acceptGzip, decoder, _protocols, sslProvider, uriTagValue);
+		int result = super.channelHash();
+		result = 31 * result + Boolean.hashCode(acceptGzip);
+		result = 31 * result + Objects.hashCode(decoder);
+		result = 31 * result + _protocols;
+		result = 31 * result + Objects.hashCode(sslProvider);
+		result = 31 * result + Objects.hashCode(uriTagValue);
+		return result;
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpResponseDecoderSpec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpResponseDecoderSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@ package reactor.netty.http.client;
 
 import reactor.netty.http.HttpDecoderSpec;
 import reactor.netty.http.server.HttpRequestDecoderSpec;
-
-import java.util.Objects;
 
 /**
  * A configuration builder to fine tune the {@link io.netty.handler.codec.http.HttpClientCodec}
@@ -105,7 +103,10 @@ public final class HttpResponseDecoderSpec extends HttpDecoderSpec<HttpResponseD
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(super.hashCode(), failOnMissingResponse, parseHttpAfterConnectRequest);
+		int result = super.hashCode();
+		result = 31 * result + Boolean.hashCode(failOnMissingResponse);
+		result = 31 * result + Boolean.hashCode(parseHttpAfterConnectRequest);
+		return result;
 	}
 
 	/**

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,7 +211,14 @@ public final class HttpServerFormDecoderProvider {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(baseDirectory, charset, maxInMemorySize, maxSize, scheduler, streaming);
+		int result = 1;
+		result = 31 * result + Objects.hashCode(baseDirectory);
+		result = 31 * result + Objects.hashCode(charset);
+		result = 31 * result + Long.hashCode(maxInMemorySize);
+		result = 31 * result + Long.hashCode(maxSize);
+		result = 31 * result + Objects.hashCode(scheduler);
+		result = 31 * result + Boolean.hashCode(streaming);
+		return result;
 	}
 
 	Mono<Path> createDefaultTempDirectory() {


### PR DESCRIPTION
This call requires an Object[] allocation and does boxing on primitives, so should not be used in high performance environments.

CPU usage before: 
<img width="1473" alt="image" src="https://user-images.githubusercontent.com/1082334/226207684-3e9468ce-ad70-49e6-9d49-c66e886811c1.png">

CPU usage after:
<img width="1504" alt="image" src="https://user-images.githubusercontent.com/1082334/226207729-0db25c57-d96f-4ecf-af04-9d006276b00e.png">

sorry for the duplicate, wrong base branch on the first time