### PR TITLE
HttpServerRequest::receiveContent() never emits any value nor completes when HTTP/1.1 TLS Upgrade (RFC-2817) kicks in

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -816,6 +816,8 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 					request.release();
 					// HTTP/1.1 TLS Upgrade (RFC-2817) on empty requests (GET/HEAD/OPTIONS)
 					if (!isHttp2() && request.headers().contains(HttpHeaderNames.UPGRADE)) {
+						//force auto read to enable more accurate close selection now inbound is done
+						channel().config().setAutoRead(true);
 						onInboundComplete();
 					}
 				}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -820,7 +820,7 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 					channel().config().setAutoRead(true);
 					onInboundComplete();
 				}
-				else if (!isHttp2() && request.headers().contains(HttpHeaderNames.UPGRADE)) {
+				else if (request.headers().contains(HttpHeaderNames.UPGRADE)) {
 					// HTTP/1.1 TLS Upgrade (RFC-2817) requests (GET/HEAD/OPTIONS) with empty / non-empty payload
 					stopReadTimeout();
 					//force auto read to enable more accurate close selection now inbound is done

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -826,6 +826,12 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 					channel().config().setAutoRead(true);
 					onInboundComplete();
 				}
+				else if (!isHttp2() && request.headers().contains(HttpHeaderNames.UPGRADE)) {
+					// HTTP/1.1 TLS Upgrade (RFC-2817) requests (GET/HEAD/OPTIONS) with empty / non-empty payload
+					// No need to call onInboundComplete(), it will be triggered by onInboundNext(...)
+					// since this is the last HTTP content
+					stopReadTimeout();
+				}
 			}
 		}
 		else if (msg instanceof LastHttpContent) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -814,12 +814,6 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 				}
 				else {
 					request.release();
-					// HTTP/1.1 TLS Upgrade (RFC-2817) on empty requests (GET/HEAD/OPTIONS)
-					if (!isHttp2() && request.headers().contains(HttpHeaderNames.UPGRADE)) {
-						//force auto read to enable more accurate close selection now inbound is done
-						channel().config().setAutoRead(true);
-						onInboundComplete();
-					}
 				}
 				if (isHttp2()) {
 					//force auto read to enable more accurate close selection now inbound is done
@@ -828,9 +822,10 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 				}
 				else if (!isHttp2() && request.headers().contains(HttpHeaderNames.UPGRADE)) {
 					// HTTP/1.1 TLS Upgrade (RFC-2817) requests (GET/HEAD/OPTIONS) with empty / non-empty payload
-					// No need to call onInboundComplete(), it will be triggered by onInboundNext(...)
-					// since this is the last HTTP content
 					stopReadTimeout();
+					//force auto read to enable more accurate close selection now inbound is done
+					channel().config().setAutoRead(true);
+					onInboundComplete();
 				}
 			}
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -814,6 +814,10 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 				}
 				else {
 					request.release();
+					// HTTP/1.1 TLS Upgrade (RFC-2817) on empty requests (GET/HEAD/OPTIONS)
+					if (!isHttp2() && request.headers().contains(HttpHeaderNames.UPGRADE)) {
+						onInboundComplete();
+					}
 				}
 				if (isHttp2()) {
 					//force auto read to enable more accurate close selection now inbound is done

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -72,6 +72,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.handler.codec.compression.Brotli;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpContentDecompressor;
@@ -1730,6 +1731,39 @@ class HttpClientTest extends BaseHttpTest {
 		    .expectNextMatches(status -> status == 413)
   		    .expectComplete()
   		    .verify(Duration.ofSeconds(30));
+	}
+
+	@Test
+	void testIssue3538GetWithPayloadAndH2cMaxContentLength() throws Exception {
+		disposableServer =
+				createServer()
+				          .protocol(HttpProtocol.H2C, HttpProtocol.HTTP11)
+				          .httpRequestDecoder(spec -> spec.h2cMaxContentLength(100))
+				          .route(r -> r.get("/", (req, res) -> {
+				              final EchoAction action = new EchoAction();
+
+				              req
+				                  .receiveContent().switchIfEmpty(Mono.just(LastHttpContent.EMPTY_LAST_CONTENT))
+				                  .subscribe(action);
+
+				              return res.sendObject(action);
+				          }
+				      ))
+				      .bindNow();
+		assertThat(disposableServer).isNotNull();
+
+		final ByteBuf content = createHttpClientForContextWithPort()
+		        .protocol(HttpProtocol.HTTP11)
+		        .headers(h ->
+		            h.add(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
+		             .add(HttpHeaderNames.UPGRADE, "TLS/1.2"))
+		        .request(HttpMethod.GET)
+		        .send((req, res) -> res.sendString(Mono.just("testIssue3538")))
+		        .uri("/")
+		        .responseContent()
+		        .blockLast(Duration.ofSeconds(30));
+
+		assertThat(content).isNotNull();
 	}
 
 	@Test
@@ -3594,14 +3628,12 @@ class HttpClientTest extends BaseHttpTest {
 
         @Override
         public void accept(HttpContent message) {
-            if (message instanceof LastHttpContent) {
-                if (message.content().readableBytes() > 0) {
-                    emitter.next(message.retain());
-                }
-                emitter.complete();
+            if (message.content().readableBytes() > 0) {
+                emitter.next(new DefaultHttpContent(message.content().retain()));
             }
-            else {
-                emitter.next(message.retain());
+
+            if (message instanceof LastHttpContent) {
+                emitter.complete();
             }
         }
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -3641,6 +3641,5 @@ class HttpClientTest extends BaseHttpTest {
         public void subscribe(Subscriber<? super HttpContent> s) {
             sender.subscribe(s);
         }
-
     }
 }


### PR DESCRIPTION
We have run into the issue with latest Apache HttpClient5 5.4.1 / Apache HttpCore5 5.3.1 as a client (Reactor Netty as the HTTP server with HTTP/1.1 and H2C protocols) that now tries HTTP/1.1 TLS Upgrade (RFC-2817) by default, see please [1] for context. The HttpServerRequest::receiveContent() never emits any value nor completes since no next / completion callbacks are called.

Closes https://github.com/reactor/reactor-netty/issues/3538