### PR TITLE
Ensure `HttpClient#mapConnect() / #doOnRequestError()` are called when `HttpClient#headersWhen()` is used

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -110,7 +110,7 @@ class HttpClientConnect extends HttpClient {
 
 		Mono<? extends Connection> mono;
 		if (config.deferredConf != null) {
-			return config.deferredConf.apply(Mono.just(config))
+			mono = config.deferredConf.apply(Mono.just(config))
 			           .flatMap(MonoHttpConnect::new);
 		}
 		else {


### PR DESCRIPTION
Fixes #2904