### PR TITLE
Depend on `Netty` `v4.1.92.Final`

### DIFF
--- a/.github/workflows/check_netty_snapshots.yml
+++ b/.github/workflows/check_netty_snapshots.yml
@@ -29,4 +29,4 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
       - name: Build with Gradle
-        run: ./gradlew clean check --no-daemon -PforceTransport=${{ matrix.transport }} -PforceNettyVersion='4.1.92.Final-SNAPSHOT'
+        run: ./gradlew clean check --no-daemon -PforceTransport=${{ matrix.transport }} -PforceNettyVersion='4.1.93.Final-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ ext {
 	logbackVersion = '1.2.12'
 
 	// Netty
-	nettyDefaultVersion = '4.1.91.Final'
+	nettyDefaultVersion = '4.1.92.Final'
 	if (!project.hasProperty("forceNettyVersion")) {
 		nettyVersion = nettyDefaultVersion
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/Http2ConnectionInfoTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/Http2ConnectionInfoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package reactor.netty.http.server;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.junit.jupiter.api.Disabled;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.client.HttpClient;
 
@@ -53,5 +54,24 @@ class Http2ConnectionInfoTests extends ConnectionInfoTests {
 		catch (SSLException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	@Override
+	@Disabled
+	void forwardedHostEmptyHostHeader() {
+		// HTTP/2 does not allow ':authority' to be empty
+		// https://datatracker.ietf.org/doc/html/rfc9113#section-8.3.1
+	}
+
+	@Override
+	void noHeadersEmptyHostHeader() {
+		// HTTP/2 does not allow ':authority' to be empty
+		// https://datatracker.ietf.org/doc/html/rfc9113#section-8.3.1
+	}
+
+	@Override
+	void xForwardedHostEmptyHostHeader() {
+		// HTTP/2 does not allow ':authority' to be empty
+		// https://datatracker.ietf.org/doc/html/rfc9113#section-8.3.1
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1876,8 +1876,8 @@ class HttpServerTests extends BaseHttpTest {
 				      .wiretap(true)
 				      .handle((req, res) -> {
 				          req.withConnection(conn -> {
-				              assertThat(conn.channel().localAddress()).isNull();
-				              assertThat(conn.channel().remoteAddress()).isNull();
+				              assertThat(conn.channel().localAddress()).isNotNull();
+				              assertThat(conn.channel().remoteAddress()).isNotNull();
 				              assertThat(req.hostAddress()).isNull();
 				              assertThat(req.remoteAddress()).isNull();
 				              assertThat(req.scheme()).isNotNull().isEqualTo(expectedScheme);


### PR DESCRIPTION
- Exclude tests in `Http2ConnectionInforTests` with `HOST` header empty
https://github.com/netty/netty/pull/13238
- Fix unix domain socket tests in `HttpServerTests` as local and remote addresses are now available 
https://github.com/netty/netty/pull/13323