### PR TITLE
Smarter usage of `FQDN` in `PoolKey`

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -637,7 +637,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 			if (holder instanceof InetSocketAddress) {
 				InetSocketAddress inetSocketAddress = (InetSocketAddress) holder;
 				if (!inetSocketAddress.isUnresolved()) {
-					// Use FDQN as a tie-breaker over IP's
+					// Use FQDN as a tie-breaker over IP's
 					fqdn = inetSocketAddress.getHostString().toLowerCase();
 				}
 			}

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/PoolKeyTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/PoolKeyTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PoolKeyTest {
 
 	@Test
-	void test() throws IllegalAccessException {
+	void test() {
 		Set<PoolKey> set = new LinkedHashSet<>();
 		PoolKey key1 = new PoolKey(AddressUtils.createUnresolved("wikipedia.org", 80), 0);
 		assertThat(set.add(key1)).isTrue();

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/PoolKeyTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/PoolKeyTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.resources;
+
+import org.junit.jupiter.api.Test;
+import reactor.netty.resources.PooledConnectionProvider.PoolKey;
+import reactor.netty.transport.AddressUtils;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PoolKeyTest {
+
+	@Test
+	void test() throws IllegalAccessException {
+		Set<PoolKey> set = new LinkedHashSet<>();
+		PoolKey key1 = new PoolKey(AddressUtils.createUnresolved("wikipedia.org", 80), 0);
+		assertThat(set.add(key1)).isTrue();
+		PoolKey key2 = new PoolKey(AddressUtils.createUnresolved("en.wikipedia.org", 80), 0);
+		assertThat(set.add(key2)).isTrue();
+		PoolKey key3 = new PoolKey(AddressUtils.createUnresolved("wikipedia.ORG", 80), 0);
+		assertThat(set.add(key3)).isFalse();
+		PoolKey key4 = new PoolKey(AddressUtils.createUnresolved("en.wikipedia.ORG", 80), 0);
+		assertThat(set.add(key4)).isFalse();
+		PoolKey key5 = new PoolKey(AddressUtils.createResolved("wikipedia.org", 80), 0);
+		assertThat(set.add(key5)).isTrue();
+		PoolKey key6 = new PoolKey(AddressUtils.createResolved("en.wikipedia.org", 80), 0);
+		assertThat(set.add(key6)).isTrue();
+		PoolKey key7 = new PoolKey(AddressUtils.createResolved("wikipedia.ORG", 80), 0);
+		assertThat(set.add(key7)).isFalse();
+		PoolKey key8 = new PoolKey(AddressUtils.createResolved("en.wikipedia.ORG", 80), 0);
+		assertThat(set.add(key8)).isFalse();
+		PoolKey key9 = new PoolKey(AddressUtils.createUnresolved("127.0.0.1", 80), 0);
+		assertThat(set.add(key9)).isTrue();
+		PoolKey key10 = new PoolKey(AddressUtils.createUnresolved("[::1]", 80), 0);
+		assertThat(set.add(key10)).isTrue();
+		PoolKey key11 = new PoolKey(AddressUtils.createUnresolved("127.0.0.1", 80), 0);
+		assertThat(set.add(key11)).isFalse();
+		PoolKey key12 = new PoolKey(AddressUtils.createUnresolved("[::1]", 80), 0);
+		assertThat(set.add(key12)).isFalse();
+		PoolKey key13 = new PoolKey(AddressUtils.createUnresolved("127.0.0.1", 443), 0);
+		assertThat(set.add(key13)).isTrue();
+		PoolKey key14 = new PoolKey(AddressUtils.createUnresolved("[::1]", 443), 0);
+		assertThat(set.add(key14)).isTrue();
+		assertThat(set.size()).isEqualTo(8);
+	}
+
+}


### PR DESCRIPTION
The SocketAddres.toString method to generate the FQDN is relatively heavy and it appears to be unnecessary given the socket address is being hashed and equaled already. This should work for unix domain sockets as well.

This code:
````java
System.out.println(AddressUtils.createUnresolved("127.0.0.1", 80));
System.out.println(AddressUtils.createUnresolved("127.0.0.1", 80).equals(AddressUtils.createUnresolved("127.0.0.1", 80)));
System.out.println(AddressUtils.createUnresolved("example.com", 80));
System.out.println(AddressUtils.createUnresolved("example.com", 80).equals(AddressUtils.createUnresolved("example.com", 80)));
System.out.println(AddressUtils.createResolved("example.com", 80));
System.out.println(AddressUtils.createResolved("example.com", 80).equals(AddressUtils.createResolved("example.com", 80)));
System.out.println(AddressUtils.createResolved("example.com", 80).equals(AddressUtils.createUnresolved("example.com", 80)));
System.out.println(UnixDomainSocketAddress.of("/tmp/mysock"));
````
prints out:
````
/127.0.0.1:80
true
example.com/<unresolved>:80
true
example.com/93.184.216.34:80
true
false
/tmp/mysock
````

before:
<img width="1483" alt="image" src="https://user-images.githubusercontent.com/1082334/226209615-1d2d6978-06b7-4ed4-a656-b72cafecab4b.png">

and after this is basically gone
<img width="1460" alt="image" src="https://user-images.githubusercontent.com/1082334/226209825-fa2662c4-98dc-4b4a-a548-1b4f531d76e6.png">

I also fixed up the hashCode like I did in https://github.com/reactor/reactor-netty/pull/2732
