### PR TITLE
Ensure `remoteAddress` metrics tag is always the real remote address regardless whether there is proxy

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
@@ -51,7 +51,7 @@ public class ChannelMetricsHandler extends AbstractChannelMetricsHandler {
 
 	@Override
 	public ChannelHandler tlsMetricsHandler() {
-		return new TlsMetricsHandler(recorder);
+		return new TlsMetricsHandler(recorder, remoteAddress);
 	}
 
 	@Override
@@ -86,11 +86,13 @@ public class ChannelMetricsHandler extends AbstractChannelMetricsHandler {
 	static class TlsMetricsHandler extends ChannelInboundHandlerAdapter {
 
 		protected final ChannelMetricsRecorder recorder;
+		protected final SocketAddress remoteAddress;
 
 		boolean listenerAdded;
 
-		TlsMetricsHandler(ChannelMetricsRecorder recorder) {
+		TlsMetricsHandler(ChannelMetricsRecorder recorder, @Nullable SocketAddress remoteAddress) {
 			this.recorder = recorder;
+			this.remoteAddress = remoteAddress;
 		}
 
 		@Override
@@ -109,7 +111,7 @@ public class ChannelMetricsHandler extends AbstractChannelMetricsHandler {
 
 		protected void recordTlsHandshakeTime(ChannelHandlerContext ctx, long tlsHandshakeTimeStart, String status) {
 			recorder.recordTlsHandshakeTime(
-					ctx.channel().remoteAddress(),
+					remoteAddress != null ? remoteAddress : ctx.channel().remoteAddress(),
 					Duration.ofNanos(System.nanoTime() - tlsHandshakeTimeStart),
 					status);
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ContextAwareChannelMetricsHandler.java
@@ -53,7 +53,7 @@ final class ContextAwareChannelMetricsHandler extends AbstractChannelMetricsHand
 
 	@Override
 	public ChannelHandler tlsMetricsHandler() {
-		return new TlsMetricsHandler(recorder);
+		return new TlsMetricsHandler(recorder, remoteAddress);
 	}
 
 	@Override
@@ -134,8 +134,8 @@ final class ContextAwareChannelMetricsHandler extends AbstractChannelMetricsHand
 
 	static final class TlsMetricsHandler extends ChannelMetricsHandler.TlsMetricsHandler {
 
-		TlsMetricsHandler(ContextAwareChannelMetricsRecorder recorder) {
-			super(recorder);
+		TlsMetricsHandler(ContextAwareChannelMetricsRecorder recorder, @Nullable SocketAddress remoteAddress) {
+			super(recorder, remoteAddress);
 		}
 
 		@Override
@@ -144,7 +144,7 @@ final class ContextAwareChannelMetricsHandler extends AbstractChannelMetricsHand
 			if (connection instanceof ConnectionObserver) {
 				((ContextAwareChannelMetricsRecorder) recorder).recordTlsHandshakeTime(
 						((ConnectionObserver) connection).currentContext(),
-						ctx.channel().remoteAddress(),
+						remoteAddress != null ? remoteAddress : ctx.channel().remoteAddress(),
 						Duration.ofNanos(System.nanoTime() - tlsHandshakeTimeStart),
 						status);
 			}

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -168,7 +168,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 				mono = mono.contextWrite(ctx -> ctx.put(CONTEXT_CALLER_EVENTLOOP, eventLoop));
 			}
 			mono.subscribe(createDisposableAcquire(config, connectionObserver,
-					poolFactory.pendingAcquireTimeout, pool, sink));
+					poolFactory.pendingAcquireTimeout, pool, remoteAddress, sink));
 		});
 	}
 
@@ -285,6 +285,16 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 			long pendingAcquireTimeout,
 			InstrumentedPool<T> pool,
 			MonoSink<Connection> sink);
+
+	protected CoreSubscriber<PooledRef<T>> createDisposableAcquire(
+			TransportConfig config,
+			ConnectionObserver connectionObserver,
+			long pendingAcquireTimeout,
+			InstrumentedPool<T> pool,
+			SocketAddress remoteAddress,
+			MonoSink<Connection> sink) {
+		return createDisposableAcquire(config, connectionObserver, pendingAcquireTimeout, pool, sink);
+	}
 
 	protected abstract InstrumentedPool<T> createPool(
 			TransportConfig config,

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/ContextAwareHttpClientMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,9 @@ final class ContextAwareHttpClientMetricsHandler extends AbstractHttpClientMetri
 	final ContextAwareHttpClientMetricsRecorder recorder;
 
 	ContextAwareHttpClientMetricsHandler(ContextAwareHttpClientMetricsRecorder recorder,
+			SocketAddress remoteAddress,
 			@Nullable Function<String, String> uriTagValue) {
-		super(uriTagValue);
+		super(remoteAddress, uriTagValue);
 		this.recorder = recorder;
 	}
 
@@ -52,7 +53,7 @@ final class ContextAwareHttpClientMetricsHandler extends AbstractHttpClientMetri
 	@Override
 	protected void recordException(ChannelHandlerContext ctx) {
 		if (contextView != null) {
-			recorder().incrementErrorsCount(contextView, ctx.channel().remoteAddress(), path);
+			recorder().incrementErrorsCount(contextView, remoteAddress, path);
 		}
 		else {
 			super.recordException(ctx);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -533,6 +533,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			ChannelOperations.OnSetup opsFactory,
 			boolean acceptGzip,
 			@Nullable ChannelMetricsRecorder metricsRecorder,
+			SocketAddress remoteAddress,
 			long responseTimeoutMillis,
 			@Nullable Function<String, String> uriTagValue) {
 
@@ -564,8 +565,8 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 				}
 				else {
 					handler = metricsRecorder instanceof ContextAwareHttpClientMetricsRecorder ?
-							new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) metricsRecorder, uriTagValue) :
-							new HttpClientMetricsHandler((HttpClientMetricsRecorder) metricsRecorder, uriTagValue);
+							new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) metricsRecorder, remoteAddress, uriTagValue) :
+							new HttpClientMetricsHandler((HttpClientMetricsRecorder) metricsRecorder, remoteAddress, uriTagValue);
 				}
 				pipeline.addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.HttpMetricsHandler, handler);
 			}
@@ -612,6 +613,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			@Nullable ChannelMetricsRecorder metricsRecorder,
 			ConnectionObserver observer,
 			ChannelOperations.OnSetup opsFactory,
+			SocketAddress remoteAddress,
 			@Nullable Function<String, String> uriTagValue) {
 		HttpClientCodec httpClientCodec =
 				new HttpClientCodec(
@@ -637,7 +639,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		Http2FrameCodec http2FrameCodec = http2FrameCodecBuilder.build();
 
 		Http2ClientUpgradeCodec upgradeCodec = new Http2ClientUpgradeCodec(http2FrameCodec,
-				new H2CleartextCodec(http2FrameCodec, opsFactory, acceptGzip, metricsRecorder, uriTagValue));
+				new H2CleartextCodec(http2FrameCodec, opsFactory, acceptGzip, metricsRecorder, remoteAddress, uriTagValue));
 
 		HttpClientUpgradeHandler upgradeHandler =
 				new ReactorNettyHttpClientUpgradeHandler(httpClientCodec, upgradeCodec, decoder.h2cMaxContentLength());
@@ -653,8 +655,8 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		if (metricsRecorder != null) {
 			if (metricsRecorder instanceof HttpClientMetricsRecorder) {
 				ChannelHandler handler = metricsRecorder instanceof ContextAwareHttpClientMetricsRecorder ?
-						new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) metricsRecorder, uriTagValue) :
-						new HttpClientMetricsHandler((HttpClientMetricsRecorder) metricsRecorder, uriTagValue);
+						new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) metricsRecorder, remoteAddress, uriTagValue) :
+						new HttpClientMetricsHandler((HttpClientMetricsRecorder) metricsRecorder, remoteAddress, uriTagValue);
 				p.addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.HttpMetricsHandler, handler);
 			}
 		}
@@ -665,6 +667,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			boolean acceptGzip,
 			HttpResponseDecoderSpec decoder,
 			@Nullable ChannelMetricsRecorder metricsRecorder,
+			SocketAddress remoteAddress,
 			@Nullable Function<String, String> uriTagValue) {
 		p.addBefore(NettyPipeline.ReactiveBridge,
 				NettyPipeline.HttpCodec,
@@ -685,8 +688,8 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		if (metricsRecorder != null) {
 			if (metricsRecorder instanceof HttpClientMetricsRecorder) {
 				ChannelHandler handler = metricsRecorder instanceof ContextAwareHttpClientMetricsRecorder ?
-						new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) metricsRecorder, uriTagValue) :
-						new HttpClientMetricsHandler((HttpClientMetricsRecorder) metricsRecorder, uriTagValue);
+						new ContextAwareHttpClientMetricsHandler((ContextAwareHttpClientMetricsRecorder) metricsRecorder, remoteAddress, uriTagValue) :
+						new HttpClientMetricsHandler((HttpClientMetricsRecorder) metricsRecorder, remoteAddress, uriTagValue);
 				p.addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.HttpMetricsHandler, handler);
 			}
 		}
@@ -733,6 +736,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		final Http2FrameCodec http2FrameCodec;
 		final ChannelMetricsRecorder metricsRecorder;
 		final ChannelOperations.OnSetup opsFactory;
+		final SocketAddress remoteAddress;
 		final Function<String, String> uriTagValue;
 
 		H2CleartextCodec(
@@ -740,11 +744,13 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 				ChannelOperations.OnSetup opsFactory,
 				boolean acceptGzip,
 				@Nullable ChannelMetricsRecorder metricsRecorder,
+				SocketAddress remoteAddress,
 				@Nullable Function<String, String> uriTagValue) {
 			this.acceptGzip = acceptGzip;
 			this.http2FrameCodec = http2FrameCodec;
 			this.metricsRecorder = metricsRecorder;
 			this.opsFactory = opsFactory;
+			this.remoteAddress = remoteAddress;
 			this.uriTagValue = uriTagValue;
 		}
 
@@ -765,11 +771,11 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 				pipeline.remove(NettyPipeline.ResponseTimeoutHandler);
 				http2MultiplexHandler = new Http2MultiplexHandler(H2InboundStreamHandler.INSTANCE,
 						new H2Codec(owner, obs, opsFactory, acceptGzip, metricsRecorder,
-								responseTimeoutHandler.getReaderIdleTimeInMillis(), uriTagValue));
+								remoteAddress, responseTimeoutHandler.getReaderIdleTimeInMillis(), uriTagValue));
 			}
 			else {
 				http2MultiplexHandler = new Http2MultiplexHandler(H2InboundStreamHandler.INSTANCE,
-						new H2Codec(owner, obs, opsFactory, acceptGzip, metricsRecorder, uriTagValue));
+						new H2Codec(owner, obs, opsFactory, acceptGzip, metricsRecorder, remoteAddress, uriTagValue));
 			}
 			pipeline.addAfter(ctx.name(), NettyPipeline.HttpCodec, http2FrameCodec)
 			        .addAfter(NettyPipeline.HttpCodec, NettyPipeline.H2MultiplexHandler, http2MultiplexHandler);
@@ -789,6 +795,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		final ChannelOperations.OnSetup opsFactory;
 		final Http2ConnectionProvider.DisposableAcquire owner;
 		final long responseTimeoutMillis;
+		final SocketAddress remoteAddress;
 		final Function<String, String> uriTagValue;
 
 		H2Codec(
@@ -797,9 +804,10 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 				ChannelOperations.OnSetup opsFactory,
 				boolean acceptGzip,
 				@Nullable ChannelMetricsRecorder metricsRecorder,
+				SocketAddress remoteAddress,
 				@Nullable Function<String, String> uriTagValue) {
 			// Handle outbound and upgrade streams
-			this(owner, observer, opsFactory, acceptGzip, metricsRecorder, -1, uriTagValue);
+			this(owner, observer, opsFactory, acceptGzip, metricsRecorder, remoteAddress, -1, uriTagValue);
 		}
 
 		H2Codec(
@@ -808,6 +816,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 				ChannelOperations.OnSetup opsFactory,
 				boolean acceptGzip,
 				@Nullable ChannelMetricsRecorder metricsRecorder,
+				SocketAddress remoteAddress,
 				long responseTimeoutMillis,
 				@Nullable Function<String, String> uriTagValue) {
 			// Handle outbound and upgrade streams
@@ -817,6 +826,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			this.opsFactory = opsFactory;
 			this.owner = owner;
 			this.responseTimeoutMillis = responseTimeoutMillis;
+			this.remoteAddress = remoteAddress;
 			this.uriTagValue = uriTagValue;
 		}
 
@@ -828,7 +838,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 					setChannelContext(ch, owner.currentContext());
 				}
 				addStreamHandlers(ch, observer.then(new StreamConnectionObserver(owner.currentContext())), opsFactory,
-						acceptGzip, metricsRecorder, responseTimeoutMillis, uriTagValue);
+						acceptGzip, metricsRecorder, remoteAddress, responseTimeoutMillis, uriTagValue);
 			}
 			else {
 				// Handle server pushes (inbound streams)
@@ -856,14 +866,16 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		final Http2Settings                              http2Settings;
 		final ChannelMetricsRecorder                     metricsRecorder;
 		final ConnectionObserver                         observer;
+		final SocketAddress                              remoteAddress;
 		final Function<String, String>                   uriTagValue;
 
-		H2OrHttp11Codec(HttpClientChannelInitializer initializer, ConnectionObserver observer) {
+		H2OrHttp11Codec(HttpClientChannelInitializer initializer, ConnectionObserver observer, SocketAddress remoteAddress) {
 			this.acceptGzip = initializer.acceptGzip;
 			this.decoder = initializer.decoder;
 			this.http2Settings = initializer.http2Settings;
 			this.metricsRecorder = initializer.metricsRecorder;
 			this.observer = observer;
+			this.remoteAddress = remoteAddress;
 			this.uriTagValue = initializer.uriTagValue;
 		}
 
@@ -881,7 +893,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 					configureHttp2Pipeline(ctx.channel().pipeline(), acceptGzip, decoder, http2Settings, observer);
 				}
 				else if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
-					configureHttp11Pipeline(ctx.channel().pipeline(), acceptGzip, decoder, metricsRecorder, uriTagValue);
+					configureHttp11Pipeline(ctx.channel().pipeline(), acceptGzip, decoder, metricsRecorder, remoteAddress, uriTagValue);
 				}
 				else {
 					throw new IllegalStateException("unknown protocol: " + protocol);
@@ -927,10 +939,10 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 				if ((protocols & h11orH2) == h11orH2) {
 					channel.pipeline()
 					       .addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.H2OrHttp11Codec,
-					               new H2OrHttp11Codec(this, observer));
+					               new H2OrHttp11Codec(this, observer, remoteAddress));
 				}
 				else if ((protocols & h11) == h11) {
-					configureHttp11Pipeline(channel.pipeline(), acceptGzip, decoder, metricsRecorder, uriTagValue);
+					configureHttp11Pipeline(channel.pipeline(), acceptGzip, decoder, metricsRecorder, remoteAddress, uriTagValue);
 				}
 				else if ((protocols & h2) == h2) {
 					configureHttp2Pipeline(channel.pipeline(), acceptGzip, decoder, http2Settings, observer);
@@ -938,10 +950,10 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			}
 			else {
 				if ((protocols & h11orH2C) == h11orH2C) {
-					configureHttp11OrH2CleartextPipeline(channel.pipeline(), acceptGzip, decoder, http2Settings, metricsRecorder, observer, opsFactory, uriTagValue);
+					configureHttp11OrH2CleartextPipeline(channel.pipeline(), acceptGzip, decoder, http2Settings, metricsRecorder, observer, opsFactory, remoteAddress, uriTagValue);
 				}
 				else if ((protocols & h11) == h11) {
-					configureHttp11Pipeline(channel.pipeline(), acceptGzip, decoder, metricsRecorder, uriTagValue);
+					configureHttp11Pipeline(channel.pipeline(), acceptGzip, decoder, metricsRecorder, remoteAddress, uriTagValue);
 				}
 				else if ((protocols & h2c) == h2c) {
 					configureHttp2Pipeline(channel.pipeline(), acceptGzip, decoder, http2Settings, observer);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package reactor.netty.http.client;
 
 import reactor.util.annotation.Nullable;
 
+import java.net.SocketAddress;
 import java.util.function.Function;
 
 /**
@@ -28,8 +29,10 @@ final class HttpClientMetricsHandler extends AbstractHttpClientMetricsHandler {
 
 	final HttpClientMetricsRecorder recorder;
 
-	HttpClientMetricsHandler(HttpClientMetricsRecorder recorder, @Nullable Function<String, String> uriTagValue) {
-		super(uriTagValue);
+	HttpClientMetricsHandler(HttpClientMetricsRecorder recorder,
+			SocketAddress remoteAddress,
+			@Nullable Function<String, String> uriTagValue) {
+		super(remoteAddress, uriTagValue);
 		this.recorder = recorder;
 	}
 


### PR DESCRIPTION
Fixes #3060