### PR TITLE
Add nightly build with `Reactor Core` `3.6 SNAPSHOTs`

### DIFF
--- a/.github/workflows/check_reactor_core_3.6_snapshots.yml
+++ b/.github/workflows/check_reactor_core_3.6_snapshots.yml
@@ -1,0 +1,20 @@
+name: Check Reactor Core 3.6 SNAPSHOTS
+
+on:
+  schedule:
+    - cron: "0 14 * * *"
+permissions: read-all
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: Build with Gradle
+        run: ./gradlew clean check --no-daemon -PreactorCoreVersion='3.6.0-SNAPSHOT'


### PR DESCRIPTION
`Reactor Netty 1.1.x` is included in `Reactor BOMs` `2022.0.x` and `2023.0.x`
thus we need to guarantee that `Reactor Netty` works properly
with `Reactor Core 3.5.x` and `Reactor Core 3.6.x`