### PR TITLE
Do not add `Transfer-Encoding` for `DELETE` with no body

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -576,8 +576,9 @@ class HttpClientConnect extends HttpClient {
 				ch.followRedirectPredicate(followRedirectPredicate);
 
 				if (!Objects.equals(method, HttpMethod.GET) &&
-							!Objects.equals(method, HttpMethod.HEAD) &&
-							!headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
+						!Objects.equals(method, HttpMethod.HEAD) &&
+						!Objects.equals(method, HttpMethod.DELETE) &&
+						!headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
 					ch.chunkedTransfer(true);
 				}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -445,7 +445,9 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 		if (source instanceof Mono) {
 			return super.send(source);
 		}
-		if (Objects.equals(method(), HttpMethod.GET) || Objects.equals(method(), HttpMethod.HEAD)) {
+		if (Objects.equals(method(), HttpMethod.GET) ||
+				Objects.equals(method(), HttpMethod.HEAD) ||
+				Objects.equals(method(), HttpMethod.DELETE)) {
 
 			ByteBufAllocator alloc = channel().alloc();
 			return new PostHeadersNettyOutbound(Flux.from(source)
@@ -480,7 +482,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 				                }
 				                for (ByteBuf bb : list) {
 				                	if (log.isDebugEnabled()) {
-						                log.debug(format(channel(), "Ignoring accumulated bytebuf on http GET {}"), bb);
+						                log.debug(format(channel(), "Ignoring accumulated bytebuf on http {} {}"), method(), bb);
 					                }
 				                	bb.release();
 				                }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -3550,16 +3550,18 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(booleans = {true, false})
-	void testDeleteMethod(boolean chunked) {
+	@ValueSource(strings = {"mono", "flux", "empty"})
+	void testDeleteMethod(String requestBodyType) {
 		disposableServer =
 				createServer()
-				        .handle((req, res) -> res.send(req.receive().retain()))
+				        .handle((req, res) -> res.sendString(
+				            Flux.concat(req.receive().retain().aggregate().asString().defaultIfEmpty("empty"),
+				                        Mono.just(" " + req.requestHeaders().get(HttpHeaderNames.CONTENT_LENGTH)))))
 				        .bindNow();
 
-		Publisher<ByteBuf> body = chunked ?
+		Publisher<ByteBuf> body = "flux".equals(requestBodyType) ?
 				ByteBufFlux.fromString(Flux.just("d", "e", "l", "e", "t", "e")) :
-				ByteBufMono.fromString(Mono.just("delete"));
+				"mono".equals(requestBodyType) ? ByteBufMono.fromString(Mono.just("delete")) : Mono.empty();
 
 		createClient(disposableServer.port())
 		        .delete()
@@ -3567,7 +3569,7 @@ class HttpClientTest extends BaseHttpTest {
 		        .send(body)
 		        .responseSingle((res, bytes) -> bytes.asString())
 		        .as(StepVerifier::create)
-		        .expectNext("delete")
+		        .expectNext("empty".equals(requestBodyType) ? "empty 0" : "delete 6")
 		        .expectComplete()
 		        .verify(Duration.ofSeconds(5));
 	}


### PR DESCRIPTION
This is a regression caused by #3481

Fixes #3548