### PR TITLE
ensures queue.clear is called in terminal cases for ASYNC fusion

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSendMany.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSendMany.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -350,6 +350,11 @@ final class MonoSendMany<I, O> extends MonoSend<I, O> implements Scannable {
 						}
 						else {
 							actual.onError(t);
+						}
+
+						if (sourceMode == ASYNC) {
+							// notify that consumption has been terminated
+							queue.clear();
 						}
 						return;
 					}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSendMany.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSendMany.java
@@ -353,7 +353,13 @@ final class MonoSendMany<I, O> extends MonoSend<I, O> implements Scannable {
 						}
 
 						if (sourceMode == ASYNC) {
-							// notify that consumption has been terminated
+							// notify that queue draining is done and no more interactions are expected for here
+							//
+							// This is needed due to ASYNC fusion contract.
+							// This call notifies upstream that the interaction with the queue is done on the
+							// downstream side.
+							// Some upstreams implementations may have `onClose()` mechanism to send notification
+							// about its termination and finalization of the offered events consumption
 							queue.clear();
 						}
 						return;


### PR DESCRIPTION
this fix ensures that in case of async fusion, the queue.clear() method is called regardless it is cancellation or terminal (via onComplete/onError)