### PR TITLE
Add request and response header iterators to `AccessLogArgProvider`

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import reactor.util.annotation.Nullable;
 
 import java.net.SocketAddress;
 import java.time.ZonedDateTime;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -160,4 +161,22 @@ public interface AccessLogArgProvider {
 	 */
 	@Nullable
 	Map<CharSequence, Set<Cookie>> cookies();
+
+	/**
+	 * Returns an iterator over all request headers.
+	 *
+	 * @return an iterator over all request headers or {@code null} if request is not available
+	 * @since 1.2.6
+	 */
+	@Nullable
+	Iterator<Map.Entry<CharSequence, CharSequence>> requestHeaderIterator();
+
+	/**
+	 * Returns an iterator over all response headers.
+	 *
+	 * @return an iterator over all response headers or {@code null} if response is not available
+	 * @since 1.2.6
+	 */
+	@Nullable
+	Iterator<Map.Entry<CharSequence, CharSequence>> responseHeaderIterator();
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProvider.java
@@ -169,7 +169,9 @@ public interface AccessLogArgProvider {
 	 * @since 1.2.6
 	 */
 	@Nullable
-	Iterator<Map.Entry<CharSequence, CharSequence>> requestHeaderIterator();
+	default Iterator<Map.Entry<CharSequence, CharSequence>> requestHeaderIterator() {
+		return null;
+	}
 
 	/**
 	 * Returns an iterator over all response headers.
@@ -178,5 +180,7 @@ public interface AccessLogArgProvider {
 	 * @since 1.2.6
 	 */
 	@Nullable
-	Iterator<Map.Entry<CharSequence, CharSequence>> responseHeaderIterator();
+	default Iterator<Map.Entry<CharSequence, CharSequence>> responseHeaderIterator() {
+		return null;
+	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProviderH1.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProviderH1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import reactor.netty.http.server.HttpServerRequest;
 import reactor.util.annotation.Nullable;
 
 import java.net.SocketAddress;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -71,6 +73,18 @@ final class AccessLogArgProviderH1 extends AbstractAccessLogArgProvider<AccessLo
 	public CharSequence responseHeader(CharSequence name) {
 		Objects.requireNonNull(name, "name");
 		return response == null ? null : response.headers().get(name);
+	}
+
+	@Override
+	@Nullable
+	public Iterator<Map.Entry<CharSequence, CharSequence>> requestHeaderIterator() {
+		return request == null ? null : request.requestHeaders().iteratorCharSequence();
+	}
+
+	@Override
+	@Nullable
+	public Iterator<Map.Entry<CharSequence, CharSequence>> responseHeaderIterator() {
+		return response == null ? null : response.headers().iteratorCharSequence();
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProviderH2.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProviderH2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import io.netty.handler.codec.http2.Http2HeadersFrame;
 import reactor.util.annotation.Nullable;
 
 import java.net.SocketAddress;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -66,6 +68,18 @@ final class AccessLogArgProviderH2 extends AbstractAccessLogArgProvider<AccessLo
 	public CharSequence responseHeader(CharSequence name) {
 		Objects.requireNonNull(name, "name");
 		return responseHeaders == null ? null : responseHeaders.headers().get(name);
+	}
+
+	@Override
+	@Nullable
+	public Iterator<Map.Entry<CharSequence, CharSequence>> requestHeaderIterator() {
+		return requestHeaders == null ? null : requestHeaders.headers().iterator();
+	}
+
+	@Override
+	@Nullable
+	public Iterator<Map.Entry<CharSequence, CharSequence>> responseHeaderIterator() {
+		return responseHeaders == null ? null : responseHeaders.headers().iterator();
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProviderH3.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/logging/AccessLogArgProviderH3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2024-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import io.netty.incubator.codec.http3.Http3HeadersFrame;
 import reactor.util.annotation.Nullable;
 
 import java.net.SocketAddress;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
 
 final class AccessLogArgProviderH3 extends AbstractAccessLogArgProvider<AccessLogArgProviderH3> {
@@ -61,6 +63,18 @@ final class AccessLogArgProviderH3 extends AbstractAccessLogArgProvider<AccessLo
 	public CharSequence responseHeader(CharSequence name) {
 		Objects.requireNonNull(name, "name");
 		return responseHeaders == null ? null : responseHeaders.headers().get(name);
+	}
+
+	@Override
+	@Nullable
+	public Iterator<Map.Entry<CharSequence, CharSequence>> requestHeaderIterator() {
+		return requestHeaders == null ? null : requestHeaders.headers().iterator();
+	}
+
+	@Override
+	@Nullable
+	public Iterator<Map.Entry<CharSequence, CharSequence>> responseHeaderIterator() {
+		return responseHeaders == null ? null : responseHeaders.headers().iterator();
 	}
 
 	@Override

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderH1Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderH1Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,8 @@ import reactor.netty.http.server.HttpServerRequest;
 
 import java.net.InetSocketAddress;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -154,6 +156,30 @@ class AccessLogArgProviderH1Tests {
 		accessLogArgProvider.response(response);
 		assertThat(accessLogArgProvider.responseHeader(HttpHeaderNames.CONTENT_TYPE))
 				.isEqualTo(HttpHeaderValues.APPLICATION_JSON.toString());
+	}
+
+	@Test
+	@SuppressWarnings({"CollectionUndefinedEquality", "DataFlowIssue"})
+	void requestHeaderIterator() {
+		assertThat(accessLogArgProvider.requestHeaderIterator()).isNull();
+		accessLogArgProvider.request(request);
+		assertThat(accessLogArgProvider.requestHeaderIterator()).isNotNull();
+		Map<CharSequence, CharSequence> requestHeaders = new HashMap<>();
+		accessLogArgProvider.requestHeaderIterator().forEachRemaining(e -> requestHeaders.put(e.getKey(), e.getValue()));
+		assertThat(requestHeaders.size()).isEqualTo(1);
+		assertThat(requestHeaders.get(HEADER_CONNECTION_NAME)).isEqualTo(HEADER_CONNECTION_VALUE);
+	}
+
+	@Test
+	@SuppressWarnings({"CollectionUndefinedEquality", "DataFlowIssue"})
+	void responseHeaderIterator() {
+		assertThat(accessLogArgProvider.responseHeaderIterator()).isNull();
+		accessLogArgProvider.response(response);
+		assertThat(accessLogArgProvider.responseHeaderIterator()).isNotNull();
+		Map<CharSequence, CharSequence> responseHeaders = new HashMap<>();
+		accessLogArgProvider.responseHeaderIterator().forEachRemaining(e -> responseHeaders.put(e.getKey(), e.getValue()));
+		assertThat(responseHeaders.size()).isEqualTo(1);
+		assertThat(responseHeaders.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(HttpHeaderValues.APPLICATION_JSON);
 	}
 
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderH2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderH2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -133,6 +135,33 @@ class AccessLogArgProviderH2Tests {
 		accessLogArgProvider.responseHeaders(responseHeaders);
 		assertThat(accessLogArgProvider.responseHeader(HttpHeaderNames.CONTENT_TYPE))
 				.isEqualTo(HttpHeaderValues.APPLICATION_JSON);
+	}
+
+	@Test
+	@SuppressWarnings({"CollectionUndefinedEquality", "DataFlowIssue"})
+	void requestHeaderIterator() {
+		assertThat(accessLogArgProvider.requestHeaderIterator()).isNull();
+		accessLogArgProvider.requestHeaders(requestHeaders);
+		assertThat(accessLogArgProvider.requestHeaderIterator()).isNotNull();
+		Map<CharSequence, CharSequence> requestHeaders = new HashMap<>();
+		accessLogArgProvider.requestHeaderIterator().forEachRemaining(e -> requestHeaders.put(e.getKey(), e.getValue()));
+		assertThat(requestHeaders.size()).isEqualTo(3);
+		assertThat(requestHeaders.get(HEADER_TEST_NAME)).isEqualTo(HEADER_TEST_VALUE);
+		assertThat(requestHeaders.get(Http2Headers.PseudoHeaderName.METHOD.value())).isEqualTo(HttpMethod.GET.name());
+		assertThat(requestHeaders.get(Http2Headers.PseudoHeaderName.PATH.value())).isEqualTo(URI);
+	}
+
+	@Test
+	@SuppressWarnings({"CollectionUndefinedEquality", "DataFlowIssue"})
+	void responseHeaderIterator() {
+		assertThat(accessLogArgProvider.responseHeaderIterator()).isNull();
+		accessLogArgProvider.responseHeaders(responseHeaders);
+		assertThat(accessLogArgProvider.responseHeaderIterator()).isNotNull();
+		Map<CharSequence, CharSequence> responseHeaders = new HashMap<>();
+		accessLogArgProvider.responseHeaderIterator().forEachRemaining(e -> responseHeaders.put(e.getKey(), e.getValue()));
+		assertThat(responseHeaders.size()).isEqualTo(2);
+		assertThat(responseHeaders.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(HttpHeaderValues.APPLICATION_JSON);
+		assertThat(responseHeaders.get(Http2Headers.PseudoHeaderName.STATUS.value())).isEqualTo(HttpResponseStatus.OK.codeAsText());
 	}
 
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,6 @@ import org.junit.jupiter.api.Test;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collections;
-import java.util.Iterator;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.netty.http.server.logging.LoggingTests.URI;
@@ -138,16 +136,6 @@ class AccessLogArgProviderTests {
 		@Override
 		public CharSequence responseHeader(CharSequence name) {
 			return "responseHeader";
-		}
-
-		@Override
-		public Iterator<Map.Entry<CharSequence, CharSequence>> requestHeaderIterator() {
-			return Collections.emptyIterator();
-		}
-
-		@Override
-		public Iterator<Map.Entry<CharSequence, CharSequence>> responseHeaderIterator() {
-			return Collections.emptyIterator();
 		}
 
 		@Override

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/logging/AccessLogArgProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.netty.http.server.logging.LoggingTests.URI;
@@ -136,6 +138,16 @@ class AccessLogArgProviderTests {
 		@Override
 		public CharSequence responseHeader(CharSequence name) {
 			return "responseHeader";
+		}
+
+		@Override
+		public Iterator<Map.Entry<CharSequence, CharSequence>> requestHeaderIterator() {
+			return Collections.emptyIterator();
+		}
+
+		@Override
+		public Iterator<Map.Entry<CharSequence, CharSequence>> responseHeaderIterator() {
+			return Collections.emptyIterator();
 		}
 
 		@Override


### PR DESCRIPTION
Introduce `requestHeaderIterator` and `responseHeaderIterator` methods for iterating through headers in `AccessLogArgProvider` and its implementations.

Related to [#781 (comment)](https://github.com/reactor/reactor-netty/issues/781#issuecomment-2832035061)