### PR TITLE
Support for dynamic proxy configuration at the HTTP protocol level

### DIFF
--- a/docs/modules/ROOT/partials/proxy.adoc
+++ b/docs/modules/ROOT/partials/proxy.adoc
@@ -22,7 +22,7 @@ include::{examples-dir}/proxy/Application.java[lines=18..42]
 
 
 // tag::proxy-when-method[]
-The `proxyWhen(BiConsumer<HttpClientConfig, ? super ProxyProvider.TypeSpec> proxyBuilder)` method allows for dynamic proxy configuration.
+The `proxyWhen(...)` method allows for dynamic proxy configuration.
 
 - `proxyWhen(...)` takes an `HttpClientConfig` and enables setting a proxy for each individual HTTP request, providing flexibility to choose different proxies depending on the request.
 - Once the proxy is set using `proxyWhen(...)`, any previous proxy settings via `proxy(...)` or `noProxy()` will be ignored.

--- a/docs/modules/ROOT/partials/proxy.adoc
+++ b/docs/modules/ROOT/partials/proxy.adoc
@@ -19,3 +19,16 @@ The following example uses `ProxyProvider`:
 include::{examples-dir}/proxy/Application.java[lines=18..42]
 ----
 <1> Configures the connection establishment timeout to 20 seconds.
+
+
+// tag::proxy-when-method[]
+The `proxyWhen(BiConsumer<HttpClientConfig, ? super ProxyProvider.TypeSpec> proxyBuilder)` method allows for dynamic proxy configuration.
+
+- `proxyWhen(...)` takes an `HttpClientConfig` and enables setting a proxy for each individual HTTP request, providing flexibility to choose different proxies depending on the request.
+- Once the proxy is set using `proxyWhen(...)`, any previous proxy settings via `proxy(...)` or `noProxy()` will be ignored.
+// end::proxy-when-method[]
+{examples-link}/proxy/deferred/Application.java
+[%unbreakable]
+----
+include::{examples-dir}/proxy/deferred/Application.java[lines=18..53]
+----

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
@@ -252,7 +252,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 		Objects.requireNonNull(proxyOptions, "proxyOptions");
 		ProxyProvider.Build builder = (ProxyProvider.Build) ProxyProvider.builder();
 		proxyOptions.accept(builder);
-		return proxyWithProxyProviderSupplier(() -> builder.build());
+		return proxyWithProxyProviderSupplier(builder::build);
 	}
 
 	final T proxyWithProxyProvider(ProxyProvider proxy) {

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -389,7 +389,7 @@ public final class ProxyProvider {
 		return Integer.parseInt(port);
 	}
 
-	static final class Build implements TypeSpec, AddressSpec, Builder {
+	static final class Build implements TypeSpec, AddressSpec, Builder, Validator {
 
 		@SuppressWarnings("UnnecessaryLambda")
 		static final Supplier<? extends HttpHeaders> NO_HTTP_HEADERS = () -> null;
@@ -512,6 +512,11 @@ public final class ProxyProvider {
 		@Override
 		public ProxyProvider build() {
 			return new ProxyProvider(this);
+		}
+
+		@Override
+		public final boolean isConfiguredCorrectly() {
+			return type != null && host != null;
 		}
 	}
 
@@ -732,5 +737,15 @@ public final class ProxyProvider {
 		 * @return builds new ProxyProvider
 		 */
 		ProxyProvider build();
+	}
+
+	public interface Validator {
+
+		/**
+		 * Checks whether the proxy configuration is correctly set.
+		 *
+		 * @return true if the required settings are completed, false if any settings are missing
+		 */
+		boolean isConfiguredCorrectly();
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -389,7 +389,7 @@ public final class ProxyProvider {
 		return Integer.parseInt(port);
 	}
 
-	static final class Build implements TypeSpec, AddressSpec, Builder, Validator {
+	static final class Build implements TypeSpec, AddressSpec, Builder {
 
 		@SuppressWarnings("UnnecessaryLambda")
 		static final Supplier<? extends HttpHeaders> NO_HTTP_HEADERS = () -> null;
@@ -512,11 +512,6 @@ public final class ProxyProvider {
 		@Override
 		public ProxyProvider build() {
 			return new ProxyProvider(this);
-		}
-
-		@Override
-		public final boolean isConfiguredCorrectly() {
-			return type != null && host != null;
 		}
 	}
 
@@ -737,15 +732,5 @@ public final class ProxyProvider {
 		 * @return builds new ProxyProvider
 		 */
 		ProxyProvider build();
-	}
-
-	public interface Validator {
-
-		/**
-		 * Checks whether the proxy configuration is correctly set.
-		 *
-		 * @return true if the required settings are completed, false if any settings are missing
-		 */
-		boolean isConfiguredCorrectly();
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/proxy/deferred/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/proxy/deferred/Application.java
@@ -15,6 +15,7 @@
  */
 package reactor.netty.examples.documentation.http.client.proxy.deferred;
 
+import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.transport.ProxyProvider;
 
@@ -25,12 +26,16 @@ public class Application {
 				HttpClient.create()
 						.proxyWhen((httpClientConfig, spec) -> {    // only applied
 							if (httpClientConfig.uri().startsWith("https://example.com")) {
-								spec.type(ProxyProvider.Proxy.HTTP)
-										.host("proxy")
-										.port(8080)
-										.nonProxyHosts("localhost")
-										.connectTimeoutMillis(20_000);
+								return Mono.justOrEmpty(
+										spec.type(ProxyProvider.Proxy.HTTP)
+												.host("proxy")
+												.port(8080)
+												.nonProxyHosts("localhost")
+												.connectTimeoutMillis(20_000)
+								);
 							}
+
+							return Mono.empty();
 						})
 						.proxy(
 								spec -> spec.type(ProxyProvider.Proxy.HTTP)

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/proxy/deferred/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/proxy/deferred/Application.java
@@ -32,12 +32,12 @@ public class Application {
 										.connectTimeoutMillis(20_000);
 							}
 						})
-						.proxy(     // ignored
+						.proxy(
 								spec -> spec.type(ProxyProvider.Proxy.HTTP)
 										.host("ignored-proxy-domain")
 										.port(9000)
 										.connectTimeoutMillis(20_000)
-						)
+						)   // ignored
 						.noProxy(); // ignored
 
 		String response =

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/proxy/deferred/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/proxy/deferred/Application.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.client.proxy.deferred;
+
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.transport.ProxyProvider;
+
+public class Application {
+
+	public static void main(String[] args) {
+		HttpClient client =
+				HttpClient.create()
+						.proxyWhen((httpClientConfig, spec) -> {    // only applied
+							if (httpClientConfig.uri().startsWith("https://example.com")) {
+								spec.type(ProxyProvider.Proxy.HTTP)
+										.host("proxy")
+										.port(8080)
+										.nonProxyHosts("localhost")
+										.connectTimeoutMillis(20_000);
+							}
+						})
+						.proxy(     // ignored
+								spec -> spec.type(ProxyProvider.Proxy.HTTP)
+										.host("ignored-proxy-domain")
+										.port(9000)
+										.connectTimeoutMillis(20_000)
+						)
+						.noProxy(); // ignored
+
+		String response =
+				client.get()
+						.uri("https://example.com/")
+						.responseContent()
+						.aggregate()
+						.asString()
+						.block();
+
+		System.out.println("Response " + response);
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -66,6 +66,7 @@ import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.tcp.SslProvider;
 import reactor.netty.tcp.TcpClient;
 import reactor.netty.transport.ClientTransport;
+import reactor.netty.transport.ProxyProvider;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.annotation.Incubating;
@@ -1632,6 +1633,35 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 				// the default security will be used thus always try to load the OpenSsl natives
 				// see HttpClientConnect.MonoHttpConnect#subscribe
 				Mono.fromRunnable(OpenSsl::version));
+	}
+
+	/**
+	 * Supports proxy configuration with a deferred approach.
+	 *
+	 * <p>When proxyWhen(...) is set, calls to proxy(...) and noProxy() methods are ignored.</p>
+	 * <p>This method allows dynamic determination of proxy settings, applying or skipping the proxy based on the configured conditions.</p>
+	 *
+	 * @param proxyBuilder a consumer for proxy configuration
+	 * @return a new {@link HttpClient} reference
+	 */
+	public final HttpClient proxyWhen(BiConsumer<HttpClientConfig, ? super ProxyProvider.TypeSpec> proxyBuilder) {
+		Objects.requireNonNull(proxyBuilder, "proxyBuilder");
+		HttpClient dup = duplicate();
+		dup.configuration()
+				.deferredConf(
+						config -> {
+							ProxyProvider.TypeSpec spec = ProxyProvider.builder();
+							proxyBuilder.accept(config, spec);
+
+							if (((ProxyProvider.Validator) spec).isConfiguredCorrectly()) {
+								ProxyProvider proxyProvider = ((ProxyProvider.Builder) spec).build();
+								config.proxyProvider(proxyProvider);
+							}
+
+							return Mono.just(config);
+						}
+				);
+		return dup;
 	}
 
 	/**

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientProxyTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientProxyTest.java
@@ -55,9 +55,6 @@ import static io.specto.hoverfly.junit.core.SimulationSource.dsl;
 import static io.specto.hoverfly.junit.dsl.HoverflyDsl.service;
 import static io.specto.hoverfly.junit.dsl.ResponseCreators.success;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static reactor.netty.Metrics.ACTIVE_CONNECTIONS;
 import static reactor.netty.Metrics.CONNECTION_PROVIDER_PREFIX;
 import static reactor.netty.Metrics.CONNECT_TIME;
@@ -179,9 +176,9 @@ class HttpClientProxyTest extends BaseHttpTest {
 								)
 				)
 				.expectNextMatches(t -> {
-					assertEquals("test", t.getT1());
-					assertEquals("FOUND", t.getT2().get("Logging-Handler"));
-					assertTrue(t.getT2().contains("Hoverfly"));
+					assertThat(t.getT1()).isEqualTo("test");
+					assertThat(t.getT2().get("Logging-Handler")).isEqualTo("FOUND");
+					assertThat(t.getT2().contains("Hoverfly")).isTrue();
 					return true;
 				})
 				.expectComplete()
@@ -194,7 +191,7 @@ class HttpClientProxyTest extends BaseHttpTest {
 				HttpClient.create()
 						.proxyWhen(
 								(config, spec) -> {
-									if(config.uri().startsWith("http://127.0.0.1")) {
+									if (config.uri().startsWith("http://127.0.0.1")) {
 										spec.type(ProxyProvider.Proxy.HTTP)
 												.host("localhost")
 												.port(hoverfly.getHoverflyConfig().getProxyPort());
@@ -220,9 +217,9 @@ class HttpClientProxyTest extends BaseHttpTest {
 								)
 				)
 				.expectNextMatches(t -> {
-					assertEquals("test", t.getT1());
-					assertEquals("FOUND", t.getT2().get("Logging-Handler"));
-					assertTrue(t.getT2().contains("Hoverfly"));
+					assertThat(t.getT1()).isEqualTo("test");
+					assertThat(t.getT2().get("Logging-Handler")).isEqualTo("FOUND");
+					assertThat(t.getT2().contains("Hoverfly")).isTrue();
 					return true;
 				})
 				.expectComplete()
@@ -241,9 +238,9 @@ class HttpClientProxyTest extends BaseHttpTest {
 								)
 				)
 				.expectNextMatches(t -> {
-					assertEquals("test", t.getT1());
-					assertEquals("NOT FOUND", t.getT2().get("Logging-Handler"));
-					assertFalse(t.getT2().contains("Hoverfly"));
+					assertThat(t.getT1()).isEqualTo("test");
+					assertThat(t.getT2().get("Logging-Handler")).isEqualTo("NOT FOUND");
+					assertThat(t.getT2().contains("Hoverfly")).isFalse();
 					return true;
 				})
 				.expectComplete()
@@ -282,9 +279,9 @@ class HttpClientProxyTest extends BaseHttpTest {
 								)
 				)
 				.expectNextMatches(t -> {
-					assertEquals("test", t.getT1());
-					assertEquals("FOUND", t.getT2().get("Logging-Handler"));
-					assertTrue(t.getT2().contains("Hoverfly"));
+					assertThat(t.getT1()).isEqualTo("test");
+					assertThat(t.getT2().get("Logging-Handler")).isEqualTo("FOUND");
+					assertThat(t.getT2().contains("Hoverfly")).isTrue();
 					return true;
 				})
 				.expectComplete()
@@ -321,9 +318,9 @@ class HttpClientProxyTest extends BaseHttpTest {
 								)
 				)
 				.expectNextMatches(t -> {
-					assertEquals("test", t.getT1());
-					assertEquals("FOUND", t.getT2().get("Logging-Handler"));
-					assertTrue(t.getT2().contains("Hoverfly"));
+					assertThat(t.getT1()).isEqualTo("test");
+					assertThat(t.getT2().get("Logging-Handler")).isEqualTo("FOUND");
+					assertThat(t.getT2().contains("Hoverfly")).isTrue();
 					return true;
 				})
 				.expectComplete()
@@ -358,10 +355,10 @@ class HttpClientProxyTest extends BaseHttpTest {
 								)
 				)
 				.expectNextMatches(t -> {
-					assertEquals("test", t.getT1());
-					assertEquals("FOUND", t.getT2().get("Logging-Handler"));
-					assertEquals("NOT FOUND", t.getT2().get("Proxy-Logging-Handler"));
-					assertFalse(t.getT2().contains("Hoverfly"));
+					assertThat(t.getT1()).isEqualTo("test");
+					assertThat(t.getT2().get("Logging-Handler")).isEqualTo("FOUND");
+					assertThat(t.getT2().get("Proxy-Logging-Handler")).isEqualTo("NOT FOUND");
+					assertThat(t.getT2().contains("Hoverfly")).isFalse();
 					return true;
 				})
 				.expectComplete()

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientProxyTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientProxyTest.java
@@ -44,6 +44,7 @@ import reactor.util.annotation.Nullable;
 import reactor.util.function.Tuple2;
 
 import java.net.SocketAddress;
+import java.nio.channels.UnresolvedAddressException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -148,14 +149,16 @@ class HttpClientProxyTest extends BaseHttpTest {
 	}
 
 	@Test
-	void proxy_with_deferred_configuration(Hoverfly hoverfly) {
+	void proxyWithDeferredConfiguration(Hoverfly hoverfly) {
 		HttpClient client =
 				HttpClient.create()
 						.proxyWhen(
-								(config, spec) ->
-										spec.type(ProxyProvider.Proxy.HTTP)
-												.host("localhost")
-												.port(hoverfly.getHoverflyConfig().getProxyPort())
+								(config, spec) -> Mono.delay(Duration.ofMillis(10))
+										.map(
+												noOp -> spec.type(ProxyProvider.Proxy.HTTP)
+														.host("localhost")
+														.port(hoverfly.getHoverflyConfig().getProxyPort())
+										)
 						)
 						.doOnResponse((res, conn) -> {
 							ChannelHandler handler = conn.channel().pipeline().get(NettyPipeline.ProxyLoggingHandler);
@@ -186,16 +189,53 @@ class HttpClientProxyTest extends BaseHttpTest {
 	}
 
 	@Test
-	void proxy_with_deferred_configuration_by_conditions(Hoverfly hoverfly) {
+	void errorOccursWhenDeferredProxyConfigurationIsInvalid() {
+		HttpClient client =
+				HttpClient.create()
+						.proxyWhen(
+								(config, spec) ->
+										Mono.just(
+												spec.type(ProxyProvider.Proxy.HTTP)
+														.host("invalid-domain")
+										)
+						)
+						.doOnResponse((res, conn) -> {
+							ChannelHandler handler = conn.channel().pipeline().get(NettyPipeline.ProxyLoggingHandler);
+							res.responseHeaders()
+									.add("Logging-Handler", handler != null ? "FOUND" : "NOT FOUND");
+						});
+
+		StepVerifier.create(
+						client.wiretap(true)
+								.get()
+								.uri("http://127.0.0.1:" + port + "/")
+								.responseSingle(
+										(response, body) ->
+												Mono.zip(
+														body.asString(),
+														Mono.just(response.responseHeaders())
+												)
+								)
+				)
+				.expectError(UnresolvedAddressException.class)
+				.verify(Duration.ofSeconds(30));
+	}
+
+	@Test
+	void proxyWithDeferredConfigurationByConditions(Hoverfly hoverfly) {
 		HttpClient client =
 				HttpClient.create()
 						.proxyWhen(
 								(config, spec) -> {
 									if (config.uri().startsWith("http://127.0.0.1")) {
-										spec.type(ProxyProvider.Proxy.HTTP)
+										ProxyProvider.Builder builder = spec.type(ProxyProvider.Proxy.HTTP)
 												.host("localhost")
 												.port(hoverfly.getHoverflyConfig().getProxyPort());
+
+										return Mono.just(builder);
 									}
+
+									return Mono.empty();
 								}
 						)
 						.doOnResponse((res, conn) -> {
@@ -248,14 +288,16 @@ class HttpClientProxyTest extends BaseHttpTest {
 	}
 
 	@Test
-	void proxy_ignored_in_static_configuration(Hoverfly hoverfly) {
+	void proxyIgnoredInStaticConfiguration(Hoverfly hoverfly) {
 		HttpClient client =
 				HttpClient.create()
 						.proxyWhen(
 								(config, spec) ->
-										spec.type(ProxyProvider.Proxy.HTTP)
-												.host("localhost")
-												.port(hoverfly.getHoverflyConfig().getProxyPort())
+										Mono.just(
+												spec.type(ProxyProvider.Proxy.HTTP)
+														.host("localhost")
+														.port(hoverfly.getHoverflyConfig().getProxyPort())
+										)
 						)
 						.proxy((spec) -> spec.type(ProxyProvider.Proxy.HTTP)
 								.host("localhost")
@@ -289,14 +331,16 @@ class HttpClientProxyTest extends BaseHttpTest {
 	}
 
 	@Test
-	void proxy_ignored_in_static_no_proxy_configuration(Hoverfly hoverfly) {
+	void proxyIgnoredInStaticNoProxyConfiguration(Hoverfly hoverfly) {
 		HttpClient client =
 				HttpClient.create()
 						.proxyWhen(
 								(config, spec) ->
-										spec.type(ProxyProvider.Proxy.HTTP)
-												.host("localhost")
-												.port(hoverfly.getHoverflyConfig().getProxyPort())
+										Mono.just(
+												spec.type(ProxyProvider.Proxy.HTTP)
+														.host("localhost")
+														.port(hoverfly.getHoverflyConfig().getProxyPort())
+										)
 						)
 						.noProxy()
 						.doOnResponse((res, conn) -> {
@@ -328,10 +372,10 @@ class HttpClientProxyTest extends BaseHttpTest {
 	}
 
 	@Test
-	void proxy_not_enabled_deferred_without_necessary_configuration() {
+	void proxyNotEnabledDeferredWithoutNecessaryConfiguration() {
 		HttpClient client =
 				HttpClient.create()
-						.proxyWhen((config, spec) -> {})
+						.proxyWhen((config, spec) -> Mono.empty())
 						.doOnResponse((res, conn) -> {
 							ChannelHandler proxyLoggingHandler = conn.channel().pipeline().get(NettyPipeline.ProxyLoggingHandler);
 							res.responseHeaders()

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientProxyTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Motivation
The existing `proxy(...)` and `noProxy()` methods are static, applying the same configuration to all requests. In scenarios where proxy behavior needs to change dynamically based on the request (e.g., host-specific proxies, conditional proxy usage), this static approach is insufficient.

The `proxyWhen(...)` method fills this gap by allowing developers to provide a function that resolves proxy settings dynamically during request execution.

## Description
- Added support for the `proxyWhen(BiConsumer<HttpClientConfig, ? super ProxyProvider.TypeSpec>)` method to `HttpClient`.
  - This method enables users to dynamically determine the proxy configuration on a per-request basis using a provided [`HttpClientConfig`](https://github.com/reactor/reactor-netty/blob/main/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java) function.
  - `proxyWhen(...)` evaluates the configuration function for each HTTP request, allowing fine-grained control over proxy settings.
- If `proxyWhen(...)` is used, any static proxy configurations applied via `proxy(...)` or `noProxy()` will be ignored.
- Internally, it uses `deferredConfig` to set the `proxyProvider` at the [`HttpClientConnect.connect()`](https://github.com/reactor/reactor-netty/blob/ec49b3dfb30ede20425a12d8d01fb3cbdd2e3496/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java#L106-L133) stage.

```java
HttpClient client = HttpClient.create()
    .proxyWhen((HttpClientConfig config, ProxyProvider.TypeSpec spec) -> {
        if (config.uri().equals("example.com")) {
            spec.type(ProxyProvider.Proxy.HTTP)
                .host("proxy.example.com")
                .port(8080);
        }
    });

client.get()
    .uri("http://example.com")
    .response()
    .block();
```

## Backward Compatibility
- The new `proxyWhen(...)` method is additive and does not interfere with existing static configurations unless explicitly used.
- Static configurations (`proxy(...)` and `noProxy()`) remain unchanged and fully functional.

## Related Issue
- https://github.com/reactor/reactor-netty/issues/2746