### PR TITLE
`Trailers` must not include `pseudo-header` fields

### DIFF
--- a/reactor-netty-http/src/http3Test/java/reactor/netty/http/Http3Tests.java
+++ b/reactor-netty-http/src/http3Test/java/reactor/netty/http/Http3Tests.java
@@ -964,6 +964,20 @@ class Http3Tests {
 		doTestTrailerHeaders(createClient(disposableServer.port()), "empty", "testTrailerHeadersNotSpecifiedUpfront");
 	}
 
+	@Test
+	void testTrailerHeadersPseudoHeaderNotAllowed() {
+		disposableServer =
+				createServer()
+				        .handle((req, res) ->
+				            res.header(HttpHeaderNames.TRAILER, ":protocol")
+				               .trailerHeaders(h -> h.set(":protocol", "test"))
+				               .sendString(Flux.just("testTrailerHeaders", "PseudoHeaderNotAllowed")))
+				        .bindNow();
+
+		// Trailers MUST NOT include pseudo-header fields
+		doTestTrailerHeaders(createClient(disposableServer.port()), "empty", "testTrailerHeadersPseudoHeaderNotAllowed");
+	}
+
 	private static void doTestTrailerHeaders(HttpClient client, String expectedHeaderValue, String expectedResponse) {
 		client.get()
 		      .uri("/")

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
@@ -16,6 +16,7 @@
 package reactor.netty.http;
 
 import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2FrameCodec;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -728,6 +729,46 @@ class Http2Tests extends BaseHttpTest {
 			provider.disposeLater()
 			        .block(Duration.ofSeconds(5));
 		}
+	}
+
+	@ParameterizedTest
+	@MethodSource("h2CompatibleCombinations")
+	@SuppressWarnings("deprecation")
+	void testTrailerHeadersPseudoHeaderNotAllowedH2(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols) {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		testTrailerHeadersPseudoHeaderNotAllowed(
+				createServer().protocol(serverProtocols).secure(spec -> spec.sslContext(serverCtx)),
+				createClient(() -> disposableServer.address()).protocol(clientProtocols).secure(spec -> spec.sslContext(clientCtx)));
+	}
+
+	@ParameterizedTest
+	@MethodSource("h2cCompatibleCombinations")
+	void testTrailerHeadersPseudoHeaderNotAllowedH2C(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols) {
+		testTrailerHeadersPseudoHeaderNotAllowed(
+				createServer().protocol(serverProtocols),
+				createClient(() -> disposableServer.address()).protocol(clientProtocols));
+	}
+
+	private void testTrailerHeadersPseudoHeaderNotAllowed(HttpServer server, HttpClient client) {
+		disposableServer =
+				server.handle((req, res) ->
+				          res.header(HttpHeaderNames.TRAILER, ":protocol")
+				             .trailerHeaders(h -> h.set(":protocol", "test"))
+				             .sendString(Flux.just("testTrailerHeaders", "PseudoHeaderNotAllowed")))
+				      .bindNow();
+
+		// Trailers MUST NOT include pseudo-header fields
+		client.get()
+		      .uri("/")
+		      .responseSingle((res, bytes) -> bytes.asString().defaultIfEmpty("empty").zipWith(res.trailerHeaders()))
+		      .as(StepVerifier::create)
+		      .expectNextMatches(t -> "testTrailerHeadersPseudoHeaderNotAllowed".equals(t.getT1()) &&
+		              "empty".equals(t.getT2().get(":protocol", "empty")))
+		      .expectComplete()
+		      .verify(Duration.ofSeconds(5));
 	}
 
 	private void http2ClientSendsError(HttpServer server, HttpClient client) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/TrailerHeadersTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/TrailerHeadersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,13 +40,14 @@ class TrailerHeadersTests {
 	static final String HEADER_NAME_1 = "foo";
 	static final String HEADER_NAME_2 = "bar";
 	static final String HEADER_VALUE = "test";
+	static final String PSEUDO_HEADER_NAME = ":protocol";
 	static final String SPACE = " ";
 
 	@ParameterizedTest
 	@MethodSource("disallowedTrailerHeaderNames")
 	void testDisallowedTrailerHeaderNames(String declaredHeaderName) {
 		assertThatExceptionOfType(IllegalArgumentException.class)
-				.isThrownBy(() -> new HttpServerOperations.TrailerHeaders(declaredHeaderName).add(declaredHeaderName, HEADER_VALUE))
+				.isThrownBy(() -> new HttpServerOperations.TrailerHeaders(declaredHeaderName, false).add(declaredHeaderName, HEADER_VALUE))
 				.withMessage(String.format(ERROR_MESSAGE, declaredHeaderName));
 	}
 
@@ -59,7 +60,7 @@ class TrailerHeadersTests {
 			HEADER_NAME_1 + COMMA + SPACE
 	})
 	void testNameIncludedInTrailerHeader(String declaredHeaderNames) {
-		HttpHeaders headers = new HttpServerOperations.TrailerHeaders(declaredHeaderNames);
+		HttpHeaders headers = new HttpServerOperations.TrailerHeaders(declaredHeaderNames, false);
 		assertThat(headers.isEmpty()).isTrue();
 		headers.add(HEADER_NAME_1, HEADER_VALUE);
 		assertThat(headers.isEmpty()).isFalse();
@@ -69,7 +70,7 @@ class TrailerHeadersTests {
 
 	@Test
 	void testNamesIncludedInTrailerHeader() {
-		HttpHeaders headers = new HttpServerOperations.TrailerHeaders(HEADER_NAME_1 + ',' + HEADER_NAME_2);
+		HttpHeaders headers = new HttpServerOperations.TrailerHeaders(HEADER_NAME_1 + ',' + HEADER_NAME_2, false);
 		assertThat(headers.isEmpty()).isTrue();
 		headers.add(HEADER_NAME_1, HEADER_VALUE);
 		headers.add(HEADER_NAME_2, HEADER_VALUE);
@@ -82,7 +83,7 @@ class TrailerHeadersTests {
 	@Test
 	void testNameNotIncludedInTrailerHeader() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
-				.isThrownBy(() -> new HttpServerOperations.TrailerHeaders(HEADER_NAME_1).add(HEADER_NAME_2, HEADER_VALUE))
+				.isThrownBy(() -> new HttpServerOperations.TrailerHeaders(HEADER_NAME_1, false).add(HEADER_NAME_2, HEADER_VALUE))
 				.withMessage(String.format(ERROR_MESSAGE, HEADER_NAME_2));
 	}
 
@@ -90,8 +91,15 @@ class TrailerHeadersTests {
 	@ValueSource(strings = {COMMA, EMPTY, SPACE})
 	void testNothingIsIncludedInTrailerHeader(String declaredHeaderNames) {
 		assertThatExceptionOfType(IllegalArgumentException.class)
-				.isThrownBy(() -> new HttpServerOperations.TrailerHeaders(declaredHeaderNames).add(EMPTY, HEADER_VALUE))
+				.isThrownBy(() -> new HttpServerOperations.TrailerHeaders(declaredHeaderNames, false).add(EMPTY, HEADER_VALUE))
 				.withMessage(String.format(ERROR_MESSAGE, EMPTY));
+	}
+
+	@Test
+	void testPseudoHeaderInTrailerHeaderNames() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new HttpServerOperations.TrailerHeaders(PSEUDO_HEADER_NAME, true).add(PSEUDO_HEADER_NAME, HEADER_VALUE))
+				.withMessage("Pseudo header name [:protocol] found in trailer headers, trailer headers cannot have pseudo headers");
 	}
 
 	static Set<String> disallowedTrailerHeaderNames() {


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc9113.html#name-http-message-framing