### PR TITLE
Wrong host port 80 when only "X-Forwarded-Proto: https" is present

### DIFF
--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -39,6 +39,8 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Mono;
 import reactor.netty.BaseHttpTest;
 import reactor.netty.Connection;
@@ -167,6 +169,37 @@ class ConnectionInfoTests extends BaseHttpTest {
 					int port = serverRequest.scheme().equals("https") ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
 					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(port);
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
+					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(port);
+				});
+	}
+
+	@Test
+	void forwardedProtoHttpOnly() {
+		testClientRequest(
+				clientRequestHeaders -> clientRequestHeaders.add("Forwarded", "proto=http")
+						.set(HttpHeaderNames.HOST, "192.168.0.1"),
+				serverRequest -> {
+					Assertions.assertThat(serverRequest.hostAddress().getHostString())
+							.containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
+					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(80);
+					Assertions.assertThat(serverRequest.hostName()).isEqualTo("192.168.0.1");
+					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(80);
+				});
+	}
+
+	@ParameterizedTest(name = "{displayName}({arguments})")
+	@ValueSource(strings = {"http", "https", "wss"})
+	void forwardedProtoOnly(String protocol) {
+		int port = protocol.equals("https") || protocol.equals("wss") ? 443 : 80;
+
+		testClientRequest(
+				clientRequestHeaders -> clientRequestHeaders.add("Forwarded", "proto=" + protocol)
+						.set(HttpHeaderNames.HOST, "192.168.0.1"),
+				serverRequest -> {
+					Assertions.assertThat(serverRequest.hostAddress().getHostString())
+							.containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
+					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(port);
+					Assertions.assertThat(serverRequest.hostName()).isEqualTo("192.168.0.1");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(port);
 				});
 	}
@@ -384,6 +417,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.remoteAddress().getHostString()).isEqualTo("192.168.0.1");
 					Assertions.assertThat(serverRequest.hostAddress().getHostString())
 							.containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
+					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(8443);
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(8443);
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("a.example.com");
 					Assertions.assertThat(serverRequest.scheme()).isEqualTo("https");
@@ -391,6 +425,26 @@ class ConnectionInfoTests extends BaseHttpTest {
 				httpClient -> httpClient.secure(ssl -> ssl.sslContext(clientSslContext)),
 				httpServer -> httpServer.secure(ssl -> ssl.sslContext(serverSslContext)),
 				true);
+	}
+
+	@ParameterizedTest(name = "{displayName}({arguments})")
+	@ValueSource(strings = {"http", "https", "wss"})
+	void xForwardedProtoOnly(String protocol) {
+		int port = protocol.equals("https") || protocol.equals("wss") ? 443 : 80;
+
+		testClientRequest(
+				clientRequestHeaders -> {
+					clientRequestHeaders.add("Host", "a.example.com");
+					clientRequestHeaders.add("X-Forwarded-Proto", protocol);
+				},
+				serverRequest -> {
+					Assertions.assertThat(serverRequest.hostAddress().getHostString())
+							.containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
+					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(port);
+					Assertions.assertThat(serverRequest.hostName()).isEqualTo("a.example.com");
+					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(port);
+					Assertions.assertThat(serverRequest.scheme()).isEqualTo(protocol);
+				});
 	}
 
 	@Test


### PR DESCRIPTION
(This PR is created for testing purpose for the moment in the main branch for the #2771 issue. If reviewed successfully, maybe we can consider to push to 1.0.x branch, then merge into main. So for the moment, I have not set any milestone).

Motivation:
When resolving forwarded headers (X-Forwarded/Forwarded), the following scenario may happen in cloud foundry:

- you send an https request to a cloud foundry application, for example an actuator request: https://cloudfoundryapplication/actuator
- the front-end proxy forwards the request to a springboot application on non secure http 8080
- The request contains a `Host` header **without any port**, as well as a `X-Forwarded-Proto: **https**" header
- in this case, the `DefaultHttpForwardedHeaderHandler` class will wrongly resolves the host port as `80` instead of 443, because the request is received on a non-secure connection.
- And the json response then contains an unexpected 80 port appended in the actuator urls:

```
{"_links":{"self":{"href":"https://cloudfoundryapplication:80/actuator","templated":false},"health-path":{"href":"https://cloudfoundryapplication:80/actuator/health/{*path}","templated":true},"health": ...
````

Have also applied the similar patch for Forwarded headers (like `Forwarded: proto=https`).
Fixes #2771 