### PR TITLE
Server might not send GOAWAY when some streams are being processed

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
@@ -551,10 +551,12 @@ public abstract class ServerTransport<T extends ServerTransport<T, CONF>,
 					// For TCP and HTTP/1.1 the channel parent is the ServerChannel
 					boolean isParentServerChannel = parent instanceof ServerChannel;
 					List<Mono<Void>> monos =
-							MapUtils.computeIfAbsent(channelsToMono,
+							channelsToMono.compute(
 									isParentServerChannel ? channel : parent,
-									key -> {
-										List<Mono<Void>> list = new ArrayList<>();
+									(key, list) -> {
+										if (list == null) {
+											list = new ArrayList<>();
+										}
 										if (!isParentServerChannel) {
 											// In case of HTTP/2 Reactor Netty will send GO_AWAY with lastStreamId to notify the
 											// client to stop opening streams, the actual CLOSE will happen when all

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java
@@ -553,7 +553,7 @@ public abstract class ServerTransport<T extends ServerTransport<T, CONF>,
 					// For TCP and HTTP/1.1 the channel parent is the ServerChannel
 					boolean isParentServerChannel = parent instanceof ServerChannel;
 					if (isParentServerChannel) {
-						// We'll handle TCP or HTTP/1.1 channels after having handled HTTP2 stream chanels
+						// We'll handle TCP or HTTP/1.1 channels after having handled HTTP2 streams.
 						nonStreamChannels.add(channel);
 					}
 					else {
@@ -572,7 +572,7 @@ public abstract class ServerTransport<T extends ServerTransport<T, CONF>,
 					}
 				}
 
-				// Now all stream channels have been processed, we can check other channels (TCP or HTTP/1.1 channels)
+				// Now all stream channels have been processed, we can check other channels for TCP or HTTP/1.1
 				for (Channel channel : nonStreamChannels) {
 					List<Mono<Void>> monos = MapUtils.computeIfAbsent(channelsToMono, channel, key -> new ArrayList<>());
 					getRunningOperations(monos, channel);

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -86,6 +86,8 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
 import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
+import io.netty.handler.codec.http2.Http2GoAwayFrame;
+import io.netty.handler.codec.http2.Http2StreamChannel;
 import io.netty.handler.ssl.SniCompletionEvent;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.handler.ssl.SslContext;
@@ -1768,6 +1770,7 @@ class HttpServerTests extends BaseHttpTest {
 	private void doTestGracefulShutdown(HttpServer server, HttpClient client) throws Exception {
 		CountDownLatch latch1 = new CountDownLatch(2);
 		CountDownLatch latch2 = new CountDownLatch(2);
+		CountDownLatch latchGoAway = new CountDownLatch(2);
 		CountDownLatch latch3 = new CountDownLatch(1);
 		LoopResources loop = LoopResources.create("testGracefulShutdown");
 		group = new DefaultChannelGroup(executor);
@@ -1789,7 +1792,22 @@ class HttpServerTests extends BaseHttpTest {
 		AtomicReference<String> result = new AtomicReference<>();
 		Flux.just("/delay500", "/delay1000")
 		    .flatMap(s ->
-		            client.get()
+		            client
+				            .doOnConnected(conn -> conn.addHandlerLast(new ChannelInboundHandlerAdapter() {
+					            @Override
+					            public void channelRead(@NotNull ChannelHandlerContext ctx, @NotNull Object msg) {
+									if (msg instanceof Http2GoAwayFrame) {
+										latchGoAway.countDown();
+						            }
+									ctx.fireChannelRead(msg);
+					            }
+				            }))
+				            .doOnResponse((res, conn) -> {
+					            if (!(conn.channel() instanceof Http2StreamChannel)) {
+						            latchGoAway.countDown(); // we are not using neither H2C nore H2
+					            }
+				            })
+				          .get()
 		                  .uri(s)
 		                  .responseContent()
 		                  .aggregate()
@@ -1805,6 +1823,7 @@ class HttpServerTests extends BaseHttpTest {
 		// Stop accepting incoming requests, wait at most 3s for the active requests to finish
 		disposableServer.disposeNow();
 
+		assertThat(latchGoAway.await(30, TimeUnit.SECONDS)).as("2 GOAWAY should have been received").isTrue();
 		assertThat(latch2.await(30, TimeUnit.SECONDS)).isTrue();
 
 		// Dispose the event loop


### PR DESCRIPTION
Motivation:

Sometimes, when initiating a graceful shutdown on an HTTP2 server, it may happen that some connections are closed without sending GOAWAY.

This may (not always) happen under the following conditions:

- the server is configured with H2/HTTP11 or H2C/HTTP11
- some streams are currently being processed on the server
- at this point a graceful shutdown is initiated

Under these conditions, the `channelGroup` that is associated to the `HttpServer` contains both stream channel as well as their corresponding parent socket channels. So, when the graceful shutdown is initiated, the [ServerTransport.disposeNow(Duration)](https://github.com/reactor/reactor-netty/blob/1.0.x/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java#L549) method is iterating on all channels registered in the channel group.

Let's say we have one http connection, and one currently active stream with id=3, so in the channelGroup, we have something like:

```
0 = NioSocketChannel [id: 0xfce41a80, L:/xxx.xxx.xxx.xxx:58780 - R:/xxx.xxx.xxx.xxx:58782]
1 = Http2MultiplexHandler$Http2MultiplexHandlerStreamChannel [id: 0xfce41a80, L:/xxx.xxx.xxx.xxx:58780 - R:/xxx.xxx.xxx.xxx:58782](H2 - 3)
```

Now, assume that during the **first** iteration over the channelGroup, `disposeNow` first finds the first channel (the parent channel: `NioSocketChannel with id: 0xfce41a80` ), then this parent channel will be registered in the `channelsToMono` map (with an empty ArrayList).

Now, for the **second** iteration, `disposeNow` method is now getting the second channel (the stream channel: `Http2MultiplexHandler$Http2MultiplexHandlerStreamChannel with id: 0xfce41a80`. In this case the parent won't be inserted in the `channelsToMono`, because the parent has already been inserted during the first iteration.

So, during the second iteration, we won't close the stream [here](https://github.com/reactor/reactor-netty/blob/1.0.x/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java#L562). 

But the stream is being processed and there is a channel operation which is active so the current operation will be added to the list [here](https://github.com/reactor/reactor-netty/blob/1.0.x/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java#L568), and because of this the parent channel also won't be closed [here](https://github.com/reactor/reactor-netty/blob/1.0.x/reactor-netty-core/src/main/java/reactor/netty/transport/ServerTransport.java#L578), and the socket will be closed when the JVM exits without having sent a GOAWAY message.

This PR first modifies the existing  `doTestGracefulShutdown` in HttpServerTests, and the method is now checking that GOAWAY are received by the client. But since map iterator ordering can vary, this test may still succeed even without any patch.

Then the PR is doing a patch in the ServerTransport.disposeNow method in order to sort the channelGroup so we first handle Stream channels before handling parent ServerChannel.

Side note: when the server is configured only with H2 or with H2C, then only the stream channels (Http2MultiplexHandlerStreamChannel) are registered in the channelGroup, and the corresponding parent channels are not registered, so we don't have the problem.
However, it may be a problem to not have the parent channels registered, because in this case, if no active streams are currently being processed, then no GOAWAY message will be sent at all, which may be a problem, because if I'm correct we should always send a GOAWAY. But this is another use case, which might be addressed in another PR, if necessary.

Related to #2735