### PR TITLE
Depend on `Netty` `v4.1.91.Final`

### DIFF
--- a/.github/workflows/check_netty_snapshots.yml
+++ b/.github/workflows/check_netty_snapshots.yml
@@ -29,4 +29,4 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
       - name: Build with Gradle
-        run: ./gradlew clean check --no-daemon -PforceTransport=${{ matrix.transport }} -PforceNettyVersion='4.1.91.Final-SNAPSHOT'
+        run: ./gradlew clean check --no-daemon -PforceTransport=${{ matrix.transport }} -PforceNettyVersion='4.1.92.Final-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ ext {
 	logbackVersion = '1.2.12'
 
 	// Netty
-	nettyDefaultVersion = '4.1.90.Final'
+	nettyDefaultVersion = '4.1.91.Final'
 	if (!project.hasProperty("forceNettyVersion")) {
 		nettyVersion = nettyDefaultVersion
 	}


### PR DESCRIPTION
In case `H2C` client tries to connect to a secured `HTTP` server, the connection is directly closed. This is a result of this `Netty` change.
https://github.com/netty/netty/pull/13314