### PR TITLE
Update to `macos-12` runner image

### DIFF
--- a/.github/workflows/check_netty_snapshots.yml
+++ b/.github/workflows/check_netty_snapshots.yml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
         transport: [native, nio]
         exclude:
           # excludes native on Windows (there's none)
           - os: windows-2019
             transport: native
           # macOS - https://github.com/netty/netty/issues/9689
-          - os: macos-11
+          - os: macos-12
             transport: native
 
     steps:

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
         transport: [native, nio]
         exclude:
           # excludes native on Windows (there's none)


### PR DESCRIPTION
The `macos-11` label has been deprecated and will no longer be available after `6/28/2024`. https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories