### PR TITLE
add netty epoll ARM 64 dependency

### DIFF
--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -108,6 +108,7 @@ dependencies {
 	else {
 		//classic build to be distributed
 		api "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
+		api "io.netty:netty-transport-native-epoll:$nettyVersion:linux-aarch_64"
 		compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
 		compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 	}


### PR DESCRIPTION
Netty native transport epoll has 2 artifacts:

- x86 64
- aarch 64

This PR adds aarch 64 (ARM 64).

