### PR TITLE
Re enable full build with jdk17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ subprojects {
 
 	java {
 		toolchain {
-			languageVersion = JavaLanguageVersion.of(8)
+			languageVersion = JavaLanguageVersion.of(name == "docs" ? 17 : 8)
 		}
 	}
 

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -15,7 +15,7 @@
  */
 import org.gradle.util.VersionNumber
 
-if (project.name == 'reactor-netty-examples' || project.name == 'reactor-netty-graalvm-smoke-tests') {
+if (project.name == 'reactor-netty-examples' || project.name == 'reactor-netty-graalvm-smoke-tests' || project.name == 'docs') {
 	return
 }
 

--- a/reactor-netty/build.gradle
+++ b/reactor-netty/build.gradle
@@ -46,10 +46,14 @@ task docsZip(type: Zip) {
 	archiveClassifier = 'docs'
 	duplicatesStrategy "fail"
 
+	if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+		logger.lifecycle("Adding dependency on :docs:antora (JDK version is >= 17)")
+		dependsOn(':docs:antora')
+	}
+
 	def docsDir = file('../docs/build/site')
 	def isSnapshot = project.version.endsWith('-SNAPSHOT')
 	def version = isSnapshot ? project.version.takeWhile { it != '-' } : project.version
-	def pdfFile = file("../docs/build/assembler/reactor-netty/${version}/reactor-netty-reference-guide.pdf")
 	boolean forcePdf = project.hasProperty('forcePdf')
 
 	doFirst {
@@ -63,14 +67,12 @@ task docsZip(type: Zip) {
 		into 'docs'
 	}
 
-	if (pdfFile.exists()) {
-		if (!isSnapshot || forcePdf) {
-			logger.lifecycle("pdf ${pdfFile} included in docs zip")
-
-			from(pdfFile) {
-				rename { fileName ->
-					"docs/reactor-netty-reference-guide-${project.version}.pdf"
-				}
+	if (!isSnapshot || forcePdf) {
+		def pdfFile = file("../docs/build/assembler/reactor-netty/${version}/reactor-netty-reference-guide.pdf")
+		logger.lifecycle("${pdfFile} will be included in docs zip")
+		from(pdfFile) {
+			rename { fileName ->
+				"docs/reactor-netty-reference-guide-${project.version}.pdf"
 			}
 		}
 	}


### PR DESCRIPTION
Since the migration to Antora, it's not possible anymore to do a full build using jdk17:

```
sdk use java 17.0.10-zulu
./gradlew publishToMavenLocal

> Configure project :
1.2.0-SNAPSHOT is a snapshot, will use 1.2.0.BUILD-202404040843 for bnd
[Spotless] Local run detected, ratchet from origin/main

> Task :docs:generatePomFileForMavenJavaPublication FAILED

FAILURE: Build failed with an exception.

* Where:
Script '/Users/***/Documents/reactor-netty/gradle/setup.gradle' line: 153

* What went wrong:
Execution failed for task ':docs:generatePomFileForMavenJavaPublication'.
> Could not apply withXml() to generated POM
   > Cannot invoke method children() on null object

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org/
```

This PR re enable full build using jdk17:

- in build.gradle: toolchain sets JDK17 for docs sub project
- in gradle/settings.gradle, the docs project must be excluded, it does not contain dependencies, that was causing the `Cannot invoke method children() on null object` error
- in reactor-netty/build.gradle: if JDK17 is used, then a dependency to `:docs:antora' is dynamically added for the docsZip task.

