### PR TITLE
Ensure the exception is propagated in case of delayed address resolution

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConnector.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/TransportConnector.java
@@ -376,7 +376,12 @@ public final class TransportConnector {
 					monoChannelPromise.tryFailure(future.cause());
 				}
 				else {
-					doConnect(selectedAddresses(config, remoteAddress, future.getNow()), bindAddress, monoChannelPromise, 0);
+					try {
+						doConnect(selectedAddresses(config, remoteAddress, future.getNow()), bindAddress, monoChannelPromise, 0);
+					}
+					catch (Throwable t) {
+						monoChannelPromise.tryFailure(t);
+					}
 				}
 			});
 			return monoChannelPromise;

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -3786,6 +3786,20 @@ class HttpClientTest extends BaseHttpTest {
 		}
 	}
 
+	@Test
+	void testSelectedIpsDelayedAddressResolution() {
+		HttpClient.create()
+		          .wiretap(true)
+		          .resolvedAddressesSelector((config, resolvedAddresses) -> null)
+		          .get()
+		          .uri("https://example.com")
+		          .responseContent()
+		          .asString()
+		          .as(StepVerifier::create)
+		          .expectErrorMatches(t -> t.getMessage() != null && t.getMessage().startsWith("Failed to resolve [example.com"))
+		          .verify(Duration.ofSeconds(5));
+	}
+
 	private static final class EchoAction implements Publisher<HttpContent>, Consumer<HttpContent> {
 		private final Publisher<HttpContent> sender;
 		private volatile FluxSink<HttpContent> emitter;


### PR DESCRIPTION
`MonoChannelPromise` has to be notified for any exception when selecting addresses.