### PR TITLE
`HttpDecoderSpec#validateHeaders()` specifies whether request/response headers are validated

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
@@ -146,12 +146,13 @@ final class Http2StreamBridgeServerHandler extends ChannelDuplexHandler {
 						readTimeout,
 						requestTimeout,
 						secured,
-						timestamp);
+						timestamp,
+						true);
 			}
 			catch (RuntimeException e) {
 				pendingResponse = false;
 				request.setDecoderResult(DecoderResult.failure(e.getCause() != null ? e.getCause() : e));
-				HttpServerOperations.sendDecodingFailures(ctx, listener, secured, e, msg, httpMessageLogFactory, true, timestamp, connectionInfo, remoteAddress);
+				HttpServerOperations.sendDecodingFailures(ctx, listener, secured, e, msg, httpMessageLogFactory, true, timestamp, connectionInfo, remoteAddress, true);
 				return;
 			}
 			ops.bind();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3ServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3ServerOperations.java
@@ -54,7 +54,7 @@ final class Http3ServerOperations extends HttpServerOperations {
 			boolean secured,
 			ZonedDateTime timestamp) {
 		super(c, listener, nettyRequest, compressionPredicate, connectionInfo, decoder, encoder, formDecoderProvider,
-				httpMessageLogFactory, isHttp2, mapHandle, readTimeout, requestTimeout, secured, timestamp);
+				httpMessageLogFactory, isHttp2, mapHandle, readTimeout, requestTimeout, secured, timestamp, true);
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3StreamBridgeServerHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3StreamBridgeServerHandler.java
@@ -142,7 +142,7 @@ final class Http3StreamBridgeServerHandler extends ChannelDuplexHandler {
 			catch (RuntimeException e) {
 				pendingResponse = false;
 				request.setDecoderResult(DecoderResult.failure(e.getCause() != null ? e.getCause() : e));
-				HttpServerOperations.sendDecodingFailures(ctx, listener, true, e, msg, httpMessageLogFactory, true, timestamp, connectionInfo, remoteAddress);
+				HttpServerOperations.sendDecodingFailures(ctx, listener, true, e, msg, httpMessageLogFactory, true, timestamp, connectionInfo, remoteAddress, true);
 				return;
 			}
 			ops.bind();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -743,7 +743,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		            NettyPipeline.HttpTrafficHandler,
 		            new HttpTrafficHandler(compressPredicate, cookieDecoder, cookieEncoder, formDecoderProvider,
 		                    forwardedHeaderHandler, httpMessageLogFactory, idleTimeout, listener, mapHandle, maxKeepAliveRequests,
-		                    readTimeout, requestTimeout));
+		                    readTimeout, requestTimeout, decoder.validateHeaders()));
 
 		if (accessLogEnabled) {
 			p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.AccessLogHandler, AccessLogHandlerFactory.H1.create(accessLog));
@@ -813,7 +813,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 		            NettyPipeline.HttpTrafficHandler,
 		            new HttpTrafficHandler(compressPredicate, cookieDecoder, cookieEncoder, formDecoderProvider,
 		                    forwardedHeaderHandler, httpMessageLogFactory, idleTimeout, listener, mapHandle, maxKeepAliveRequests,
-		                    readTimeout, requestTimeout));
+		                    readTimeout, requestTimeout, decoder.validateHeaders()));
 
 		if (accessLogEnabled) {
 			p.addAfter(NettyPipeline.HttpTrafficHandler, NettyPipeline.AccessLogHandler, AccessLogHandlerFactory.H1.create(accessLog));

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -2133,7 +2133,8 @@ class HttpServerTests extends BaseHttpTest {
 				null,
 				null,
 				false,
-				ZonedDateTime.now(ReactorNetty.ZONE_ID_SYSTEM));
+				ZonedDateTime.now(ReactorNetty.ZONE_ID_SYSTEM),
+				true);
 		ops.status(status);
 		HttpMessage response = ops.newFullBodyMessage(Unpooled.EMPTY_BUFFER);
 		assertThat(((FullHttpResponse) response).status().reasonPhrase()).isEqualTo(status.reasonPhrase());
@@ -3136,7 +3137,8 @@ class HttpServerTests extends BaseHttpTest {
 				null,
 				null,
 				false,
-				ZonedDateTime.now(ReactorNetty.ZONE_ID_SYSTEM));
+				ZonedDateTime.now(ReactorNetty.ZONE_ID_SYSTEM),
+				true);
 		assertThat(ops.isFormUrlencoded()).isEqualTo(expectation);
 		// "FutureReturnValueIgnored" is suppressed deliberately
 		channel.close();


### PR DESCRIPTION
This is related only to `HTTP/1.1`, for `HTTP/2` and `HTTP/3` headers are always validated.
By default the validation is enabled.