### PR TITLE
Preserve exception cause in `ChannelBindException`

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/ChannelBindException.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/ChannelBindException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package reactor.netty;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Objects;
@@ -39,13 +38,6 @@ public class ChannelBindException extends RuntimeException {
 	 */
 	public static ChannelBindException fail(SocketAddress bindAddress, @Nullable Throwable cause) {
 		Objects.requireNonNull(bindAddress, "bindAddress");
-		if (cause instanceof java.net.BindException ||
-				// With epoll/kqueue transport it is
-				// io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Address already in use
-				(cause instanceof IOException && cause.getMessage() != null &&
-						cause.getMessage().contains("bind(..)"))) {
-			cause = null;
-		}
 		if (!(bindAddress instanceof InetSocketAddress)) {
 			return new ChannelBindException(bindAddress.toString(), cause);
 		}

--- a/reactor-netty-core/src/test/java/reactor/netty/ChannelBindExceptionTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/ChannelBindExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,27 +28,30 @@ class ChannelBindExceptionTest {
 	@Test
 	void testFailBindExceptionCause() {
 
-		UnsupportedOperationException cause = new UnsupportedOperationException();
+		Exception cause = new UnsupportedOperationException();
 		ChannelBindException ex = ChannelBindException.fail(new InetSocketAddress("test", 4956), cause);
 		assertThat(ex.getCause()).isEqualTo(cause);
 		assertThat(ex.localHost()).isEqualTo("test");
 		assertThat(ex.localPort()).isEqualTo(4956);
 
-		ex = ChannelBindException.fail(new InetSocketAddress("test", 4956), new BindException("Address already in use"));
-		assertThat(ex.getCause()).isEqualTo(null);
+		cause = new BindException("Address already in use");
+		ex = ChannelBindException.fail(new InetSocketAddress("test", 4956), cause);
+		assertThat(ex.getCause()).isEqualTo(cause);
 		assertThat(ex.localHost()).isEqualTo("test");
 		assertThat(ex.localPort()).isEqualTo(4956);
 
 		// Not possible to mock io.netty.channel.unix.Errors.NativeIoException or create a new instance because of Jni errors
 		// java.lang.UnsatisfiedLinkError: 'int io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods.errnoENOENT()'
-		ex = ChannelBindException.fail(new InetSocketAddress("test", 4956), new IOException("bind(..) failed: Address already in use"));
-		assertThat(ex.getCause()).isEqualTo(null);
+		cause = new IOException("bind(..) failed: Address already in use");
+		ex = ChannelBindException.fail(new InetSocketAddress("test", 4956), cause);
+		assertThat(ex.getCause()).isEqualTo(cause);
 		assertThat(ex.localHost()).isEqualTo("test");
 		assertThat(ex.localPort()).isEqualTo(4956);
 
 		// Issue-1668
-		ex = ChannelBindException.fail(new InetSocketAddress("test", 4956), new IOException("bind(..) failed: Die Adresse wird bereits verwendet"));
-		assertThat(ex.getCause()).isEqualTo(null);
+		cause = new IOException("bind(..) failed: Die Adresse wird bereits verwendet");
+		ex = ChannelBindException.fail(new InetSocketAddress("test", 4956), cause);
+		assertThat(ex.getCause()).isEqualTo(cause);
 		assertThat(ex.localHost()).isEqualTo("test");
 		assertThat(ex.localPort()).isEqualTo(4956);
 


### PR DESCRIPTION
Related to https://github.com/spring-projects/spring-boot/issues/47618