### PR TITLE
Reuse reactor-netty-github-repo-attribute when possible

### DIFF
--- a/docs/modules/ROOT/pages/about-doc.adoc
+++ b/docs/modules/ROOT/pages/about-doc.adoc
@@ -22,7 +22,7 @@ copy contains this `Copyright Notice`, whether distributed in print or electroni
 == Contributing to the Documentation
 The reference guide is written in
 https://asciidoctor.org/docs/asciidoc-writers-guide/[Asciidoc] using https://docs.antora.org/antora/latest/[Antora], and you can find its
-sources at https://github.com/reactor/reactor-netty/tree/main/docs.
+sources at {reactor-netty-github-repo}/docs.
 
 If you have an improvement, we will be happy to get a pull request from you!
 
@@ -49,5 +49,5 @@ https://stackoverflow.com/tags/reactor-netty[`reactor-netty`].
 https://github.com/reactor/reactor-netty/issues[reactor-netty].
 
 NOTE: All of `Reactor Netty` is open source,
-https://github.com/reactor/reactor-netty/tree/main/docs/asciidoc[including this
+{reactor-netty-github-repo}/docs[including this
 documentation].


### PR DESCRIPTION
Reuse the {reactor-netty-github-repo-attribute} attribute when possible.