### PR TITLE
Add dependency to `Netty HTTP3 Codec` for aggregated javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,8 @@ ext {
 					"https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/",
 					"https://projectreactor.io/docs/core/release/api/",
 					"https://netty.io/4.1/api/",
-					"https://projectreactor.io/docs/netty/release/api/",] as String[]
+					"https://projectreactor.io/docs/netty/release/api/",
+					"https://javadoc.io/doc/io.netty.incubator/netty-incubator-codec-classes-quic/latest/"] as String[]
 }
 
 nohttp {

--- a/reactor-netty/build.gradle
+++ b/reactor-netty/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	compileOnly "io.netty:netty-codec-haproxy:$nettyVersion"
 	compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
 	compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
+	compileOnly "io.netty.incubator:netty-incubator-codec-http3:$nettyHttp3Version"
 	compileOnly "io.projectreactor.addons:reactor-pool:$reactorPoolVersion"
 }
 


### PR DESCRIPTION
Without this dependency the javadoc cannot be built correctly.

Related to #1531