### PR TITLE
Extend the documentation for the shared (default) `ConnectionProvider` and `Event Loop Group`

### DIFF
--- a/docs/asciidoc/eventloop.adoc
+++ b/docs/asciidoc/eventloop.adoc
@@ -3,9 +3,8 @@
 === Event Loop Group
 
 By default `Reactor Netty` uses an "`Event Loop Group`", where the number of the worker threads equals the number of
-processors available to the runtime on initialization (but with a minimum value of 4). When you need a different configuration,
-you can use one of the {javadoc}/reactor/netty/resources/LoopResources.html[`LoopResources`]`#create`
-methods.
+processors available to the runtime on initialization (but with a minimum value of 4). This "`Event Loop Group`" is shared between all servers and clients in one JVM.
+When you need a different configuration, you can use one of the {javadoc}/reactor/netty/resources/LoopResources.html[`LoopResources`]`#create` methods.
 
 The following listing shows the default configuration for the Event Loop Group:
 

--- a/docs/asciidoc/http-client-conn-provider.adoc
+++ b/docs/asciidoc/http-client-conn-provider.adoc
@@ -1,7 +1,11 @@
 == Connection Pool
-By default, `HttpClient` uses a "`fixed`" connection pool with `500` as the maximum number of active channels
-and `1000` as the maximum number of further channel acquisition attempts allowed to be kept in a pending state
-(for the rest of the configurations check the system properties or the builder configurations below).
+By default, `HttpClient` (`HttpClient.create()`) uses a shared `ConnectionProvider`. This `ConnectionProvider` is configured to create
+a "`fixed`" connection pool per remote host (a remote host implies the combination of a hostname and its associated port number) with:
+
+* `500` as the maximum number of active channels
+* `1000` as the maximum number of further channel acquisition attempts allowed to be kept in a pending state
+* The rest of the configurations are the defaults (check the system properties or the builder configurations below)
+
 This means that the implementation creates a new channel if someone tries to acquire a channel
 as long as less than `500` have been created and are managed by the pool.
 When the maximum number of channels in the pool is reached, up to `1000` new attempts to

--- a/docs/asciidoc/tcp-client-conn-provider.adoc
+++ b/docs/asciidoc/tcp-client-conn-provider.adoc
@@ -1,7 +1,11 @@
 == Connection Pool
-By default, `TcpClient` uses a "`fixed`" connection pool with `500` as the maximum number of active channels
-and `1000` as the maximum number of further channel acquisition attempts allowed to be kept in a pending state
-(for the rest of the configurations check the system properties or the builder configurations below).
+By default, `TcpClient` (`TcpClient.create()`) uses a shared `ConnectionProvider`. This `ConnectionProvider` is configured to create
+a "`fixed`" connection pool per remote host (a remote host implies the combination of a hostname and its associated port number) with:
+
+* `500` as the maximum number of active channels
+* `1000` as the maximum number of further channel acquisition attempts allowed to be kept in a pending state
+* The rest of the configurations are the defaults (check the system properties or the builder configurations below)
+
 This means that the implementation creates a new channel if someone tries to acquire a channel
 as long as less than `500` have been created and are managed by the pool.
 When the maximum number of channels in the pool is reached, up to `1000` new attempts to


### PR DESCRIPTION
Fixes #3253