### PR TITLE
fix: HttpClient.reactorNettyVersion() throws NullPointException

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1606,9 +1606,11 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	}
 
 	static String reactorNettyVersion() {
-		return Optional.ofNullable(HttpClient.class.getPackage()
-		                                           .getImplementationVersion())
-		               .orElse("dev");
+		Package pac = HttpClient.class.getPackage();
+		if (pac == null) {
+			return "dev";
+		}
+		return Optional.ofNullable(pac.getImplementationVersion()).orElse("dev");
 	}
 
 	static final Logger log = Loggers.getLogger(HttpClient.class);


### PR DESCRIPTION
fix: [#3265](https://github.com/reactor/reactor-netty/issues/3265)