### PR TITLE
Ensure `HttpClient` does not add `Content-Length` header when the send function does not change `NettyOutbound` or returns `Mono#empty`

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -645,7 +645,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 						"zero-length header"));
 			}
 			//"FutureReturnValueIgnored" this is deliberate
-			channel().writeAndFlush(newFullBodyMessage(Unpooled.EMPTY_BUFFER));
+			channel().writeAndFlush(newFullBodyMessage());
 		}
 		else if (markSentBody()) {
 			//"FutureReturnValueIgnored" this is deliberate
@@ -869,6 +869,15 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 		return request;
 	}
 
+	HttpMessage newFullBodyMessage() {
+		HttpRequest request = new DefaultFullHttpRequest(version(), method(), uri(), Unpooled.EMPTY_BUFFER);
+
+		requestHeaders.remove(HttpHeaderNames.TRANSFER_ENCODING);
+
+		request.headers().set(requestHeaders);
+		return request;
+	}
+
 	@Override
 	protected Throwable wrapInboundError(Throwable err) {
 		if (err instanceof ClosedChannelException) {
@@ -886,7 +895,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 			return Mono.error(AbortedException.beforeSend());
 		}
 		return FutureMono.deferFuture(() -> markSentHeaderAndBody() ?
-				channel().writeAndFlush(newFullBodyMessage(Unpooled.EMPTY_BUFFER)) :
+				channel().writeAndFlush(newFullBodyMessage()) :
 				channel().newSucceededFuture());
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -411,13 +411,13 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		List<HttpProtocol> protocols = Arrays.asList(clientProtocols);
 		int[] numWrites = new int[]{5, 7};
 		int[] numReads = new int[]{1, 2};
-		int[] bytesWrite = new int[]{106, 122};
+		int[] bytesWrite = new int[]{103, 118};
 		int[] bytesRead = new int[]{37, 48};
 		int connIndex = 1;
 		if ((serverProtocols.length == 1 && serverProtocols[0] == HttpProtocol.HTTP11) ||
 				(clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11)) {
 			numWrites = new int[]{1, 2};
-			bytesWrite = new int[]{123, 246};
+			bytesWrite = new int[]{104, 208};
 			bytesRead = new int[]{64, 128};
 			connIndex = 2;
 		}
@@ -425,7 +425,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				Arrays.equals(clientProtocols, new HttpProtocol[]{HttpProtocol.H2C, HttpProtocol.HTTP11})) {
 			numWrites = new int[]{4, 6};
 			numReads = new int[]{2, 3};
-			bytesWrite = new int[]{287, 345};
+			bytesWrite = new int[]{268, 323};
 			bytesRead = new int[]{108, 119};
 		}
 		else if (protocols.contains(HttpProtocol.H2) || protocols.contains(HttpProtocol.H2C)) {
@@ -1365,7 +1365,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		assertCounter(registry, CLIENT_ERRORS, summaryTags1).isNull();
 		assertDistributionSummary(registry, CLIENT_DATA_SENT, summaryTags2)
 				.hasCountGreaterThanOrEqualTo(1)
-				.hasTotalAmountGreaterThanOrEqualTo(118);
+				.hasTotalAmountGreaterThanOrEqualTo(99);
 		assertCounter(registry, CLIENT_ERRORS, summaryTags2).isNull();
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.LastHttpContent;
@@ -1047,13 +1048,13 @@ class HttpProtocolsTests extends BaseHttpTest {
 	@ParameterizedCompatibleCombinationsTest
 	void testIssue3524MonoEmpty(HttpServer server, HttpClient client) {
 		// sends "full" request
-		testRequestBody(server, client, sender -> sender.send((req, out) -> Mono.empty()), 1);
+		testRequestBody(server, client, sender -> sender.send((req, out) -> Mono.empty()), 1, true);
 	}
 
 	@ParameterizedCompatibleCombinationsTest
 	void testIssue3524NoBody(HttpServer server, HttpClient client) {
 		// sends "full" request
-		testRequestBody(server, client, sender -> sender.send((req, out) -> out), 1);
+		testRequestBody(server, client, sender -> sender.send((req, out) -> out), 1, true);
 	}
 
 	@ParameterizedCompatibleCombinationsTest
@@ -1063,17 +1064,24 @@ class HttpProtocolsTests extends BaseHttpTest {
 				sender -> sender.send((req, out) -> out.sendObject(Unpooled.wrappedBuffer("test".getBytes(Charset.defaultCharset())))), 1);
 	}
 
-	@SuppressWarnings("FutureReturnValueIgnored")
 	private void testRequestBody(HttpServer server, HttpClient client,
 			Function<HttpClient.RequestSender, HttpClient.ResponseReceiver<?>> sendFunction, int expectedMsg) {
+		testRequestBody(server, client, sendFunction, expectedMsg, false);
+	}
+
+	@SuppressWarnings("FutureReturnValueIgnored")
+	private void testRequestBody(HttpServer server, HttpClient client,
+			Function<HttpClient.RequestSender, HttpClient.ResponseReceiver<?>> sendFunction, int expectedMsg, boolean contentHeadersDoNotExist) {
 		disposableServer =
 				server.handle((req, res) -> req.receive()
 				                               .then(res.send()))
 				      .bindNow(Duration.ofSeconds(30));
 
 		AtomicInteger counter = new AtomicInteger();
+		AtomicReference<HttpHeaders> requestHeaders = new AtomicReference<>();
 		sendFunction.apply(
 		                client.port(disposableServer.port())
+		                      .doAfterRequest((req, conn) -> requestHeaders.set(req.requestHeaders()))
 		                      .doOnRequest((req, conn) -> {
 		                          ChannelPipeline pipeline = conn.channel() instanceof Http2StreamChannel ?
 		                                  conn.channel().parent().pipeline() : conn.channel().pipeline();
@@ -1121,6 +1129,10 @@ class HttpProtocolsTests extends BaseHttpTest {
 		            .block(Duration.ofSeconds(30));
 
 		assertThat(counter.get()).isEqualTo(expectedMsg);
+		if (contentHeadersDoNotExist) {
+			assertThat(requestHeaders.get().get(HttpHeaderNames.CONTENT_LENGTH)).isNull();
+			assertThat(requestHeaders.get().get(HttpHeaderNames.TRANSFER_ENCODING)).isNull();
+		}
 	}
 
 	static final class IdleTimeoutTestChannelInboundHandler extends ChannelInboundHandlerAdapter {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -3606,7 +3606,8 @@ class HttpClientTest extends BaseHttpTest {
 				createServer()
 				        .handle((req, res) -> res.sendString(
 				            Flux.concat(req.receive().aggregate().asString().defaultIfEmpty("empty"),
-				                        Mono.just(" " + req.requestHeaders().get(HttpHeaderNames.CONTENT_LENGTH)))))
+				                        Mono.just(" " + req.requestHeaders().get(HttpHeaderNames.CONTENT_LENGTH) +
+				                        " " + req.requestHeaders().get(HttpHeaderNames.TRANSFER_ENCODING)))))
 				        .bindNow();
 
 		Publisher<ByteBuf> body = "flux".equals(requestBodyType) ?
@@ -3619,7 +3620,7 @@ class HttpClientTest extends BaseHttpTest {
 		        .send(body)
 		        .responseSingle((res, bytes) -> bytes.asString())
 		        .as(StepVerifier::create)
-		        .expectNext("empty".equals(requestBodyType) ? "empty 0" : "delete 6")
+		        .expectNext("empty".equals(requestBodyType) ? "empty null null" : "delete 6 null")
 		        .expectComplete()
 		        .verify(Duration.ofSeconds(5));
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientWithTomcatTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientWithTomcatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -233,7 +233,7 @@ class HttpClientWithTomcatTest {
 		assertThat(r).isNotNull();
 
 		assertThat(r.getT1()).isEqualTo(HttpResponseStatus.NOT_FOUND);
-		assertThat(headers.get().get("Content-Length")).isEqualTo("0");
+		assertThat(headers.get().get("Content-Length")).isNull();
 		assertThat(headers.get().get("Transfer-Encoding")).isNull();
 	}
 


### PR DESCRIPTION
Fixes #3603