### PR TITLE
Ensure `100-Continue` is handled when collecting client's metrics

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/AbstractHttpClientMetricsHandler.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.LastHttpContent;
 import reactor.netty.channel.ChannelOperations;
 import reactor.util.annotation.Nullable;
@@ -73,6 +74,8 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelDuplexHandler {
 
 	int lastWriteSeq;
 
+	boolean isNot100Continue;
+
 	protected AbstractHttpClientMetricsHandler(SocketAddress remoteAddress, @Nullable SocketAddress proxyAddress, @Nullable Function<String, String> uriTagValue) {
 		this.proxyAddress = proxyAddress;
 		this.remoteAddress = remoteAddress;
@@ -93,6 +96,7 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelDuplexHandler {
 		this.uriTagValue = copy.uriTagValue;
 		this.lastWriteSeq = copy.lastWriteSeq;
 		this.lastReadSeq = copy.lastReadSeq;
+		this.isNot100Continue = copy.isNot100Continue;
 	}
 
 	@Override
@@ -139,14 +143,18 @@ abstract class AbstractHttpClientMetricsHandler extends ChannelDuplexHandler {
 	public void channelRead(ChannelHandlerContext ctx, Object msg) {
 		try {
 			if (msg instanceof HttpResponse) {
-				status = ((HttpResponse) msg).status().codeAsText().toString();
+				HttpResponseStatus httpResponseStatus = ((HttpResponse) msg).status();
+				isNot100Continue = httpResponseStatus.code() != HttpResponseStatus.CONTINUE.code();
+				if (isNot100Continue) {
+					status = httpResponseStatus.codeAsText().toString();
 
-				startRead((HttpResponse) msg);
+					startRead((HttpResponse) msg);
+				}
 			}
 
 			dataReceived += extractProcessedDataFromBuffer(msg);
 
-			if (msg instanceof LastHttpContent) {
+			if (isNot100Continue && msg instanceof LastHttpContent) {
 				// Detect if we have received an early response before the request has been fully flushed.
 				// In this case, invoke #recordWrite now (because next we will reset all class fields).
 				lastReadSeq = (lastReadSeq + 1) & 0x7F_FF_FF_FF;


### PR DESCRIPTION
Fixes #3883