### PR TITLE
Fixes atlas-extension order

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -1,10 +1,11 @@
 antora:
   extensions:
     - '@springio/antora-extensions/partial-build-extension'
+    # atlas-extension must be before latest-version-extension so latest versions are applied to imported versions
+    - '@antora/atlas-extension'
     - require: '@springio/antora-extensions/latest-version-extension'
     - require: '@springio/antora-extensions/inject-collector-cache-config-extension'
     - '@antora/collector-extension'
-    - '@antora/atlas-extension'
     - id: pdf-extension # pdf-extension is enabled from antora-docs.gradle
       require: '@antora/pdf-extension'
       enabled: false


### PR DESCRIPTION
The atlas-extension must be registered before the latest-version-extension so that the latest version logic is applied to versions imported from the atlas-extension.

