### PR TITLE
Fix ClassCastException in `HttpOperations#initShortId()`

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
@@ -379,7 +379,7 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 	protected final String initShortId() {
 		Connection connection = connection();
 		if (connection instanceof AtomicLong) {
-			return channel().id().asShortText() + '-' + ((AtomicLong) connection).incrementAndGet();
+			return connection.channel().id().asShortText() + '-' + ((AtomicLong) connection).incrementAndGet();
 		}
 		return super.initShortId();
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
@@ -377,8 +377,9 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 
 	@Override
 	protected final String initShortId() {
-		if (connection() instanceof AtomicLong) {
-			return channel().id().asShortText() + '-' + ((AtomicLong) connection()).incrementAndGet();
+		Connection connection = connection();
+		if (connection instanceof AtomicLong) {
+			return channel().id().asShortText() + '-' + ((AtomicLong) connection).incrementAndGet();
 		}
 		return super.initShortId();
 	}


### PR DESCRIPTION
Calling `HttpOperations#initShortId()` could cause a `ClassCastException` if the underlying connection was replaced between checking its type and casting it to `AtomicLong`, for example if `ChannelOperations#terminate()` was called on another thread.

See also:
https://github.com/reactor/reactor-netty/blob/667f8c9cbf5a227a15f6d0a2f3aab7c4777613da/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java#L515

Fixes #3541