### PR TITLE
Fix Authors attribute

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -2,9 +2,6 @@ name: reactor-netty
 version: true
 title: Reactor Netty Reference Guide
 start_page: about-doc.adoc
-author:
-    - Stephane Maldini <https://twitter.com/smaldini[@smaldini]>
-    - Violeta Georgieva <https://twitter.com/violeta_g_g[@violeta_g_g]>
 nav:
   - modules/ROOT/nav.adoc
 ext:
@@ -28,3 +25,6 @@ asciidoc:
     http-source-link: '{reactor-netty-github-repo}/reactor-netty-http/src/main/java'
     javadoc: 'https://projectreactor.io/docs/netty/{project-version}/api'
     nettyjavadoc: 'https://netty.io/4.1/api'
+    author:
+        - Stephane Maldini
+        - Violeta Georgieva


### PR DESCRIPTION
currently, authors are declared in two places:

- in docs/modules/ROOT/pages/about-doc.adoc: authors are declared in the [Multiple authors line](https://docs.asciidoctor.org/asciidoc/latest/document/author-attribute-entries), in the start page (about-adoc.adoc). Authors are then displayed when browsing antora documentation (in the start page).

- in antora.yml, using an author attribute: this was attempt to make the authors also appearing in the front page of the generated pdf.

But the authors are not currently included in the front page of the PDF.

this PR moves the author attribute from the antora attributes to the asciidoc attributes in the antora.yml, and this fixes the problem: authors are now displayed in the front page of the generated PDF.