### PR TITLE
Parse X-Forwarded-Port header even if X-Forwarded-Host is not present

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
@@ -97,28 +97,24 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 			connectionInfo = connectionInfo.withScheme(protoHeader.split(",", 2)[0].trim());
 		}
 		String hostHeader = request.headers().get(X_FORWARDED_HOST_HEADER);
-		int port = -1;
 		if (hostHeader != null) {
-			port = getDefaultHostPort(connectionInfo);
 			connectionInfo = connectionInfo.withHostAddress(
-					AddressUtils.parseAddress(hostHeader.split(",", 2)[0].trim(), port, DEFAULT_FORWARDED_HEADER_VALIDATION));
+					AddressUtils.parseAddress(hostHeader.split(",", 2)[0].trim(),
+							getDefaultHostPort(connectionInfo), DEFAULT_FORWARDED_HEADER_VALIDATION));
 		}
 
 		String portHeader = request.headers().get(X_FORWARDED_PORT_HEADER);
 		if (portHeader != null && !portHeader.isEmpty()) {
-			if (port == -1) {
-				port = getDefaultHostPort(connectionInfo);
-			}
 			String portStr = portHeader.split(",", 2)[0].trim();
 			if (portStr.chars().allMatch(Character::isDigit)) {
-				port = Integer.parseInt(portStr);
+				int port = Integer.parseInt(portStr);
+				connectionInfo = new ConnectionInfo(
+						AddressUtils.createUnresolved(connectionInfo.getHostAddress().getHostString(), port),
+						connectionInfo.getHostName(), port, connectionInfo.getRemoteAddress(), connectionInfo.getScheme());
 			}
 			else if (DEFAULT_FORWARDED_HEADER_VALIDATION) {
 				throw new IllegalArgumentException("Failed to parse a port from " + portHeader);
 			}
-			connectionInfo = new ConnectionInfo(
-					AddressUtils.createUnresolved(connectionInfo.getHostAddress().getHostString(), port),
-					connectionInfo.getHostName(), port, connectionInfo.getRemoteAddress(), connectionInfo.getScheme());
 		}
 		return connectionInfo;
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -382,6 +382,8 @@ class ConnectionInfoTests extends BaseHttpTest {
 				},
 				serverRequest -> {
 					Assertions.assertThat(serverRequest.remoteAddress().getHostString()).isEqualTo("192.168.0.1");
+					Assertions.assertThat(serverRequest.hostAddress().getHostString())
+							.containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(8443);
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("a.example.com");
 					Assertions.assertThat(serverRequest.scheme()).isEqualTo("https");


### PR DESCRIPTION
Always takes into account any available `X-Forwarded-Port` header even if the `X-Forwarded-Host` header is missing.

Fixes #2751
