### PR TITLE
Enhance robustness of publish.yml related to Antora

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,7 +114,7 @@ jobs:
   deploySnapshot:
     name: deploySnapshot
     runs-on: ubuntu-20.04
-    needs: [ reactor-netty-core, reactor-netty-http, reactor-netty-http-brave, reactor-netty-incubator-quic ]
+    needs: [ reactor-netty-core, reactor-netty-http, reactor-netty-http-brave, reactor-netty-incubator-quic, build-branch-doc ]
     if: needs.reactor-netty-core.outputs.versionType == 'SNAPSHOT'
     environment: snapshots
     steps:
@@ -139,7 +139,7 @@ jobs:
   deployMilestone:
     name: deployMilestone
     runs-on: ubuntu-20.04
-    needs: [ reactor-netty-core, reactor-netty-http, reactor-netty-http-brave, reactor-netty-incubator-quic ]
+    needs: [ reactor-netty-core, reactor-netty-http, reactor-netty-http-brave, reactor-netty-incubator-quic, build-branch-doc ]
     if: needs.reactor-netty-core.outputs.versionType == 'MILESTONE'
     environment: releases
     steps:
@@ -166,7 +166,7 @@ jobs:
   deployRelease:
     name: deployRelease
     runs-on: ubuntu-20.04
-    needs: [ reactor-netty-core, reactor-netty-http, reactor-netty-http-brave, reactor-netty-incubator-quic ]
+    needs: [ reactor-netty-core, reactor-netty-http, reactor-netty-http-brave, reactor-netty-incubator-quic, build-branch-doc ]
     if: needs.reactor-netty-core.outputs.versionType == 'RELEASE'
     environment: releases
     steps:
@@ -222,8 +222,8 @@ jobs:
           git push --tags
 
   cleanup:
-    needs: [ reactor-netty-core, tagRelease, tagMilestone, deploySnapshot ]
-    if: always() # cleanup always run after all needed jobs, regardless of whether they were successful
+    needs: [ deploySnapshot, tagRelease, tagMilestone ]
+    if: always() && (needs.deploySnapshot.result == 'success' || needs.tagRelease.result == 'success' || needs.tagMilestone.result == 'success')
     runs-on: ubuntu-20.04
     permissions:
         actions: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:
           name: ${{ env.DOCS_BUILD_ARTIFACT }}
-          retention-days: 1
+          retention-days: 3
           if-no-files-found: error
           path: docs/build
 


### PR DESCRIPTION
This proposes three enhacements related to Antora when publishing from the CI:

- first, the `deploySnapshot`, `deployMilestone`, and `deployRelease` were not depending on the `build-branch-doc` job. so far, it worked because the docs generation is faster then the `deploySnapshot`, `deployMilestone`, and `deployRelease` jobs. But for sake of robustness, let's explicitly make `deploySnapshot`, `deployMilestone`, and `deployRelease` depending on the `build-branch-doc` job.

- second, in case some flaky tests are taking place, the cleanup job is currently always executed, meaning that the generated docs zip is then deleted from the workflow run. So this prevents to rerun the deploy jobs, which will fail because the generated docs zip has been deleted by cleanup. To fix this: the cleanup job is now run only if: either the `deploySnapshot`, `tagRelease`, or `tagMilestone` jobs status is successful. If one of these task is successful, it means the deployment has been fully performed, and we can then cleanup the docs zip attached to the workflow run

- third, in case either artifactory or sonatype is temporarily unavailable, the docs zip retention days has been increased to three days, allows one to rerun the publish job before at most three days. beyond 3 days, the docs zip will be automatically removed froml the worflow run, in this case, one will need to restart everything.