### PR TITLE
Experiment Concurrent Pools in HTTP/2 Connection Pool

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
@@ -204,6 +204,10 @@ public class Metrics {
 	 */
 	public static final String PENDING_STREAMS = ".pending.streams";
 
+	/**
+	 * The number of HTTP/2 stream acquisitions steal count.
+	 */
+	public static final String STEAL_STREAMS = ".steal.streams";
 
 	// ByteBufAllocator Metrics
 	/**

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -528,6 +528,20 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 		}
 
 		public InstrumentedPool<T> newPool(
+		        PoolBuilder<T, PoolConfig<T>> poolBuilder,
+				int maxConnections,
+				@Nullable AllocationStrategy<?> allocationStrategy,
+				Function<T, Publisher<Void>> destroyHandler,
+				BiPredicate<T, PooledRefMetadata> defaultEvictionPredicate,
+				Function<PoolConfig<T>, InstrumentedPool<T>> poolFactory) {
+			if (disposeTimeout != null) {
+				return newPoolInternal(poolBuilder, maxConnections, allocationStrategy, destroyHandler, defaultEvictionPredicate, null)
+					.build(poolFactory.andThen(InstrumentedPoolDecorators::gracefulShutdown));
+			}
+			return newPoolInternal(poolBuilder, maxConnections, allocationStrategy, destroyHandler, defaultEvictionPredicate, null).build(poolFactory);
+		}
+
+		public InstrumentedPool<T> newPool(
 				Publisher<T> allocator,
 				Function<T, Publisher<Void>> destroyHandler,
 				BiPredicate<T, PooledRefMetadata> defaultEvictionPredicate,
@@ -538,6 +552,21 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 						.build(poolFactory.andThen(InstrumentedPoolDecorators::gracefulShutdown));
 			}
 			return newPoolInternal(allocator, destroyHandler, defaultEvictionPredicate, poolMetricsRecorder).build(poolFactory);
+		}
+
+		public InstrumentedPool<T> newPool(
+				PoolBuilder<T, PoolConfig<T>> poolBuilder,
+				int maxConnections,
+				@Nullable AllocationStrategy<?> allocationStrategy,
+				Function<T, Publisher<Void>> destroyHandler,
+				BiPredicate<T, PooledRefMetadata> defaultEvictionPredicate,
+				PoolMetricsRecorder poolMetricsRecorder,
+				Function<PoolConfig<T>, InstrumentedPool<T>> poolFactory) {
+			if (disposeTimeout != null) {
+				return newPoolInternal(poolBuilder, maxConnections, allocationStrategy, destroyHandler, defaultEvictionPredicate, poolMetricsRecorder)
+						.build(poolFactory.andThen(InstrumentedPoolDecorators::gracefulShutdown));
+			}
+			return newPoolInternal(poolBuilder, maxConnections, allocationStrategy, destroyHandler, defaultEvictionPredicate, poolMetricsRecorder).build(poolFactory);
 		}
 
 		PoolBuilder<T, PoolConfig<T>> newPoolInternal(
@@ -552,11 +581,22 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 				Function<T, Publisher<Void>> destroyHandler,
 				BiPredicate<T, PooledRefMetadata> defaultEvictionPredicate,
 				@Nullable PoolMetricsRecorder poolMetricsRecorder) {
-			PoolBuilder<T, PoolConfig<T>> poolBuilder =
-					PoolBuilder.from(allocator)
-					           .destroyHandler(destroyHandler)
-					           .maxPendingAcquire(pendingAcquireMaxCount)
-					           .evictInBackground(evictionInterval);
+			return newPoolInternal(PoolBuilder.from(allocator), -1, null, destroyHandler, defaultEvictionPredicate, poolMetricsRecorder);
+		}
+
+		PoolBuilder<T, PoolConfig<T>> newPoolInternal(
+				PoolBuilder<T, PoolConfig<T>> poolBuilder,
+				int maxConnections,
+				@Nullable AllocationStrategy<?> allocationStrategy,
+				Function<T, Publisher<Void>> destroyHandler,
+				BiPredicate<T, PooledRefMetadata> defaultEvictionPredicate,
+				@Nullable PoolMetricsRecorder poolMetricsRecorder) {
+			maxConnections = (maxConnections == -1) ? this.maxConnections : maxConnections;
+			allocationStrategy = (allocationStrategy == null) ? this.allocationStrategy : allocationStrategy;
+			poolBuilder = poolBuilder
+							.destroyHandler(destroyHandler)
+							.maxPendingAcquire(pendingAcquireMaxCount)
+							.evictInBackground(evictionInterval);
 
 			if (this.evictionPredicate != null) {
 				poolBuilder = poolBuilder.evictionPredicate(

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProviderMeters.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProviderMeters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,26 @@ enum Http2ConnectionProviderMeters implements MeterDocumentation {
 		@Override
 		public Meter.Type getType() {
 			return Meter.Type.GAUGE;
+		}
+	},
+
+	/**
+	 * The number of HTTP/2 stream acquisition steal count.
+	 */
+	STEAL_STREAMS {
+		@Override
+		public String getName() {
+			return "reactor.netty.connection.provider.steal.streams";
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return Http2ConnectionProviderMetersTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.COUNTER;
 		}
 	},
 


### PR DESCRIPTION
This draft PR experiments the concurrent pools feature (work in progress) from https://github.com/reactor/reactor-pool/pull/179 applied to Reactor Netty HTTP/2 Connection Pool.

For the moment, `workStealing` mode can only be configured for HTTP/2 HttpClient via a new `enableWorkStealing` method added in Http2AllocationStrategy interface.

So, basically, when an HttpClient is configured with work stealing mode, sub pools (Http2Pool instances) will be created and assigned to each HttpClient's Event Loops, and HTTP2 Connection acquisition tasks will be distributed across all sub pools.

This [benchmarks](https://github.com/pderop/reactor-netty-httpclient-benchmarks) projects can be used to experiment the new client. See the README for the details.

This work is still in progress. Ideally, this PR could be merged into a temporary reactor-netty branch for easier finalization. To be confirmed by the Reactor Netty team.