### PR TITLE
Polish Javadoc for HttpClient.compress()

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -520,6 +520,8 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * <p>Note: Brotli and zstd compressions require additional dependencies.
 	 *
+	 * <p>Note: For zstd compression, {@literal Accept-Encoding: zstd} header needs to be added explicitly.
+	 *
 	 * @param compressionEnabled if true, compression (gzip, Brotli, and zstd) is enabled, otherwise disabled (default: false)
 	 * @return a new {@link HttpClient}
 	 */

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -516,9 +516,11 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	}
 
 	/**
-	 * Specifies whether GZip compression is enabled.
+	 * Specifies whether compression (gzip, Brotli, and zstd) is enabled.
 	 *
-	 * @param compressionEnabled if true GZip compression is enabled otherwise disabled (default: false)
+	 * <p>Note: Brotli and zstd compressions require additional dependencies.
+	 *
+	 * @param compressionEnabled if true, compression (gzip, Brotli, and zstd) is enabled, otherwise disabled (default: false)
 	 * @return a new {@link HttpClient}
 	 */
 	public final HttpClient compress(boolean compressionEnabled) {


### PR DESCRIPTION
This PR polishes Javadoc for the `HttpClient.compress()`.