### PR TITLE
Support a custom DnsAddressResolverGroup builder function

### DIFF
--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -537,6 +537,7 @@ Default: 0.
 | `completeOncePreferredResolved` | When this setting is enabled, the resolver notifies as soon as all queries for the preferred address type are complete.
 When this setting is disabled, the resolver notifies when all possible address types are complete.
 This configuration is applicable for `DnsNameResolver#resolveAll(String)`. By default, this setting is enabled.
+| `dnsAddressResolverGroupProvider` | Sets a custom function to create a `DnsAddressResolverGroup` given a `DnsNameResolverBuilder`
 | `disableOptionalRecord` | Disables the automatic inclusion of an optional record that tries to give a hint to the remote DNS server about
 how much data the resolver can read per response. By default, this setting is enabled.
 | `disableRecursionDesired` | Specifies whether this resolver has to send a DNS query with the recursion desired (RD) flag set.

--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -419,6 +419,7 @@ The following listing shows the available configurations:
 | `completeOncePreferredResolved` | When this setting is enabled, the resolver notifies as soon as all queries for the preferred address type are complete.
 When this setting is disabled, the resolver notifies when all possible address types are complete.
 This configuration is applicable for `DnsNameResolver#resolveAll(String)`. By default, this setting is enabled.
+| `dnsAddressResolverGroupProvider` | Sets a custom function to create a `DnsAddressResolverGroup` given a `DnsNameResolverBuilder`
 | `disableOptionalRecord` | Disables the automatic inclusion of an optional record that tries to give a hint to the remote DNS server about
  how much data the resolver can read per response. By default, this setting is enabled.
 | `disableRecursionDesired` | Specifies whether this resolver has to send a DNS query with the recursion desired (RD) flag set.

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -240,6 +240,8 @@ task japicmp(type: JapicmpTask) {
 	compatibilityChangeExcludes = [ "METHOD_NEW_DEFAULT" ]
 
 	methodExcludes = [
+			'reactor.netty.transport.NameResolverProvider#dnsAddressResolverGroupProvider()',
+			'reactor.netty.transport.NameResolverProvider$NameResolverSpec#dnsAddressResolverGroupProvider(java.util.function.Function)'
 	]
 }
 

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
@@ -19,9 +19,12 @@ import io.netty.channel.EventLoop;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.logging.LogLevel;
 import io.netty.resolver.ResolvedAddressTypes;
+import io.netty.resolver.dns.DnsAddressResolverGroup;
 import io.netty.resolver.dns.DnsCache;
 import io.netty.resolver.dns.DnsCacheEntry;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.resolver.dns.DnsServerAddressStreamProviders;
+import io.netty.resolver.dns.RoundRobinDnsAddressResolverGroup;
 import io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +39,7 @@ import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -126,6 +130,15 @@ class NameResolverProviderTest {
 	}
 
 	@Test
+	void dnsAddressResolverGroupProvider() {
+		assertThat(builder.build().dnsAddressResolverGroupProvider()).isNull();
+
+		Function<DnsNameResolverBuilder, DnsAddressResolverGroup> provider = RoundRobinDnsAddressResolverGroup::new;
+		builder.dnsAddressResolverGroupProvider(provider);
+		assertThat(builder.build().dnsAddressResolverGroupProvider()).isEqualTo(provider);
+	}
+
+	@Test
 	void disableOptionalRecord() {
 		assertThat(builder.build().isDisableOptionalRecord()).isFalse();
 
@@ -143,10 +156,10 @@ class NameResolverProviderTest {
 
 	@Test
 	void hostsFileEntriesResolver() {
-		assertThat(builder.build().hostsFileEntriesResolver).isNull();
+		assertThat(builder.build().hostsFileEntriesResolver()).isNull();
 
 		builder.hostsFileEntriesResolver((inetHost, resolvedAddressTypes) -> null);
-		assertThat(builder.build().hostsFileEntriesResolver).isNotNull();
+		assertThat(builder.build().hostsFileEntriesResolver()).isNotNull();
 	}
 
 	@Test


### PR DESCRIPTION
This PR is in draft to get feedback on the signature to allow a user supplied function to create a DnsAddressResolverGroup.

Our use-case is to use our extended version of RoundRobinInetAddressResolver with the HttpClient.

Keen to get your thoughts @violetagg on if this is the most sensible way to achieve this.

Work remaining
- Docs
- JAPI compare