### PR TITLE
Fix `Http3.isHttp3Available()` to check for native `QUIC` library

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/internal/Http3.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/internal/Http3.java
@@ -15,6 +15,8 @@
  */
 package reactor.netty.http.internal;
 
+import io.netty.handler.codec.quic.Quic;
+
 /**
  * Utility class around HTTP/3.
  * <p><strong>Note:</strong> This utility class is for internal use only. It can be removed at any time.
@@ -24,26 +26,13 @@ package reactor.netty.http.internal;
  */
 public final class Http3 {
 
-	static final boolean isHttp3Available;
-	static {
-		boolean http3;
-		try {
-			Class.forName("io.netty.handler.codec.http3.Http3");
-			http3 = true;
-		}
-		catch (Throwable t) {
-			http3 = false;
-		}
-		isHttp3Available = http3;
-	}
-
 	/**
 	 * Check if the current runtime supports HTTP/3, by verifying if {@code io.netty:netty-codec-native-quic} is on the classpath.
 	 *
 	 * @return true if {@code io.netty:netty-codec-native-quic} is available
 	 */
 	public static boolean isHttp3Available() {
-		return isHttp3Available;
+		return Quic.isAvailable();
 	}
 
 	private Http3() {}


### PR DESCRIPTION
Replace incorrect `Class.forName` check for `io.netty.handler.codec.http3.Http3` (which is always available on the classpath) with `Quic.isAvailable()` to properly verify that the native `QUIC` library (`io.netty:netty-codec-native-quic`) is available at runtime.

Fixes #4010