### PR TITLE
When `HTTP/2` apply always the trailer headers

### DIFF
--- a/reactor-netty-http/src/http3Test/java/reactor/netty/http/Http3Tests.java
+++ b/reactor-netty-http/src/http3Test/java/reactor/netty/http/Http3Tests.java
@@ -29,6 +29,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.ssl.SniCompletionEvent;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -856,7 +857,61 @@ class Http3Tests {
 	}
 
 	@Test
-	void testTrailerHeadersFullResponse() {
+	void testTrailerHeadersFullResponseSend() {
+		disposableServer =
+				createServer()
+				        .handle((req, res) ->
+				            res.header(HttpHeaderNames.TRAILER, "foo")
+				               .trailerHeaders(h -> h.set("foo", "bar"))
+				               .send())
+				        .bindNow();
+
+		doTestTrailerHeaders(createClient(disposableServer.port()), "bar", "empty");
+	}
+
+	@Test
+	void testTrailerHeadersFullResponseSendFluxContentAlwaysEmpty() {
+		disposableServer =
+				createServer()
+				        .handle((req, res) ->
+				            res.header(HttpHeaderNames.TRAILER, "foo")
+				               .trailerHeaders(h -> h.set("foo", "bar"))
+				               .status(HttpResponseStatus.NO_CONTENT)
+				               .sendString(Flux.just("test", "Trailer", "Headers", "Full", "Response")))
+				        .bindNow();
+
+		doTestTrailerHeaders(createClient(disposableServer.port()), "bar", "empty");
+	}
+
+	@Test
+	void testTrailerHeadersFullResponseSendFluxContentLengthZero() {
+		disposableServer =
+				createServer()
+				        .handle((req, res) ->
+				            res.header(HttpHeaderNames.TRAILER, "foo")
+				               .header(HttpHeaderNames.CONTENT_LENGTH, "0")
+				               .trailerHeaders(h -> h.set("foo", "bar"))
+				               .sendString(Flux.just("test", "Trailer", "Headers", "Full", "Response")))
+				        .bindNow();
+
+		doTestTrailerHeaders(createClient(disposableServer.port()), "bar", "empty");
+	}
+
+	@Test
+	void testTrailerHeadersFullResponseSendHeaders() {
+		disposableServer =
+				createServer()
+				        .handle((req, res) ->
+				            res.header(HttpHeaderNames.TRAILER, "foo")
+				               .trailerHeaders(h -> h.set("foo", "bar"))
+				               .sendHeaders())
+				        .bindNow();
+
+		doTestTrailerHeaders(createClient(disposableServer.port()), "bar", "empty");
+	}
+
+	@Test
+	void testTrailerHeadersFullResponseSendMono() {
 		disposableServer =
 				createServer()
 				        .handle((req, res) ->
@@ -865,7 +920,34 @@ class Http3Tests {
 				               .sendString(Mono.just("testTrailerHeadersFullResponse")))
 				        .bindNow();
 
-		doTestTrailerHeaders(createClient(disposableServer.port()), "empty", "testTrailerHeadersFullResponse");
+		doTestTrailerHeaders(createClient(disposableServer.port()), "bar", "testTrailerHeadersFullResponse");
+	}
+
+	@Test
+	void testTrailerHeadersFullResponseSendMonoEmpty() {
+		disposableServer =
+				createServer()
+				        .handle((req, res) -> {
+				            res.header(HttpHeaderNames.TRAILER, "foo")
+				               .trailerHeaders(h -> h.set("foo", "bar"));
+				            return Mono.empty();
+				        })
+				        .bindNow();
+
+		doTestTrailerHeaders(createClient(disposableServer.port()), "bar", "empty");
+	}
+
+	@Test
+	void testTrailerHeadersFullResponseSendObject() {
+		disposableServer =
+				createServer()
+				        .handle((req, res) ->
+				            res.header(HttpHeaderNames.TRAILER, "foo")
+				               .trailerHeaders(h -> h.set("foo", "bar"))
+				               .sendObject(Unpooled.wrappedBuffer("testTrailerHeadersFullResponse".getBytes(Charset.defaultCharset()))))
+				        .bindNow();
+
+		doTestTrailerHeaders(createClient(disposableServer.port()), "bar", "testTrailerHeadersFullResponse");
 	}
 
 	@Test
@@ -885,7 +967,7 @@ class Http3Tests {
 	private static void doTestTrailerHeaders(HttpClient client, String expectedHeaderValue, String expectedResponse) {
 		client.get()
 		      .uri("/")
-		      .responseSingle((res, bytes) -> bytes.asString().zipWith(res.trailerHeaders()))
+		      .responseSingle((res, bytes) -> bytes.asString().defaultIfEmpty("empty").zipWith(res.trailerHeaders()))
 		      .as(StepVerifier::create)
 		      .expectNextMatches(t -> expectedResponse.equals(t.getT1()) &&
 		              expectedHeaderValue.equals(t.getT2().get("foo", "empty")))


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc9113.html#name-field-section-compression-a 
https://www.rfc-editor.org/rfc/rfc9113.html#name-http-message-framing