### PR TITLE
Resolve on demand the path from the request uri

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpInfos.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpInfos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ public interface HttpInfos {
 	 * Returns the decoded path portion from the {@link #uri()}.
 	 *
 	 * @return the decoded path portion from the {@link #uri()}
+	 * @throws IllegalArgumentException if the {@link #uri()} violates RFC2396
 	 * @since 0.9.6
 	 */
 	String fullPath();
@@ -93,6 +94,7 @@ public interface HttpInfos {
 	 * Returns the decoded path portion from the {@link #uri()} without the leading and trailing '/' if present.
 	 *
 	 * @return the decoded path portion from the {@link #uri()} without the leading and trailing '/' if present
+	 * @throws IllegalArgumentException if the {@link #uri()} violates RFC2396
 	 */
 	default String path() {
 		String path = fullPath();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
@@ -259,11 +259,18 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 
 	@Override
 	public String toString() {
+		String path;
+		try {
+			path = fullPath();
+		}
+		catch (Exception e) {
+			path = "/bad-request";
+		}
 		if (isWebsocket()) {
-			return "ws{uri=" + fullPath() + ", connection=" + connection() + "}";
+			return "ws{uri=" + path + ", connection=" + connection() + "}";
 		}
 
-		return method().name() + "{uri=" + fullPath() + ", connection=" + connection() + "}";
+		return method().name() + "{uri=" + path + ", connection=" + connection() + "}";
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
@@ -189,7 +189,7 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelDuplexHandler {
 		ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
 		if (channelOps instanceof HttpClientOperations) {
 			HttpClientOperations ops = (HttpClientOperations) channelOps;
-			path = uriTagValue == null ? ops.path : uriTagValue.apply(ops.path);
+			path = uriTagValue == null ? resolvePath(ops) : uriTagValue.apply(resolvePath(ops));
 			contextView = ops.currentContextView();
 		}
 
@@ -271,6 +271,15 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelDuplexHandler {
 
 	protected void startWrite(HttpRequest msg, Channel channel, SocketAddress address) {
 		dataSentTime = System.nanoTime();
+	}
+
+	static String resolvePath(HttpClientOperations ops) {
+		try {
+			return ops.fullPath();
+		}
+		catch (Exception e) {
+			return "/bad-request";
+		}
 	}
 
 	private String resolveUri(ChannelHandlerContext ctx) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -55,7 +55,6 @@ import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
 import reactor.netty.NettyOutbound;
 import reactor.netty.channel.AbortedException;
-import reactor.netty.http.HttpOperations;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.tcp.TcpClientConfig;
 import reactor.netty.transport.AddressUtils;
@@ -528,7 +527,8 @@ class HttpClientConnect extends HttpClient {
 				                        .setProtocolVersion(HttpVersion.HTTP_1_1)
 				                        .headers();
 
-				ch.path = HttpOperations.resolvePath(ch.uri());
+				// Reset to pickup the actual uri()
+				ch.path = null;
 
 				if (!defaultHeaders.isEmpty()) {
 					headers.set(defaultHeaders);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -528,7 +528,10 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 
 	@Override
 	public final String fullPath() {
-		return this.path;
+		if (path == null) {
+			path = resolvePath(uri());
+		}
+		return path;
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
@@ -174,7 +174,7 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 					HttpServerOperations ops = (HttpServerOperations) channelOps;
 					if (!initialized) {
 						method = methodTagValue.apply(ops.method().name());
-						path = uriTagValue == null ? ops.path : uriTagValue.apply(ops.path);
+						path = uriTagValue == null ? resolvePath(ops) : uriTagValue.apply(resolvePath(ops));
 						// Always take the remote address from the operations in order to consider proxy information
 						// Use remoteSocketAddress() in order to obtain UDS info
 						remoteSocketAddress = ops.remoteSocketAddress();
@@ -249,7 +249,7 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 				if (channelOps instanceof HttpServerOperations) {
 					ops = (HttpServerOperations) channelOps;
 					method = methodTagValue.apply(ops.method().name());
-					path = uriTagValue == null ? ops.path : uriTagValue.apply(ops.path);
+					path = uriTagValue == null ? resolvePath(ops) : uriTagValue.apply(resolvePath(ops));
 					// Always take the remote address from the operations in order to consider proxy information
 					// Use remoteSocketAddress() in order to obtain UDS info
 					remoteSocketAddress = ops.remoteSocketAddress();
@@ -439,6 +439,15 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 		path = null;
 		remoteSocketAddress = null;
 		status = null;
+	}
+
+	static String resolvePath(HttpServerOperations ops) {
+		try {
+			return ops.fullPath();
+		}
+		catch (Exception e) {
+			return "/bad-request";
+		}
 	}
 
 	static final Set<String> STANDARD_METHODS;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3ServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3ServerOperations.java
@@ -57,27 +57,6 @@ final class Http3ServerOperations extends HttpServerOperations {
 				httpMessageLogFactory, isHttp2, mapHandle, readTimeout, requestTimeout, secured, timestamp);
 	}
 
-	Http3ServerOperations(
-			Connection c,
-			ConnectionObserver listener,
-			HttpRequest nettyRequest,
-			@Nullable BiPredicate<HttpServerRequest, HttpServerResponse> compressionPredicate,
-			ConnectionInfo connectionInfo,
-			ServerCookieDecoder decoder,
-			ServerCookieEncoder encoder,
-			HttpServerFormDecoderProvider formDecoderProvider,
-			HttpMessageLogFactory httpMessageLogFactory,
-			boolean isHttp2,
-			@Nullable BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>> mapHandle,
-			@Nullable Duration readTimeout,
-			@Nullable Duration requestTimeout,
-			boolean resolvePath,
-			boolean secured,
-			ZonedDateTime timestamp) {
-		super(c, listener, nettyRequest, compressionPredicate, connectionInfo, decoder, encoder, formDecoderProvider,
-				httpMessageLogFactory, isHttp2, mapHandle, readTimeout, requestTimeout, resolvePath, secured, timestamp);
-	}
-
 	@Override
 	public SocketAddress connectionHostAddress() {
 		return ((QuicChannel) channel().parent()).localSocketAddress();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -180,24 +180,6 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 			@Nullable Duration requestTimeout,
 			boolean secured,
 			ZonedDateTime timestamp) {
-		this(c, listener, nettyRequest, compressionPredicate, connectionInfo, decoder, encoder, formDecoderProvider,
-				httpMessageLogFactory, isHttp2, mapHandle, readTimeout, requestTimeout, true, secured, timestamp);
-	}
-
-	HttpServerOperations(Connection c, ConnectionObserver listener, HttpRequest nettyRequest,
-			@Nullable BiPredicate<HttpServerRequest, HttpServerResponse> compressionPredicate,
-			ConnectionInfo connectionInfo,
-			ServerCookieDecoder decoder,
-			ServerCookieEncoder encoder,
-			HttpServerFormDecoderProvider formDecoderProvider,
-			HttpMessageLogFactory httpMessageLogFactory,
-			boolean isHttp2,
-			@Nullable BiFunction<? super Mono<Void>, ? super Connection, ? extends Mono<Void>> mapHandle,
-			@Nullable Duration readTimeout,
-			@Nullable Duration requestTimeout,
-			boolean resolvePath,
-			boolean secured,
-			ZonedDateTime timestamp) {
 		super(c, listener, httpMessageLogFactory);
 		this.compressionPredicate = compressionPredicate;
 		this.configuredCompressionPredicate = compressionPredicate;
@@ -212,12 +194,6 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		this.mapHandle = mapHandle;
 		this.nettyRequest = nettyRequest;
 		this.nettyResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
-		if (resolvePath) {
-			this.path = resolvePath(nettyRequest.uri());
-		}
-		else {
-			this.path = null;
-		}
 		this.readTimeout = readTimeout;
 		this.requestTimeout = requestTimeout;
 		this.responseHeaders = nettyResponse.headers();
@@ -730,7 +706,10 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 
 	@Override
 	public String fullPath() {
-		if (path != null) {
+		if (nettyRequest != null) {
+			if (path == null) {
+				path = resolvePath(nettyRequest.uri());
+			}
 			return path;
 		}
 		throw new IllegalStateException("request not parsed");
@@ -1245,17 +1224,17 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 				ConnectionInfo connectionInfo) {
 			super(c, listener, nettyRequest, null, connectionInfo,
 					ServerCookieDecoder.STRICT, ServerCookieEncoder.STRICT, DEFAULT_FORM_DECODER_SPEC, httpMessageLogFactory, isHttp2,
-					null, null, null, false, secure, timestamp);
+					null, null, null, secure, timestamp);
 			this.customResponse = nettyResponse;
-			String tempPath = "";
+		}
+
+		@Override
+		public String fullPath() {
 			try {
-				tempPath = resolvePath(nettyRequest.uri());
+				return resolvePath(nettyRequest.uri());
 			}
 			catch (RuntimeException e) {
-				tempPath = "/bad-request";
-			}
-			finally {
-				this.path = tempPath;
+				return "/bad-request";
 			}
 		}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -65,6 +65,7 @@ import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpContent;
@@ -1754,7 +1755,16 @@ class HttpServerTests extends BaseHttpTest {
 				                      ctx.write(msg, promise);
 				                  }
 				              }))
-				          .handle((req, res) -> res.sendString(Mono.just("testIssue1001")))
+				          .handle((req, res) -> {
+				              try {
+				                  String path = res.fullPath();
+				                  return res.sendString(Mono.just("testIssue1001 " + path));
+				              }
+				              catch(Exception e) {
+				                  ((HttpServerOperations) req).nettyRequest.setDecoderResult(DecoderResult.failure(e.getCause() != null ? e.getCause() : e));
+				                  return res.status(400).header(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE).send();
+				              }
+				          })
 				          .bindNow();
 
 		int port = disposableServer.port();
@@ -1791,8 +1801,12 @@ class HttpServerTests extends BaseHttpTest {
 
 		StepVerifier.create(
 		        createClient(disposableServer::address)
-		                  .get()
+		                  .request(HttpMethod.GET)
 		                  .uri("/<")
+		                  .send((req, out) -> {
+		                      req.fullPath();
+		                      return out;
+		                  })
 		                  .response())
 		            .expectError(IllegalArgumentException.class)
 		            .verify(Duration.ofSeconds(30));

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1760,7 +1760,7 @@ class HttpServerTests extends BaseHttpTest {
 				                  String path = res.fullPath();
 				                  return res.sendString(Mono.just("testIssue1001 " + path));
 				              }
-				              catch(Exception e) {
+				              catch (Exception e) {
 				                  ((HttpServerOperations) req).nettyRequest.setDecoderResult(DecoderResult.failure(e.getCause() != null ? e.getCause() : e));
 				                  return res.status(400).header(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE).send();
 				              }


### PR DESCRIPTION
`HttpInfos#fullPath` and `HttpInfos#path` may throw `IllegalArgumentException` if the request uri violates `RFC2396`

Frameworks that use Reactor Netty may have their own request uri parser, therefor Reactor Netty will resolve on demand the path from the request uri.