### PR TITLE
Ensure `HttpClient` does not add `Content-Length` header when `GET/HEAD/DELETE` and the send `Publisher` does not provide content

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -474,7 +474,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 			                .flatMap(list -> {
 				                if (markSentHeaderAndBody(list.toArray())) {
 					                if (list.isEmpty()) {
-						                return FutureMono.from(channel().writeAndFlush(newFullBodyMessage(Unpooled.EMPTY_BUFFER)));
+						                return FutureMono.from(channel().writeAndFlush(newFullBodyMessage()));
 					                }
 
 					                ByteBuf output;
@@ -496,7 +496,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 						                return FutureMono.from(channel().writeAndFlush(newFullBodyMessage(output)));
 					                }
 					                output.release();
-					                return FutureMono.from(channel().writeAndFlush(newFullBodyMessage(Unpooled.EMPTY_BUFFER)));
+					                return FutureMono.from(channel().writeAndFlush(newFullBodyMessage()));
 				                }
 				                for (ByteBuf bb : list) {
 				                	if (log.isDebugEnabled()) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
@@ -59,6 +59,7 @@ import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Signal;
+import reactor.core.publisher.SynchronousSink;
 import reactor.core.scheduler.Schedulers;
 import reactor.netty.BaseHttpTest;
 import reactor.netty.ByteBufFlux;
@@ -101,6 +102,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 import static io.netty.handler.codec.http.HttpMethod.GET;
 import static io.netty.handler.codec.http.HttpMethod.POST;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -1040,13 +1042,31 @@ class HttpProtocolsTests extends BaseHttpTest {
 	}
 
 	@ParameterizedCompatibleCombinationsTest
-	void testMonoRequestBodySentAsFullRequest_MonoEmpty(HttpServer server, HttpClient client) {
+	void testMonoRequestBodySentAsFullRequest_MonoEmptyGet(HttpServer server, HttpClient client) {
+		// sends "full" request
+		testRequestBody(server, client, GET, sender -> sender.send(Mono.empty()), 1, null, true);
+	}
+
+	@ParameterizedCompatibleCombinationsTest
+	void testMonoRequestBodySentAsFullRequest_MonoEmptyPost(HttpServer server, HttpClient client) {
 		// sends "full" request
 		testRequestBody(server, client, POST, sender -> sender.send(Mono.empty()), 1, "0", false);
 	}
 
 	@ParameterizedCompatibleCombinationsTest
-	void testIssue3524Flux(HttpServer server, HttpClient client) {
+	void testIssue3524FluxGet1(HttpServer server, HttpClient client) {
+		// sends "full" request
+		testRequestBody(server, client, GET, sender -> sender.send((req, out) -> out.send(Flux.just(EMPTY_BUFFER, EMPTY_BUFFER, EMPTY_BUFFER))), 1, null, true);
+	}
+
+	@ParameterizedCompatibleCombinationsTest
+	void testIssue3524FluxGet2(HttpServer server, HttpClient client) {
+		// sends "full" request
+		testRequestBody(server, client, GET, sender -> sender.send((req, out) -> out.send(Flux.generate(SynchronousSink::complete))), 1, null, true);
+	}
+
+	@ParameterizedCompatibleCombinationsTest
+	void testIssue3524FluxPost(HttpServer server, HttpClient client) {
 		// sends the message and then last http content
 		testRequestBody(server, client, POST, sender -> sender.send((req, out) -> out.sendString(Flux.just("te", "st"))), 3, null, false);
 	}


### PR DESCRIPTION
Fixes #3604