### PR TITLE
Ensure `ChannelHandlerContext.isRemoved` is called only when in event loop

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -991,7 +991,8 @@ final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.
 		@Nullable
 		ChannelHandlerContext http2FrameCodecCtx() {
 			ChannelHandlerContext ctx = http2FrameCodecCtx;
-			if (ctx != null && !ctx.isRemoved()) {
+			// ChannelHandlerContext.isRemoved is only meant to be called from within the EventLoop
+			if (ctx != null && connection.channel().eventLoop().inEventLoop() && !ctx.isRemoved()) {
 				return ctx;
 			}
 			ctx = connection.channel().pipeline().context(Http2FrameCodec.class);
@@ -1002,7 +1003,8 @@ final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.
 		@Nullable
 		ChannelHandlerContext http2MultiplexHandlerCtx() {
 			ChannelHandlerContext ctx = http2MultiplexHandlerCtx;
-			if (ctx != null && !ctx.isRemoved()) {
+			// ChannelHandlerContext.isRemoved is only meant to be called from within the EventLoop
+			if (ctx != null && connection.channel().eventLoop().inEventLoop() && !ctx.isRemoved()) {
 				return ctx;
 			}
 			ctx = connection.channel().pipeline().context(Http2MultiplexHandler.class);
@@ -1013,7 +1015,8 @@ final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.
 		@Nullable
 		ChannelHandlerContext h2cUpgradeHandlerCtx() {
 			ChannelHandlerContext ctx = h2cUpgradeHandlerCtx;
-			if (ctx != null && !ctx.isRemoved()) {
+			// ChannelHandlerContext.isRemoved is only meant to be called from within the EventLoop
+			if (ctx != null && connection.channel().eventLoop().inEventLoop() && !ctx.isRemoved()) {
 				return ctx;
 			}
 			ctx = connection.channel().pipeline().context(NettyPipeline.H2CUpgradeHandler);


### PR DESCRIPTION
Related to #2981