### PR TITLE
responseContent() remove excess ByteBufFlux conversion

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
@@ -105,15 +105,9 @@ final class HttpClientFinalizer extends HttpClientConnect implements HttpClient.
 
 	@Override
 	public ByteBufFlux responseContent() {
-		ByteBufAllocator alloc = (ByteBufAllocator) configuration().options()
-		                                                           .get(ChannelOption.ALLOCATOR);
-		if (alloc == null) {
-			alloc = ByteBufAllocator.DEFAULT;
-		}
-
 		@SuppressWarnings("unchecked")
 		Mono<ChannelOperations<?, ?>> connector = (Mono<ChannelOperations<?, ?>>) connect();
-		return ByteBufFlux.fromInbound(connector.flatMapMany(contentReceiver), alloc);
+		return connector.flatMapMany(ChannelOperations::receiveObject);
 	}
 
 	@Override
@@ -164,8 +158,6 @@ final class HttpClientFinalizer extends HttpClientConnect implements HttpClient.
 			c.discard();
 		}
 	}
-
-	static final Function<ChannelOperations<?, ?>, Publisher<ByteBuf>> contentReceiver = ChannelOperations::receive;
 
 	static final Function<HttpClientOperations, HttpClientResponse> RESPONSE_ONLY = ops -> {
 		//defer the dispose to avoid over disposing on receive

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
@@ -105,9 +105,15 @@ final class HttpClientFinalizer extends HttpClientConnect implements HttpClient.
 
 	@Override
 	public ByteBufFlux responseContent() {
+		ByteBufAllocator alloc = (ByteBufAllocator) configuration().options()
+				.get(ChannelOption.ALLOCATOR);
+		if (alloc == null) {
+			alloc = ByteBufAllocator.DEFAULT;
+		}
+
 		@SuppressWarnings("unchecked")
 		Mono<ChannelOperations<?, ?>> connector = (Mono<ChannelOperations<?, ?>>) connect();
-		return connector.flatMapMany(ChannelOperations::receiveObject);
+		return ByteBufFlux.fromInbound(connector.flatMapMany(ChannelOperations::receiveObject), alloc);
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
@@ -113,7 +113,7 @@ final class HttpClientFinalizer extends HttpClientConnect implements HttpClient.
 
 		@SuppressWarnings("unchecked")
 		Mono<ChannelOperations<?, ?>> connector = (Mono<ChannelOperations<?, ?>>) connect();
-		return ByteBufFlux.fromInbound(connector.flatMapMany(ChannelOperations::receiveObject), alloc);
+		return ByteBufFlux.fromInbound(connector.flatMapMany(contentReceiver), alloc);
 	}
 
 	@Override
@@ -164,6 +164,8 @@ final class HttpClientFinalizer extends HttpClientConnect implements HttpClient.
 			c.discard();
 		}
 	}
+
+	static final Function<ChannelOperations<?, ?>, Flux<?>> contentReceiver = ChannelOperations::receiveObject;
 
 	static final Function<HttpClientOperations, HttpClientResponse> RESPONSE_ONLY = ops -> {
 		//defer the dispose to avoid over disposing on receive

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientFinalizer.java
@@ -106,7 +106,7 @@ final class HttpClientFinalizer extends HttpClientConnect implements HttpClient.
 	@Override
 	public ByteBufFlux responseContent() {
 		ByteBufAllocator alloc = (ByteBufAllocator) configuration().options()
-				.get(ChannelOption.ALLOCATOR);
+		                                                           .get(ChannelOption.ALLOCATOR);
 		if (alloc == null) {
 			alloc = ByteBufAllocator.DEFAULT;
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
@@ -31,6 +31,8 @@ import reactor.netty.channel.ChannelOperations;
 import reactor.netty.http.websocket.WebsocketInbound;
 import reactor.netty.http.websocket.WebsocketOutbound;
 
+import static reactor.netty.http.client.HttpClientFinalizer.contentReceiver;
+
 /**
  * Configures the Websocket request before calling one of the terminal,
  * {@link Publisher} based, {@link WebsocketReceiver} API.
@@ -114,7 +116,7 @@ final class WebsocketFinalizer extends HttpClientConnect implements HttpClient.W
 
 		@SuppressWarnings("unchecked")
 		Mono<ChannelOperations<?, ?>> connector = (Mono<ChannelOperations<?, ?>>) connect();
-		return ByteBufFlux.fromInbound(connector.flatMapMany(ChannelOperations::receiveObject), alloc);
+		return ByteBufFlux.fromInbound(connector.flatMapMany(contentReceiver), alloc);
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
@@ -107,7 +107,7 @@ final class WebsocketFinalizer extends HttpClientConnect implements HttpClient.W
 	@Override
 	public ByteBufFlux receive() {
 		ByteBufAllocator alloc = (ByteBufAllocator) configuration().options()
-				.get(ChannelOption.ALLOCATOR);
+		                                                           .get(ChannelOption.ALLOCATOR);
 		if (alloc == null) {
 			alloc = ByteBufAllocator.DEFAULT;
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
@@ -108,15 +108,9 @@ final class WebsocketFinalizer extends HttpClientConnect implements HttpClient.W
 
 	@Override
 	public ByteBufFlux receive() {
-		ByteBufAllocator alloc = (ByteBufAllocator) configuration().options()
-		                                                           .get(ChannelOption.ALLOCATOR);
-		if (alloc == null) {
-			alloc = ByteBufAllocator.DEFAULT;
-		}
-
 		@SuppressWarnings("unchecked")
 		Mono<ChannelOperations<?, ?>> connector = (Mono<ChannelOperations<?, ?>>) connect();
-		return ByteBufFlux.fromInbound(connector.flatMapMany(contentReceiver), alloc);
+		return connector.flatMapMany(ChannelOperations::receiveObject);
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/WebsocketFinalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
When I looked at the implementation of the class **HttpClientFinalizer** code, I found that the logic of the **responseContent** method was a bit strange. HttpClientFinalizer.contentReceiver represents **ChannelOperations::receive**, while ChannelOperations::receive internal implementation has already made a call to **ByteBufFlux.fromInbound** to return a **ByteBufFlux**, and a call and encapsulation of ByteBufFlux.fromInbound has also been made in the responseContent method, This is actually unnecessary, so you can directly refer to the internal implementation of ChannelOperations::receive in the responseContent method to generate ByteBufFlux, which will result in better performance and clearer logic. Similarly, there are similar issues with **WebsocketFinalizer:responseContent**, which is why this PR.