### PR TITLE
Add apidocs classifier for publishing to docs.spring.io

### DIFF
--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -1,9 +1,5 @@
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
-import java.time.temporal.ChronoField
-
 /*
- * Copyright (c) 2019-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +13,9 @@ import java.time.temporal.ChronoField
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoField
 
 if (project.hasProperty("releaserDryRun") && project.findProperty("releaserDryRun") != "false") {
 	println "Adding MavenLocal() for benefit of releaser dry run"
@@ -95,6 +93,12 @@ if (project.hasProperty("artifactory_publish_password")) {
 					repoKey = "${artifactory_publish_repoKey}"
 					username = "${artifactory_publish_username}"
 					password = "${artifactory_publish_password}"
+				}
+				defaults {
+					properties {
+						// Add artifactory metadata properties to deploy reactor-netty apidocs zip in docs.spring.io
+						all 'io.projectreactor.netty:reactor-netty:*:apidocs@zip', 'zip.name': 'reactor-netty', 'zip.displayname': 'Reactor Netty', 'zip.type': 'docs', 'zip.deployed': 'false'
+					}
 				}
 			}
 			clientConfig.setIncludeEnvVars(false)

--- a/reactor-netty/build.gradle
+++ b/reactor-netty/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,5 +41,33 @@ javadoc.dependsOn(aggregateJavadoc)
 
 //add docs.zip to the publication
 publishing.publications.mavenJava.artifact(docsZip)
+
+// Define a task to create a reactor-netty apidocs zip classifier which includes both javadoc, reference doc, and reference pdf if any.
+// this classifier will be published to artifactory using some special artifactory properties so it will be also
+// published to https://docs.spring.io/projectreactor/netty/docs/<version>/ directory.
+// (see releaser.gradle which adds the specific properties metadata (zip.name / zip.deployed=false)
+task apidocsZip(type: Zip, dependsOn: [asciidoctor, asciidoctorPdf]) {
+	archiveBaseName.set("reactor-netty")
+	archiveClassifier.set("apidocs")
+
+	afterEvaluate() {
+		//we copy the pdf late, when a potential customVersion has been applied to rootProject
+		from(asciidoctorPdf) {
+			into("reference/pdf/")
+			rename("index.pdf", "reactor-netty-reference-guide-${rootProject.version}.pdf")
+		}
+	}
+	from(asciidoctor) {
+		includeEmptyDirs = false
+		exclude "**/index.pdf"
+		into("reference/html/")
+	}
+	from(aggregateJavadoc) {
+		into "api"
+	}
+}
+
+//add apidocs.zip to the publication
+publishing.publications.mavenJava.artifact(apidocsZip)
 
 description = "Reactor Netty with all modules"


### PR DESCRIPTION
in docs.spring.io, there is an `autorepo` script which automates the deployment to `docs.spring.io` of any docs zip deployed to artifactory.

the convention is the following:

1) any docs zip published to artifactory should contain `zip.type=docs`, and `zip.deployed=false` special artifactory properties. see [spring framework](https://github.com/spring-projects/spring-framework/blob/8ef74dfdad1f7c55757ed52599358815e2756c98/.github/workflows/build-and-deploy-snapshot.yml#L52) example, or [spring pulsar](https://github.com/spring-projects/spring-pulsar/blob/main/buildSrc/src/main/groovy/io/spring/gradle/convention/ArtifactoryPlugin.groovy#L51) example.

2) the structure of the docs zip should be like this:

- api/* -> contains javadoc
- reference/html/ -> contains reference flat html files
- reference/pdf/ -> contains reference pdf file (if any)

Now, our current reactor-netty-docs zip contains only the html files and the structure is different (`docs/*`).
We can't change the layout of the reactor-netty-docs zip, else it could break any other components, like the projectreactor.io site, which expects reference documentation to be located in docs/* sub directory of the docs zip.

So, this PR just adds a new reactor-netty `apidocs` classifier which contains:

- api/* -> javadoc
- reference/html/* -> reference html doc files
- reference/pdf/ -> pdf reference doc, if any

the new apidocs artifact will be published with the special properties `zip.type=docs` and `zip.deployed=false`, so the content of the apidocs artifact will also be copied to:

- `https://docs.spring.io/projectreactor/netty/docs/VERSION/api/` (javadoc)
- `https://docs.spring.io/projectreactor/netty/docs/VERSION/reference/html/` (reference doc)
- `https://docs.spring.io/projectreactor/netty/docs/VERSION/reference/pdf/` (pdf reference doc)

not that the autorepo script also uses [autoln](https://github.com/spring-io/autoln), which will maintain symbolic links like:

- `https://docs.spring.io/projectreactor/netty/docs/current ->` (the latest stable docs)
- `https://docs.spring.io/projectreactor/netty/docs/current-SNAPSHOT ->` (the most recent snapshot docs)
- `https://docs.spring.io/projectreactor/netty/docs/<major>.<minor>.x ->` (the most recently released version starting with `<major>.<minor>`)
- `https://docs.spring.io/projectreactor/netty/docs/<major>.<minor>.x-SNAPSHOT ->` (the most recent snapshot docs starting with `<major>.<minor>`)


