### PR TITLE
Ensure `ResponseTimeoutHandler` is added as one of the first handlers in the pipeline

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -612,6 +612,18 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 		}
 
 		ChannelPipeline pipeline = ch.pipeline();
+
+		if (responseTimeoutMillis > -1 && ch.pipeline().get(NettyPipeline.ResponseTimeoutHandler) == null) {
+			// This handler has to be always as early as possible in order to handle correctly the time for receiving the read/readComplete events.
+			// We don't want other handlers to delay read/readComplete events delivery.
+			ch.pipeline().addLast(NettyPipeline.ResponseTimeoutHandler,
+					new ReadTimeoutHandler(responseTimeoutMillis, TimeUnit.MILLISECONDS));
+			Connection conn = Connection.from(ch);
+			if (conn.isPersistent()) {
+				conn.onTerminate().subscribe(null, null, () -> conn.removeHandler(NettyPipeline.ResponseTimeoutHandler));
+			}
+		}
+
 		pipeline.addLast(NettyPipeline.H2ToHttp11Codec, HTTP2_STREAM_FRAME_TO_HTTP_OBJECT)
 				.addLast(NettyPipeline.HttpTrafficHandler, HTTP_2_STREAM_BRIDGE_CLIENT_HANDLER);
 
@@ -651,23 +663,6 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 					}
 				}
 				pipeline.addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.HttpMetricsHandler, handler);
-			}
-		}
-
-		if (responseTimeoutMillis > -1) {
-			Connection conn = Connection.from(ch);
-			if (ch.pipeline().get(NettyPipeline.HttpMetricsHandler) != null) {
-				if (ch.pipeline().get(NettyPipeline.ResponseTimeoutHandler) == null) {
-					ch.pipeline().addBefore(NettyPipeline.HttpMetricsHandler, NettyPipeline.ResponseTimeoutHandler,
-							new ReadTimeoutHandler(responseTimeoutMillis, TimeUnit.MILLISECONDS));
-					if (conn.isPersistent()) {
-						conn.onTerminate().subscribe(null, null, () -> conn.removeHandler(NettyPipeline.ResponseTimeoutHandler));
-					}
-				}
-			}
-			else {
-				conn.addHandlerFirst(NettyPipeline.ResponseTimeoutHandler,
-						new ReadTimeoutHandler(responseTimeoutMillis, TimeUnit.MILLISECONDS));
 			}
 		}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -40,11 +40,13 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.unix.DomainSocketChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpConstants;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -674,19 +676,32 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 			channel().writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
 		}
 		listener().onStateChange(this, HttpClientState.REQUEST_SENT);
-		if (responseTimeout != null) {
-			if (channel().pipeline().get(NettyPipeline.HttpMetricsHandler) != null) {
-				if (channel().pipeline().get(NettyPipeline.ResponseTimeoutHandler) == null) {
-					channel().pipeline().addBefore(NettyPipeline.HttpMetricsHandler, NettyPipeline.ResponseTimeoutHandler,
-							new ReadTimeoutHandler(responseTimeout.toMillis(), TimeUnit.MILLISECONDS));
-					if (isPersistent()) {
-						onTerminate().subscribe(null, null, () -> removeHandler(NettyPipeline.ResponseTimeoutHandler));
-					}
-				}
+		ChannelPipeline pipeline = channel().pipeline();
+		if (responseTimeout != null && pipeline.get(NettyPipeline.ResponseTimeoutHandler) == null) {
+			// This handler has to be always as early as possible in order to handle correctly the time for receiving the read/readComplete events.
+			// We don't want other handlers to delay read/readComplete events delivery.
+			String baseName = null;
+			if (pipeline.get(NettyPipeline.HttpCodec) != null) {
+				baseName = NettyPipeline.HttpCodec;
+			}
+			else if (pipeline.get(NettyPipeline.H2ToHttp11Codec) != null) {
+					baseName = NettyPipeline.H2ToHttp11Codec;
 			}
 			else {
-				addHandlerFirst(NettyPipeline.ResponseTimeoutHandler,
-						new ReadTimeoutHandler(responseTimeout.toMillis(), TimeUnit.MILLISECONDS));
+				ChannelHandler httpClientCodec = pipeline.get(HttpClientCodec.class);
+				if (httpClientCodec != null) {
+					baseName = pipeline.context(httpClientCodec).name();
+				}
+			}
+			pipeline.addBefore(baseName, NettyPipeline.ResponseTimeoutHandler,
+					new ReadTimeoutHandler(responseTimeout.toMillis(), TimeUnit.MILLISECONDS));
+			if (log.isDebugEnabled()) {
+				log.debug(format(channel(), "Added encoder [{}] at the beginning of the user pipeline, full pipeline: {}"),
+						NettyPipeline.ResponseTimeoutHandler,
+						pipeline.names());
+			}
+			if (isPersistent()) {
+				onTerminate().subscribe(null, null, () -> removeHandler(NettyPipeline.ResponseTimeoutHandler));
 			}
 		}
 		channel().read();


### PR DESCRIPTION
Ensure `ResponseTimeoutHandler` is added as one of the first handlers in the pipeline in order to handle correctly the time for receiving the `read`/`readComplete` events. We don't want other handlers to delay `read`/`readComplete` events delivery.

Fixes #3849