### PR TITLE
Introducing Reactor Netty Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 [![publish](https://github.com/reactor/reactor-netty/actions/workflows/publish.yml/badge.svg)](https://github.com/reactor/reactor-netty/actions/workflows/publish.yml) [![CodeQL](https://github.com/reactor/reactor-netty/workflows/CodeQL/badge.svg?event=push)](https://github.com/reactor/reactor-netty/actions?query=workflow%3ACodeQL)
 
+[![](https://img.shields.io/badge/Gurubase-Ask%20Reactor%20Netty%20Guru-006BFF)](https://gurubase.io/g/reactor-netty)
+
 `Reactor Netty` offers non-blocking and backpressure-ready `TCP`/`HTTP`/`UDP`/`QUIC`
 clients & servers based on `Netty` framework.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Reactor Netty Guru](https://gurubase.io/g/reactor-netty) to Gurubase. Reactor Netty Guru uses the data from this repo and data from the [docs](https://projectreactor.io/docs/netty/release/reference/index.html#about-doc) to answer questions by leveraging the LLM.

In this PR, I showcased the "Reactor Netty Guru" badge, which highlights that Reactor Netty now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Reactor Netty Guru in Gurubase, just let me know that's totally fine.
