### PR TITLE
Limit permission in publish cleanup job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -225,7 +225,8 @@ jobs:
     needs: [ reactor-netty-core, tagRelease, tagMilestone, deploySnapshot ]
     if: always() # cleanup always run after all needed jobs, regardless of whether they were successful
     runs-on: ubuntu-20.04
-    permissions: write-all
+    permissions:
+        contents: write
     steps:
       - name: delete antora docs-build artifact
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -226,7 +226,7 @@ jobs:
     if: always() # cleanup always run after all needed jobs, regardless of whether they were successful
     runs-on: ubuntu-20.04
     permissions:
-        contents: write
+        actions: write
     steps:
       - name: delete antora docs-build artifact
         env:


### PR DESCRIPTION
in the publish CI, the `cleanup` job is using a too broad permission (`permissions: write-all`) when deleting the docs-build artifact.

According to https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#delete-an-artifact, we can limit the permission to only the necessary level: `actions: write`

