### PR TITLE
Release the partial `HttpData` only if it is not released by Netty

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerFormDecoderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -395,7 +395,7 @@ public final class HttpServerFormDecoderProvider {
 		public void destroy() {
 			super.destroy();
 			InterfaceHttpData partial = currentPartialHttpData();
-			if (partial != null) {
+			if (partial != null && partial.refCnt() > 0) {
 				partial.release();
 			}
 		}
@@ -452,7 +452,7 @@ public final class HttpServerFormDecoderProvider {
 		public void destroy() {
 			super.destroy();
 			InterfaceHttpData partial = currentPartialHttpData();
-			if (partial != null) {
+			if (partial != null && partial.refCnt() > 0) {
 				partial.release();
 			}
 		}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerPostFormTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerPostFormTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import reactor.netty.http.Http2SslContextSpec;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.client.HttpClient;
 import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
@@ -265,6 +266,8 @@ class HttpServerPostFormTests extends BaseHttpTest {
 	private void doTestPostForm(HttpServer server, HttpClient client,
 			Consumer<HttpServerFormDecoderProvider.Builder> provider, boolean configOnServer,
 			boolean multipart, boolean streaming, @Nullable String expectedResponse) throws Exception {
+		AtomicReference<Throwable> error = new AtomicReference<>();
+		Consumer<Throwable> onErrorDropped = error::set;
 		AtomicReference<List<HttpData>> originalHttpData1 = new AtomicReference<>(new ArrayList<>());
 		AtomicReference<List<HttpData>> originalHttpData2 = new AtomicReference<>(new ArrayList<>());
 		AtomicReference<Map<String, CompositeByteBuf>> copiedHttpData = new AtomicReference<>(new HashMap<>());
@@ -295,7 +298,8 @@ class HttpServerPostFormTests extends BaseHttpTest {
 		                                data.isCompleted() + "] ");
 		                    })
 		                    .onErrorResume(t -> Mono.just(t.getCause().getMessage()))
-		                    .log()));
+		                    .log()
+		                    .contextWrite(Context.of("reactor.onErrorDropped.local", onErrorDropped))));
 
 		disposableServer = server.bindNow();
 
@@ -349,6 +353,8 @@ class HttpServerPostFormTests extends BaseHttpTest {
 				}
 			}
 		}
+
+		assertThat(error.get()).isNull();
 	}
 
 	private void testContent(CompositeByteBuf file, byte[] expectedBytes) {


### PR DESCRIPTION
Fixes #3740