### PR TITLE
Remove deprecated `SslProvider$DefaultConfigurationSpec` and `SslProvider$DefaultConfigurationType`

### DIFF
--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -243,6 +243,16 @@ task japicmp(type: JapicmpTask) {
 	compatibilityChangeExcludes = [ "METHOD_NEW_DEFAULT" ]
 
 	methodExcludes = [
+			// Deprecated methods are removed
+			'reactor.netty.tcp.SslProvider$SslContextSpec#sslContext(io.netty.handler.ssl.SslContextBuilder)',
+			'reactor.netty.tcp.SslProvider#getDefaultConfigurationType()',
+			'reactor.netty.tcp.SslProvider#updateDefaultConfiguration(reactor.netty.tcp.SslProvider, reactor.netty.tcp.SslProvider$DefaultConfigurationType)'
+	]
+
+	classExcludes = [
+			// Deprecated classes are removed
+			'reactor.netty.tcp.SslProvider$DefaultConfigurationSpec',
+			'reactor.netty.tcp.SslProvider$DefaultConfigurationType'
 	]
 }
 

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.net.SocketAddress;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,15 +36,10 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
-import io.netty.handler.ssl.ApplicationProtocolConfig;
-import io.netty.handler.ssl.ApplicationProtocolNames;
-import io.netty.handler.ssl.IdentityCipherSuiteFilter;
-import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
-import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.util.AsyncMapping;
 import reactor.core.Exceptions;
 import reactor.netty.NettyPipeline;
@@ -85,20 +79,6 @@ public final class SslProvider {
 		Objects.requireNonNull(provider, "provider");
 		Objects.requireNonNull(handlerConfigurator, "handlerConfigurator");
 		return new SslProvider(provider, handlerConfigurator);
-	}
-
-	/**
-	 * Updates the {@link DefaultConfigurationType} used by this {@link SslProvider}.
-	 *
-	 * @deprecated as of 1.0.6. Prefer {@link SslProvider.SslContextSpec#sslContext(ProtocolSslContextSpec)},
-	 * where the default configuration is applied before any other custom configuration.
-	 * This will be removed in version 1.2.0.
-	 */
-	@Deprecated
-	public static SslProvider updateDefaultConfiguration(SslProvider provider, DefaultConfigurationType type) {
-		Objects.requireNonNull(provider, "provider");
-		Objects.requireNonNull(type, "type");
-		return new SslProvider(provider, type);
 	}
 
 	/**
@@ -247,8 +227,7 @@ public final class SslProvider {
 		/**
 		 * SslContext builder that provides, specific for the protocol, default configuration
 		 * e.g. {@link DefaultSslContextSpec}, {@link TcpSslContextSpec} etc.
-		 * As opposed to {@link #sslContext(SslContextBuilder)}, the default configuration is applied before
-		 * any other custom configuration.
+		 * The default configuration is applied before any other custom configuration.
 		 *
 		 * @param spec SslContext builder that provides, specific for the protocol, default configuration
 		 * @return {@literal this}
@@ -264,67 +243,6 @@ public final class SslProvider {
 		 * @return {@literal this}
 		 */
 		Builder sslContext(SslContext sslContext);
-
-		/**
-		 * The SslContextBuilder for building a new {@link SslContext}. The default configuration is applied after
-		 * the custom configuration.
-		 *
-		 * @return {@literal this}
-		 * @deprecated as of 1.0.6. Prefer {@link #sslContext(ProtocolSslContextSpec)}, where the default
-		 * configuration is applied before any other custom configuration.
-		 * This method will be removed in version 1.2.0.
-		 */
-		@Deprecated
-		DefaultConfigurationSpec sslContext(SslContextBuilder sslCtxBuilder);
-	}
-
-	/**
-	 * Default configuration that will be applied to the provided
-	 * {@link SslContextBuilder}.
-	 * @deprecated as of 1.0.6. Prefer {@link SslProvider.SslContextSpec#sslContext(ProtocolSslContextSpec)},
-	 * where the default configuration is applied before any other custom configuration.
-	 * This will be removed in version 1.2.0.
-	 */
-	@Deprecated
-	public enum DefaultConfigurationType {
-		/**
-		 * There will be no default configuration.
-		 */
-		NONE,
-		/**
-		 * {@link io.netty.handler.ssl.SslProvider} will be set depending on
-		 * <code>OpenSsl.isAvailable()</code>.
-		 */
-		TCP,
-		/**
-		 * {@link io.netty.handler.ssl.SslProvider} will be set depending on
-		 * <code>OpenSsl.isAlpnSupported()</code>,
-		 * {@link #HTTP2_CIPHERS},
-		 * ALPN support,
-		 * HTTP/1.1 and HTTP/2 support.
-		 */
-		H2
-	}
-
-	/**
-	 * Default configuration type that will be applied to the provided
-	 * {@link SslContextBuilder}.
-	 *
-	 * @deprecated as of 1.0.6. Prefer {@link SslProvider.SslContextSpec#sslContext(ProtocolSslContextSpec)},
-	 * where the default configuration is applied before any other custom configuration.
-	 * This will be removed in version 1.2.0.
-	 */
-	@Deprecated
-	public interface DefaultConfigurationSpec {
-
-		/**
-		 * Default configuration type that will be applied to the provided
-		 * {@link SslContextBuilder}.
-		 *
-		 * @param type The default configuration type.
-		 * @return {@code this}
-		 */
-		Builder defaultConfiguration(DefaultConfigurationType type);
 	}
 
 	/**
@@ -353,8 +271,6 @@ public final class SslProvider {
 	}
 
 	final SslContext                   sslContext;
-	final SslContextBuilder            sslContextBuilder;
-	final DefaultConfigurationType     type;
 	final long                         handshakeTimeoutMillis;
 	final long                         closeNotifyFlushTimeoutMillis;
 	final long                         closeNotifyReadTimeoutMillis;
@@ -365,21 +281,8 @@ public final class SslProvider {
 	final AsyncMapping<String, SslProvider> sniMappings;
 
 	SslProvider(SslProvider.Build builder) {
-		this.sslContextBuilder = builder.sslCtxBuilder;
-		this.type = builder.type;
 		if (builder.sslContext == null) {
-			if (sslContextBuilder != null) {
-				if (type != null) {
-					updateDefaultConfiguration();
-				}
-				try {
-					this.sslContext = sslContextBuilder.build();
-				}
-				catch (SSLException e) {
-					throw Exceptions.propagate(e);
-				}
-			}
-			else if (builder.protocolSslContextSpec != null) {
+			if (builder.protocolSslContextSpec != null) {
 				try {
 					this.sslContext = builder.protocolSslContextSpec.sslContext();
 				}
@@ -415,12 +318,7 @@ public final class SslProvider {
 		this.confPerDomainName = builder.confPerDomainName;
 		this.sniMappings = builder.sniMappings;
 		if (!confPerDomainName.isEmpty()) {
-			if (this.type != null) {
-				this.sniProvider = updateAllSslProviderConfiguration(confPerDomainName, this, type);
-			}
-			else {
-				this.sniProvider = new SniProvider(confPerDomainName, this);
-			}
+			this.sniProvider = new SniProvider(confPerDomainName, this);
 		}
 		else if (sniMappings != null) {
 			this.sniProvider = new SniProvider(sniMappings, builder.handshakeTimeoutMillis);
@@ -432,8 +330,6 @@ public final class SslProvider {
 
 	SslProvider(SslProvider from, Consumer<? super SslHandler> handlerConfigurator) {
 		this.sslContext = from.sslContext;
-		this.sslContextBuilder = from.sslContextBuilder;
-		this.type = from.type;
 		if (from.handlerConfigurator == null) {
 			this.handlerConfigurator = handlerConfigurator;
 		}
@@ -452,77 +348,6 @@ public final class SslProvider {
 		this.sniProvider = from.sniProvider;
 	}
 
-	SslProvider(SslProvider from, DefaultConfigurationType type) {
-		this.sslContextBuilder = from.sslContextBuilder;
-		this.type = type;
-		if (this.sslContextBuilder != null) {
-			updateDefaultConfiguration();
-			try {
-				this.sslContext = sslContextBuilder.build();
-			}
-			catch (SSLException e) {
-				throw Exceptions.propagate(e);
-			}
-		}
-		else {
-			this.sslContext = from.sslContext;
-		}
-		this.handlerConfigurator = from.handlerConfigurator;
-		this.handshakeTimeoutMillis = from.handshakeTimeoutMillis;
-		this.closeNotifyFlushTimeoutMillis = from.closeNotifyFlushTimeoutMillis;
-		this.closeNotifyReadTimeoutMillis = from.closeNotifyReadTimeoutMillis;
-		this.builderHashCode = from.builderHashCode;
-		this.confPerDomainName = from.confPerDomainName;
-		this.sniMappings = from.sniMappings;
-		if (from.sniProvider != null) {
-			if (!confPerDomainName.isEmpty()) {
-				this.sniProvider = updateAllSslProviderConfiguration(confPerDomainName, this, type);
-			}
-			else {
-				this.sniProvider = new SniProvider(sniMappings, from.handshakeTimeoutMillis);
-			}
-		}
-		else {
-			this.sniProvider = null;
-		}
-	}
-
-	SniProvider updateAllSslProviderConfiguration(Map<String, SslProvider> confPerDomainName,
-			SslProvider defaultSslProvider, SslProvider.DefaultConfigurationType type) {
-		Map<String, SslProvider> config = new HashMap<>();
-		confPerDomainName.forEach((s, sslProvider) ->
-				config.put(s, SslProvider.updateDefaultConfiguration(sslProvider, type)));
-		return new SniProvider(config, defaultSslProvider);
-	}
-
-	void updateDefaultConfiguration() {
-		switch (type) {
-			case H2:
-				sslContextBuilder.sslProvider(
-				                     io.netty.handler.ssl.SslProvider.isAlpnSupported(io.netty.handler.ssl.SslProvider.OPENSSL) ?
-				                             io.netty.handler.ssl.SslProvider.OPENSSL :
-				                             io.netty.handler.ssl.SslProvider.JDK)
-				                 .ciphers(HTTP2_CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
-				                 .applicationProtocolConfig(new ApplicationProtocolConfig(
-				                     ApplicationProtocolConfig.Protocol.ALPN,
-				                     ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
-				                     ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
-				                     ApplicationProtocolNames.HTTP_2,
-				                     ApplicationProtocolNames.HTTP_1_1));
-				break;
-			case TCP:
-				sslContextBuilder.sslProvider(
-				                     OpenSsl.isAvailable() ?
-				                             io.netty.handler.ssl.SslProvider.OPENSSL :
-				                             io.netty.handler.ssl.SslProvider.JDK)
-				                 .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
-				                 .applicationProtocolConfig(null);
-				break;
-			case NONE:
-				break; //no default configuration
-		}
-	}
-
 	/**
 	 * Returns {@code SslContext} instance with configured settings.
 	 *
@@ -530,16 +355,6 @@ public final class SslProvider {
 	 */
 	public SslContext getSslContext() {
 		return this.sslContext;
-	}
-
-	/**
-	 * Returns the configured default configuration type.
-	 *
-	 * @return the configured default configuration type.
-	 */
-	@Nullable
-	public DefaultConfigurationType getDefaultConfigurationType() {
-		return this.type;
 	}
 
 	public void configure(SslHandler sslHandler) {
@@ -597,7 +412,6 @@ public final class SslProvider {
 	@Override
 	public String toString() {
 		return "SslProvider {" +
-				"type=" + type +
 				", handshakeTimeoutMillis=" + handshakeTimeoutMillis +
 				", closeNotifyFlushTimeoutMillis=" + closeNotifyFlushTimeoutMillis +
 				", closeNotifyReadTimeoutMillis=" + closeNotifyReadTimeoutMillis +
@@ -633,7 +447,7 @@ public final class SslProvider {
 		}
 	}
 
-	static final class Build implements SslContextSpec, DefaultConfigurationSpec, Builder {
+	static final class Build implements SslContextSpec, Builder {
 
 		/**
 		 * Default SSL handshake timeout (milliseconds), fallback to 10 seconds.
@@ -643,9 +457,7 @@ public final class SslProvider {
 						ReactorNetty.SSL_HANDSHAKE_TIMEOUT,
 						"10000"));
 
-		SslContextBuilder sslCtxBuilder;
 		ProtocolSslContextSpec protocolSslContextSpec;
-		DefaultConfigurationType type;
 		SslContext sslContext;
 		Consumer<? super SslHandler> handlerConfigurator;
 		long handshakeTimeoutMillis = DEFAULT_SSL_HANDSHAKE_TIMEOUT;
@@ -660,28 +472,12 @@ public final class SslProvider {
 		@Override
 		public Builder sslContext(ProtocolSslContextSpec protocolSslContextSpec) {
 			this.protocolSslContextSpec = protocolSslContextSpec;
-			this.type = DefaultConfigurationType.NONE;
 			return this;
 		}
 
 		@Override
 		public final Builder sslContext(SslContext sslContext) {
 			this.sslContext = Objects.requireNonNull(sslContext, "sslContext");
-			this.type = DefaultConfigurationType.NONE;
-			return this;
-		}
-
-		@Override
-		public final DefaultConfigurationSpec sslContext(SslContextBuilder sslCtxBuilder) {
-			this.sslCtxBuilder = Objects.requireNonNull(sslCtxBuilder, "sslCtxBuilder");
-			return this;
-		}
-
-		//DefaultConfigurationSpec
-
-		@Override
-		public final Builder defaultConfiguration(DefaultConfigurationType type) {
-			this.type = Objects.requireNonNull(type, "type");
 			return this;
 		}
 
@@ -797,8 +593,6 @@ public final class SslProvider {
 			return handshakeTimeoutMillis == build.handshakeTimeoutMillis &&
 					closeNotifyFlushTimeoutMillis == build.closeNotifyFlushTimeoutMillis &&
 					closeNotifyReadTimeoutMillis == build.closeNotifyReadTimeoutMillis &&
-					Objects.equals(sslCtxBuilder, build.sslCtxBuilder) &&
-					type == build.type &&
 					Objects.equals(sslContext, build.sslContext) &&
 					Objects.equals(handlerConfigurator, build.handlerConfigurator) &&
 					Objects.equals(serverNames, build.serverNames) &&
@@ -809,8 +603,6 @@ public final class SslProvider {
 		@Override
 		public int hashCode() {
 			int result = 1;
-			result = 31 * result + Objects.hashCode(sslCtxBuilder);
-			result = 31 * result + Objects.hashCode(type);
 			result = 31 * result + Objects.hashCode(sslContext);
 			result = 31 * result + Objects.hashCode(handlerConfigurator);
 			result = 31 * result + Long.hashCode(handshakeTimeoutMillis);
@@ -873,34 +665,4 @@ public final class SslProvider {
 	static final LoggingHandler LOGGING_HANDLER =
 			AdvancedByteBufFormat.HEX_DUMP
 					.toLoggingHandler("reactor.netty.tcp.ssl", LogLevel.DEBUG, Charset.defaultCharset());
-
-	/**
-	 * <a href="https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility">Mozilla Modern Cipher
-	 * Suites</a> minus the following cipher suites that are black listed by the
-	 * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">HTTP/2 RFC</a>.
-	 * Copied from io.netty.handler.codec.http2.Http2SecurityUtil
-	 */
-	static final List<String> HTTP2_CIPHERS =
-			Collections.unmodifiableList(Arrays.asList(
-					/* openssl = ECDHE-ECDSA-AES128-GCM-SHA256 */
-					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-
-					/* REQUIRED BY HTTP/2 SPEC */
-					/* openssl = ECDHE-RSA-AES128-GCM-SHA256 */
-					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-					/* REQUIRED BY HTTP/2 SPEC */
-
-					/* openssl = ECDHE-ECDSA-AES256-GCM-SHA384 */
-					"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-					/* openssl = ECDHE-RSA-AES256-GCM-SHA384 */
-					"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-					/* openssl = ECDHE-ECDSA-CHACHA20-POLY1305 */
-					"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-					/* openssl = ECDHE-RSA-CHACHA20-POLY1305 */
-					"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-
-					/* TLS 1.3 ciphers */
-					"TLS_AES_128_GCM_SHA256",
-					"TLS_AES_256_GCM_SHA384",
-					"TLS_CHACHA20_POLY1305_SHA256"));
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServerBind.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServerBind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 package reactor.netty.tcp;
 
 import io.netty.channel.ChannelOption;
-import reactor.core.publisher.Mono;
-import reactor.netty.DisposableServer;
 import reactor.netty.internal.util.MapUtils;
 
 import java.net.InetSocketAddress;
@@ -49,15 +47,6 @@ final class TcpServerBind extends TcpServer {
 
 	TcpServerBind(TcpServerConfig config) {
 		this.config = config;
-	}
-
-	@Override
-	@SuppressWarnings("deprecation")
-	public Mono<? extends DisposableServer> bind() {
-		if (config.sslProvider != null && config.sslProvider.getDefaultConfigurationType() == null) {
-			config.sslProvider = SslProvider.updateDefaultConfiguration(config.sslProvider, SslProvider.DefaultConfigurationType.TCP);
-		}
-		return super.bind();
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -60,7 +60,6 @@ import reactor.netty.http.HttpProtocol;
 import reactor.netty.tcp.TcpClientConfig;
 import reactor.netty.transport.AddressUtils;
 import reactor.netty.transport.ProxyProvider;
-import reactor.netty.tcp.SslProvider;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
@@ -203,7 +202,6 @@ class HttpClientConnect extends HttpClient {
 		}
 
 		@Override
-		@SuppressWarnings("deprecation")
 		public void subscribe(CoreSubscriber<? super Connection> actual) {
 			HttpClientHandler handler = new HttpClientHandler(config);
 
@@ -227,17 +225,6 @@ class HttpClientConnect extends HttpClient {
 											"Use the non Clear-Text H2 protocol via HttpClient#protocol or disable TLS " +
 											"via HttpClient#noSSL()"));
 							return;
-						}
-					}
-
-					if (_config.sslProvider.getDefaultConfigurationType() == null) {
-						if (_config.checkProtocol(HttpClientConfig.h2)) {
-							_config.sslProvider = SslProvider.updateDefaultConfiguration(_config.sslProvider,
-									SslProvider.DefaultConfigurationType.H2);
-						}
-						else {
-							_config.sslProvider = SslProvider.updateDefaultConfiguration(_config.sslProvider,
-									SslProvider.DefaultConfigurationType.TCP);
 						}
 					}
 				}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerBind.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerBind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import io.netty.util.AttributeKey;
 import reactor.core.publisher.Mono;
 import reactor.netty.DisposableServer;
 import reactor.netty.internal.util.MapUtils;
-import reactor.netty.tcp.SslProvider;
 import reactor.netty.tcp.TcpServerConfig;
 
 import java.net.InetSocketAddress;
@@ -56,7 +55,6 @@ final class HttpServerBind extends HttpServer {
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public Mono<? extends DisposableServer> bind() {
 		if (config.sslProvider != null) {
 			if ((config._protocols & HttpServerConfig.h2c) == HttpServerConfig.h2c) {
@@ -64,19 +62,6 @@ final class HttpServerBind extends HttpServer {
 						"Configured H2 Clear-Text protocol with TLS. " +
 								"Use the non Clear-Text H2 protocol via " +
 								"HttpServer#protocol or disable TLS via HttpServer#noSSL())"));
-			}
-			if (config.sslProvider.getDefaultConfigurationType() == null) {
-				HttpServer dup = duplicate();
-				HttpServerConfig _config = dup.configuration();
-				if ((_config._protocols & HttpServerConfig.h2) == HttpServerConfig.h2) {
-					_config.sslProvider = SslProvider.updateDefaultConfiguration(_config.sslProvider,
-							SslProvider.DefaultConfigurationType.H2);
-				}
-				else {
-					_config.sslProvider = SslProvider.updateDefaultConfiguration(_config.sslProvider,
-							SslProvider.DefaultConfigurationType.TCP);
-				}
-				return dup.bind();
 			}
 		}
 		else {


### PR DESCRIPTION
This is a problematic deprecated API that we would like to remove sooner than later.

This is in preparation for HTTP/3 support.