### PR TITLE
Pdf is not included in milestone release

### DIFF
--- a/reactor-netty/build.gradle
+++ b/reactor-netty/build.gradle
@@ -48,7 +48,7 @@ task docsZip(type: Zip) {
 
 	def docsDir = file('../docs/build/site')
 	def isSnapshot = project.version.endsWith('-SNAPSHOT')
-	def version = project.version.takeWhile { it != '-' }
+	def version = isSnapshot ? project.version.takeWhile { it != '-' } : project.version
 	def pdfFile = file("../docs/build/assembler/reactor-netty/${version}/reactor-netty-reference-guide.pdf")
 	boolean forcePdf = project.hasProperty('forcePdf')
 


### PR DESCRIPTION
when running "./gradlew antora", if the version is not a -SNAPSHOT version, then the pdf is generated in docs/build/assembler/reactor-netty/version/reactor-netty-reference-guide.pdf

for example:

- if version is 1.2.0, then "./gradlew antora" generates the pdf in docs/build/assembler/reactor-netty/1.2.0/reactor-netty-reference-guide.pdf
- if version is 1.2.0-M1, then "./gradlew antora" generates the pdf in docs/build/assembler/reactor-netty/1.2.0-M1/reactor-netty-reference-guide.pdf

so, now, when running "./gradlew publishToMavenLocal", the **docsZip** in reactor-netty/build.gradle is stripping the version, like this:

```
task docsZip(type: Zip) {
        ...
	def isSnapshot = project.version.endsWith('-SNAPSHOT')
	def version = project.version.takeWhile { it != '-' }
	def pdfFile = file("../docs/build/assembler/reactor-netty/${version}/reactor-netty-reference-guide.pdf")
        ...
```

so, if version is 1.2.0, then it's ok, the pdf from docs/build/assembler/reactor-netty/1.2.0/reactor-netty-reference-guide.pdf will be included in the docs.zip.

but if version is 1.2.0-M1, then the pdf won't be included, because the version will be wrongly stripped to 1.2.0 while it should not be stripped and kept to 1.2.0-M1, because the pdf top copy from is in 
docs/build/assembler/reactor-netty/1.2.0-M1/reactor-netty-reference-guide.pdf


the docsZip in reactor-netty/build.gradle should be corrected like this in order to include the pdf for milestone versions:

```
task docsZip(type: Zip) {
        ...
	def isSnapshot = project.version.endsWith('-SNAPSHOT')
	def version = isSnapshot ? project.version.takeWhile { it != '-' } : project.version
	def pdfFile = file("../docs/build/assembler/reactor-netty/${version}/reactor-netty-reference-guide.pdf")
        ...
```


