### PR TITLE
Publish javadoc / reference docs to spring.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,13 @@ jobs:
           ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
         run: |
           ./gradlew assemble artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-snapshot-local
+      - name: deploy docs
+        env:
+          DOCS_USER: ${{ secrets.DOCS_USERNAME }}
+          DOCS_HOST: ${{ secrets.DOCS_HOST }}
+          DOCS_KEY: ${{ secrets.DOCS_SSH_KEY }}
+          DOCS_HOST_KEY: ${{ secrets.DOCS_SSH_HOST_KEY }}
+        run: ./gradlew deployDocs -PdeployDocsHost=$DOCS_HOST -PdeployDocsSshUsername=$DOCS_USER -PdeployDocsSshKey="$DOCS_KEY" -PdeployDocsSshHostKey="$DOCS_HOST_KEY"
 
   #sign the milestone artifacts and deploy them to Artifactory
   deployMilestone:
@@ -116,6 +123,13 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{secrets.SIGNING_PASSPHRASE}}
         run: |
           ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-milestone-local
+      - name: deploy docs
+        env:
+          DOCS_USER: ${{ secrets.DOCS_USERNAME }}
+          DOCS_HOST: ${{ secrets.DOCS_HOST }}
+          DOCS_KEY: ${{ secrets.DOCS_SSH_KEY }}
+          DOCS_HOST_KEY: ${{ secrets.DOCS_SSH_HOST_KEY }}
+        run: ./gradlew deployDocs -PdeployDocsHost=$DOCS_HOST -PdeployDocsSshUsername=$DOCS_USER -PdeployDocsSshKey="$DOCS_KEY" -PdeployDocsSshHostKey="$DOCS_HOST_KEY"
 
   #sign the release artifacts and deploy them to Artifactory
   deployRelease:
@@ -140,6 +154,13 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{secrets.SONATYPE_PASSWORD}}
         run: |
           ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io  -Partifactory_publish_repoKey=libs-release-local publishMavenJavaPublicationToSonatypeRepository
+      - name: deploy docs
+        env:
+          DOCS_USER: ${{ secrets.DOCS_USERNAME }}
+          DOCS_HOST: ${{ secrets.DOCS_HOST }}
+          DOCS_KEY: ${{ secrets.DOCS_SSH_KEY }}
+          DOCS_HOST_KEY: ${{ secrets.DOCS_SSH_HOST_KEY }}
+        run: ./gradlew deployDocs -PdeployDocsHost=$DOCS_HOST -PdeployDocsSshUsername=$DOCS_USER -PdeployDocsSshKey="$DOCS_KEY" -PdeployDocsSshHostKey="$DOCS_HOST_KEY"
 
   tagMilestone:
     name: Tag milestone

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ plugins {
 	id 'biz.aQute.bnd.builder' version '6.4.0' apply false
 	id 'org.graalvm.buildtools.native' version '0.9.25' apply false
 	id 'net.ltgt.errorprone' version '4.0.1' apply false
+	id 'org.hidetake.ssh' version '2.10.1' apply false
 }
 
 description = 'Reactive Streams Netty driver'

--- a/buildSrc/src/main/groovy/reactor/netty/docs/gradle/DeployDocs.groovy
+++ b/buildSrc/src/main/groovy/reactor/netty/docs/gradle/DeployDocs.groovy
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.docs.gradle
+
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.bundling.Zip;
+
+/**
+ * The purpose of this plugin is to prepare and upload javadoc + reference docs to docs.spring.io server.
+ */
+class DeployDocs implements Plugin<Project> {
+	// Define constants for property keys
+	static final String SSH_HOST_KEY = 'deployDocsSshHostKey'
+	static final String SSH_HOST = 'deployDocsHost'
+	static final String SSH_USERNAME = 'deployDocsSshUsername'
+	static final String SSH_KEY = 'deployDocsSshKey'
+
+	@Override
+	public void apply(Project project) {
+		// We are using this ssh plugin (take care: requires a JDK11 compatible version)
+		project.getPluginManager().apply('org.hidetake.ssh')
+
+		// configure task that creates a temporary zip (with both javadoc + reference doc) that will be uploaded to remote docs host
+		configureDeployDocsZipTask(project)
+
+		// configure task that upload the zip and install it on the remote docs host using ssh commands
+		configureDeployDocsTask(project)
+	}
+
+	private void configureDeployDocsZipTask(Project project) {
+		project.tasks.register('deployDocsZip', Zip) {
+			def buildDir = new File("${project.rootProject.projectDir}/reactor-netty/build")
+			if (!buildDir.exists()) {
+				logger.debug('Adding dependency on asciidoctor, asciidoctorPdf, javadoc')
+				dependsOn(':reactor-netty:asciidoctor', ':reactor-netty:asciidoctorPdf', ':reactor-netty:javadoc')
+			}
+
+			archiveBaseName.set("reactor-netty")
+			archiveClassifier.set("apidocs")
+
+			from("${project.rootProject.projectDir}/reactor-netty/build/asciidoc/pdf") {
+				include 'index.pdf'  // Include only the index.pdf file
+				into("reference/pdf/")
+				includeEmptyDirs = false
+				eachFile { fileCopyDetails ->
+					if (fileCopyDetails.name == 'index.pdf') {
+						fileCopyDetails.name = "reactor-netty-reference-guide-${rootProject.version}.pdf"
+					}
+				}
+			}
+			from("${project.rootProject.projectDir}/reactor-netty/build/asciidoc/") {
+				includeEmptyDirs = false
+				exclude "**/index.pdf"
+				into("reference/html/")
+			}
+			from("${project.rootProject.projectDir}/reactor-netty/build/docs/javadoc/") {
+				into "api"
+			}
+		}
+	}
+
+	private void configureDeployDocsTask(Project project) {
+		project.task('deployDocs') {
+			dependsOn 'deployDocsZip'
+			doLast {
+				configureSsh(project)
+
+				project.ssh.run {
+					session(project.remotes.docs) {
+						def now = System.currentTimeMillis()
+						def name = project.rootProject.name
+						def version = project.rootProject.version
+						def tempPath = "/tmp/${name}-${now}-docs/".replaceAll(' ', '_')
+						execute "mkdir -p $tempPath"
+
+						project.tasks.deployDocsZip.outputs.each { o ->
+							put from: o.files, into: tempPath
+						}
+
+						execute "unzip $tempPath*.zip -d $tempPath"
+
+						def extractPath = "/opt/www/domains/spring.io/docs/htdocs/projectreactor/${name}/docs/${version}/"
+
+						execute "rm -rf $extractPath"
+						execute "mkdir -p $extractPath"
+						execute "mv $tempPath* $extractPath"
+						execute "chmod -R g+w $extractPath"
+						execute "rm -rf $tempPath"
+						execute "rm -f $extractPath*.zip"
+
+						// update sym links with autoln command
+						execute "/opt/www/domains/spring.io/docs/autoln/bin/autoln create --scan-dir=/opt/www/domains/spring.io/docs/htdocs/projectreactor/${name}/docs/ --maxdepth=2"
+					}
+				}
+			}
+		}
+	}
+
+	private void configureSsh(Project project) {
+		project.remotes {
+			docs {
+				validateProperties(project)
+
+				// write content of known hosts into a temp file
+				def knownHostsFile = File.createTempFile("known_hosts_", ".txt")
+				knownHostsFile.text = project.findProperty(SSH_HOST_KEY)
+				knownHostsFile.deleteOnExit()
+
+				// configure ssh
+				role 'docs'
+				knownHosts = knownHostsFile
+				host = project.findProperty(SSH_HOST)
+				user = project.findProperty(SSH_USERNAME)
+				identity = identity = project.findProperty(SSH_KEY)
+				retryCount = 5 // retry 5 times (default is 0)
+				retryWaitSec = 3 // wait 10 seconds between retries (default is 0)
+			}
+		}
+	}
+
+	private void validateProperties(Project project) {
+		def requiredProperties = [SSH_HOST_KEY, SSH_HOST, SSH_USERNAME, SSH_KEY]
+		requiredProperties.each { prop ->
+			if (!project.hasProperty(prop)) {
+				throw new GradleException("deployDocs task failed: ${prop} property undefined")
+			}
+		}
+		if (!project.name) {
+			throw new GradleException("deployDocs task failed: property name undefined")
+		}
+		if (!project.version) {
+			throw new GradleException("deployDocs task failed: property version undefined")
+		}
+	}
+}

--- a/reactor-netty/build.gradle
+++ b/reactor-netty/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 apply plugin: 'io.spring.javadoc-aggregate'
 apply from: "${rootDir}/gradle/asciidoc.gradle"
+apply plugin: reactor.netty.docs.gradle.DeployDocs
 
 dependencies {
 	api project(':reactor-netty-core')


### PR DESCRIPTION
This PR is meant to publish javadoc and reference docs to docs.spring.io/projecrtreactor/reactor-netty/

In this PR, a new deployDocs gradle plugin is used to prepare/upload and install javadoc/reference docs.
The deployDocs gradle plugin is now using [SimpleSSH](https://github.com/RationaleEmotions/SimpleSSH/blob/master/README.md) java library which supports JDK 8, so it drastically simplifies everything.

note that SimpleSSH depends on an old com.jcraft:jsch project which is deprecated and this PR replaces it with https://github.com/mwiede/jsch, which can be used as a drop-in replacement for old com.jcraft:jsch.

on each push, the following docs will be updated here:

`https://docs.spring.io/projectreactor/reactor-netty/docs/VERSION/api/` (javadoc)
`https://docs.spring.io/projectreactor/reactor-netty/docs/VERSION/reference/html/` (reference doc)
`https://docs.spring.io/projectreactor/reactor-netty/docs/VERSION/reference/pdf/` (pdf reference doc)
`https://docs.spring.io/projectreactor/reactor-netty/docs/current` -> (the latest stable docs)
`https://docs.spring.io/projectreactor/reactor-netty/docs/current-SNAPSHOT` -> (the most recent snapshot docs)
`https://docs.spring.io/projectreactor/reactor-netty/docs/<major>.<minor>.x` -> (the most recently released version starting with `<major>.<minor>`)
`https://docs.spring.io/projectreactor/reactor-netty/docs/<major>.<minor>.x-SNAPSHOT` -> (the most recent snapshot docs starting with `<major>.<minor>`)

you can check existing docs which have been manually uploaded in https://docs.spring.io/projectreactor/reactor-netty/docs/

