### PR TITLE
Support error log handler for Http server

### DIFF
--- a/docs/modules/ROOT/pages/http-server.adoc
+++ b/docs/modules/ROOT/pages/http-server.adoc
@@ -412,10 +412,13 @@ The following example uses a domain name containing a wildcard:
 include::{examples-dir}/sni/Application.java[lines=18..47]
 ----
 
-[[http-access-log]]
-== HTTP Access Log
+[[http-log]]
+== HTTP Log
 
-You can enable the `HTTP` access log either programmatically or by configuration. By default, it is disabled.
+You can enable the `HTTP` access or error log either programmatically or by configuration. By default, it is disabled.
+
+[[access-log]]
+=== Access Log
 
 You can use `-Dreactor.netty.http.server.accessLogEnabled=true` to enable the `HTTP` access log by configuration.
 
@@ -472,6 +475,63 @@ include::{examples-dir}/accessLog/CustomFormatAndFilterAccessLogApplication.java
 <1> Specifies the filter predicate to use
 <2> Specifies the custom format to apply
 
+[[error-log]]
+=== Error Log
+
+You can use `-Dreactor.netty.http.server.errorLogEnabled=true` to enable the `HTTP` error log by configuration.
+
+You can use the following configuration (for Logback or similar logging frameworks) to have a separate
+`HTTP` error log file:
+
+[source,xml]
+----
+<appender name="errorLog" class="ch.qos.logback.core.FileAppender">
+    <file>error_log.log</file>
+    <encoder>
+        <pattern>%msg%n</pattern>
+    </encoder>
+</appender>
+<appender name="async" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="errorLog" />
+</appender>
+
+<logger name="reactor.netty.http.server.ErrorLog" level="ERROR" additivity="false">
+    <appender-ref ref="async"/>
+</logger>
+----
+
+The following example enables it programmatically:
+
+{examples-link}/errorLog/Application.java
+----
+include::{examples-dir}/errorLog/Application.java[lines=21..32]
+----
+
+Calling this method takes precedence over the system property configuration.
+
+By default, the logging format is `[{datetime}] [error] [client {remote address}] {exception message}`, but you can
+specify a custom one as a parameter, as in the following example:
+
+{examples-link}/errorLog/CustomLogErrorFormatApplication.java
+----
+include::{examples-dir}/errorLog/CustomLogErrorFormatApplication.java[lines=22..36]
+----
+
+You can also filter `HTTP` error logs by using the `ErrorLogFactory#createFilter` method, as in the following example:
+
+{examples-link}/errorLog/FilterLogErrorApplication.java
+----
+include::{examples-dir}/errorLog/FilterLogErrorApplication.java[lines=22..36]
+----
+
+Note that this method can take a custom format parameter too, as in this example:
+
+{examples-link}/errorLog/CustomFormatAndFilterErrorLogApplication.java.java
+----
+include::{examples-dir}/errorLog/CustomFormatAndFilterErrorLogApplication.java[lines=23..40]
+----
+<1> Specifies the filter predicate to use
+<2> Specifies the custom format to apply
 
 [[HTTP2]]
 == HTTP/2

--- a/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,7 @@ public interface NettyPipeline {
 	String RIGHT                 = "reactor.right.";
 
 	String AccessLogHandler      = LEFT + "accessLogHandler";
+	String ErrorLogHandler      = LEFT + "errorLogHandler";
 	String ChannelMetricsHandler = LEFT + "channelMetricsHandler";
 	String ChunkedWriter         = LEFT + "chunkedWriter";
 	String CompressionHandler    = LEFT + "compressionHandler";

--- a/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
@@ -89,7 +89,7 @@ public interface NettyPipeline {
 	String RIGHT                 = "reactor.right.";
 
 	String AccessLogHandler      = LEFT + "accessLogHandler";
-	String ErrorLogHandler      = LEFT + "errorLogHandler";
+	String ErrorLogHandler       = LEFT + "errorLogHandler";
 	String ChannelMetricsHandler = LEFT + "channelMetricsHandler";
 	String ChunkedWriter         = LEFT + "chunkedWriter";
 	String CompressionHandler    = LEFT + "compressionHandler";

--- a/reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ReactorNetty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,6 +193,12 @@ public final class ReactorNetty {
 	 * By default, it is disabled.
 	 */
 	public static final String ACCESS_LOG_ENABLED = "reactor.netty.http.server.accessLogEnabled";
+
+	/**
+	 * Specifies whether the Http Server error log will be enabled.
+	 * By default, it is disabled.
+	 */
+	public static final String ERROR_LOG_ENABLED = "reactor.netty.http.server.errorLogEnabled";
 
 	/**
 	 *  Specifies the zone id used by the access log.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/errorLog/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/errorLog/Application.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.server.errorLog;
+
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+public class Application {
+
+	public static void main(String[] args) {
+		DisposableServer server =
+				HttpServer.create()
+						.errorLog(true)
+						.bindNow();
+
+		server.onDispose()
+				.block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/errorLog/CustomFormatAndFilterErrorLogApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/errorLog/CustomFormatAndFilterErrorLogApplication.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.server.errorLog;
+
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+import reactor.netty.http.server.logging.error.ErrorLog;
+import reactor.netty.http.server.logging.error.ErrorLogFactory;
+
+public class CustomFormatAndFilterErrorLogApplication {
+
+	public static void main(String[] args) {
+		DisposableServer server =
+				HttpServer.create()
+						.errorLog(
+								true,
+								ErrorLogFactory.createFilter(
+										p -> p.cause() instanceof RuntimeException, //<1>
+										x -> ErrorLog.create("method={}, uri={}", x.httpServerInfos().method(), x.httpServerInfos().uri()) //<2>
+								)
+						)
+						.bindNow();
+
+		server.onDispose()
+				.block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/errorLog/CustomFormatAndFilterErrorLogApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/errorLog/CustomFormatAndFilterErrorLogApplication.java
@@ -17,7 +17,7 @@ package reactor.netty.examples.documentation.http.server.errorLog;
 
 import reactor.netty.DisposableServer;
 import reactor.netty.http.server.HttpServer;
-import reactor.netty.http.server.logging.error.ErrorLog;
+import reactor.netty.http.server.logging.error.DefaultErrorLog;
 import reactor.netty.http.server.logging.error.ErrorLogFactory;
 
 public class CustomFormatAndFilterErrorLogApplication {
@@ -29,7 +29,7 @@ public class CustomFormatAndFilterErrorLogApplication {
 								true,
 								ErrorLogFactory.createFilter(
 										p -> p.cause() instanceof RuntimeException, //<1>
-										x -> ErrorLog.create("method={}, uri={}", x.httpServerInfos().method(), x.httpServerInfos().uri()) //<2>
+										x -> DefaultErrorLog.create("method={}, uri={}", x.httpServerInfos().method(), x.httpServerInfos().uri()) //<2>
 								)
 						)
 						.bindNow();

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/errorLog/CustomLogErrorFormatApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/errorLog/CustomLogErrorFormatApplication.java
@@ -17,7 +17,7 @@ package reactor.netty.examples.documentation.http.server.errorLog;
 
 import reactor.netty.DisposableServer;
 import reactor.netty.http.server.HttpServer;
-import reactor.netty.http.server.logging.error.ErrorLog;
+import reactor.netty.http.server.logging.error.DefaultErrorLog;
 
 public class CustomLogErrorFormatApplication {
 
@@ -26,7 +26,7 @@ public class CustomLogErrorFormatApplication {
 				HttpServer.create()
 						.errorLog(
 								true,
-								x -> ErrorLog.create("method={}, uri={}", x.httpServerInfos().method(), x.httpServerInfos().uri())
+								x -> DefaultErrorLog.create("method={}, uri={}", x.httpServerInfos().method(), x.httpServerInfos().uri())
 						)
 						.bindNow();
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/errorLog/CustomLogErrorFormatApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/errorLog/CustomLogErrorFormatApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.server.errorLog;
+
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+import reactor.netty.http.server.logging.error.ErrorLog;
+
+public class CustomLogErrorFormatApplication {
+
+	public static void main(String[] args) {
+		DisposableServer server =
+				HttpServer.create()
+						.errorLog(
+								true,
+								x -> ErrorLog.create("method={}, uri={}", x.httpServerInfos().method(), x.httpServerInfos().uri())
+						)
+						.bindNow();
+
+		server.onDispose()
+				.block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/errorLog/FilterLogErrorApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/errorLog/FilterLogErrorApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.server.errorLog;
+
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+import reactor.netty.http.server.logging.error.ErrorLogFactory;
+
+public class FilterLogErrorApplication {
+
+	public static void main(String[] args) {
+		DisposableServer server =
+				HttpServer.create()
+						.errorLog(
+								true,
+								ErrorLogFactory.createFilter(p -> p.cause() instanceof RuntimeException)
+						)
+						.bindNow();
+
+		server.onDispose()
+				.block();
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3Codec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3Codec.java
@@ -35,6 +35,9 @@ import reactor.netty.http.server.compression.HttpCompressionOptionsSpec;
 import reactor.netty.http.server.logging.AccessLog;
 import reactor.netty.http.server.logging.AccessLogArgProvider;
 import reactor.netty.http.server.logging.AccessLogHandlerFactory;
+import reactor.netty.http.server.logging.error.DefaultErrorLogHandler;
+import reactor.netty.http.server.logging.error.ErrorLog;
+import reactor.netty.http.server.logging.error.ErrorLogArgProvider;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
@@ -52,6 +55,8 @@ final class Http3Codec extends ChannelInitializer<QuicStreamChannel> {
 
 	final boolean                                                 accessLogEnabled;
 	final Function<AccessLogArgProvider, AccessLog>               accessLog;
+	final boolean                                                 errorLogEnabled;
+	final Function<ErrorLogArgProvider, ErrorLog>               errorLog;
 	final HttpCompressionOptionsSpec                              compressionOptions;
 	final BiPredicate<HttpServerRequest, HttpServerResponse>      compressPredicate;
 	final ServerCookieDecoder                                     cookieDecoder;
@@ -74,6 +79,8 @@ final class Http3Codec extends ChannelInitializer<QuicStreamChannel> {
 	Http3Codec(
 			boolean accessLogEnabled,
 			@Nullable Function<AccessLogArgProvider, AccessLog> accessLog,
+			boolean errorLogEnabled,
+			@Nullable Function<ErrorLogArgProvider, ErrorLog> errorLog,
 			@Nullable HttpCompressionOptionsSpec compressionOptions,
 			@Nullable BiPredicate<HttpServerRequest, HttpServerResponse> compressPredicate,
 			ServerCookieDecoder decoder,
@@ -93,6 +100,8 @@ final class Http3Codec extends ChannelInitializer<QuicStreamChannel> {
 			boolean validate) {
 		this.accessLogEnabled = accessLogEnabled;
 		this.accessLog = accessLog;
+		this.errorLogEnabled = errorLogEnabled;
+		this.errorLog = errorLog;
 		this.compressionOptions = compressionOptions;
 		this.compressPredicate = compressPredicate;
 		this.cookieDecoder = decoder;
@@ -149,6 +158,10 @@ final class Http3Codec extends ChannelInitializer<QuicStreamChannel> {
 			}
 		}
 
+		if (errorLogEnabled) {
+			p.addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.ErrorLogHandler, new DefaultErrorLogHandler(errorLog));
+		}
+
 		channel.pipeline().remove(this);
 
 		if (log.isDebugEnabled()) {
@@ -159,6 +172,8 @@ final class Http3Codec extends ChannelInitializer<QuicStreamChannel> {
 	static ChannelHandler newHttp3ServerConnectionHandler(
 			boolean accessLogEnabled,
 			@Nullable Function<AccessLogArgProvider, AccessLog> accessLog,
+			boolean errorLogEnabled,
+			@Nullable Function<ErrorLogArgProvider, ErrorLog> errorLog,
 			@Nullable HttpCompressionOptionsSpec compressionOptions,
 			@Nullable BiPredicate<HttpServerRequest, HttpServerResponse> compressPredicate,
 			ServerCookieDecoder decoder,
@@ -177,8 +192,8 @@ final class Http3Codec extends ChannelInitializer<QuicStreamChannel> {
 			@Nullable Function<String, String> uriTagValue,
 			boolean validate) {
 		return new Http3ServerConnectionHandler(
-				new Http3Codec(accessLogEnabled, accessLog, compressionOptions, compressPredicate, decoder, encoder, formDecoderProvider, forwardedHeaderHandler,
-						httpMessageLogFactory, listener, mapHandle, methodTagValue, metricsRecorder, minCompressionSize,
-						opsFactory, readTimeout, requestTimeout, uriTagValue, validate));
+				new Http3Codec(accessLogEnabled, accessLog, errorLogEnabled, errorLog, compressionOptions, compressPredicate, decoder, encoder,
+						formDecoderProvider, forwardedHeaderHandler, httpMessageLogFactory, listener, mapHandle, methodTagValue, metricsRecorder,
+						minCompressionSize, opsFactory, readTimeout, requestTimeout, uriTagValue, validate));
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3Codec.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3Codec.java
@@ -56,7 +56,7 @@ final class Http3Codec extends ChannelInitializer<QuicStreamChannel> {
 	final boolean                                                 accessLogEnabled;
 	final Function<AccessLogArgProvider, AccessLog>               accessLog;
 	final boolean                                                 errorLogEnabled;
-	final Function<ErrorLogArgProvider, ErrorLog>               errorLog;
+	final Function<ErrorLogArgProvider, ErrorLog>                 errorLog;
 	final HttpCompressionOptionsSpec                              compressionOptions;
 	final BiPredicate<HttpServerRequest, HttpServerResponse>      compressPredicate;
 	final ServerCookieDecoder                                     cookieDecoder;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -296,6 +296,7 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 *
 	 * @param enable enable or disable the error log
 	 * @return a new {@link HttpServer}
+	 * @since 1.2.5
 	 */
 	public final HttpServer errorLog(boolean enable) {
 		HttpServer dup = duplicate();
@@ -316,8 +317,8 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 *                   (req, res) -> res.header(CONTENT_TYPE, TEXT_PLAIN)
 	 *                                    .sendString(Mono.just("Hello World!"))))
 	 *           .errorLog(true, ErrorLogFactory.createFilter(
-	 * 								args -> args.cause() instanceof RuntimeException,
-	 * 								args -> ErrorLog.create("host-name={}", args.httpServerInfos().hostName())))
+	 *                              args -> args.cause() instanceof RuntimeException,
+	 *                              args -> ErrorLog.create("host-name={}", args.httpServerInfos().hostName())))
 	 *           .bindNow()
 	 *           .onDispose()
 	 *           .block();
@@ -332,6 +333,7 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 * @param enable enable or disable the error log
 	 * @param errorLogFactory the {@link ErrorLogFactory} that creates an {@link ErrorLog} given an {@link ErrorLogArgProvider}
 	 * @return a new {@link HttpServer}
+	 * @since 1.2.5
 	 */
 	public final HttpServer errorLog(boolean enable, ErrorLogFactory errorLogFactory) {
 		Objects.requireNonNull(errorLogFactory, "errorLogFactory");

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -52,6 +52,7 @@ import reactor.netty.http.server.logging.AccessLogArgProvider;
 import reactor.netty.http.server.logging.AccessLogFactory;
 import reactor.netty.http.server.logging.error.ErrorLog;
 import reactor.netty.http.server.logging.error.ErrorLogArgProvider;
+import reactor.netty.http.server.logging.error.DefaultErrorLoggingEvent;
 import reactor.netty.http.server.logging.error.ErrorLogFactory;
 import reactor.netty.internal.util.Metrics;
 import reactor.netty.tcp.SslProvider;
@@ -1324,6 +1325,8 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 				}
 				catch (Throwable t) {
 					log.error(format(connection.channel(), ""), t);
+					connection.channel().pipeline()
+							.fireUserEventTriggered(new DefaultErrorLoggingEvent(t));
 					//"FutureReturnValueIgnored" this is deliberate
 					connection.channel()
 					          .close();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -50,6 +50,9 @@ import reactor.netty.http.server.compression.HttpCompressionOptionsSpec;
 import reactor.netty.http.server.logging.AccessLog;
 import reactor.netty.http.server.logging.AccessLogArgProvider;
 import reactor.netty.http.server.logging.AccessLogFactory;
+import reactor.netty.http.server.logging.error.ErrorLog;
+import reactor.netty.http.server.logging.error.ErrorLogArgProvider;
+import reactor.netty.http.server.logging.error.ErrorLogFactory;
 import reactor.netty.internal.util.Metrics;
 import reactor.netty.tcp.SslProvider;
 import reactor.netty.tcp.TcpServer;
@@ -267,6 +270,74 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 		Objects.requireNonNull(accessLogFactory, "accessLogFactory");
 		HttpServer dup = duplicate();
 		dup.configuration().accessLog = accessLogFactory;
+		return dup;
+	}
+
+	/**
+	 * Enable or disable the error log. If enabled, the default log system will be used.
+	 * <p>
+	 * Example:
+	 * <pre>
+	 * {@code
+	 * HttpServer.create()
+	 *           .port(8080)
+	 *           .route(r -> r.get("/hello",
+	 *                   (req, res) -> res.header(CONTENT_TYPE, TEXT_PLAIN)
+	 *                                    .sendString(Mono.just("Hello World!"))))
+	 *           .errorLog(true)
+	 *           .bindNow()
+	 *           .onDispose()
+	 *           .block();
+	 * }
+	 * </pre>
+	 * <p>
+	 *
+	 * Note that this method takes precedence over the {@value reactor.netty.ReactorNetty#ERROR_LOG_ENABLED} system property.
+	 *
+	 * @param enable enable or disable the error log
+	 * @return a new {@link HttpServer}
+	 */
+	public final HttpServer errorLog(boolean enable) {
+		HttpServer dup = duplicate();
+		dup.configuration().errorLog = null;
+		dup.configuration().errorLogEnabled = enable;
+		return dup;
+	}
+
+	/**
+	 * Enable or disable the error log and customize it through an {@link ErrorLogFactory}.
+	 * <p>
+	 * Example:
+	 * <pre>
+	 * {@code
+	 * HttpServer.create()
+	 *           .port(8080)
+	 *           .route(r -> r.get("/hello",
+	 *                   (req, res) -> res.header(CONTENT_TYPE, TEXT_PLAIN)
+	 *                                    .sendString(Mono.just("Hello World!"))))
+	 *           .errorLog(true, ErrorLogFactory.createFilter(
+	 * 								args -> args.cause() instanceof RuntimeException,
+	 * 								args -> ErrorLog.create("host-name={}", args.httpServerInfos().hostName())))
+	 *           .bindNow()
+	 *           .onDispose()
+	 *           .block();
+	 * }
+	 * </pre>
+	 * <p>
+	 * The {@link ErrorLogFactory} class offers several helper methods to generate such a function,
+	 * notably if one wants to {@link ErrorLogFactory#createFilter(Predicate) filter} some exceptions out of the error log.
+	 * <p>
+	 * Note that this method takes precedence over the {@value reactor.netty.ReactorNetty#ERROR_LOG_ENABLED} system property.
+	 *
+	 * @param enable enable or disable the error log
+	 * @param errorLogFactory the {@link ErrorLogFactory} that creates an {@link ErrorLog} given an {@link ErrorLogArgProvider}
+	 * @return a new {@link HttpServer}
+	 */
+	public final HttpServer errorLog(boolean enable, ErrorLogFactory errorLogFactory) {
+		Objects.requireNonNull(errorLogFactory, "errorLogFactory");
+		HttpServer dup = duplicate();
+		dup.configuration().errorLog = enable ? errorLogFactory : null;
+		dup.configuration().errorLogEnabled = enable;
 		return dup;
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -293,6 +293,7 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	 * <p>
 	 *
 	 * Note that this method takes precedence over the {@value reactor.netty.ReactorNetty#ERROR_LOG_ENABLED} system property.
+	 * By default, error logs are formatted as "[{datetime}] [pid {pid}] [client {remote address}] {error message}".
 	 *
 	 * @param enable enable or disable the error log
 	 * @return a new {@link HttpServer}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -95,6 +95,7 @@ import reactor.netty.http.HttpOperations;
 import reactor.netty.http.logging.HttpMessageArgProviderFactory;
 import reactor.netty.http.logging.HttpMessageLogFactory;
 import reactor.netty.http.server.compression.HttpCompressionOptionsSpec;
+import reactor.netty.http.server.logging.error.DefaultErrorLoggingEvent;
 import reactor.netty.http.websocket.WebsocketInbound;
 import reactor.netty.http.websocket.WebsocketOutbound;
 import reactor.util.Logger;
@@ -1176,6 +1177,8 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 	 */
 	@Override
 	protected void onOutboundError(Throwable err) {
+		channel().pipeline()
+				.fireUserEventTriggered(new DefaultErrorLoggingEvent(err));
 
 		if (!channel().isActive()) {
 			super.onOutboundError(err);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/AbstractErrorLogArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/AbstractErrorLogArgProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server.logging.error;
+
+import reactor.netty.http.server.HttpServerInfos;
+import reactor.util.annotation.Nullable;
+
+import java.net.SocketAddress;
+import java.time.ZonedDateTime;
+import java.util.function.Supplier;
+
+/**
+ * Provides information for logging errors that occur on the HTTP Server.
+ *
+ * @author raccoonback
+ */
+abstract class AbstractErrorLogArgProvider<SELF extends AbstractErrorLogArgProvider<SELF>>
+		implements ErrorLogArgProvider, Supplier<SELF> {
+
+	protected final SocketAddress remoteAddress;
+	protected HttpServerInfos httpServerInfos;
+	protected ZonedDateTime errorDateTime;
+
+	AbstractErrorLogArgProvider(SocketAddress remoteAddress) {
+		this.remoteAddress = remoteAddress;
+	}
+
+	@Override
+	public ZonedDateTime errorDateTime() {
+		return errorDateTime;
+	}
+
+	@Override
+	public SocketAddress remoteAddress() {
+		return remoteAddress;
+	}
+
+	@Override
+	@Nullable
+	public HttpServerInfos httpServerInfos() {
+		return httpServerInfos;
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/AbstractErrorLogArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/AbstractErrorLogArgProvider.java
@@ -34,7 +34,7 @@ abstract class AbstractErrorLogArgProvider<SELF extends AbstractErrorLogArgProvi
 	protected HttpServerInfos httpServerInfos;
 	protected ZonedDateTime errorDateTime;
 
-	AbstractErrorLogArgProvider(SocketAddress remoteAddress) {
+	AbstractErrorLogArgProvider(@Nullable SocketAddress remoteAddress) {
 		this.remoteAddress = remoteAddress;
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/BaseErrorLogHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/BaseErrorLogHandler.java
@@ -30,8 +30,9 @@ class BaseErrorLogHandler extends ChannelDuplexHandler {
 
 	static {
 		String jvmName = ManagementFactory.getRuntimeMXBean().getName();
-		if (jvmName.contains("@")) {
-			PID = jvmName.split("@")[0];
+		int index = jvmName.indexOf('@');
+		if (index != -1) {
+			PID = jvmName.substring(0, index);
 		}
 		else {
 			PID = jvmName;
@@ -44,7 +45,7 @@ class BaseErrorLogHandler extends ChannelDuplexHandler {
 	static final String MISSING = "-";
 
 	static final Function<ErrorLogArgProvider, ErrorLog> DEFAULT_ERROR_LOG =
-			args -> ErrorLog.create(
+			args -> DefaultErrorLog.create(
 					DEFAULT_LOG_FORMAT,
 					args.errorDateTime().format(DATE_TIME_FORMATTER),
 					refinedRemoteAddress(args.remoteAddress()),

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/BaseErrorLogHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/BaseErrorLogHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server.logging.error;
+
+import io.netty.channel.ChannelDuplexHandler;
+import reactor.util.annotation.Nullable;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.function.Function;
+
+class BaseErrorLogHandler extends ChannelDuplexHandler {
+
+	static final String DEFAULT_LOG_FORMAT = "[{}] {}";
+	static final String MISSING = "-";
+
+	static final Function<ErrorLogArgProvider, ErrorLog> DEFAULT_ERROR_LOG =
+			args -> ErrorLog.create(
+					DEFAULT_LOG_FORMAT,
+					refinedRemoteAddress(args.remoteAddress()),
+					refinedExceptionMessage(args.cause().getMessage()),
+					args.cause()
+			);
+
+	final Function<ErrorLogArgProvider, ErrorLog> errorLog;
+
+	BaseErrorLogHandler(@Nullable Function<ErrorLogArgProvider, ErrorLog> errorLog) {
+		this.errorLog = errorLog == null ? DEFAULT_ERROR_LOG : errorLog;
+	}
+
+	private static String refinedRemoteAddress(@Nullable SocketAddress remoteAddress) {
+		if (remoteAddress instanceof InetSocketAddress) {
+			return ((InetSocketAddress) remoteAddress).getHostString();
+		}
+
+		return MISSING;
+	}
+
+	private static String refinedExceptionMessage(@Nullable String message) {
+		if (message != null) {
+			return message;
+		}
+
+		return MISSING;
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLog.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLog.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server.logging.error;
+
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import java.util.Objects;
+
+/**
+ * Log the http default error information into a Logger named {@code reactor.netty.http.server.DefaultErrorLog} at ERROR level.
+ * <p>
+ * See {@link ErrorLogFactory} for convenience methods to create an access log factory to be passed to
+ * {@link reactor.netty.http.server.HttpServer#errorLog(boolean, ErrorLogFactory)} during server configuration.
+ *
+ * @author raccoonback
+ */
+public final class DefaultErrorLog implements ErrorLog {
+
+	static final Logger LOGGER = Loggers.getLogger("reactor.netty.http.server.ErrorLog");
+
+	final String logFormat;
+	final Object[] args;
+
+	private DefaultErrorLog(String logFormat, Object... args) {
+		Objects.requireNonNull(logFormat, "logFormat");
+		this.logFormat = logFormat;
+		this.args = args;
+	}
+
+	/**
+	 * Creates an ErrorLog with the given format and arguments.
+	 *
+	 * @return exception
+	 */
+	public static DefaultErrorLog create(String logFormat, Object... args) {
+		return new DefaultErrorLog(logFormat, args);
+	}
+
+	@Override
+	public void log() {
+		if (LOGGER.isErrorEnabled()) {
+			LOGGER.error(logFormat, args);
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogArgProvider.java
@@ -16,8 +16,6 @@
 package reactor.netty.http.server.logging.error;
 
 import io.netty.channel.Channel;
-import reactor.netty.Connection;
-import reactor.netty.ConnectionObserver;
 import reactor.netty.ReactorNetty;
 import reactor.netty.channel.ChannelOperations;
 import reactor.netty.http.server.HttpServerInfos;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogArgProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server.logging.error;
+
+import io.netty.channel.Channel;
+import reactor.netty.Connection;
+import reactor.netty.ConnectionObserver;
+import reactor.netty.ReactorNetty;
+import reactor.netty.channel.ChannelOperations;
+import reactor.netty.http.server.HttpServerInfos;
+import reactor.util.annotation.Nullable;
+
+import java.net.SocketAddress;
+import java.time.ZonedDateTime;
+
+/**
+ * Provides default information for logging errors that occur on the HTTP Server.
+ *
+ * @author raccoonback
+ */
+final class DefaultErrorLogArgProvider extends AbstractErrorLogArgProvider<DefaultErrorLogArgProvider> {
+
+	private Throwable cause;
+
+	DefaultErrorLogArgProvider(@Nullable SocketAddress remoteAddress) {
+		super(remoteAddress);
+	}
+
+	@Override
+	public DefaultErrorLogArgProvider get() {
+		return this;
+	}
+
+	@Override
+	public Throwable cause() {
+		return cause;
+	}
+
+	public void clear() {
+		cause = null;
+	}
+
+	void applyThrowable(Throwable cause) {
+		this.errorDateTime = ZonedDateTime.now(ReactorNetty.ZONE_ID_SYSTEM);
+		this.cause = cause;
+	}
+
+	void applyConnectionInfo(Channel channel) {
+		ChannelOperations<?, ?> ops = ChannelOperations.get(channel);
+		if (ops instanceof HttpServerInfos) {
+			this.httpServerInfos = (HttpServerInfos) ops;
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogArgProvider.java
@@ -47,8 +47,10 @@ final class DefaultErrorLogArgProvider extends AbstractErrorLogArgProvider<Defau
 		return cause;
 	}
 
-	public void clear() {
+	void clear() {
 		cause = null;
+		errorDateTime = null;
+		httpServerInfos = null;
 	}
 
 	void applyThrowable(Throwable cause) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server.logging.error;
+
+import io.netty.channel.ChannelHandlerContext;
+import reactor.util.annotation.Nullable;
+
+import java.util.function.Function;
+
+/**
+ * Handler for logging errors that occur in the HTTP Server.
+ *
+ * @author raccoonback
+ */
+public final class DefaultErrorLogHandler extends BaseErrorLogHandler {
+
+	DefaultErrorLogArgProvider errorLogArgProvider;
+
+	public DefaultErrorLogHandler(@Nullable Function<ErrorLogArgProvider, ErrorLog> errorLog) {
+		super(errorLog);
+	}
+
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+		if (errorLogArgProvider == null) {
+			errorLogArgProvider = new DefaultErrorLogArgProvider(ctx.channel().remoteAddress());
+		}
+		else {
+			errorLogArgProvider.clear();
+		}
+
+		errorLogArgProvider.applyThrowable(cause);
+		errorLogArgProvider.applyConnectionInfo(ctx.channel());
+
+		ErrorLog log = errorLog.apply(errorLogArgProvider);
+		if (log != null) {
+			log.log();
+		}
+
+		super.exceptionCaught(ctx, cause);
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogHandler.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
  */
 public final class DefaultErrorLogHandler extends BaseErrorLogHandler {
 
-	DefaultErrorLogArgProvider errorLogArgProvider;
+	private DefaultErrorLogArgProvider errorLogArgProvider;
 
 	public DefaultErrorLogHandler(@Nullable Function<ErrorLogArgProvider, ErrorLog> errorLog) {
 		super(errorLog);
@@ -52,5 +52,14 @@ public final class DefaultErrorLogHandler extends BaseErrorLogHandler {
 		}
 
 		super.exceptionCaught(ctx, cause);
+	}
+
+	@Override
+	public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+		if (evt instanceof DefaultErrorLoggingEvent) {
+			exceptionCaught(ctx, ((DefaultErrorLoggingEvent) evt).getThrowable());
+		}
+
+		super.userEventTriggered(ctx, evt);
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogHandler.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
  * Handler for logging errors that occur in the HTTP Server.
  *
  * @author raccoonback
+ * @since 1.2.5
  */
 public final class DefaultErrorLogHandler extends BaseErrorLogHandler {
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLogHandler.java
@@ -18,7 +18,6 @@ package reactor.netty.http.server.logging.error;
 import io.netty.channel.ChannelHandlerContext;
 import reactor.util.annotation.Nullable;
 
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -28,8 +27,6 @@ import java.util.function.Function;
  * @since 1.2.5
  */
 public final class DefaultErrorLogHandler extends BaseErrorLogHandler {
-
-	private final ReentrantLock lock = new ReentrantLock();
 
 	private DefaultErrorLogArgProvider errorLogArgProvider;
 
@@ -41,22 +38,16 @@ public final class DefaultErrorLogHandler extends BaseErrorLogHandler {
 	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
 		ErrorLog log;
 
-		lock.lock();
-		try {
-			if (errorLogArgProvider == null) {
-				errorLogArgProvider = new DefaultErrorLogArgProvider(ctx.channel().remoteAddress());
-			}
-			else {
-				errorLogArgProvider.clear();
-			}
+		if (errorLogArgProvider == null) {
+			errorLogArgProvider = new DefaultErrorLogArgProvider(ctx.channel().remoteAddress());
+		}
+		else {
+			errorLogArgProvider.clear();
+		}
 
-			errorLogArgProvider.applyThrowable(cause);
-			errorLogArgProvider.applyConnectionInfo(ctx.channel());
-			log = errorLog.apply(errorLogArgProvider);
-		}
-		finally {
-			lock.unlock();
-		}
+		errorLogArgProvider.applyThrowable(cause);
+		errorLogArgProvider.applyConnectionInfo(ctx.channel());
+		log = errorLog.apply(errorLogArgProvider);
 
 		if (log != null) {
 			log.log();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLoggingEvent.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/DefaultErrorLoggingEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server.logging.error;
+
+/**
+ * Provide a default implementation of an error logging event for UserEvent delivery.
+ *
+ * @author raccoonback
+ * @since 1.2.5
+ */
+public class DefaultErrorLoggingEvent implements ErrorLoggingEvent {
+
+	private final Throwable throwable;
+
+	public DefaultErrorLoggingEvent(Throwable throwable) {
+		this.throwable = throwable;
+	}
+
+	public Throwable getThrowable() {
+		return throwable;
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLog.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLog.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server.logging.error;
+
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import java.util.Objects;
+
+/**
+ * Log the http error information into a Logger named {@code reactor.netty.http.server.ErrorLog} at ERROR level.
+ * <p>
+ * See {@link ErrorLogFactory} for convenience methods to create an access log factory to be passed to
+ * {@link reactor.netty.http.server.HttpServer#errorLog(boolean, ErrorLogFactory)} during server configuration.
+ *
+ * @author raccoonback
+ */
+public final class ErrorLog {
+
+	static final Logger LOGGER = Loggers.getLogger("reactor.netty.http.server.ErrorLog");
+
+	final String logFormat;
+	final Object[] args;
+
+	private ErrorLog(String logFormat, Object... args) {
+		Objects.requireNonNull(logFormat, "logFormat");
+		this.logFormat = logFormat;
+		this.args = args;
+	}
+
+	/**
+	 * Creates an ErrorLog with the given format and arguments.
+	 *
+	 * @return exception
+	 */
+	public static ErrorLog create(String logFormat, Object... args) {
+		return new ErrorLog(logFormat, args);
+	}
+
+	void log() {
+		if (LOGGER.isErrorEnabled()) {
+			LOGGER.error(logFormat, args);
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLog.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLog.java
@@ -15,44 +15,16 @@
  */
 package reactor.netty.http.server.logging.error;
 
-import reactor.util.Logger;
-import reactor.util.Loggers;
-
-import java.util.Objects;
-
 /**
- * Log the http error information into a Logger named {@code reactor.netty.http.server.ErrorLog} at ERROR level.
- * <p>
- * See {@link ErrorLogFactory} for convenience methods to create an access log factory to be passed to
- * {@link reactor.netty.http.server.HttpServer#errorLog(boolean, ErrorLogFactory)} during server configuration.
+ * Represents a log entry for HTTP server errors.
+ * Implementations of this interface define how the error information is logged.
  *
  * @author raccoonback
  */
-public final class ErrorLog {
-
-	static final Logger LOGGER = Loggers.getLogger("reactor.netty.http.server.ErrorLog");
-
-	final String logFormat;
-	final Object[] args;
-
-	private ErrorLog(String logFormat, Object... args) {
-		Objects.requireNonNull(logFormat, "logFormat");
-		this.logFormat = logFormat;
-		this.args = args;
-	}
+public interface ErrorLog {
 
 	/**
-	 * Creates an ErrorLog with the given format and arguments.
-	 *
-	 * @return exception
+	 * Logs the error information.
 	 */
-	public static ErrorLog create(String logFormat, Object... args) {
-		return new ErrorLog(logFormat, args);
-	}
-
-	void log() {
-		if (LOGGER.isErrorEnabled()) {
-			LOGGER.error(logFormat, args);
-		}
-	}
+	void log();
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLogArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLogArgProvider.java
@@ -27,6 +27,7 @@ import java.util.function.BiFunction;
  * Provides information for logging errors that occur on the HTTP Server.
  *
  * @author raccoonback
+ * @since 1.2.5
  */
 public interface ErrorLogArgProvider {
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLogArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLogArgProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server.logging.error;
+
+import reactor.netty.http.server.ConnectionInformation;
+import reactor.netty.http.server.HttpServerInfos;
+import reactor.util.annotation.Nullable;
+
+import java.net.SocketAddress;
+import java.time.ZonedDateTime;
+import java.util.function.BiFunction;
+
+/**
+ * Provides information for logging errors that occur on the HTTP Server.
+ *
+ * @author raccoonback
+ */
+public interface ErrorLogArgProvider {
+
+	/**
+	 * Returns the date-time of the moment when the exception occurred.
+	 *
+	 * @return zoned date-time
+	 */
+	ZonedDateTime errorDateTime();
+
+	/**
+	 * Returns the address of the remote peer in case of Unix Domain Sockets.
+	 *
+	 * @return the peer's address
+	 */
+	SocketAddress remoteAddress();
+
+	/**
+	 * Returns information about the HTTP server-side connection information.
+	 * <p> Note that the {@link ConnectionInformation#remoteAddress()} will return the forwarded
+	 * remote client address if the server is configured in forwarded mode.
+	 *
+	 * @return HTTP server-side connection information
+	 * @see reactor.netty.http.server.HttpServer#forwarded(BiFunction)
+	 */
+	@Nullable
+	HttpServerInfos httpServerInfos();
+
+	/**
+	 * Returns the exception that occurred.
+	 *
+	 * @return exception
+	 */
+	Throwable cause();
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLogFactory.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLogFactory.java
@@ -51,9 +51,8 @@ public interface ErrorLogFactory extends Function<ErrorLogArgProvider, ErrorLog>
 	 * Any exception (represented as an {@link ErrorLogArgProvider}) that doesn't match the
 	 * provided {@link Predicate} is excluded from the error log. Other exceptions are logged
 	 * using the provided formatting {@link Function}.
-	 * Said function is expected to {@link ErrorLog#create(String, Object...) create} an {@link ErrorLog} instance,
-	 * defining both the String format and a vararg of the relevant arguments, extracted from the
-	 * {@link ErrorLogArgProvider}.
+	 * Create an {@link ErrorLog} instance by defining both the String format and a vararg of the relevant arguments,
+	 * extracted from the {@link ErrorLogArgProvider}.
 	 * <p>
 	 *
 	 * @param predicate      the filter that returns {@code true} if the exception should be logged, {@code false} otherwise

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLogFactory.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLogFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server.logging.error;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * An interface to declare more concisely a {@link Function} that apply an {@link ErrorLog} by an
+ * {@link ErrorLogArgProvider}.
+ * <p>
+ * Can be used in {@link reactor.netty.http.server.HttpServer#errorLog(boolean, ErrorLogFactory) errorLog} method for example.
+ *
+ * @author raccoonback
+ */
+public interface ErrorLogFactory extends Function<ErrorLogArgProvider, ErrorLog> {
+
+	/**
+	 * Helper method to create an error log factory that selectively enables error logs.
+	 * <p>
+	 * Any exception (represented as an {@link ErrorLogArgProvider}) that doesn't match the
+	 * provided {@link Predicate} is excluded from the error log. Other exceptions are logged
+	 * using the default format.
+	 *
+	 * @param predicate the filter that returns {@code true} if the exception should be logged, {@code false} otherwise
+	 * @return an {@link ErrorLogFactory} to be used in
+	 * {@link reactor.netty.http.server.HttpServer#errorLog(boolean, ErrorLogFactory)}
+	 */
+	static ErrorLogFactory createFilter(Predicate<ErrorLogArgProvider> predicate) {
+		return input -> predicate.test(input) ? BaseErrorLogHandler.DEFAULT_ERROR_LOG.apply(input) : null;
+	}
+
+	/**
+	 * Helper method to create an error log factory that selectively enables error logs and customizes
+	 * the format to apply.
+	 * <p>
+	 * Any exception (represented as an {@link ErrorLogArgProvider}) that doesn't match the
+	 * provided {@link Predicate} is excluded from the error log. Other exceptions are logged
+	 * using the provided formatting {@link Function}.
+	 * Said function is expected to {@link ErrorLog#create(String, Object...) create} an {@link ErrorLog} instance,
+	 * defining both the String format and a vararg of the relevant arguments, extracted from the
+	 * {@link ErrorLogArgProvider}.
+	 * <p>
+	 *
+	 * @param predicate      the filter that returns {@code true} if the exception should be logged, {@code false} otherwise
+	 * @param formatFunction the {@link ErrorLogFactory} that creates {@link ErrorLog} instances, encapsulating the
+	 *                       format
+	 *                       and the extraction of relevant arguments
+	 * @return an {@link ErrorLogFactory} to be used in
+	 * {@link reactor.netty.http.server.HttpServer#errorLog(boolean, ErrorLogFactory)}
+	 */
+	static ErrorLogFactory createFilter(Predicate<ErrorLogArgProvider> predicate, ErrorLogFactory formatFunction) {
+		return input -> predicate.test(input) ? formatFunction.apply(input) : null;
+	}
+
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLogFactory.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLogFactory.java
@@ -25,6 +25,7 @@ import java.util.function.Predicate;
  * Can be used in {@link reactor.netty.http.server.HttpServer#errorLog(boolean, ErrorLogFactory) errorLog} method for example.
  *
  * @author raccoonback
+ * @since 1.2.5
  */
 public interface ErrorLogFactory extends Function<ErrorLogArgProvider, ErrorLog> {
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLoggingEvent.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/error/ErrorLoggingEvent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server.logging.error;
+
+/**
+ * Define an interface to handle error logging events propagated through UserEvent.
+ *
+ * @author raccoonback
+ * @since 1.2.5
+ */
+public interface ErrorLoggingEvent {
+}

--- a/reactor-netty-http/src/main/resources/META-INF/native-image/io.projectreactor.netty/reactor-netty-http/reflect-config.json
+++ b/reactor-netty-http/src/main/resources/META-INF/native-image/io.projectreactor.netty/reactor-netty-http/reflect-config.json
@@ -327,5 +327,19 @@
 		},
 		"name": "reactor.netty.http.server.logging.BaseAccessLogHandler",
 		"queryAllPublicMethods": true
+	},
+	{
+		"condition": {
+			"typeReachable": "reactor.netty.http.server.logging.error.DefaultErrorLogHandler"
+		},
+		"name": "reactor.netty.http.server.logging.error.DefaultErrorLogHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"condition": {
+			"typeReachable": "reactor.netty.http.server.logging.error.BaseErrorLogHandler"
+		},
+		"name": "reactor.netty.http.server.logging.error.BaseErrorLogHandler",
+		"queryAllPublicMethods": true
 	}
 ]

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/error/ErrorLogTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/error/ErrorLogTest.java
@@ -83,7 +83,7 @@ class ErrorLogTest extends BaseHttpTest {
 		assertThat(relevantLog.getMessage())
 				.isEqualTo(BaseErrorLogHandler.DEFAULT_LOG_FORMAT);
 		assertThat(relevantLog.getFormattedMessage())
-				.matches("\\[([0-9a-fA-F:.]+)(:\\d)*] -");
+				.matches("\\[(\\d{4}-\\d{2}-\\d{2}) (\\d{2}:\\d{2}:\\d{2})\\+\\d{4}] \\[pid (\\d+)] \\[client ([0-9a-fA-F:.]+)(:\\d)*] java.lang.RuntimeException");
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/error/ErrorLogTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/error/ErrorLogTest.java
@@ -19,15 +19,29 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
 import reactor.netty.BaseHttpTest;
+import reactor.netty.http.Http11SslContextSpec;
+import reactor.netty.http.Http2SslContextSpec;
+import reactor.netty.http.HttpProtocol;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.client.HttpClientConfig;
+import reactor.netty.http.server.HttpServer;
+import reactor.netty.http.server.HttpServerConfig;
+import reactor.util.function.Tuple2;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.netty.http.server.logging.error.ErrorLog.LOGGER;
@@ -59,9 +73,10 @@ class ErrorLogTest extends BaseHttpTest {
 		ROOT.detachAppender(mockedAppender);
 	}
 
-	@Test
-	void errorLogDefaultFormat() {
-		disposableServer = createServer()
+	@ParameterizedTest
+	@MethodSource("dataCompatibleCombinations")
+	void errorLogDefaultFormat(HttpServer httpServer, HttpClient httpClient) {
+		disposableServer = httpServer
 				.handle((req, resp) -> {
 					resp.withConnection(
 							conn -> conn.channel()
@@ -73,7 +88,7 @@ class ErrorLogTest extends BaseHttpTest {
 				.errorLog(true)
 				.bindNow();
 
-		getHttpClientResponse("/example/test");
+		getHttpClientResponse(httpClient, "/example/test");
 
 		Mockito.verify(mockedAppender, Mockito.times(1))
 				.doAppend(loggingEventArgumentCaptor.capture());
@@ -86,9 +101,10 @@ class ErrorLogTest extends BaseHttpTest {
 				.matches("\\[(\\d{4}-\\d{2}-\\d{2}) (\\d{2}:\\d{2}:\\d{2})\\+\\d{4}] \\[pid (\\d+)] \\[client ([0-9a-fA-F:.]+)(:\\d)*] java.lang.RuntimeException");
 	}
 
-	@Test
-	void errorLogCustomFormat() {
-		disposableServer = createServer()
+	@ParameterizedTest
+	@MethodSource("dataCompatibleCombinations")
+	void errorLogCustomFormat(HttpServer httpServer, HttpClient httpClient) {
+		disposableServer = httpServer
 				.handle((req, resp) -> {
 					resp.withConnection(
 							conn -> conn.channel()
@@ -107,7 +123,7 @@ class ErrorLogTest extends BaseHttpTest {
 				)
 				.bindNow();
 
-		getHttpClientResponse("/example/test");
+		getHttpClientResponse(httpClient, "/example/test");
 
 		Mockito.verify(mockedAppender, Mockito.times(1))
 				.doAppend(loggingEventArgumentCaptor.capture());
@@ -120,9 +136,10 @@ class ErrorLogTest extends BaseHttpTest {
 				.isEqualTo("method=GET, uri=/example/test");
 	}
 
-	@Test
-	void secondCallToErrorLogOverridesPreviousOne() {
-		disposableServer = createServer()
+	@ParameterizedTest
+	@MethodSource("dataCompatibleCombinations")
+	void secondCallToErrorLogOverridesPreviousOne(HttpServer httpServer, HttpClient httpClient) {
+		disposableServer = httpServer
 				.handle((req, resp) -> {
 					resp.withConnection(
 							conn -> conn.channel()
@@ -142,16 +159,17 @@ class ErrorLogTest extends BaseHttpTest {
 				.errorLog(false)
 				.bindNow();
 
-		getHttpClientResponse("/example/test");
+		getHttpClientResponse(httpClient, "/example/test");
 
 		Mockito.verify(mockedAppender, Mockito.times(0))
 				.doAppend(loggingEventArgumentCaptor.capture());
 		assertThat(loggingEventArgumentCaptor.getAllValues()).isEmpty();
 	}
 
-	@Test
-	void errorLogFilteringAndFormatting() {
-		disposableServer = createServer()
+	@ParameterizedTest
+	@MethodSource("dataCompatibleCombinations")
+	void errorLogFilteringAndFormatting(HttpServer httpServer, HttpClient httpClient) {
+		disposableServer = httpServer
 				.handle((req, resp) -> {
 					resp.withConnection(
 							conn -> conn.channel()
@@ -169,8 +187,8 @@ class ErrorLogTest extends BaseHttpTest {
 				)
 				.bindNow();
 
-		getHttpClientResponse("/example/test");
-		getHttpClientResponse("/filtered/test");
+		getHttpClientResponse(httpClient, "/example/test");
+		getHttpClientResponse(httpClient, "/filtered/test");
 
 		Mockito.verify(mockedAppender, Mockito.times(1)).doAppend(loggingEventArgumentCaptor.capture());
 		assertThat(loggingEventArgumentCaptor.getAllValues()).hasSize(1);
@@ -182,9 +200,9 @@ class ErrorLogTest extends BaseHttpTest {
 				.isEqualTo("method=GET, uri=/filtered/test");
 	}
 
-	private void getHttpClientResponse(String uri) {
+	private void getHttpClientResponse(HttpClient httpClient, String uri) {
 		try {
-			createClient(disposableServer.port())
+			httpClient.port(disposableServer.port())
 					.get()
 					.uri(uri)
 					.response()
@@ -193,5 +211,65 @@ class ErrorLogTest extends BaseHttpTest {
 		catch (Exception e) {
 			// ignore
 		}
+	}
+
+	static Object[][] dataCompatibleCombinations() throws Exception {
+		SelfSignedCertificate cert = new SelfSignedCertificate();
+		Http11SslContextSpec serverCtxHttp11 = Http11SslContextSpec.forServer(cert.certificate(), cert.privateKey());
+		Http11SslContextSpec clientCtxHttp11 =
+				Http11SslContextSpec.forClient()
+						.configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		Http2SslContextSpec serverCtxHttp2 = Http2SslContextSpec.forServer(cert.certificate(), cert.privateKey());
+		Http2SslContextSpec clientCtxHttp2 =
+				Http2SslContextSpec.forClient()
+						.configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+
+		HttpServer _server = createServer().httpRequestDecoder(spec -> spec.h2cMaxContentLength(256));
+
+		HttpServer[] servers = new HttpServer[]{
+				_server, // by default protocol is HTTP/1.1
+				_server.protocol(HttpProtocol.H2C),
+				_server.protocol(HttpProtocol.HTTP11, HttpProtocol.H2C),
+				_server.secure(spec -> spec.sslContext(serverCtxHttp11)), // by default protocol is HTTP/1.1
+				_server.secure(spec -> spec.sslContext(serverCtxHttp2)).protocol(HttpProtocol.H2),
+				_server.secure(spec -> spec.sslContext(serverCtxHttp2)).protocol(HttpProtocol.HTTP11, HttpProtocol.H2)
+		};
+
+		HttpClient _client = HttpClient.create();
+		_client = _client.wiretap(true);
+
+		HttpClient[] clients = new HttpClient[]{
+				_client, // by default protocol is HTTP/1.1
+				_client.protocol(HttpProtocol.H2C),
+				_client.protocol(HttpProtocol.HTTP11, HttpProtocol.H2C),
+				_client.secure(spec -> spec.sslContext(clientCtxHttp11)), // by default protocol is HTTP/1.1
+				_client.secure(spec -> spec.sslContext(clientCtxHttp2)).protocol(HttpProtocol.H2),
+				_client.secure(spec -> spec.sslContext(clientCtxHttp2)).protocol(HttpProtocol.HTTP11, HttpProtocol.H2)
+		};
+
+		Flux<HttpServer> f1 = Flux.fromArray(servers).concatMap(o -> Flux.just(o).repeat(clients.length - 1));
+		Flux<HttpClient> f2 = Flux.fromArray(clients).repeat(servers.length - 1);
+
+		return Flux.zip(f1, f2)
+				.filter(tuple2 -> {
+					HttpServerConfig serverConfig = tuple2.getT1().configuration();
+					HttpClientConfig clientConfig = tuple2.getT2().configuration();
+					List<HttpProtocol> serverProtocols = Arrays.asList(serverConfig.protocols());
+					List<HttpProtocol> clientProtocols = Arrays.asList(clientConfig.protocols());
+					if (serverConfig.isSecure() != clientConfig.isSecure()) {
+						return false;
+					}
+					else if (serverProtocols.size() == 1 && serverProtocols.get(0) == HttpProtocol.H2C &&
+							clientProtocols.size() == 2) {
+						return false;
+					}
+					return serverProtocols.containsAll(clientProtocols) ||
+							clientProtocols.containsAll(serverProtocols);
+
+				})
+				.map(Tuple2::toArray)
+				.collectList()
+				.block(Duration.ofSeconds(30))
+				.toArray(new Object[0][2]);
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/error/ErrorLogTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/error/ErrorLogTest.java
@@ -83,7 +83,7 @@ class ErrorLogTest extends BaseHttpTest {
 		assertThat(relevantLog.getMessage())
 				.isEqualTo(BaseErrorLogHandler.DEFAULT_LOG_FORMAT);
 		assertThat(relevantLog.getFormattedMessage())
-				.matches("\\[([0-9a-fA-F:]+):(\\d+)] -");
+				.matches("\\[([0-9a-fA-F:.]+)(:\\d)*] -");
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/error/ErrorLogTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/error/ErrorLogTest.java
@@ -44,7 +44,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static reactor.netty.http.server.logging.error.ErrorLog.LOGGER;
+import static reactor.netty.http.server.logging.error.DefaultErrorLog.LOGGER;
 
 /**
  * This test class verifies {@link DefaultErrorLogHandler}.
@@ -115,7 +115,7 @@ class ErrorLogTest extends BaseHttpTest {
 				})
 				.errorLog(
 						true,
-						args -> ErrorLog.create(
+						args -> DefaultErrorLog.create(
 								CUSTOM_FORMAT,
 								args.httpServerInfos().method(),
 								args.httpServerInfos().uri()
@@ -150,7 +150,7 @@ class ErrorLogTest extends BaseHttpTest {
 				})
 				.errorLog(
 						true,
-						args -> ErrorLog.create(
+						args -> DefaultErrorLog.create(
 								CUSTOM_FORMAT,
 								args.httpServerInfos().method(),
 								args.httpServerInfos().uri()
@@ -182,7 +182,7 @@ class ErrorLogTest extends BaseHttpTest {
 						true,
 						ErrorLogFactory.createFilter(
 								p -> p.httpServerInfos().uri().startsWith("/filtered"),
-								args -> ErrorLog.create(CUSTOM_FORMAT, args.httpServerInfos().method(), args.httpServerInfos().uri())
+								args -> DefaultErrorLog.create(CUSTOM_FORMAT, args.httpServerInfos().method(), args.httpServerInfos().uri())
 						)
 				)
 				.bindNow();

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/error/ErrorLogTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/error/ErrorLogTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server.logging.error;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+import reactor.netty.BaseHttpTest;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.netty.http.server.logging.error.ErrorLog.LOGGER;
+
+/**
+ * This test class verifies {@link DefaultErrorLogHandler}.
+ *
+ * @author raccoonback
+ */
+class ErrorLogTest extends BaseHttpTest {
+
+	static final Logger ROOT = (Logger) LoggerFactory.getLogger(LOGGER.getName());
+	static final String CUSTOM_FORMAT = "method={}, uri={}";
+
+	private Appender<ILoggingEvent> mockedAppender;
+	private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+	@BeforeEach
+	@SuppressWarnings("unchecked")
+	void setUp() {
+		mockedAppender = (Appender<ILoggingEvent>) Mockito.mock(Appender.class);
+		loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+		Mockito.when(mockedAppender.getName()).thenReturn("MOCK");
+		ROOT.addAppender(mockedAppender);
+	}
+
+	@AfterEach
+	void tearDown() {
+		ROOT.detachAppender(mockedAppender);
+	}
+
+	@Test
+	void errorLogDefaultFormat() {
+		disposableServer = createServer()
+				.handle((req, resp) -> {
+					resp.withConnection(
+							conn -> conn.channel()
+									.pipeline()
+									.fireExceptionCaught(new RuntimeException())
+					);
+					return resp.send();
+				})
+				.errorLog(true)
+				.bindNow();
+
+		getHttpClientResponse("/example/test");
+
+		Mockito.verify(mockedAppender, Mockito.times(1))
+				.doAppend(loggingEventArgumentCaptor.capture());
+		assertThat(loggingEventArgumentCaptor.getAllValues()).hasSize(1);
+
+		LoggingEvent relevantLog = loggingEventArgumentCaptor.getAllValues().get(0);
+		assertThat(relevantLog.getMessage())
+				.isEqualTo(BaseErrorLogHandler.DEFAULT_LOG_FORMAT);
+		assertThat(relevantLog.getFormattedMessage())
+				.matches("\\[([0-9a-fA-F:]+):(\\d+)] -");
+	}
+
+	@Test
+	void errorLogCustomFormat() {
+		disposableServer = createServer()
+				.handle((req, resp) -> {
+					resp.withConnection(
+							conn -> conn.channel()
+									.pipeline()
+									.fireExceptionCaught(new RuntimeException())
+					);
+					return resp.send();
+				})
+				.errorLog(
+						true,
+						args -> ErrorLog.create(
+								CUSTOM_FORMAT,
+								args.httpServerInfos().method(),
+								args.httpServerInfos().uri()
+						)
+				)
+				.bindNow();
+
+		getHttpClientResponse("/example/test");
+
+		Mockito.verify(mockedAppender, Mockito.times(1))
+				.doAppend(loggingEventArgumentCaptor.capture());
+		assertThat(loggingEventArgumentCaptor.getAllValues()).hasSize(1);
+
+		LoggingEvent relevantLog = loggingEventArgumentCaptor.getAllValues().get(0);
+		assertThat(relevantLog.getMessage())
+				.isEqualTo(CUSTOM_FORMAT);
+		assertThat(relevantLog.getFormattedMessage())
+				.isEqualTo("method=GET, uri=/example/test");
+	}
+
+	@Test
+	void secondCallToErrorLogOverridesPreviousOne() {
+		disposableServer = createServer()
+				.handle((req, resp) -> {
+					resp.withConnection(
+							conn -> conn.channel()
+									.pipeline()
+									.fireExceptionCaught(new RuntimeException())
+					);
+					return resp.send();
+				})
+				.errorLog(
+						true,
+						args -> ErrorLog.create(
+								CUSTOM_FORMAT,
+								args.httpServerInfos().method(),
+								args.httpServerInfos().uri()
+						)
+				)
+				.errorLog(false)
+				.bindNow();
+
+		getHttpClientResponse("/example/test");
+
+		Mockito.verify(mockedAppender, Mockito.times(0))
+				.doAppend(loggingEventArgumentCaptor.capture());
+		assertThat(loggingEventArgumentCaptor.getAllValues()).isEmpty();
+	}
+
+	@Test
+	void errorLogFilteringAndFormatting() {
+		disposableServer = createServer()
+				.handle((req, resp) -> {
+					resp.withConnection(
+							conn -> conn.channel()
+									.pipeline()
+									.fireExceptionCaught(new RuntimeException())
+					);
+					return resp.send();
+				})
+				.errorLog(
+						true,
+						ErrorLogFactory.createFilter(
+								p -> p.httpServerInfos().uri().startsWith("/filtered"),
+								args -> ErrorLog.create(CUSTOM_FORMAT, args.httpServerInfos().method(), args.httpServerInfos().uri())
+						)
+				)
+				.bindNow();
+
+		getHttpClientResponse("/example/test");
+		getHttpClientResponse("/filtered/test");
+
+		Mockito.verify(mockedAppender, Mockito.times(1)).doAppend(loggingEventArgumentCaptor.capture());
+		assertThat(loggingEventArgumentCaptor.getAllValues()).hasSize(1);
+
+		final LoggingEvent relevantLog = loggingEventArgumentCaptor.getAllValues().get(0);
+		assertThat(relevantLog.getMessage())
+				.isEqualTo(CUSTOM_FORMAT);
+		assertThat(relevantLog.getFormattedMessage())
+				.isEqualTo("method=GET, uri=/filtered/test");
+	}
+
+	private void getHttpClientResponse(String uri) {
+		try {
+			createClient(disposableServer.port())
+					.get()
+					.uri(uri)
+					.response()
+					.block(Duration.ofSeconds(30));
+		}
+		catch (Exception e) {
+			// ignore
+		}
+	}
+}


### PR DESCRIPTION

## Description
This PR introduces an **error logging mechanism** similar to Apache HTTPD's errorLog, addressing [#3257](https://github.com/reactor/reactor-netty/issues/3257). 
Currently, Reactor Netty does not log errors when exceptions are fired, so this update ensures that such errors are captured separately from access logs.

## Key Changes
- Add `DefaultErrorLogHandler` handler to log error when exceptions are fired.
- The log format can be customized just like AccessLog using `ErrorLogFactory`. 
Log format customization, similar to `AccessLog`, is available using `ErrorLogFactory`.
- Filtering can also be done using `ErrorLogFactory`.
Filtering information includes `RemoteAddress`, `HttpServerInfos,` and `Throwable`.


## Related Issue
- https://github.com/reactor/reactor-netty/issues/3257

## Additional Context
For reference, this implementation follows the Apache HTTPD error log format:
🔗 [Apache HTTPD Error Log Documentation](https://httpd.apache.org/docs/2.4/logs.html#page-header)