### PR TITLE
Provide better exception message for invalid `PORT` env variable

### DIFF
--- a/docs/asciidoc/http-client.adoc
+++ b/docs/asciidoc/http-client.adoc
@@ -16,6 +16,7 @@ and adds Reactive Streams backpressure.
 
 To connect the `HTTP` client to a given `HTTP` endpoint, you must create and configure a
 {javadoc}/reactor/netty/http/client/HttpClient.html[`HttpClient`] instance.
+By default, the host is configured for `localhost` and the port is `80`.
 The following example shows how to do so:
 
 ====
@@ -55,6 +56,8 @@ include::{examplesdir}/address/Application.java[lines=18..33]
 <1> Configures the `HTTP` host
 <2> Configures the `HTTP` port
 ====
+
+NOTE: The port can be specified also with *PORT* environment variable.
 
 == Eager Initialization
 

--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -49,6 +49,8 @@ include::{examplesdir}/address/Application.java[lines=18..33]
 <2> Configures the `TCP` port
 ====
 
+NOTE: The port can be specified also with *PORT* environment variable.
+
 == Eager Initialization
 
 By default, the initialization of the `TcpClient` resources happens on demand. This means that the `connect

--- a/docs/asciidoc/udp-client.adoc
+++ b/docs/asciidoc/udp-client.adoc
@@ -48,6 +48,8 @@ include::{examplesdir}/address/Application.java[lines=18..34]
 <2> Configures the `port` to which this client should connect
 ====
 
+NOTE: The port can be specified also with *PORT* environment variable.
+
 == Eager Initialization
 
 By default, the initialization of the `UdpClient` resources happens on demand. This means that the `connect

--- a/docs/asciidoc/udp-server.adoc
+++ b/docs/asciidoc/udp-server.adoc
@@ -48,6 +48,8 @@ include::{examplesdir}/address/Application.java[lines=18..34]
 <2> Configures the `UDP` server port
 ====
 
+NOTE: The port can be specified also with *PORT* environment variable.
+
 == Eager Initialization
 
 By default, the initialization of the `UdpServer` resources happens on demand. This means that the `bind

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -275,6 +275,14 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 		return super.option(key, value);
 	}
 
+	/**
+	 * The port to which this client should connect.
+	 * If a port is not specified, the default port {@code 12012} is used.
+	 * <p><strong>Note:</strong> The port can be specified also with {@code PORT} environment variable.
+	 *
+	 * @param port the port to connect to
+	 * @return a new {@link TcpClient}
+	 */
 	@Override
 	public TcpClient port(int port) {
 		return super.port(port);

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConnect.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,8 +54,20 @@ final class TcpClientConnect extends TcpClient {
 	}
 
 	/**
-	 * The default port for reactor-netty servers. Defaults to 12012 but can be tuned via
+	 * The default port for reactor-netty TCP clients. Defaults to 12012 but can be tuned via
 	 * the {@code PORT} <b>environment variable</b>.
 	 */
-	static final int DEFAULT_PORT = System.getenv("PORT") != null ? Integer.parseInt(System.getenv("PORT")) : 12012;
+	static final int DEFAULT_PORT;
+	static {
+		int port;
+		String portStr = null;
+		try {
+			portStr = System.getenv("PORT");
+			port = portStr != null ? Integer.parseInt(portStr) : 12012;
+		}
+		catch (NumberFormatException e) {
+			throw new IllegalArgumentException("Invalid environment variable [PORT=" + portStr + "].", e);
+		}
+		DEFAULT_PORT = port;
+	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServer.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,6 +146,13 @@ public abstract class TcpServer extends ServerTransport<TcpServer, TcpServerConf
 		return this;
 	}
 
+	/**
+	 * The port to which this server should bind.
+	 * If a port is not specified, the system picks up an ephemeral port.
+	 *
+	 * @param port The port to bind to.
+	 * @return a new {@link TcpServer}
+	 */
 	@Override
 	public TcpServer port(int port) {
 		return super.port(port);

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClient.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,6 +150,14 @@ public abstract class UdpClient extends ClientTransport<UdpClient, UdpClientConf
 		return super.option(key, value);
 	}
 
+	/**
+	 * The port to which this client should connect.
+	 * If a port is not specified, the default port {@code 12012} is used.
+	 * <p><strong>Note:</strong> The port can be specified also with {@code PORT} environment variable.
+	 *
+	 * @param port the port to connect to
+	 * @return a new {@link UdpClient} reference
+	 */
 	@Override
 	public final UdpClient port(int port) {
 		return super.port(port);

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConnect.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClientConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,8 +56,20 @@ final class UdpClientConnect extends UdpClient {
 	}
 
 	/**
-	 * The default port for reactor-netty servers. Defaults to 12012 but can be tuned via
+	 * The default port for reactor-netty UDP clients. Defaults to 12012 but can be tuned via
 	 * the {@code PORT} <b>environment variable</b>.
 	 */
-	static final int DEFAULT_PORT = System.getenv("PORT") != null ? Integer.parseInt(System.getenv("PORT")) : 12012;
+	static final int DEFAULT_PORT;
+	static {
+		int port;
+		String portStr = null;
+		try {
+			portStr = System.getenv("PORT");
+			port = portStr != null ? Integer.parseInt(portStr) : 12012;
+		}
+		catch (NumberFormatException e) {
+			throw new IllegalArgumentException("Invalid environment variable [PORT=" + portStr + "].", e);
+		}
+		DEFAULT_PORT = port;
+	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServer.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -217,6 +217,8 @@ public abstract class UdpServer extends Transport<UdpServer, UdpServerConfig> {
 
 	/**
 	 * The port to which this server should bind.
+	 * If a port is not specified, the default port {@code 12012} is used.
+	 * <p><strong>Note:</strong> The port can be specified also with {@code PORT} environment variable.
 	 *
 	 * @param port The port to bind to.
 	 * @return a new {@link UdpServer} reference

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServerBind.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServerBind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,8 +72,20 @@ final class UdpServerBind extends UdpServer {
 	}
 
 	/**
-	 * The default port for reactor-netty servers. Defaults to 12012 but can be tuned via
+	 * The default port for reactor-netty UDP servers. Defaults to 12012 but can be tuned via
 	 * the {@code PORT} <b>environment variable</b>.
 	 */
-	static final int DEFAULT_PORT = System.getenv("PORT") != null ? Integer.parseInt(System.getenv("PORT")) : 12012;
+	static final int DEFAULT_PORT;
+	static {
+		int port;
+		String portStr = null;
+		try {
+			portStr = System.getenv("PORT");
+			port = portStr != null ? Integer.parseInt(portStr) : 12012;
+		}
+		catch (NumberFormatException e) {
+			throw new IllegalArgumentException("Invalid environment variable [PORT=" + portStr + "].", e);
+		}
+		DEFAULT_PORT = port;
+	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1283,6 +1283,14 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		return request(HttpMethod.PATCH);
 	}
 
+	/**
+	 * The port to which this client should connect.
+	 * If a port is not specified, the default port {@code 80} is used.
+	 * <p><strong>Note:</strong> The port can be specified also with {@code PORT} environment variable.
+	 *
+	 * @param port the port to connect to
+	 * @return a new {@link HttpClient}
+	 */
 	@Override
 	public final HttpClient port(int port) {
 		return super.port(port);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -701,9 +701,25 @@ class HttpClientConnect extends HttpClient {
 
 	static final AsciiString ALL = new AsciiString("*/*");
 
-	static final int DEFAULT_PORT = System.getenv("PORT") != null ? Integer.parseInt(System.getenv("PORT")) : 80;
-
 	static final Logger log = Loggers.getLogger(HttpClientConnect.class);
 
 	static final BiFunction<String, Integer, InetSocketAddress> URI_ADDRESS_MAPPER = AddressUtils::createUnresolved;
+
+	/**
+	 * The default port for reactor-netty HTTP clients. Defaults to 80 but can be tuned via
+	 * the {@code PORT} <b>environment variable</b>.
+	 */
+	static final int DEFAULT_PORT;
+	static {
+		int port;
+		String portStr = null;
+		try {
+			portStr = System.getenv("PORT");
+			port = portStr != null ? Integer.parseInt(portStr) : 80;
+		}
+		catch (NumberFormatException e) {
+			throw new IllegalArgumentException("Invalid environment variable [PORT=" + portStr + "].", e);
+		}
+		DEFAULT_PORT = port;
+	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -787,6 +787,13 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 		return this;
 	}
 
+	/**
+	 * The port to which this server should bind.
+	 * If a port is not specified, the system picks up an ephemeral port.
+	 *
+	 * @param port The port to bind to.
+	 * @return a new {@link HttpServer}
+	 */
 	@Override
 	public final HttpServer port(int port) {
 		return super.port(port);

--- a/reactor-netty-incubator-quic/src/main/java/reactor/netty/incubator/quic/QuicClient.java
+++ b/reactor-netty-incubator-quic/src/main/java/reactor/netty/incubator/quic/QuicClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,6 +156,8 @@ public abstract class QuicClient extends QuicTransport<QuicClient, QuicClientCon
 
 	/**
 	 * The port to which this client should connect.
+	 * If a port is not specified, the default port {@code 12012} is used.
+	 * <p><strong>Note:</strong> The port can be specified also with {@code QUIC_PORT} environment variable.
 	 *
 	 * @param port the port to connect to
 	 * @return a {@link QuicClient} reference

--- a/reactor-netty-incubator-quic/src/main/java/reactor/netty/incubator/quic/QuicClientConnect.java
+++ b/reactor-netty-incubator-quic/src/main/java/reactor/netty/incubator/quic/QuicClientConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,13 +113,6 @@ final class QuicClientConnect extends QuicClient {
 		Objects.requireNonNull(config.remoteAddress, "remoteAddress");
 		Objects.requireNonNull(config.sslEngineProvider, "sslEngineProvider");
 	}
-
-	/**
-	 * The default port for reactor-netty QUIC clients. Defaults to 12012 but can be tuned via
-	 * the {@code QUIC_PORT} <b>environment variable</b>.
-	 */
-	static final int DEFAULT_PORT =
-			System.getenv("QUIC_PORT") != null ? Integer.parseInt(System.getenv("QUIC_PORT")) : 12012;
 
 	static final class DisposableConnect implements CoreSubscriber<Channel>, Disposable {
 
@@ -278,5 +271,23 @@ final class QuicClientConnect extends QuicClient {
 			sink.error(error);
 			childObs.onUncaughtException(connection, error);
 		}
+	}
+
+	/**
+	 * The default port for reactor-netty QUIC clients. Defaults to 12012 but can be tuned via
+	 * the {@code QUIC_PORT} <b>environment variable</b>.
+	 */
+	static final int DEFAULT_PORT;
+	static {
+		int port;
+		String portStr = null;
+		try {
+			portStr = System.getenv("QUIC_PORT");
+			port = portStr != null ? Integer.parseInt(portStr) : 12012;
+		}
+		catch (NumberFormatException e) {
+			throw new IllegalArgumentException("Invalid environment variable [QUIC_PORT=" + portStr + "].", e);
+		}
+		DEFAULT_PORT = port;
 	}
 }

--- a/reactor-netty-incubator-quic/src/main/java/reactor/netty/incubator/quic/QuicServer.java
+++ b/reactor-netty-incubator-quic/src/main/java/reactor/netty/incubator/quic/QuicServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,6 +148,7 @@ public abstract class QuicServer extends QuicTransport<QuicServer, QuicServerCon
 
 	/**
 	 * The port to which this server should bind.
+	 * If a port is not specified, the system picks up an ephemeral port.
 	 *
 	 * @param port The port to bind to.
 	 * @return a {@link QuicServer} reference


### PR DESCRIPTION
- Update javadoc
- Update reference documentation

Fixes #3070