### PR TITLE
Enhance Antora gradle build

### DIFF
--- a/gradle/antora-docs.gradle
+++ b/gradle/antora-docs.gradle
@@ -38,7 +38,7 @@ antora {
 			logger.log(LogLevel.DEBUG, "enabling antora pdf-extension")
 			options.add('--extension=pdf-extension')
 		} else {
-			logger.lifecycle("PDF not generated, asciidoctor-pdf not found from the PATH.")
+			throw new GradleException("PDF cannot be generated, asciidoctor-pdf not found from the PATH.")
 		}
 	}
 

--- a/reactor-netty/build.gradle
+++ b/reactor-netty/build.gradle
@@ -46,23 +46,20 @@ task docsZip(type: Zip) {
 	group = 'Distribution'
 	archiveClassifier = 'docs'
 	duplicatesStrategy "fail"
+	def docsDir = file('../docs/build/site')
 
 	if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
 		logger.lifecycle("Adding dependency on :docs:antora (JDK version is >= 17)")
 		dependsOn(':docs:antora')
 	}
+	else if (!docsDir.exists() || !Files.list(docsDir.toPath()).findFirst().isPresent()) {
+		logger.lifecycle("Docs directory does not exist and JDK version is lower than 17. Skipping docsZip task.")
+		enabled = false
+	}
 
-	def docsDir = file('../docs/build/site')
 	def isSnapshot = project.version.endsWith('-SNAPSHOT')
 	def version = isSnapshot ? project.version.takeWhile { it != '-' } : project.version
 	boolean forcePdf = project.hasProperty('forcePdf')
-
-	doFirst {
-		if (!docsDir.exists() || !Files.list(docsDir.toPath()).findFirst().isPresent()) {
-			logger.lifecycle("Docs directory does not exist or is empty. Skipping docsZip task.")
-			enabled = false
-		}
-	}
 
 	from ('../docs/build/site') {
 		into 'docs'
@@ -82,6 +79,13 @@ task docsZip(type: Zip) {
 javadoc.dependsOn(aggregateJavadoc)
 
 //add docs.zip to the publication
-if (tasks.docsZip.enabled) {
-	publishing.publications.mavenJava.artifact(docsZip)
+publishing.publications.mavenJava.artifact(docsZip)
+
+// If current JDK version is lower than JDK17, report errors in case user invokes documentation related tasks
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+	task antora {
+		doLast {
+			throw new GradleException("antora task requires JDK 17 or higher.")
+		}
+	}
 }


### PR DESCRIPTION
This PR tries to enhance user experience when building reactor netty/antora:

1.  if the current JDK version is < JDK17 and if one invokes "./gradlew antora", the currently, the following error is logged:

```
Task 'antora' not found in root project 'reactor-netty' and its subprojects.
``` 
instead of that, a clear error should be logged in order to indicate that the current JDK version is lower than 17, and JDK17+ version is required:
```
./gradlew antora
> antora task requires JDK 17 or higher.
```

2. if the current JDK version is < JDK17 and if one invokes "./gradlew docs", and if the docs have not been previously built  with a JDK17+ version, then currently nothing is displayed. A clear  message should be logged in order to indicate that JDK17+ version is required to build the doc:
```
./gradlew docs
> docs task requires JDK 17 or higher
```

3. if one is not interested in docs, and wants to just use just JDK8 and publish everything to local M2 without the doc, then currently, it's not possible and you get this error:
```
./gradlew publishToMavenLocal
Execution failed for task ':reactor-netty:publishMavenJavaPublicationToMavenLocal'.
> Failed to publish publication 'mavenJava' to repository 'mavenLocal'
   > Invalid publication 'mavenJava': artifact file does not exist: '/private/tmp/xx/reactor-netty/reactor-netty/build/distributions/reactor-netty-1.2.0-SNAPSHOT-docs.zip'
```
Instead, a warn message should just indicate that the current JDK version is lower than JDK17, and the docs won't be included in the local M2:
```
./gradlew publishToMavenLocal
Docs directory does not exist and JDK version is lower than 17. Skipping docsZip task.
```

4. if one needs to build the doc with PDF convertion, but the `asciidoctor-pdf` command is not found from the PATH, then the build should fail and a clear error message should be diplayed:
```
./gradlew docs -PforcePdf
> PDF cannot be generated, asciidoctor-pdf not found from the PATH.
```