### PR TITLE
Switch from `macOS-12` to `macOS-13` runner image

### DIFF
--- a/.github/workflows/check_graalvm.yml
+++ b/.github/workflows/check_graalvm.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2022]
+        os: [ubuntu-20.04, macos-13, windows-2022]
         transport: [native, nio]
         exclude:
           # excludes native on Windows (there's none)

--- a/.github/workflows/check_netty_snapshots.yml
+++ b/.github/workflows/check_netty_snapshots.yml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-20.04, macos-13, windows-2019]
         transport: [native, nio]
         exclude:
           # excludes native on Windows (there's none)
           - os: windows-2019
             transport: native
           # macOS - https://github.com/netty/netty/issues/9689
-          - os: macos-12
+          - os: macos-13
             transport: native
 
     steps:

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-20.04, macos-13, windows-2019]
         transport: [native, nio]
         exclude:
           # excludes native on Windows (there's none)


### PR DESCRIPTION
`macOS-12` is deprecated and will be removed
https://github.com/actions/runner-images/issues/10721