### PR TITLE
Initialise lazy the `ProxyProvider` configuration

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 	 * @return true if that {@link ClientTransportConfig} is configured with a proxy
 	 */
 	public final boolean hasProxy() {
-		return proxyProvider != null;
+		return proxyProvider != null || proxyProviderSupplier != null;
 	}
 
 	/**
@@ -125,6 +125,16 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 	@Nullable
 	public final ProxyProvider proxyProvider() {
 		return proxyProvider;
+	}
+
+	/**
+	 * Return the {@link ProxyProvider} supplier if any or null.
+	 *
+	 * @return the {@link ProxyProvider} supplier if any or null
+	 */
+	@Nullable
+	public final Supplier<ProxyProvider> proxyProviderSupplier() {
+		return proxyProviderSupplier;
 	}
 
 	/**
@@ -155,11 +165,12 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 	Consumer<? super CONF>                   doOnConnect;
 	Consumer<? super Connection>             doOnConnected;
 	Consumer<? super Connection>             doOnDisconnected;
-	Consumer<? super Connection>                doOnResolve;
+	Consumer<? super Connection>             doOnResolve;
 	BiConsumer<? super Connection, ? super SocketAddress> doAfterResolve;
 	BiConsumer<? super Connection, ? super Throwable> doOnResolveError;
 	NameResolverProvider                     nameResolverProvider;
 	ProxyProvider                            proxyProvider;
+	Supplier<ProxyProvider>                  proxyProviderSupplier;
 	Supplier<? extends SocketAddress>        remoteAddress;
 	AddressResolverGroup<?>                  resolver;
 
@@ -181,6 +192,7 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 		this.doOnResolveError = parent.doOnResolveError;
 		this.nameResolverProvider = parent.nameResolverProvider;
 		this.proxyProvider = parent.proxyProvider;
+		this.proxyProviderSupplier = parent.proxyProviderSupplier;
 		this.remoteAddress = parent.remoteAddress;
 		this.resolver = parent.resolver;
 	}
@@ -222,6 +234,10 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 
 	protected void proxyProvider(@Nullable ProxyProvider proxyProvider) {
 		this.proxyProvider = proxyProvider;
+	}
+
+	protected void proxyProviderSupplier(@Nullable Supplier<ProxyProvider> proxyProviderSupplier) {
+		this.proxyProviderSupplier = proxyProviderSupplier;
 	}
 
 	protected AddressResolverGroup<?> resolverInternal() {

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,29 +62,29 @@ public final class ProxyProvider {
 	}
 
 	final String username;
-	final Function<? super String, ? extends String> password;
-	final Supplier<? extends InetSocketAddress> address;
+	final String password;
+	final InetSocketAddress address;
 	final Predicate<SocketAddress> nonProxyHostPredicate;
-	final Supplier<? extends HttpHeaders> httpHeaders;
+	final HttpHeaders httpHeaders;
 	final Proxy type;
 	final long connectTimeoutMillis;
 
 	ProxyProvider(ProxyProvider.Build builder) {
 		this.username = builder.username;
-		this.password = builder.password;
+		this.password = builder.password != null ? builder.password : getPasswordValue(builder.passwordFunction);
 		this.nonProxyHostPredicate = builder.nonProxyHostPredicate;
 		if (Objects.isNull(builder.address)) {
 			if (builder.host != null) {
-				this.address = () -> AddressUtils.createResolved(builder.host, builder.port);
+				this.address = AddressUtils.createResolved(builder.host, builder.port);
 			}
 			else {
 				throw new IllegalArgumentException("Neither address nor host is specified");
 			}
 		}
 		else {
-			this.address = builder.address;
+			this.address = builder.address.get();
 		}
-		this.httpHeaders = builder.httpHeaders;
+		this.httpHeaders = builder.httpHeaders.get();
 		this.type = builder.type;
 		this.connectTimeoutMillis = builder.connectTimeoutMillis;
 	}
@@ -104,6 +104,15 @@ public final class ProxyProvider {
 	 * @return The supplier for the address to connect to.
 	 */
 	public final Supplier<? extends InetSocketAddress> getAddress() {
+		return () -> this.address;
+	}
+
+	/**
+	 * The address to connect to.
+	 *
+	 * @return The address to connect to.
+	 */
+	public final SocketAddress getSocketAddress() {
 		return this.address;
 	}
 
@@ -125,28 +134,23 @@ public final class ProxyProvider {
 	 * @return a new eventual {@link ProxyHandler}
 	 */
 	public final ProxyHandler newProxyHandler() {
-		InetSocketAddress proxyAddr = this.address.get();
-
 		final boolean b = Objects.nonNull(username) && Objects.nonNull(password);
-
-		String username = this.username;
-		String password = b ? this.password.apply(username) : null;
 
 		final ProxyHandler proxyHandler;
 		switch (this.type) {
 			case HTTP:
 				proxyHandler = b ?
-						new HttpProxyHandler(proxyAddr, username, password, this.httpHeaders.get()) :
-						new HttpProxyHandler(proxyAddr, this.httpHeaders.get());
+						new HttpProxyHandler(address, username, password, this.httpHeaders) :
+						new HttpProxyHandler(address, this.httpHeaders);
 				break;
 			case SOCKS4:
-				proxyHandler = Objects.nonNull(username) ? new Socks4ProxyHandler(proxyAddr, username) :
-						new Socks4ProxyHandler(proxyAddr);
+				proxyHandler = Objects.nonNull(username) ? new Socks4ProxyHandler(address, username) :
+						new Socks4ProxyHandler(address);
 				break;
 			case SOCKS5:
 				proxyHandler = b ?
-						new Socks5ProxyHandler(proxyAddr, username, password) :
-						new Socks5ProxyHandler(proxyAddr);
+						new Socks5ProxyHandler(address, username, password) :
+						new Socks5ProxyHandler(address);
 				break;
 			default:
 				throw new IllegalArgumentException("Proxy type unsupported : " + this.type);
@@ -195,7 +199,7 @@ public final class ProxyProvider {
 	@Override
 	public String toString() {
 		return "ProxyProvider {" +
-				"address=" + address.get() +
+				"address=" + address +
 				", nonProxyHosts=" + nonProxyHostPredicate +
 				", type=" + type +
 				'}';
@@ -211,11 +215,11 @@ public final class ProxyProvider {
 		}
 		ProxyProvider that = (ProxyProvider) o;
 		return Objects.equals(username, that.username) &&
-				Objects.equals(getPasswordValue(), that.getPasswordValue()) &&
-				Objects.equals(getAddress().get(), that.getAddress().get()) &&
+				Objects.equals(password, that.password) &&
+				Objects.equals(address, that.address) &&
 				getNonProxyHostsValue() == that.getNonProxyHostsValue() &&
-				Objects.equals(httpHeaders.get(), that.httpHeaders.get()) &&
-				getType() == that.getType() &&
+				Objects.equals(httpHeaders, that.httpHeaders) &&
+				type == that.type &&
 				connectTimeoutMillis == that.connectTimeoutMillis;
 	}
 
@@ -223,25 +227,25 @@ public final class ProxyProvider {
 	public int hashCode() {
 		int result = 1;
 		result = 31 * result + Objects.hashCode(username);
-		result = 31 * result + Objects.hashCode(getPasswordValue());
-		result = 31 * result + Objects.hashCode(getAddress().get());
+		result = 31 * result + Objects.hashCode(password);
+		result = 31 * result + Objects.hashCode(address);
 		result = 31 * result + Boolean.hashCode(getNonProxyHostsValue());
-		result = 31 * result + Objects.hashCode(httpHeaders.get());
-		result = 31 * result + Objects.hashCode(getType());
+		result = 31 * result + Objects.hashCode(httpHeaders);
+		result = 31 * result + Objects.hashCode(type);
 		result = 31 * result + Long.hashCode(connectTimeoutMillis);
 		return result;
 	}
 
 	private boolean getNonProxyHostsValue() {
-		return nonProxyHostPredicate.test(getAddress().get());
+		return nonProxyHostPredicate.test(address);
 	}
 
 	@Nullable
-	private String getPasswordValue() {
-		if (username == null || password == null) {
+	private String getPasswordValue(@Nullable Function<? super String, ? extends String> passwordFunction) {
+		if (username == null || passwordFunction == null) {
 			return null;
 		}
-		return password.apply(username);
+		return passwordFunction.apply(username);
 	}
 
 	static final LoggingHandler LOGGING_HANDLER =
@@ -311,17 +315,17 @@ public final class ProxyProvider {
 		String nonProxyHosts = properties.getProperty(HTTP_NON_PROXY_HOSTS, DEFAULT_NON_PROXY_HOSTS);
 		RegexShouldProxyPredicate transformedNonProxyHosts = RegexShouldProxyPredicate.fromWildcardedPattern(nonProxyHosts);
 
-		ProxyProvider.Builder proxy = ProxyProvider.builder()
-				.type(ProxyProvider.Proxy.HTTP)
+		ProxyProvider.Build proxy = new ProxyProvider.Build();
+		proxy.type(ProxyProvider.Proxy.HTTP)
 				.host(hostname)
 				.port(port)
 				.nonProxyHostsPredicate(transformedNonProxyHosts);
 
 		if (properties.containsKey(userProperty)) {
-			proxy = proxy.username(properties.getProperty(userProperty));
+			proxy.username(properties.getProperty(userProperty));
 
 			if (properties.containsKey(passwordProperty)) {
-				proxy = proxy.password(u -> properties.getProperty(passwordProperty));
+				proxy.password(properties.getProperty(passwordProperty));
 			}
 			else {
 				throw new NullPointerException("Proxy username is set via '" + userProperty + "', but '" + passwordProperty + "' is not set.");
@@ -342,16 +346,16 @@ public final class ProxyProvider {
 		ProxyProvider.Proxy type = SOCKS_VERSION_5.equals(version) ? Proxy.SOCKS5 : Proxy.SOCKS4;
 		int port = parsePort(properties.getProperty(SOCKS_PROXY_PORT, "1080"), SOCKS_PROXY_PORT);
 
-		ProxyProvider.Builder proxy = ProxyProvider.builder()
-				.type(type)
+		ProxyProvider.Build proxy = new ProxyProvider.Build();
+		proxy.type(type)
 				.host(hostname)
 				.port(port);
 
 		if (properties.containsKey(SOCKS_USERNAME)) {
-			proxy = proxy.username(properties.getProperty(SOCKS_USERNAME));
+			proxy.username(properties.getProperty(SOCKS_USERNAME));
 		}
 		if (properties.containsKey(SOCKS_PASSWORD)) {
-			proxy = proxy.password(u -> properties.getProperty(SOCKS_PASSWORD));
+			proxy.password(properties.getProperty(SOCKS_PASSWORD));
 		}
 
 		return proxy.build();
@@ -382,7 +386,8 @@ public final class ProxyProvider {
 		static final Predicate<SocketAddress> ALWAYS_PROXY = a -> false;
 
 		String username;
-		Function<? super String, ? extends String> password;
+		String password;
+		Function<? super String, ? extends String> passwordFunction;
 		String host;
 		int port;
 		Supplier<? extends InetSocketAddress> address;
@@ -401,8 +406,15 @@ public final class ProxyProvider {
 		}
 
 		@Override
-		public final Builder password(Function<? super String, ? extends String> password) {
+		public final Builder password(Function<? super String, ? extends String> passwordFunction) {
+			this.password = null;
+			this.passwordFunction = passwordFunction;
+			return this;
+		}
+
+		final Builder password(String password) {
 			this.password = password;
+			this.passwordFunction = null;
 			return this;
 		}
 

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -112,7 +112,7 @@ public final class ProxyProvider {
 	 *
 	 * @return The address to connect to.
 	 */
-	public final SocketAddress getSocketAddress() {
+	public final SocketAddress getProxyAddress() {
 		return this.address;
 	}
 

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -213,11 +213,13 @@ class ClientTransportTest {
 	void proxyOverriddenWithNullIfSystemPropertiesHaveNoProxySet() {
 		TestClientTransport transport = createTestTransportForProxy();
 		transport.proxy(spec -> spec.type(ProxyProvider.Proxy.HTTP).host("proxy").port(8080));
-		assertThat(transport.configuration().proxyProvider).isNotNull();
+		assertThat(transport.configuration().proxyProvider).isNull();
+		assertThat(transport.configuration().proxyProviderSupplier).isNotNull();
 		assertThat(transport.configuration().resolver()).isSameAs(NoopAddressResolverGroup.INSTANCE);
 
 		transport.proxyWithSystemProperties(new Properties());
 		assertThat(transport.configuration().proxyProvider).isNull();
+		assertThat(transport.configuration().proxyProviderSupplier).isNull();
 		assertThat(transport.configuration().resolver()).isNull();
 	}
 
@@ -225,10 +227,12 @@ class ClientTransportTest {
 	void noProxyIfSystemPropertiesHaveNoProxySet() {
 		TestClientTransport transport = createTestTransportForProxy();
 		assertThat(transport.configuration().proxyProvider).isNull();
+		assertThat(transport.configuration().proxyProviderSupplier).isNull();
 		assertThat(transport.configuration().resolver()).isNull();
 
 		transport.proxyWithSystemProperties(new Properties());
 		assertThat(transport.configuration().proxyProvider).isNull();
+		assertThat(transport.configuration().proxyProviderSupplier).isNull();
 		assertThat(transport.configuration().resolver()).isNull();
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
@@ -120,7 +120,7 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 		boolean acceptGzip = false;
 		ChannelMetricsRecorder metricsRecorder = config.metricsRecorder() != null ? config.metricsRecorder().get() : null;
 		SocketAddress proxyAddress = ((ClientTransportConfig<?>) config).proxyProvider() != null ?
-				((ClientTransportConfig<?>) config).proxyProvider().getSocketAddress() : null;
+				((ClientTransportConfig<?>) config).proxyProvider().getProxyAddress() : null;
 		Function<String, String> uriTagValue = null;
 		if (config instanceof HttpClientConfig) {
 			acceptGzip = ((HttpClientConfig) config).acceptGzip;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
@@ -120,7 +120,7 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 		boolean acceptGzip = false;
 		ChannelMetricsRecorder metricsRecorder = config.metricsRecorder() != null ? config.metricsRecorder().get() : null;
 		SocketAddress proxyAddress = ((ClientTransportConfig<?>) config).proxyProvider() != null ?
-				((ClientTransportConfig<?>) config).proxyProvider().getAddress().get() : null;
+				((ClientTransportConfig<?>) config).proxyProvider().getSocketAddress() : null;
 		Function<String, String> uriTagValue = null;
 		if (config instanceof HttpClientConfig) {
 			acceptGzip = ((HttpClientConfig) config).acceptGzip;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -990,7 +990,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			this.metricsRecorder = config.metricsRecorderInternal();
 			this.opsFactory = config.channelOperationsProvider();
 			this.protocols = config._protocols;
-			this.proxyAddress = config.proxyProvider() != null ? config.proxyProvider().getSocketAddress() : null;
+			this.proxyAddress = config.proxyProvider() != null ? config.proxyProvider().getProxyAddress() : null;
 			this.sslProvider = config.sslProvider;
 			this.uriTagValue = config.uriTagValue;
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -457,6 +457,11 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 	}
 
 	@Override
+	protected void proxyProviderSupplier(Supplier<ProxyProvider> proxyProviderSupplier) {
+		super.proxyProviderSupplier(proxyProviderSupplier);
+	}
+
+	@Override
 	protected AddressResolverGroup<?> resolverInternal() {
 		return super.resolverInternal();
 	}
@@ -985,7 +990,7 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			this.metricsRecorder = config.metricsRecorderInternal();
 			this.opsFactory = config.channelOperationsProvider();
 			this.protocols = config._protocols;
-			this.proxyAddress = config.proxyProvider() != null ? config.proxyProvider().getAddress().get() : null;
+			this.proxyAddress = config.proxyProvider() != null ? config.proxyProvider().getSocketAddress() : null;
 			this.sslProvider = config.sslProvider;
 			this.uriTagValue = config.uriTagValue;
 		}


### PR DESCRIPTION
Configurations like `address`, `headers`, `password` are calculated just before sending the request. If a configuration is changed a new `connection pool` will be created.

Fixes #3501