### PR TITLE
Remove unnecessary `:toc:` from `appendices.adoc`

### DIFF
--- a/docs/modules/ROOT/pages/appendices.adoc
+++ b/docs/modules/ROOT/pages/appendices.adoc
@@ -1,6 +1,5 @@
 = Appendices
 :sectnums:
-:toc:
 
 [appendix]
 include::faq.adoc[leveloffset=1]

--- a/docs/modules/ROOT/pages/appendices.adoc
+++ b/docs/modules/ROOT/pages/appendices.adoc
@@ -1,5 +1,4 @@
 = Appendices
-:sectnums:
 
 [appendix]
 include::faq.adoc[leveloffset=1]


### PR DESCRIPTION
`:toc:` in `appendices.adoc` makes the table of contents to be rendered under the navigation on the left
![Screenshot 2024-04-18 at 15 55 54](https://github.com/reactor/reactor-netty/assets/696661/8111de68-0697-4086-ab5f-7a73e02a4969)
