### PR TITLE
Ensure body is sent when `DELETE` and `Transfer-Encoding`

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -559,7 +559,6 @@ class HttpClientConnect extends HttpClient {
 
 				if (!Objects.equals(method, HttpMethod.GET) &&
 							!Objects.equals(method, HttpMethod.HEAD) &&
-							!Objects.equals(method, HttpMethod.DELETE) &&
 							!headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
 					ch.chunkedTransfer(true);
 				}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -98,6 +98,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -3444,5 +3445,28 @@ class HttpClientTest extends BaseHttpTest {
 		      .as(StepVerifier::create)
 		      .expectComplete()
 		      .verify(Duration.ofSeconds(5));
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void testDeleteMethod(boolean chunked) {
+		disposableServer =
+				createServer()
+				        .handle((req, res) -> res.send(req.receive().retain()))
+				        .bindNow();
+
+		Publisher<ByteBuf> body = chunked ?
+				ByteBufFlux.fromString(Flux.just("d", "e", "l", "e", "t", "e")) :
+				ByteBufMono.fromString(Mono.just("delete"));
+
+		createClient(disposableServer.port())
+		        .delete()
+		        .uri("/")
+		        .send(body)
+		        .responseSingle((res, bytes) -> bytes.asString())
+		        .as(StepVerifier::create)
+		        .expectNext("delete")
+		        .expectComplete()
+		        .verify(Duration.ofSeconds(5));
 	}
 }


### PR DESCRIPTION
According to the spec https://www.rfc-editor.org/rfc/rfc9110.html#name-delete

```
A client SHOULD NOT generate content in a DELETE request unless it is made
directly to an origin server that has previously indicated, in or out of band, that
such a request has a purpose and will be adequately supported.
```

When a user sends `DELETE` with content this means there is an indication that the server supports this type of requests.