### PR TITLE
Parse X-Forwarded-Prefix request header

### DIFF
--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -249,6 +249,7 @@ task japicmp(type: JapicmpTask) {
 
 	compatibilityChangeExcludes = [ "METHOD_NEW_DEFAULT" ]
 	methodExcludes = [
+			"reactor.netty.http.server.HttpServerRequest#forwardedPrefix()"
 	]
 }
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ConnectionInfo.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ConnectionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,8 @@ public final class ConnectionInfo {
 
 	final boolean isInetAddress;
 
+	final String forwardedPrefix;
+
 	static ConnectionInfo from(Channel channel, HttpRequest request, boolean secured, SocketAddress remoteAddress,
 			@Nullable BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> forwardedHeaderHandler) {
 		String hostName = DEFAULT_HOST_NAME;
@@ -94,12 +96,18 @@ public final class ConnectionInfo {
 
 	ConnectionInfo(SocketAddress hostAddress, String hostName, int hostPort,
 			SocketAddress remoteAddress, String scheme, boolean isInetAddress) {
+		this(hostAddress, hostName, hostPort, remoteAddress, scheme, isInetAddress, "");
+	}
+
+	ConnectionInfo(SocketAddress hostAddress, String hostName, int hostPort,
+			SocketAddress remoteAddress, String scheme, boolean isInetAddress, String forwardedPrefix) {
 		this.hostAddress = hostAddress;
 		this.hostName = hostName;
 		this.hostPort = hostPort;
 		this.isInetAddress = isInetAddress;
 		this.remoteAddress = remoteAddress;
 		this.scheme = scheme;
+		this.forwardedPrefix = forwardedPrefix;
 	}
 
 	/**
@@ -174,6 +182,18 @@ public final class ConnectionInfo {
 	}
 
 	/**
+	 * Return a new {@link ConnectionInfo} with the forwardedPrefix set.
+	 * @param forwardedPrefix the prefix provided via X-Forwarded-Prefix header
+	 * @return a new {@link ConnectionInfo}
+	 * @since 1.1.23
+	 */
+	public ConnectionInfo withForwardedPrefix(String forwardedPrefix) {
+		requireNonNull(forwardedPrefix, "forwardedPrefix");
+		return new ConnectionInfo(this.hostAddress, this.hostName, this.hostPort, this.remoteAddress, this.scheme,
+				this.isInetAddress, forwardedPrefix);
+	}
+
+	/**
 	 * Returns the connection host name.
 	 * @return the connection host name
 	 * @since 1.0.32
@@ -189,6 +209,15 @@ public final class ConnectionInfo {
 	 */
 	public int getHostPort() {
 		return hostPort != -1 ? hostPort : getDefaultHostPort(scheme);
+	}
+
+	/**
+	 * Returns the X-Forwarded-Prefix if it was part of the request headers.
+	 * @return the X-Forwarded-Prefix
+	 * @since 1.1.23
+	 */
+	public String getForwardedPrefix() {
+		return forwardedPrefix;
 	}
 
 	/**

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ConnectionInfo.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ConnectionInfo.java
@@ -57,6 +57,7 @@ public final class ConnectionInfo {
 
 	final boolean isInetAddress;
 
+	@Nullable
 	final String forwardedPrefix;
 
 	static ConnectionInfo from(Channel channel, HttpRequest request, boolean secured, SocketAddress remoteAddress,
@@ -96,11 +97,11 @@ public final class ConnectionInfo {
 
 	ConnectionInfo(SocketAddress hostAddress, String hostName, int hostPort,
 			SocketAddress remoteAddress, String scheme, boolean isInetAddress) {
-		this(hostAddress, hostName, hostPort, remoteAddress, scheme, isInetAddress, "");
+		this(hostAddress, hostName, hostPort, remoteAddress, scheme, isInetAddress, null);
 	}
 
 	ConnectionInfo(SocketAddress hostAddress, String hostName, int hostPort,
-			SocketAddress remoteAddress, String scheme, boolean isInetAddress, String forwardedPrefix) {
+			SocketAddress remoteAddress, String scheme, boolean isInetAddress, @Nullable String forwardedPrefix) {
 		this.hostAddress = hostAddress;
 		this.hostName = hostName;
 		this.hostPort = hostPort;
@@ -216,6 +217,7 @@ public final class ConnectionInfo {
 	 * @return the X-Forwarded-Prefix
 	 * @since 1.1.23
 	 */
+	@Nullable
 	public String getForwardedPrefix() {
 		return forwardedPrefix;
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
@@ -16,8 +16,6 @@
 package reactor.netty.http.server;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.StringTokenizer;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 	static final String  X_FORWARDED_HOST_HEADER  = "X-Forwarded-Host";
 	static final String  X_FORWARDED_PORT_HEADER  = "X-Forwarded-Port";
 	static final String  X_FORWARDED_PROTO_HEADER = "X-Forwarded-Proto";
+	static final String  X_FORWARDED_PREFIX_HEADER = "X-Forwarded-Prefix";
 
 	static final Pattern FORWARDED_HOST_PATTERN   = Pattern.compile("host=\"?([^;,\"]+)\"?");
 	static final Pattern FORWARDED_PROTO_PATTERN  = Pattern.compile("proto=\"?([^;,\"]+)\"?");
@@ -114,6 +115,11 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 			else if (DEFAULT_FORWARDED_HEADER_VALIDATION) {
 				throw new IllegalArgumentException("Failed to parse a port from " + portHeader);
 			}
+		}
+
+		String prefixHeader = request.headers().get(X_FORWARDED_PREFIX_HEADER);
+		if (prefixHeader != null && !prefixHeader.isEmpty()) {
+			connectionInfo = connectionInfo.withForwardedPrefix(prefixHeader);
 		}
 		return connectionInfo;
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
@@ -138,7 +138,11 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 			}
 			prefix.append((endIndex != rawPrefix.length() ? rawPrefix.substring(0, endIndex) : rawPrefix));
 		}
-		return prefix.toString();
+		String parsedPrefix = prefix.toString();
+		if (!parsedPrefix.isEmpty() && DEFAULT_FORWARDED_HEADER_VALIDATION && !parsedPrefix.startsWith("/")) {
+			throw new IllegalArgumentException("X-Forwarded-Prefix did not start with a slash (\"/\"): " + prefixHeader);
+		}
+		return parsedPrefix;
 	}
 
 	private static String[] tokenizeToStringArray(String str) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
@@ -139,7 +139,7 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 			prefix.append((endIndex != rawPrefix.length() ? rawPrefix.substring(0, endIndex) : rawPrefix));
 		}
 		String parsedPrefix = prefix.toString();
-		if (!parsedPrefix.isEmpty() && DEFAULT_FORWARDED_HEADER_VALIDATION && !parsedPrefix.startsWith("/")) {
+		if (!parsedPrefix.isEmpty() && DEFAULT_FORWARDED_HEADER_VALIDATION && parsedPrefix.charAt(0) != '/') {
 			throw new IllegalArgumentException("X-Forwarded-Prefix did not start with a slash (\"/\"): " + prefixHeader);
 		}
 		return parsedPrefix;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -530,6 +530,11 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 	}
 
 	@Override
+	public String forwardedPrefix() {
+		return connectionInfo.getForwardedPrefix();
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	public NettyOutbound send(Publisher<? extends ByteBuf> source) {
 		if (!channel().isActive()) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,4 +158,11 @@ public interface HttpServerRequest extends NettyInbound, HttpServerInfos {
 	 * @since 1.0.28
 	 */
 	ZonedDateTime timestamp();
+
+	/**
+	 * Returns the X-Forwarded-Prefix if it was part of the request headers.
+	 * @return the X-Forwarded-Prefix
+	 * @since 1.1.23
+	 */
+	String forwardedPrefix();
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRequest.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerRequest.java
@@ -164,5 +164,6 @@ public interface HttpServerRequest extends NettyInbound, HttpServerInfos {
 	 * @return the X-Forwarded-Prefix
 	 * @since 1.1.23
 	 */
+	@Nullable
 	String forwardedPrefix();
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -315,12 +315,28 @@ class ConnectionInfoTests extends BaseHttpTest {
 	void xForwardedPrefix(boolean useCustomForwardedHandler) {
 		testClientRequest(
 				clientRequestHeaders -> {
-					clientRequestHeaders.add("X-Forwarded-Prefix", "test-prefix");
+					clientRequestHeaders.add("X-Forwarded-Prefix", "/test-prefix");
 				},
 				serverRequest -> {
-					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("test-prefix");
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("/test-prefix");
 				},
 				useCustomForwardedHandler);
+	}
+
+	@Test
+	void xForwardedPrefixWithoutForwardSlash() {
+		testClientRequest(
+				clientRequestHeaders -> {
+					clientRequestHeaders.add("X-Forwarded-Prefix", "forward-slash-missing");
+				},
+				serverRequest -> {
+
+				},
+				null,
+				httpClient -> httpClient,
+				httpServer -> httpServer.port(8080),
+				false,
+				true);
 	}
 
 	@ParameterizedTest
@@ -376,7 +392,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					clientRequestHeaders.add("X-Forwarded-Port", "8081");
 					clientRequestHeaders.add("X-Forwarded-Proto", "http");
 					clientRequestHeaders.add("X-Forwarded-Proto", "https");
-					clientRequestHeaders.add("X-Forwarded-Prefix", "test-prefix");
+					clientRequestHeaders.add("X-Forwarded-Prefix", "/test-prefix");
 				},
 				serverRequest -> {
 					Assertions.assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("192.168.0.1");
@@ -384,7 +400,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("192.168.0.1");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(8080);
 					Assertions.assertThat(serverRequest.scheme()).isEqualTo("http");
-					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("test-prefix");
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("/test-prefix");
 				},
 				useCustomForwardedHandler);
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -218,6 +218,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 				serverRequest -> {
 					Assertions.assertThat(serverRequest.remoteAddress().getHostString()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
 					Assertions.assertThat(serverRequest.remoteAddress().getPort()).isEqualTo(8080);
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
 				},
 				useCustomForwardedHandler);
 	}
@@ -234,6 +235,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(port);
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(port);
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
 				},
 				useCustomForwardedHandler);
 	}
@@ -250,6 +252,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(port);
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(port);
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
 				},
 				useCustomForwardedHandler);
 	}
@@ -265,6 +268,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(9090);
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("1abc:2abc:3abc:0:0:0:5abc:6abc");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(9090);
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
 				},
 				useCustomForwardedHandler);
 	}
@@ -282,6 +286,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(8080);
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("192.168.0.1");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(8080);
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
 				},
 				useCustomForwardedHandler);
 	}
@@ -299,6 +304,31 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(8080);
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("192.168.0.1");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(8080);
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
+				},
+				useCustomForwardedHandler);
+	}
+
+	@ParameterizedTest(name = "{displayName}({arguments})")
+	@ValueSource(booleans = {true, false})
+	void xForwardedPrefix(boolean useCustomForwardedHandler) {
+		testClientRequest(
+				clientRequestHeaders -> {
+					clientRequestHeaders.add("X-Forwarded-Prefix", "test-prefix");
+				},
+				serverRequest -> {
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("test-prefix");
+				},
+				useCustomForwardedHandler);
+	}
+
+	@ParameterizedTest(name = "{displayName}({arguments})")
+	@ValueSource(booleans = {true, false})
+	void xForwardedPrefixEmpty(boolean useCustomForwardedHandler) {
+		testClientRequest(
+				clientRequestHeaders -> {},
+				serverRequest -> {
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
 				},
 				useCustomForwardedHandler);
 	}
@@ -314,6 +344,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					clientRequestHeaders.add("X-Forwarded-Port", "8081");
 					clientRequestHeaders.add("X-Forwarded-Proto", "http");
 					clientRequestHeaders.add("X-Forwarded-Proto", "https");
+					clientRequestHeaders.add("X-Forwarded-Prefix", "test-prefix");
 				},
 				serverRequest -> {
 					Assertions.assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("192.168.0.1");
@@ -321,6 +352,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("192.168.0.1");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(8080);
 					Assertions.assertThat(serverRequest.scheme()).isEqualTo("http");
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("test-prefix");
 				},
 				useCustomForwardedHandler);
 	}
@@ -339,6 +371,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(port);
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("192.168.0.1");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(port);
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
 				},
 				getForwardedHandler(useCustomForwardedHandler),
 				httpClient -> httpClient,
@@ -359,6 +392,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(8080);
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("192.168.0.1");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(8080);
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
 				},
 				getForwardedHandler(useCustomForwardedHandler),
 				httpClient -> httpClient,
@@ -382,6 +416,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostAddress().getPort()).isEqualTo(8080);
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("a.example.com");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(8080);
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
 				},
 				useCustomForwardedHandler);
 	}
@@ -403,6 +438,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("a.example.com");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(8080);
 					Assertions.assertThat(serverRequest.scheme()).isEqualTo("http");
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
 				},
 				useCustomForwardedHandler);
 	}
@@ -424,6 +460,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("a.example.com");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(8080);
 					Assertions.assertThat(serverRequest.scheme()).isEqualTo("http");
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
 				},
 				useCustomForwardedHandler);
 	}
@@ -449,6 +486,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(8443);
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("a.example.com");
 					Assertions.assertThat(serverRequest.scheme()).isEqualTo("https");
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
 				},
 				getForwardedHandler(useCustomForwardedHandler),
 				httpClient -> httpClient.secure(ssl -> ssl.sslContext(clientSslContext)),
@@ -471,6 +509,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostName()).isEqualTo("a.example.com");
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(getDefaultHostPort(protocol));
 					Assertions.assertThat(serverRequest.scheme()).isEqualTo(protocol);
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("");
 				},
 				useCustomForwardedHandler);
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/forwardheaderhandler/CustomXForwardedHeadersHandler.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/forwardheaderhandler/CustomXForwardedHeadersHandler.java
@@ -77,7 +77,7 @@ public final class CustomXForwardedHeadersHandler {
 		}
 
 		String prefixHeader = request.headers().get(X_FORWARDED_PREFIX_HEADER);
-		if (prefixHeader != null && !prefixHeader.isEmpty()) {
+		if (prefixHeader != null) {
 			connectionInfo = connectionInfo.withForwardedPrefix(prefixHeader);
 		}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/forwardheaderhandler/CustomXForwardedHeadersHandler.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/forwardheaderhandler/CustomXForwardedHeadersHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2023-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ public final class CustomXForwardedHeadersHandler {
 	static final String X_FORWARDED_HOST_HEADER = "X-Forwarded-Host";
 	static final String X_FORWARDED_PORT_HEADER = "X-Forwarded-Port";
 	static final String X_FORWARDED_PROTO_HEADER = "X-Forwarded-Proto";
+	static final String X_FORWARDED_PREFIX_HEADER = "X-Forwarded-Prefix";
 
 	private CustomXForwardedHeadersHandler() {
 	}
@@ -74,6 +75,12 @@ public final class CustomXForwardedHeadersHandler {
 				throw new IllegalArgumentException("Failed to parse a port from " + portHeader);
 			}
 		}
+
+		String prefixHeader = request.headers().get(X_FORWARDED_PREFIX_HEADER);
+		if (prefixHeader != null && !prefixHeader.isEmpty()) {
+			connectionInfo = connectionInfo.withForwardedPrefix(prefixHeader);
+		}
+
 		return connectionInfo;
 	}
 }


### PR DESCRIPTION
The X-Forwarded-Prefix can be obtained via `HttpServerRequest#forwardedPrefix()`.