### PR TITLE
DefaultLoopIOUring should not depend on netty incubator io_uring package

### DIFF
--- a/reactor-netty-core/build.gradle
+++ b/reactor-netty-core/build.gradle
@@ -35,7 +35,6 @@ ext {
 					"!javax.annotation",
 					"io.netty.channel.kqueue;resolution:=optional;version=\"[4.2,5)\"",
 					"io.netty.channel.uring;resolution:=optional;version=\"[4.2,5)\"",
-					"io.netty.incubator.channel.uring;resolution:=optional",
 					"io.micrometer.*;resolution:=optional",
 					"*"
 			].join(","),
@@ -86,7 +85,6 @@ dependencies {
 		//so that the main code compiles
 		compileOnly "io.netty:netty-transport-native-epoll:$nettyVersion"
 		compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
-		compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 		compileOnly "io.netty:netty-transport-native-io_uring:$nettyVersion"
 		testImplementation "io.netty:netty-transport-native-epoll:$nettyVersion"
 		testImplementation "io.netty:netty-transport-native-kqueue:$nettyVersion"
@@ -111,7 +109,6 @@ dependencies {
 		//classic build to be distributed
 		api "io.netty:netty-transport-native-epoll:$nettyVersion:linux-x86_64"
 		compileOnly "io.netty:netty-transport-native-kqueue:$nettyVersion"
-		compileOnly "io.netty.incubator:netty-incubator-transport-native-io_uring:$nettyIoUringVersion"
 		compileOnly "io.netty:netty-transport-native-io_uring:$nettyVersion"
 		testImplementation "io.netty:netty-transport-native-kqueue:$nettyVersion"
 		testImplementation "io.netty:netty-transport-native-io_uring:$nettyVersion"


### PR DESCRIPTION
Now that Reactor Netty depends on Netty 4.2.X we should no longer depend on the io_uring incubator package.

> In Netty 4.2.0.Final we have graduated the io_uring transport from incubator, to a fully supported first-class transport module. (https://netty.io/news/2025/04/03/4-2-0.html)

If a project includes reactor netty and uses a JDK lower than 17, we get the default `DefaultLoopIOUring` class. If the incubator packages are not on the class path `isIoUringAvailable` will end up evaluating to false (even when io.netty:netty-transport-native-io_uring is included). Given that the incubator is not being updated we should mirror the logic from `DefaultLoopIOUring` from the multi release (17) class.