### PR TITLE
Switch to `windows-2022` runner

### DIFF
--- a/.github/workflows/check_netty_snapshots.yml
+++ b/.github/workflows/check_netty_snapshots.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-2022]
         transport: [native, nio]
         exclude:
           # excludes native on Windows (there's none)
-          - os: windows-2019
+          - os: windows-2022
             transport: native
           # macOS - https://github.com/netty/netty/issues/9689
           - os: macos-13

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -43,11 +43,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-2022]
         transport: [native, nio]
         exclude:
           # excludes native on Windows (there's none)
-          - os: windows-2019
+          - os: windows-2022
             transport: native
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
`windows-2019` runner is deprecated
https://github.com/actions/runner-images/issues/12045