### PR TITLE
Add root cause exception when throwing PrematureCloseException

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
@@ -248,6 +248,8 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 			if (log.isDebugEnabled()) {
 				log.debug(format(channel(), "An outbound error could not be processed"), t);
 			}
+			// Let any child class process the outbound error which has not been processed
+			onUnprocessedOutboundError(t);
 			return;
 		}
 		OUTBOUND_CLOSE.set(this, Operators.cancelledSubscription());
@@ -563,6 +565,14 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 	 * @since 1.0.37
 	 */
 	protected void onWritabilityChanged() {
+	}
+
+	/**
+	 * React on an unprocessed outbound error.
+	 *
+	 * @since 1.0.39
+	 */
+	protected void onUnprocessedOutboundError(Throwable t) {
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -122,7 +122,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 	Consumer<HttpClientRequest> redirectRequestConsumer;
 	HttpHeaders previousRequestHeaders;
 	BiConsumer<HttpHeaders, HttpClientRequest> redirectRequestBiConsumer;
-	Throwable unprocessedOutboundError;
+	volatile Throwable unprocessedOutboundError;
 
 	final static String INBOUND_CANCEL_LOG = "Http client inbound receiver cancelled, closing channel.";
 
@@ -879,7 +879,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 		}
 	}
 
-	final Throwable addOutboundErrorCause(Throwable exception, Throwable cause) {
+	static Throwable addOutboundErrorCause(Throwable exception, @Nullable Throwable cause) {
 		if (cause != null) {
 			cause.setStackTrace(new StackTraceElement[0]);
 			exception.initCause(cause);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -147,6 +147,10 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 		this.responseTimeout = replaced.responseTimeout;
 		this.is100Continue = replaced.is100Continue;
 		this.trailerHeaders = replaced.trailerHeaders;
+		// No need to copy the unprocessedOutboundError field from the replaced instance. The reason for this is that the
+		// "unprocessedOutboundError" field contains an error that occurs when the connection of the HttpClientOperations
+		// is already closed. In essence, this error represents the final state for the HttpClientOperations, and there's
+		// no need to carry it over because it's considered as a terminal/concluding state.
 	}
 
 	HttpClientOperations(Connection c, ConnectionObserver listener, ClientCookieEncoder encoder,


### PR DESCRIPTION
Reactor Netty’s HttpClient relies on Netty’s Http2FrameCodecBuilder. This codec, by default, **enforces** the MAX_HEADER_LIST_SIZE found in the SETTINGS sent by the server, meaning that If a request’s header list size exceeds the SETTINGS MAX_HEADER_LIST_SIZE limit, then HpackEncoder throws a **HeaderListSizeException**. Consequently, the request **is not sent**, and the client receives a PrematureCloseException error without any details.

Let's just add more specific root cause to the PrematureCloseException in order to make it meaningful in the case the request header size exceeds MAX_HEADER_LIST_SIZE (or if whatever Netty Http2 Codec exceptions are caught while writing the request out).

Example:

```
reactor.netty.http.client.PrematureCloseException: Connection prematurely closed BEFORE response
Caused by: io.netty.handler.codec.http2.Http2Exception$HeaderListSizeException: Header size exceeded max allowed size (1024)
```

Fixes #2927
