### PR TITLE
Replace gradle/wrapper-validation-action with gradle/actions/wrapper-validation

### DIFF
--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -51,7 +51,7 @@ jobs:
             transport: native
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: gradle/wrapper-validation-action@b5418f5a58f5fd2eb486dd7efb368fe7be7eae45
+      - uses: gradle/actions/wrapper-validation@6cec5d49d4d6d4bb982fbed7047db31ea6d38f11
       - name: Set up JDK 1.8
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         with:


### PR DESCRIPTION
The action `gradle/wrapper-validation-action` has been replaced by `gradle/actions/wrapper-validation`. See https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlewrapper-validation-action-has-been-replaced-by-gradleactionswrapper-validation