### PR TITLE
Fix for https://github.com/reactor/reactor-netty/issues/2959

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/AbortedException.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/AbortedException.java
@@ -49,10 +49,10 @@ public class AbortedException extends RuntimeException {
 		                                       err.getMessage()
 		                                          .contains("Broken pipe") ||
 		                                       err.getMessage()
-		                                          .contains("Connection reset by peer"))) ||
+		                                          .contains("Connection reset"))) ||
 		       (err instanceof SocketException && err.getMessage() != null &&
 		                                          err.getMessage()
-		                                             .contains("Connection reset by peer"));
+		                                             .contains("Connection reset"));
 	}
 
 	public static AbortedException beforeSend() {


### PR DESCRIPTION
reactor.netty.channel.AbortedException

public static boolean isConnectionReset(Throwable err) {
return err instanceof AbortedException && "Connection has been closed BEFORE send operation".equals(err.getMessage()) || err instanceof IOException && (err.getMessage() == null || err.getMessage().contains("Broken pipe") || err.getMessage().contains("Connection reset by peer")) || err instanceof SocketException && err.getMessage() != null && err.getMessage().contains("Connection reset by peer");
}

Currently for Connection Reset issue, the error message is "Connection reset" instead of "Connection reset by peer".