### PR TITLE
Make it obvious that the test fails with `UnsupportedMessageTypeException`

### DIFF
--- a/reactor-netty-core/src/test/java/reactor/netty/NettyOutboundTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/NettyOutboundTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.FileRegion;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.UnsupportedMessageTypeException;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
@@ -244,6 +245,8 @@ class NettyOutboundTest {
 				.endsWith("End of File");
 
 		assertThat(f.isSuccess()).isFalse();
+		assertThat(f.cause()).isNotNull()
+				.isInstanceOf(UnsupportedMessageTypeException.class);
 		assertThat(channel.finishAndReleaseAll()).isTrue();
 	}
 


### PR DESCRIPTION
Related to #2754