### PR TITLE
Enable `DNS` `retryOnTimeout` with `TCP`

### DIFF
--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -564,6 +564,8 @@ Default: -1 (to determine the value from the OS on Unix or use a value of 1 othe
 | `queryTimeout` | Sets the timeout of each DNS query performed by this resolver (resolution: milliseconds). Default: 5000.
 | `resolveCache` | The cache to use to store resolved DNS entries.
 | `resolvedAddressTypes` | The list of the protocol families of the resolved address.
+| `retryTcpOnTimeout` | Specifies whether this resolver will also fallback to TCP if a timeout is detected.
+By default, the resolver will only try to use TCP if the response is marked as truncated.
 | `roundRobinSelection` | Enables an
 {nettyjavadoc}/io/netty/resolver/AddressResolverGroup.html[`AddressResolverGroup`] of
 {nettyjavadoc}/io/netty/resolver/dns/DnsNameResolver.html[`DnsNameResolver`] that supports random selection

--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -418,6 +418,8 @@ Default: {nettyjavadoc}/io/netty/resolver/DefaultHostsFileEntriesResolver.html[`
 | `queryTimeout` | Sets the timeout of each DNS query performed by this resolver (resolution: milliseconds). Default: 5000.
 | `resolveCache` | The cache to use to store resolved DNS entries.
 | `resolvedAddressTypes` | The list of the protocol families of the resolved address.
+| `retryTcpOnTimeout` | Specifies whether this resolver will also fallback to TCP if a timeout is detected.
+By default, the resolver will only try to use TCP if the response is marked as truncated.
 | `roundRobinSelection` | Enables an
  {nettyjavadoc}/io/netty/resolver/AddressResolverGroup.html[`AddressResolverGroup`] of
  {nettyjavadoc}/io/netty/resolver/dns/DnsNameResolver.html[`DnsNameResolver`] that supports random selection

--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -240,6 +240,8 @@ task japicmp(type: JapicmpTask) {
 	compatibilityChangeExcludes = [ "METHOD_NEW_DEFAULT" ]
 
 	methodExcludes = [
+			'reactor.netty.transport.NameResolverProvider#retryTcpOnTimeout()',
+			'reactor.netty.transport.NameResolverProvider$NameResolverSpec#retryTcpOnTimeout(boolean)'
 	]
 }
 

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/NameResolverProviderTest.java
@@ -274,6 +274,14 @@ class NameResolverProviderTest {
 	}
 
 	@Test
+	void retryTcpOnTimeout() {
+		assertThat(builder.build().isRetryTcpOnTimeout()).isFalse();
+
+		builder.retryTcpOnTimeout(true);
+		assertThat(builder.build().isRetryTcpOnTimeout()).isTrue();
+	}
+
+	@Test
 	void roundRobinSelection() {
 		assertThat(builder.build().isRoundRobinSelection()).isFalse();
 


### PR DESCRIPTION
Add an API for configuring the resolver to fallback to `TCP` if a timeout is detected. By default, the resolver will only try to use `TCP` if the response is marked as truncated.

Fixes #3059