### PR TITLE
Add timeout for `DefaultLoopResources#disposeLater`

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopResources.java
@@ -130,7 +130,8 @@ final class DefaultLoopResources extends AtomicLong implements LoopResources {
 				}
 			}
 
-			return Mono.when(clMono, sslMono, slMono, cnclMono, cnslMono, cnsrvlMono);
+			return Mono.when(clMono, sslMono, slMono, cnclMono, cnslMono, cnsrvlMono)
+			           .timeout(timeout, Mono.error(new IllegalStateException("LoopResources couldn't be disposed within " + timeout.toMillis() + "ms")));
 		});
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1914,6 +1914,7 @@ class HttpServerTests extends BaseHttpTest {
 				                       // Simulate some long-running CPU-intensive work
 				                       boolean stop = false;
 				                       while (!stop) {
+				                       // this is deliberate
 				                       }
 				                       return res.sendString(Mono.just("cpuIntensive"));
 				                   }))


### PR DESCRIPTION
When shutting down `EventLoopGroup`, `Netty` tries to add for an execution a task that will stop `EventLoops`. However if there is a CPU intensive task running on `EventLoop`, the execution of the shutting down task might never happen.

This change adds a timeout for `DefaultLoopResources#disposeLater` so that the user will be notified that some `EventLoops` cannot be stopped.

Note: Having blocking and CPU intensive tasks on `EventLoops` is strongly discouraged and can lead to unpredictable failures.

Fixes #3509