### PR TITLE
Do not forward the last inbound data frame when it is empty

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -752,7 +752,9 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 				log.debug(format(channel(), "Received last HTTP packet"));
 			}
 			if (msg != LastHttpContent.EMPTY_LAST_CONTENT) {
-				if (redirecting != null) {
+				// When there is HTTP/2 response with INBOUND HEADERS(endStream=false) followed by INBOUND DATA(endStream=true length=0),
+				// Netty sends LastHttpContent with empty buffer instead of EMPTY_LAST_CONTENT
+				if (redirecting != null || ((LastHttpContent) msg).content().readableBytes() == 0) {
 					ReferenceCountUtil.release(msg);
 				}
 				else {


### PR DESCRIPTION
There is no need to forward an empty buffer to the response consumers, directly invoke complete.

Related to https://github.com/spring-projects/spring-framework/issues/31810