### PR TITLE
Build Antora only when publishing

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -20,5 +20,3 @@ plugins {
 apply from: "${rootDir}/gradle/antora-docs.gradle"
 
 description = "Reactor Netty Antora Docs"
-
-build.dependsOn(':docs:antora')

--- a/reactor-netty/build.gradle
+++ b/reactor-netty/build.gradle
@@ -78,10 +78,6 @@ task docsZip(type: Zip) {
 	}
 }
 
-artifacts {
-	archives docsZip
-}
-
 javadoc.dependsOn(aggregateJavadoc)
 
 //add docs.zip to the publication


### PR DESCRIPTION
This PR is an attempt to accelerate the build when using JDK17, and when you don't need to generate antora docs.

typically, it should accelerate commands like `./gradlew clean build`

to build the documentation:
- `./gradlew antora` (docs is generated to docs/build/site/ as before)
- or `./gradlew publishToMavenLocal`

modifications:

- the docs/build.gradle is not making the build depending on antora anymore
- removed the following unnecessary declaration in reactor-netty/build.gradle, which comes from spring-pulsar, we don't need this, and it forces the docsZip to be created when building or assembling the project:
```
artifacts {
	archives docsZip
}
```


Fixes #3157 