### PR TITLE
Enhance Task Monitoring by Printing Stack Traces for Blocking Tasks

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java
@@ -204,6 +204,11 @@ public final class ReactorNetty {
 	public static final String REACTOR_NETTY_SEND_MAX_PREFETCH_SIZE = "reactor.netty.send.maxPrefetchSize";
 
 	/**
+	 * Default pending task log threshold, fallback to -1 (no logging).
+	 */
+	public static final String PENDING_TASK_LOG_THRESHOLD = "reactor.netty.pendingTaskLogThreshold";
+
+	/**
 	 * Try to call {@link ReferenceCounted#release()} if the specified message implements {@link ReferenceCounted}.
 	 * If the specified message doesn't implement {@link ReferenceCounted} or it is already released,
 	 * this method does nothing.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/LoopResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/LoopResources.java
@@ -35,6 +35,13 @@ import reactor.netty.ReactorNetty;
 public interface LoopResources extends Disposable {
 
 	/**
+	 * Default pending task log threshold, fallback to -1 (no logging).
+	 */
+	int DEFAULT_PENDING_TASK_LOG_THRESHOLD = Integer.parseInt(System.getProperty(
+			ReactorNetty.PENDING_TASK_LOG_THRESHOLD,
+			"" + -1));
+
+	/**
 	 * Default worker thread count, fallback to available processor
 	 * (but with a minimum value of 4).
 	 */
@@ -43,11 +50,12 @@ public interface LoopResources extends Disposable {
 			"" + Math.max(Runtime.getRuntime().availableProcessors(), 4)));
 
 	/**
-	 * Default selector thread count, fallback to -1 (no selector thread).
+	 * Default selector thread count, fallback to -1 (no selector thread),
+	 * but fallback to 1 if pending task logging is enabled.
 	 */
 	int DEFAULT_IO_SELECT_COUNT = Integer.parseInt(System.getProperty(
 			ReactorNetty.IO_SELECT_COUNT,
-			"" + -1));
+			DEFAULT_PENDING_TASK_LOG_THRESHOLD > -1 ? "" + 1 : "" + -1));
 
 	/**
 	 * Default value whether the native transport (epoll, kqueue) will be preferred,


### PR DESCRIPTION
Hello, I’m suggesting an enhancement to add blocking task detection. When the number of blocking tasks exceeds a specified threshold, it would trigger the printing of worker thread stack traces. This would enable faster identification and troubleshooting of the issues.
