### PR TITLE
Ensure `HttpInfos#version` returns the correct protocol when `Unix Domain Sockets`

### DIFF
--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -66,4 +66,4 @@ jobs:
         run: ./gradlew clean check -x :reactor-netty-core:java17Test --no-daemon -x spotlessCheck -PforceTransport=${{ matrix.transport }}
       - name: Build and test UDS with NIO on Java 17
         if: ${{ ! startsWith(matrix.os, 'windows') }}
-        run: ./gradlew reactor-netty-http:test --tests reactor.netty.http.server.HttpServerTests.testHttpServerWithDomainSockets_HTTP11 -PtestToolchain=17 --no-daemon -x spotlessCheck -PforceTransport=nio
+        run: ./gradlew reactor-netty-http:test --tests reactor.netty.http.server.HttpServerTests.testHttpServerWithDomainSockets_HTTP11Post -PtestToolchain=17 --no-daemon -x spotlessCheck -PforceTransport=nio

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -41,6 +41,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.unix.DomainSocketChannel;
 import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpRequest;
@@ -180,7 +181,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 		if (c.channel() instanceof Http2StreamChannel) {
 			this.version = H2;
 		}
-		else if (c.channel() instanceof SocketChannel) {
+		else if (c.channel() instanceof SocketChannel || c.channel() instanceof DomainSocketChannel) {
 			HttpVersion version = this.nettyRequest.protocolVersion();
 			if (version.equals(HttpVersion.HTTP_1_0)) {
 				this.version = HttpVersion.HTTP_1_0;

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -168,6 +168,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import static reactor.netty.http.server.HttpServerFormDecoderProvider.DEFAULT_FORM_DECODER_SPEC;
 import static reactor.netty.http.server.ConnectionInfo.DEFAULT_HOST_NAME;
 import static reactor.netty.http.server.ConnectionInfo.DEFAULT_HTTP_PORT;
+import static reactor.netty.http.server.HttpTrafficHandler.H2;
 import static reactor.netty.resources.LoopResources.DEFAULT_SHUTDOWN_TIMEOUT;
 
 /**
@@ -2015,13 +2016,18 @@ class HttpServerTests extends BaseHttpTest {
 	}
 
 	@Test
-	void testHttpServerWithDomainSockets_HTTP11() {
-		doTestHttpServerWithDomainSockets(HttpServer.create(), HttpClient.create(), "http");
+	void testHttpServerWithDomainSockets_HTTP11Get() {
+		doTestHttpServerWithDomainSockets(HttpServer.create(), HttpClient.create(), HttpMethod.GET, "http", HttpVersion.HTTP_1_1);
+	}
+
+	@Test
+	void testHttpServerWithDomainSockets_HTTP11Post() {
+		doTestHttpServerWithDomainSockets(HttpServer.create(), HttpClient.create(), HttpMethod.POST, "http", HttpVersion.HTTP_1_1);
 	}
 
 	@Test
 	@SuppressWarnings("deprecation")
-	void testHttpServerWithDomainSockets_HTTP2() {
+	void testHttpServerWithDomainSockets_HTTP2Get() {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =
 				Http2SslContextSpec.forClient()
@@ -2029,10 +2035,24 @@ class HttpServerTests extends BaseHttpTest {
 		doTestHttpServerWithDomainSockets(
 				HttpServer.create().protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(serverCtx)),
 				HttpClient.create().protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(clientCtx)),
-				"https");
+				HttpMethod.GET, "https", H2);
 	}
 
-	private void doTestHttpServerWithDomainSockets(HttpServer server, HttpClient client, String expectedScheme) {
+	@Test
+	@SuppressWarnings("deprecation")
+	void testHttpServerWithDomainSockets_HTTP2Post() {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestHttpServerWithDomainSockets(
+				HttpServer.create().protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(serverCtx)),
+				HttpClient.create().protocol(HttpProtocol.H2).secure(spec -> spec.sslContext(clientCtx)),
+				HttpMethod.POST, "https", H2);
+	}
+
+	private void doTestHttpServerWithDomainSockets(HttpServer server, HttpClient client, HttpMethod method,
+			String expectedScheme, HttpVersion expectedVersion) {
 		boolean isJava17 = System.getProperty("java.version").startsWith("17");
 		assumeThat(LoopResources.hasNativeSupport() || isJava17).isTrue();
 		disposableServer =
@@ -2045,6 +2065,7 @@ class HttpServerTests extends BaseHttpTest {
 				              assertThat(req.hostAddress()).isNull();
 				              assertThat(req.remoteAddress()).isNull();
 				              assertThat(req.scheme()).isNotNull().isEqualTo(expectedScheme);
+				              assertThat(req.version()).isEqualTo(expectedVersion);
 				          });
 				          assertThat(req.requestHeaders().get(HttpHeaderNames.HOST)).isEqualTo("localhost");
 				          return res.send(req.receive().retain());
@@ -2054,15 +2075,20 @@ class HttpServerTests extends BaseHttpTest {
 		String response =
 				client.remoteAddress(disposableServer::address)
 				      .wiretap(true)
-				      .post()
+				      .request(method)
 				      .uri("/")
-				      .send(ByteBufFlux.fromString(Flux.just("1", "2", "3")))
+				      .send((req, out) -> HttpMethod.POST.equals(method) ? out.sendString(Flux.just("1", "2", "3")) : Mono.empty())
 				      .responseContent()
 				      .aggregate()
 				      .asString()
 				      .block(Duration.ofSeconds(30));
 
-		assertThat(response).isEqualTo("123");
+		if (HttpMethod.POST.equals(method)) {
+			assertThat(response).isEqualTo("123");
+		}
+		else {
+			assertThat(response).isNull();
+		}
 	}
 
 	private static SocketAddress createDomainSocketAddress(boolean isJava17) {


### PR DESCRIPTION
Fixes #3692