### PR TITLE
Make `ChannelOperations.DisposedChannel#close` non operational

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java
@@ -710,6 +710,17 @@ public class ChannelOperations<INBOUND extends NettyInbound, OUTBOUND extends Ne
 		}
 
 		@Override
+		public ChannelFuture close() {
+			return newSucceededFuture();
+		}
+
+		@Override
+		public ChannelFuture close(ChannelPromise promise) {
+			promise.setSuccess();
+			return promise;
+		}
+
+		@Override
 		public ChannelFuture closeFuture() {
 			return newSucceededFuture();
 		}


### PR DESCRIPTION
`DisposedChannel` is effective when request/response is terminated and replaces the actual channel. At that point `ChannelOperations.DisposedChannel#close` must be non operational.

Fixes #3591