### PR TITLE
Adapt `SslProviderTests` to a change in `Netty` `SNAPSHOT`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -254,6 +254,7 @@ subprojects {
 		if (project.hasProperty("forceTransport")) {
 			systemProperty("forceTransport", forceTransport)
 		}
+		systemProperty("nettyVersionMicro", VersionNumber.parse(nettyVersion.toString()).micro)
 		scanForTestClasses = false
 		include '**/*Tests.*'
 		include '**/*Test.*'

--- a/reactor-netty-http/src/test/java/reactor/netty/tcp/SslProviderTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/tcp/SslProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -394,7 +394,14 @@ class SslProviderTests extends BaseHttpTest {
 
 		final OpenSslSessionContext sessionContext = clientContext.sessionContext();
 		assertThat(sessionContext.getSessionTimeout()).isEqualTo(300);
-		assertThat(sessionContext.isSessionCacheEnabled()).isFalse();
+		String nettyVersionMicro = System.getProperty("nettyVersionMicro");
+		// https://github.com/netty/netty/pull/13562
+		// This change enables client side session cache when using native SSL by default
+		if (nettyVersionMicro != null && !nettyVersionMicro.isEmpty() && Integer.parseInt(nettyVersionMicro) >= 98) {
+			assertThat(sessionContext.isSessionCacheEnabled()).isTrue();
+		} else {
+			assertThat(sessionContext.isSessionCacheEnabled()).isFalse();
+		}
 	}
 
 	@Test


### PR DESCRIPTION
https://github.com/netty/netty/pull/13562
This change enables client side session cache when using native SSL by default

The current CI build with Netty SNAPSHOT fails
https://github.com/reactor/reactor-netty/actions/runs/6025947526