### PR TITLE
Configuration for setting maximum number of connection pools to be created

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -394,6 +394,9 @@ public interface ConnectionProvider extends Disposable {
 	final class Builder extends ConnectionPoolSpec<Builder> {
 
 		static final Duration DISPOSE_INACTIVE_POOLS_IN_BACKGROUND_DISABLED = Duration.ZERO;
+		static final int EXPECTED_CONNECTION_POOLS_DISABLED = -1;
+
+		int expectedConnectionPools = EXPECTED_CONNECTION_POOLS_DISABLED;
 
 		String name;
 		Duration inactivePoolDisposeInterval = DISPOSE_INACTIVE_POOLS_IN_BACKGROUND_DISABLED;
@@ -417,6 +420,7 @@ public interface ConnectionProvider extends Disposable {
 			this.inactivePoolDisposeInterval = copy.inactivePoolDisposeInterval;
 			this.poolInactivity = copy.poolInactivity;
 			this.disposeTimeout = copy.disposeTimeout;
+			this.expectedConnectionPools = copy.expectedConnectionPools;
 			copy.confPerRemoteHost.forEach((address, spec) -> this.confPerRemoteHost.put(address, new ConnectionPoolSpec<>(spec)));
 		}
 
@@ -488,6 +492,18 @@ public interface ConnectionProvider extends Disposable {
 			return this;
 		}
 
+		/**
+		 * Specifies the expected number of connection pools that the provider can create.
+		 * If the number of connection pools created exceeds this value, a warning message is logged.
+		 * The value must be positive; otherwise, the connection pools check is ignored.
+		 *
+		 * @param expectedConnectionPools the number of connection pools expected to be created.
+		 * @return the current {@link Builder} instance with the updated configuration.
+		 */
+		public Builder expectedConnectionPools(int expectedConnectionPools) {
+			this.expectedConnectionPools = expectedConnectionPools;
+			return this;
+		}
 		/**
 		 * Builds new ConnectionProvider.
 		 *

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -394,9 +394,9 @@ public interface ConnectionProvider extends Disposable {
 	final class Builder extends ConnectionPoolSpec<Builder> {
 
 		static final Duration DISPOSE_INACTIVE_POOLS_IN_BACKGROUND_DISABLED = Duration.ZERO;
-		static final int EXPECTED_CONNECTION_POOLS_DISABLED = -1;
+		static final int MAX_CONNECTION_POOLS = -1;
 
-		int expectedConnectionPools = EXPECTED_CONNECTION_POOLS_DISABLED;
+		int maxConnectionPools = MAX_CONNECTION_POOLS;
 
 		String name;
 		Duration inactivePoolDisposeInterval = DISPOSE_INACTIVE_POOLS_IN_BACKGROUND_DISABLED;
@@ -420,7 +420,7 @@ public interface ConnectionProvider extends Disposable {
 			this.inactivePoolDisposeInterval = copy.inactivePoolDisposeInterval;
 			this.poolInactivity = copy.poolInactivity;
 			this.disposeTimeout = copy.disposeTimeout;
-			this.expectedConnectionPools = copy.expectedConnectionPools;
+			this.maxConnectionPools = copy.maxConnectionPools;
 			copy.confPerRemoteHost.forEach((address, spec) -> this.confPerRemoteHost.put(address, new ConnectionPoolSpec<>(spec)));
 		}
 
@@ -493,15 +493,15 @@ public interface ConnectionProvider extends Disposable {
 		}
 
 		/**
-		 * Specifies the expected number of connection pools that the provider can create.
+		 * Specifies the maximum number of connection pools that the provider can create.
 		 * If the number of connection pools created exceeds this value, a warning message is logged.
-		 * The value must be positive; otherwise, the connection pools check is ignored.
+		 * The value must be positive or zero; otherwise, the connection pools check is ignored.
 		 *
-		 * @param expectedConnectionPools the number of connection pools expected to be created.
+		 * @param maxConnectionPools the number of connection pools expected to be created.
 		 * @return the current {@link Builder} instance with the updated configuration.
 		 */
-		public Builder expectedConnectionPools(int expectedConnectionPools) {
-			this.expectedConnectionPools = expectedConnectionPools;
+		public Builder maxConnectionPools(int maxConnectionPools) {
+			this.maxConnectionPools = maxConnectionPools;
 			return this;
 		}
 		/**

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -495,12 +495,15 @@ public interface ConnectionProvider extends Disposable {
 		/**
 		 * Specifies the maximum number of connection pools that the provider can create.
 		 * If the number of connection pools created exceeds this value, a warning message is logged.
-		 * The value must be positive or zero; otherwise, the connection pools check is ignored.
-		 *
-		 * @param maxConnectionPools the number of connection pools expected to be created.
+		 * The value must be strictly positive or -1; otherwise, the connection pools check is ignored.
+		 * Setting the configuration to -1 disables the setting.
+		 * @param maxConnectionPools the maximum number of connection pools that can be created.
 		 * @return the current {@link Builder} instance with the updated configuration.
 		 */
 		public Builder maxConnectionPools(int maxConnectionPools) {
+			if (maxConnectionPools != MAX_CONNECTION_POOLS && maxConnectionPools <= 0) {
+				throw new IllegalArgumentException("Maximum connection pools setting must be strictly positive.");
+			}
 			this.maxConnectionPools = maxConnectionPools;
 			return this;
 		}

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -92,7 +92,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 	final Duration inactivePoolDisposeInterval;
 	final Duration poolInactivity;
 	final Duration disposeTimeout;
-	final int expectedConnectionPools;
+	final int maxConnectionPools;
 	final AtomicInteger connectionPoolCount = new AtomicInteger(0);
 	final Map<SocketAddress, Integer> maxConnections = new HashMap<>();
 	Mono<Void> onDispose;
@@ -108,7 +108,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 		this.inactivePoolDisposeInterval = builder.inactivePoolDisposeInterval;
 		this.poolInactivity = builder.poolInactivity;
 		this.disposeTimeout = builder.disposeTimeout;
-		this.expectedConnectionPools = builder.expectedConnectionPools;
+		this.maxConnectionPools = builder.maxConnectionPools;
 		this.defaultPoolFactory = new PoolFactory<>(builder, builder.disposeTimeout, clock);
 		for (Map.Entry<SocketAddress, ConnectionPoolSpec<?>> entry : builder.confPerRemoteHost.entrySet()) {
 			poolFactoryPerRemoteHost.put(entry.getKey(), new PoolFactory<>(entry.getValue(), builder.disposeTimeout));
@@ -136,10 +136,10 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 					log.debug("Creating a new [{}] client pool [{}] for [{}]", name, poolFactory, remoteAddress);
 				}
 
-				if (expectedConnectionPools > Builder.EXPECTED_CONNECTION_POOLS_DISABLED && connectionPoolCount.incrementAndGet() > expectedConnectionPools) {
+				if (maxConnectionPools > Builder.MAX_CONNECTION_POOLS && connectionPoolCount.incrementAndGet() > maxConnectionPools) {
 					if (log.isWarnEnabled()) {
 						log.warn("Connection pool creation limit exceeded: {} pools created, maximum expected is {}", connectionPoolCount.get(),
-								expectedConnectionPools);
+								maxConnectionPools);
 					}
 				}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -674,7 +674,7 @@ class HttpClientTest extends BaseHttpTest {
 						.handle((req, resp) -> resp.sendString(Flux.just("hello ", req.uri())))
 						.bindNow();
 
-		ConnectionProvider connectionProvider = ConnectionProvider.builder("expected-connection-pool").build();
+		ConnectionProvider connectionProvider = ConnectionProvider.builder("max-connection-pools").build();
 
 		StepVerifier.create(
 						Flux.range(1, 2)

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -622,6 +622,8 @@ class HttpClientTest extends BaseHttpTest {
 	@ParameterizedTest
 	@ValueSource(booleans = {true, false})
 	void testMaxConnectionPools(boolean withMaxConnectionPools) throws SSLException {
+		Logger spyLogger = Mockito.spy(log);
+		Loggers.useCustomLoggers(s -> spyLogger);
 
 		ConnectionProvider connectionProvider = withMaxConnectionPools ? ConnectionProvider
 				.builder("max-connection-pools")
@@ -632,8 +634,6 @@ class HttpClientTest extends BaseHttpTest {
 
 		try {
 			ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
-			Logger spyLogger = Mockito.spy(log);
-			Loggers.useCustomLoggers(s -> spyLogger);
 
 			SslContext sslServer = SslContextBuilder
 					.forServer(ssc.certificate(), ssc.privateKey())

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -677,8 +677,8 @@ class HttpClientTest extends BaseHttpTest {
 			}
 		}
 		finally {
-			connectionProvider.dispose();
 			Loggers.resetLoggerFactory();
+			connectionProvider.dispose();
 		}
 
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -101,7 +101,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;


### PR DESCRIPTION
Introduce a configuration option to specify the maximum number of connection pools a `ConnectionProvider` should create. Once the maximum number is exceeded, a warning message is logged.

Fixes #3318.