### PR TITLE
Obtain the channel from `ChannelHandlerContext` instead of `HttpServerOperations`

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
@@ -175,16 +175,13 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 
 			if (msg instanceof LastHttpContent) {
 				promise.addListener(future -> {
-					ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
-					if (channelOps instanceof HttpServerOperations) {
-						try {
-							recordWrite((HttpServerOperations) channelOps);
-						}
-						catch (RuntimeException e) {
-							// Allow request-response exchange to continue, unaffected by metrics problem
-							if (log.isWarnEnabled()) {
-								log.warn(format(ctx.channel(), "Exception caught while recording metrics."), e);
-							}
+					try {
+						recordWrite(ctx.channel());
+					}
+					catch (RuntimeException e) {
+						// Allow request-response exchange to continue, unaffected by metrics problem
+						if (log.isWarnEnabled()) {
+							log.warn(format(ctx.channel(), "Exception caught while recording metrics."), e);
 						}
 					}
 
@@ -299,7 +296,7 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 		recorder().recordDataReceived(remoteSocketAddress, path, dataReceived);
 	}
 
-	protected void recordWrite(HttpServerOperations ops) {
+	protected void recordWrite(Channel channel) {
 		Duration dataSentTimeDuration = Duration.ofNanos(System.nanoTime() - dataSentTime);
 		recorder().recordDataSentTime(path, method, status, dataSentTimeDuration);
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsHandler.java
@@ -15,6 +15,7 @@
  */
 package reactor.netty.http.server;
 
+import io.netty.channel.Channel;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.ContextView;
 
@@ -72,7 +73,7 @@ final class ContextAwareHttpServerMetricsHandler extends AbstractHttpServerMetri
 	}
 
 	@Override
-	protected void recordWrite(HttpServerOperations ops) {
+	protected void recordWrite(Channel channel) {
 		Duration dataSentTimeDuration = Duration.ofNanos(System.nanoTime() - dataSentTime);
 		recorder().recordDataSentTime(contextView, path, method, status, dataSentTimeDuration);
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java
@@ -19,6 +19,7 @@ import io.micrometer.common.KeyValues;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.transport.RequestReplyReceiverContext;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import reactor.netty.observability.ReactorNettyHandlerContext;
@@ -85,7 +86,7 @@ final class MicrometerHttpServerMetricsHandler extends AbstractHttpServerMetrics
 	}
 
 	@Override
-	protected void recordWrite(HttpServerOperations ops) {
+	protected void recordWrite(Channel channel) {
 		Duration dataSentTimeDuration = Duration.ofNanos(System.nanoTime() - dataSentTime);
 		recorder().recordDataSentTime(path, method, status, dataSentTimeDuration);
 
@@ -100,7 +101,7 @@ final class MicrometerHttpServerMetricsHandler extends AbstractHttpServerMetrics
 		// Move the implementation from the recorder here
 		responseTimeObservation.stop();
 
-		setChannelContext(ops.channel(), parentContextView);
+		setChannelContext(channel, parentContextView);
 
 		responseTimeHandlerContext = null;
 		responseTimeObservation = null;


### PR DESCRIPTION
This is in addition to #3211