### PR TITLE
validate zstd compression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,7 @@ ext {
 
 	// Testing
 	brotli4jVersion = '1.16.0'
+	zstdJniVersion = '1.5.6-1'
 	jacksonDatabindVersion = '2.17.0'
 	testAddonVersion = reactorCoreVersion
 	assertJVersion = '3.25.3'

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -150,6 +150,9 @@ dependencies {
 	testRuntimeOnly "org.slf4j:jcl-over-slf4j:$slf4jVersion"
 	testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 
+	// Needed for zstd compression
+	testImplementation "com.github.luben:zstd-jni:$zstdJniVersion"
+
 	// Needed for Brotli compression
 	testImplementation "com.aayushatharva.brotli4j:brotli4j:$brotli4jVersion"
 	if (osdetector.classifier == "linux-aarch_64" || osdetector.classifier == "osx-aarch_64") {


### PR DESCRIPTION
Netty supports zstd compression.

This PR validates that zstd compression is working as expected.

https://github.com/luben/zstd-jni

