### PR TITLE
Use `Http2SslContextSpec` to build `SslContext` when `http2` enabled

### DIFF
--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/echo/EchoServer.java
@@ -17,6 +17,7 @@ package reactor.netty.examples.http.echo;
 
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import reactor.netty.http.Http11SslContextSpec;
+import reactor.netty.http.Http2SslContextSpec;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.server.HttpServer;
 
@@ -48,8 +49,12 @@ public final class EchoServer {
 
 		if (SECURE) {
 			SelfSignedCertificate ssc = new SelfSignedCertificate();
-			server = server.secure(
-					spec -> spec.sslContext(Http11SslContextSpec.forServer(ssc.certificate(), ssc.privateKey())));
+			if (HTTP2) {
+				server = server.secure(spec -> spec.sslContext(Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey())));
+			}
+			else {
+				server = server.secure(spec -> spec.sslContext(Http11SslContextSpec.forServer(ssc.certificate(), ssc.privateKey())));
+			}
 		}
 
 		if (HTTP2) {

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldServer.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/http/helloworld/HelloWorldServer.java
@@ -18,6 +18,7 @@ package reactor.netty.examples.http.helloworld;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.Http11SslContextSpec;
+import reactor.netty.http.Http2SslContextSpec;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.server.HttpServer;
 
@@ -49,8 +50,12 @@ public final class HelloWorldServer {
 
 		if (SECURE) {
 			SelfSignedCertificate ssc = new SelfSignedCertificate();
-			server = server.secure(
-					spec -> spec.sslContext(Http11SslContextSpec.forServer(ssc.certificate(), ssc.privateKey())));
+			if (HTTP2) {
+				server = server.secure(spec -> spec.sslContext(Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey())));
+			}
+			else {
+				server = server.secure(spec -> spec.sslContext(Http11SslContextSpec.forServer(ssc.certificate(), ssc.privateKey())));
+			}
 		}
 
 		if (HTTP2) {


### PR DESCRIPTION
Iam getting error when try to run http2 on Netty examples
I found that it uses `Http11SslContextSpec` to generate certificates for both `http11` and `http2` which should use `Http2SslContextSpec` for `http2`