### PR TITLE
Make `MonoSend.MAX_SIZE` configurable by system property

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -197,6 +197,11 @@ public final class ReactorNetty {
 	 *  Specifies the zone id used by the access log.
 	 */
 	public static final ZoneId ZONE_ID_SYSTEM = ZoneId.systemDefault();
+
+	/**
+	 * Default prefetch size ({@link Subscription#request(long)}) for data stream Publisher, fallback to 128.
+	 */
+	public static final String REACTOR_NETTY_SEND_MAX_PREFETCH_SIZE = "reactor.netty.send.maxPrefetchSize";
 
 	/**
 	 * Try to call {@link ReferenceCounted#release()} if the specified message implements {@link ReferenceCounted}.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSend.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,8 @@ abstract class MonoSend<I, O> extends Mono<Void> {
 		return (ToIntFunction) SIZE_OF;
 	}
 
-	static final int                    MAX_SIZE    = 128;
+	static final int                    MAX_SIZE =
+			Integer.parseInt(System.getProperty("reactor.netty.channel.send.prefetch.maxSize", "128"));
 
 	static final int                    REFILL_SIZE = MAX_SIZE / 2;
 

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSend.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MonoSend.java
@@ -59,7 +59,7 @@ abstract class MonoSend<I, O> extends Mono<Void> {
 	}
 
 	static final int                    MAX_SIZE =
-			Integer.parseInt(System.getProperty("reactor.netty.channel.send.prefetch.maxSize", "128"));
+			Integer.parseInt(System.getProperty(ReactorNetty.REACTOR_NETTY_SEND_MAX_PREFETCH_SIZE, "128"));
 
 	static final int                    REFILL_SIZE = MAX_SIZE / 2;
 


### PR DESCRIPTION
MonoSend.MAX_SIZE is a constant used by MonoSendMany and its SendManyInner class to request initial items from a publisher to send to an output Channel. This PR introduces a way to configure MonoSend.MAX_SIZE by using `reactor.netty.channel.send.prefetch.maxSize`(Upd. `reactor.netty.send.maxPrefetchSize`) system property. A custom value for the property may be necessary if requested items from publisher are large and requesting default number of items (128) requires too much memory. 

Fixes #3255