### PR TITLE
Avoid using static exceptions for better debugging experience

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -1618,7 +1618,7 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 			@SuppressWarnings("FutureReturnValueIgnored")
 			public void run() {
 				if (!requestAvailable) {
-					ctx.fireExceptionCaught(RequestTimeoutException.INSTANCE);
+					ctx.fireExceptionCaught(RequestTimeoutException.requestTimedOut());
 					//"FutureReturnValueIgnored" this is deliberate
 					ctx.close();
 				}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -1341,7 +1341,7 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		@SuppressWarnings("FutureReturnValueIgnored")
 		public void run() {
 			if (ctx.channel().isActive() && !(isInboundCancelled() || isInboundDisposed())) {
-				onInboundError(RequestTimeoutException.INSTANCE);
+				onInboundError(RequestTimeoutException.requestTimedOut());
 				//"FutureReturnValueIgnored" this is deliberate
 				ctx.close();
 			}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/RequestTimeoutException.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/RequestTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2023-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,20 @@ package reactor.netty.http.server;
 import io.netty.channel.ChannelException;
 
 final class RequestTimeoutException extends ChannelException {
-
-	static final RequestTimeoutException INSTANCE = new RequestTimeoutException();
+	static final String REQUEST_TIMED_OUT = "Request timed out";
 
 	private static final long serialVersionUID = 422626851161276356L;
 
-	RequestTimeoutException() {
-		super(null, null, true);
+	RequestTimeoutException(String message) {
+		super(message);
 	}
 
 	@Override
 	public synchronized Throwable fillInStackTrace() {
 		return this;
+	}
+
+	static RequestTimeoutException requestTimedOut() {
+		return new RequestTimeoutException(REQUEST_TIMED_OUT);
 	}
 }


### PR DESCRIPTION
Before this change:

```
AbstractErrorWebExceptionHandler : [0861a0da-1]  500 Server Error for HTTP POST "/"

reactor.netty.http.server.RequestTimeoutException: null
```

After this change:

```
AbstractErrorWebExceptionHandler : [dbf4f5fb-1]  500 Server Error for HTTP POST "/"

reactor.netty.http.server.RequestTimeoutException: Request timed out
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException:
Error has been observed at the following site(s):
	*__checkpoint ⇢ Handler com.example.MyController#hello(ServerHttpRequest) [DispatcherHandler]
	*__checkpoint ⇢ HTTP POST "/" [ExceptionHandlingWebHandler]
Original Stack Trace:
```