### PR TITLE
Ensure `reactor.netty.http.server.connections.active` is updated when there is no `HttpServerOperations`

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
@@ -195,9 +195,11 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 				if (isHttp11 && LAST_FLUSH_WHEN_NO_READ) {
 					copy = createMetricsArgProvider();
 					ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+					HttpServerOperations ops = null;
 					if (channelOps instanceof HttpServerOperations) {
-						recordInactiveConnectionOrStream(ctx.channel(), (HttpServerOperations) channelOps);
+						ops = (HttpServerOperations) channelOps;
 					}
+					recordInactiveConnectionOrStream(ctx.channel(), ops);
 				}
 				else {
 					copy = null;
@@ -220,9 +222,11 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 
 					if (copy == null) {
 						ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+						HttpServerOperations ops = null;
 						if (channelOps instanceof HttpServerOperations) {
-							recordInactiveConnectionOrStream(ctx.channel(), (HttpServerOperations) channelOps);
+							ops = (HttpServerOperations) channelOps;
 						}
+						recordInactiveConnectionOrStream(ctx.channel(), ops);
 					}
 				});
 			}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #3723