### PR TITLE
Add proper initialisation of `maxConcurrentStreams` when successful `HTTP/1.1` to `HTTP/2` upgrade

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -972,7 +972,6 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 				this.applicationProtocol = null;
 			}
 			initMaxConcurrentStreams();
-			TOTAL_MAX_CONCURRENT_STREAMS.addAndGet(this.pool, this.maxConcurrentStreams);
 		}
 
 		void initMaxConcurrentStreams() {
@@ -982,6 +981,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 				this.maxConcurrentStreams = pool.maxConcurrentStreams == -1 ? maxConcurrentStreams :
 						Math.min(pool.maxConcurrentStreams, maxConcurrentStreams);
 			}
+			TOTAL_MAX_CONCURRENT_STREAMS.addAndGet(this.pool, this.maxConcurrentStreams);
 		}
 
 		boolean canOpenStream() {
@@ -1072,6 +1072,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 				}
 				pool.poolConfig.allocationStrategy().returnPermits(1);
 				TOTAL_MAX_CONCURRENT_STREAMS.addAndGet(this.pool, -maxConcurrentStreams);
+				maxConcurrentStreams = 0;
 			}
 		}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -99,6 +99,8 @@ import reactor.util.context.Context;
 import static reactor.netty.ReactorNetty.format;
 import static reactor.netty.ReactorNetty.setChannelContext;
 import static reactor.netty.http.client.Http2ConnectionProvider.OWNER;
+import static reactor.netty.http.client.Http2ConnectionProvider.http2PooledRef;
+import static reactor.netty.http.client.Http2ConnectionProvider.logStreamsState;
 import static reactor.netty.http.client.Http3Codec.newHttp3ClientConnectionHandler;
 
 /**
@@ -892,9 +894,11 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			ConnectionObserver channelOwner = ctx.channel().attr(OWNER).get();
 			Http2ConnectionProvider.DisposableAcquire owner = null;
 			ConnectionObserver obs = null;
+			Http2Pool.Http2PooledRef http2PooledRef = null;
 			if (channelOwner instanceof Http2ConnectionProvider.DisposableAcquire) {
 				owner = (Http2ConnectionProvider.DisposableAcquire) channelOwner;
 				obs = owner.obs;
+				http2PooledRef = http2PooledRef(owner.pooledRef);
 			}
 			if (responseTimeoutHandler != null) {
 				pipeline.remove(NettyPipeline.ResponseTimeoutHandler);
@@ -913,6 +917,10 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 			}
 			pipeline.remove(NettyPipeline.ReactiveBridge);
 			pipeline.remove(this);
+
+			if (http2PooledRef != null) {
+				http2PooledRef.slot.initMaxConcurrentStreams();
+			}
 		}
 	}
 
@@ -972,6 +980,9 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 				}
 				addStreamHandlers(ch, observer.then(new StreamConnectionObserver(owner.currentContext())), opsFactory,
 						acceptGzip, metricsRecorder, proxyAddress, remoteAddress, responseTimeoutMillis, uriTagValue);
+				if (log.isDebugEnabled()) {
+					logStreamsState(ch, http2PooledRef(owner.pooledRef).slot, "Stream opened");
+				}
 			}
 			else {
 				// Handle server pushes (inbound streams)


### PR DESCRIPTION
- Reset `maxConcurrentStreams` to `0` when invalidating a connection
- Add logging when an upgrade stream is opened