### PR TITLE
Temporarily disable publish action for netty5 branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
     branches: # For branches, better to list them explicitly than regexp include
       - main
       - 1.0.x
-      - netty5
+#      - netty5
 permissions: read-all
 jobs:
   # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push


### PR DESCRIPTION
Currently, we depend now on socks-proxy/codec-multipart snapshots, so for the moment, let's disable publish action.
