### PR TITLE
Fix `HTTP` protocol version logging for `HTTP/2` and `HTTP/3`

### DIFF
--- a/reactor-netty-http/src/http3Test/java/reactor/netty/http/Http3Tests.java
+++ b/reactor-netty-http/src/http3Test/java/reactor/netty/http/Http3Tests.java
@@ -1223,6 +1223,28 @@ class Http3Tests {
 		        .verify(Duration.ofSeconds(30));
 	}
 
+	@Test
+	void testIssue3522() throws Exception {
+		disposableServer = createServer().handle((req, res) -> res.sendString(Mono.just("testIssue3522"))).bindNow();
+
+		String message = "HTTP/3.0 200";
+		try (LogTracker logTracker = new LogTracker("reactor.netty.http.client.HttpClientOperations", message)) {
+			createClient(disposableServer.port())
+			        .get()
+			        .uri("/")
+			        .responseSingle((res, buf) -> buf.asString())
+			        .as(StepVerifier::create)
+			        .expectNext("testIssue3522")
+			        .expectComplete()
+			        .verify(Duration.ofSeconds(5));
+
+			assertThat(logTracker.latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+			assertThat(logTracker.actualMessages).hasSize(1);
+			assertThat(logTracker.actualMessages.get(0).getFormattedMessage()).contains(message);
+		}
+	}
+
 	static HttpClient createClient(int port) {
 		return createClient(null, port);
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
@@ -225,7 +225,7 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 	@Override
 	protected String asDebugLogMessage(Object o) {
 		return o instanceof HttpObject ?
-				httpMessageLogFactory.debug(HttpMessageArgProviderFactory.create(o)) :
+				httpMessageLogFactory.debug(HttpMessageArgProviderFactory.create(o, version())) :
 				o.toString();
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -210,22 +210,13 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 		this.trailerHeaders = Sinks.unsafe().one();
 	}
 
-	private HttpVersion initHttpVersion(Connection c) {
+	private static HttpVersion initHttpVersion(Connection c) {
 		HttpVersion version;
 		if (c.channel() instanceof Http2StreamChannel) {
 			version = H2;
 		}
 		else if (c.channel() instanceof SocketChannel || c.channel() instanceof DomainSocketChannel) {
-			HttpVersion protocolVersion = this.nettyRequest.protocolVersion();
-			if (protocolVersion.equals(HttpVersion.HTTP_1_0)) {
-				version = HttpVersion.HTTP_1_0;
-			}
-			else if (protocolVersion.equals(HttpVersion.HTTP_1_1)) {
-				version = HttpVersion.HTTP_1_1;
-			}
-			else {
-				throw new IllegalStateException(protocolVersion.protocolName() + " not supported");
-			}
+			version = HttpVersion.HTTP_1_1;
 		}
 		else {
 			version = H3;
@@ -819,7 +810,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 			if (started) {
 				if (log.isDebugEnabled()) {
 					log.debug(format(channel(), "HttpClientOperations cannot proceed more than one response {}"),
-							httpMessageLogFactory().debug(HttpMessageArgProviderFactory.create(response)));
+							httpMessageLogFactory().debug(HttpMessageArgProviderFactory.create(response, version)));
 				}
 				ReferenceCountUtil.release(msg);
 				return;
@@ -839,7 +830,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 			if (log.isDebugEnabled()) {
 				log.debug(format(channel(), "Received response (auto-read:{}) : {}"),
 						channel().config().isAutoRead(),
-						httpMessageLogFactory().debug(HttpMessageArgProviderFactory.create(response)));
+						httpMessageLogFactory().debug(HttpMessageArgProviderFactory.create(response, version)));
 			}
 
 			if (notRedirected(response)) {
@@ -976,7 +967,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 			}
 			if (log.isDebugEnabled()) {
 				log.debug(format(channel(), "Received redirect location: {}"),
-						httpMessageLogFactory().debug(HttpMessageArgProviderFactory.create(response)));
+						httpMessageLogFactory().debug(HttpMessageArgProviderFactory.create(response, version)));
 			}
 			return false;
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/logging/FullHttpRequestArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/logging/FullHttpRequestArgProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package reactor.netty.http.logging;
 
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpVersion;
+import reactor.util.annotation.Nullable;
 
 import static reactor.netty.http.logging.HttpMessageType.FULL_REQUEST;
 
@@ -27,11 +29,11 @@ final class FullHttpRequestArgProvider extends LastHttpContentArgProvider {
 	final String protocol;
 	final String uri;
 
-	FullHttpRequestArgProvider(FullHttpRequest fullHttpRequest) {
+	FullHttpRequestArgProvider(FullHttpRequest fullHttpRequest, @Nullable HttpVersion actualVersion) {
 		super(fullHttpRequest);
 		this.httpHeaders = fullHttpRequest.headers();
 		this.method = fullHttpRequest.method().name();
-		this.protocol = fullHttpRequest.protocolVersion().text();
+		this.protocol = actualVersion != null ? actualVersion.text() : fullHttpRequest.protocolVersion().text();
 		this.uri = fullHttpRequest.uri();
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/logging/FullHttpResponseArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/logging/FullHttpResponseArgProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package reactor.netty.http.logging;
 
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpVersion;
+import reactor.util.annotation.Nullable;
 
 import static reactor.netty.http.logging.HttpMessageType.FULL_RESPONSE;
 
@@ -26,10 +28,10 @@ final class FullHttpResponseArgProvider extends LastHttpContentArgProvider {
 	final String protocol;
 	final String status;
 
-	FullHttpResponseArgProvider(FullHttpResponse fullHttpResponse) {
+	FullHttpResponseArgProvider(FullHttpResponse fullHttpResponse, @Nullable HttpVersion actualVersion) {
 		super(fullHttpResponse);
 		this.httpHeaders = fullHttpResponse.headers();
-		this.protocol = fullHttpResponse.protocolVersion().text();
+		this.protocol = actualVersion != null ? actualVersion.text() : fullHttpResponse.protocolVersion().text();
 		this.status = fullHttpResponse.status().toString();
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/logging/HttpMessageArgProviderFactory.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/logging/HttpMessageArgProviderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,9 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
+import reactor.util.annotation.Nullable;
 
 /**
  * Factory for creating {@link HttpContentArgProvider} based on the provided HTTP object.
@@ -37,17 +39,29 @@ public final class HttpMessageArgProviderFactory {
 	 * @return a new {@link HttpContentArgProvider}
 	 */
 	public static HttpMessageArgProvider create(Object httpObject) {
+		return create(httpObject, null);
+	}
+
+	/**
+	 * Creates {@link HttpContentArgProvider} based on the provided HTTP object and actual protocol version.
+	 *
+	 * @param httpObject the HTTP object
+	 * @param actualVersion the actual HTTP version (optional, used to override the protocol version from the HTTP message)
+	 * @return a new {@link HttpContentArgProvider}
+	 * @since 1.2.14
+	 */
+	public static HttpMessageArgProvider create(Object httpObject, @Nullable HttpVersion actualVersion) {
 		if (httpObject instanceof FullHttpRequest) {
-			return new FullHttpRequestArgProvider((FullHttpRequest) httpObject);
+			return new FullHttpRequestArgProvider((FullHttpRequest) httpObject, actualVersion);
 		}
 		else if (httpObject instanceof HttpRequest) {
-			return new HttpRequestArgProvider((HttpRequest) httpObject);
+			return new HttpRequestArgProvider((HttpRequest) httpObject, actualVersion);
 		}
 		else if (httpObject instanceof FullHttpResponse) {
-			return new FullHttpResponseArgProvider((FullHttpResponse) httpObject);
+			return new FullHttpResponseArgProvider((FullHttpResponse) httpObject, actualVersion);
 		}
 		else if (httpObject instanceof HttpResponse) {
-			return new HttpResponseArgProvider((HttpResponse) httpObject);
+			return new HttpResponseArgProvider((HttpResponse) httpObject, actualVersion);
 		}
 		else if (httpObject instanceof LastHttpContent) {
 			return new LastHttpContentArgProvider((LastHttpContent) httpObject);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/logging/HttpMessageType.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/logging/HttpMessageType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public enum HttpMessageType {
 	 * <ul>
 	 *     <li>the decoding results</li>
 	 *     <li>the request method</li>
-	 *     <li>the the request uri</li>
+	 *     <li>the request uri</li>
 	 *     <li>the protocol version</li>
 	 *     <li>the request headers</li>
 	 * </ul>
@@ -49,7 +49,7 @@ public enum HttpMessageType {
 	 *     <li>the decoding results</li>
 	 *     <li>the HTTP content</li>
 	 *     <li>the request method</li>
-	 *     <li>the the request uri</li>
+	 *     <li>the request uri</li>
 	 *     <li>the protocol version</li>
 	 *     <li>the request headers</li>
 	 *     <li>the trailing headers</li>

--- a/reactor-netty-http/src/main/java/reactor/netty/http/logging/HttpRequestArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/logging/HttpRequestArgProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package reactor.netty.http.logging;
 
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import reactor.util.annotation.Nullable;
 
 import static reactor.netty.http.logging.HttpMessageType.REQUEST;
 
@@ -27,11 +29,11 @@ final class HttpRequestArgProvider extends AbstractHttpMessageArgProvider {
 	final String protocol;
 	final String uri;
 
-	HttpRequestArgProvider(HttpRequest httpRequest) {
+	HttpRequestArgProvider(HttpRequest httpRequest, @Nullable HttpVersion actualVersion) {
 		super(httpRequest.decoderResult());
 		this.httpHeaders = httpRequest.headers();
 		this.method = httpRequest.method().name();
-		this.protocol = httpRequest.protocolVersion().text();
+		this.protocol = actualVersion != null ? actualVersion.text() : httpRequest.protocolVersion().text();
 		this.uri = httpRequest.uri();
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/logging/HttpResponseArgProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/logging/HttpResponseArgProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package reactor.netty.http.logging;
 
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpVersion;
+import reactor.util.annotation.Nullable;
 
 import static reactor.netty.http.logging.HttpMessageType.RESPONSE;
 
@@ -26,10 +28,10 @@ final class HttpResponseArgProvider extends AbstractHttpMessageArgProvider {
 	final String protocol;
 	final String status;
 
-	HttpResponseArgProvider(HttpResponse httpResponse) {
+	HttpResponseArgProvider(HttpResponse httpResponse, @Nullable HttpVersion actualVersion) {
 		super(httpResponse.decoderResult());
 		this.httpHeaders = httpResponse.headers();
-		this.protocol = httpResponse.protocolVersion().text();
+		this.protocol = actualVersion != null ? actualVersion.text() : httpResponse.protocolVersion().text();
 		this.status = httpResponse.status().toString();
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
@@ -35,6 +35,7 @@ import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
@@ -45,6 +46,7 @@ import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
 import reactor.netty.ReactorNetty;
+import reactor.netty.channel.ChannelOperations;
 import reactor.netty.http.logging.HttpMessageArgProviderFactory;
 import reactor.netty.http.logging.HttpMessageLogFactory;
 import reactor.netty.http.server.compression.HttpCompressionOptionsSpec;
@@ -169,10 +171,13 @@ final class Http2StreamBridgeServerHandler extends ChannelDuplexHandler {
 		}
 		else if (!pendingResponse) {
 			if (HttpServerOperations.log.isDebugEnabled()) {
+				ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+				HttpVersion version = channelOps instanceof HttpServerOperations ?
+						((HttpServerOperations) channelOps).version() : null;
 				HttpServerOperations.log.debug(
 						format(ctx.channel(), "Dropped HTTP content, since response has been sent already: {}"),
 						msg instanceof HttpObject ?
-								httpMessageLogFactory.debug(HttpMessageArgProviderFactory.create(msg)) : msg);
+								httpMessageLogFactory.debug(HttpMessageArgProviderFactory.create(msg, version)) : msg);
 			}
 			ReferenceCountUtil.release(msg);
 			ctx.read();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3StreamBridgeServerHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3StreamBridgeServerHandler.java
@@ -29,6 +29,7 @@ import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
@@ -39,6 +40,7 @@ import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
 import reactor.netty.ReactorNetty;
+import reactor.netty.channel.ChannelOperations;
 import reactor.netty.http.logging.HttpMessageArgProviderFactory;
 import reactor.netty.http.logging.HttpMessageLogFactory;
 import reactor.netty.http.server.compression.HttpCompressionOptionsSpec;
@@ -159,10 +161,13 @@ final class Http3StreamBridgeServerHandler extends ChannelDuplexHandler {
 		}
 		else if (!pendingResponse) {
 			if (HttpServerOperations.log.isDebugEnabled()) {
+				ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+				HttpVersion version = channelOps instanceof HttpServerOperations ?
+						((HttpServerOperations) channelOps).version() : null;
 				HttpServerOperations.log.debug(
 						format(ctx.channel(), "Dropped HTTP content, since response has been sent already: {}"),
 						msg instanceof HttpObject ?
-								httpMessageLogFactory.debug(HttpMessageArgProviderFactory.create(msg)) : msg);
+								httpMessageLogFactory.debug(HttpMessageArgProviderFactory.create(msg, version)) : msg);
 			}
 			ReferenceCountUtil.release(msg);
 			ctx.read();

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -1133,9 +1133,17 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 		Throwable cause = t.getCause() != null ? t.getCause() : t;
 
 		if (log.isWarnEnabled()) {
+			HttpVersion version = null;
+			ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+			if (channelOps instanceof HttpServerOperations) {
+				version = ((HttpServerOperations) channelOps).version();
+			}
+			else if (isHttp2) {
+				version = H2;
+			}
 			log.warn(format(ctx.channel(), "Decoding failed: {}"),
 					msg instanceof HttpObject ?
-							httpMessageLogFactory.warn(HttpMessageArgProviderFactory.create(msg)) : msg);
+							httpMessageLogFactory.warn(HttpMessageArgProviderFactory.create(msg, version)) : msg);
 		}
 
 		ReferenceCountUtil.release(msg);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -294,10 +294,13 @@ final class HttpTrafficHandler extends ChannelDuplexHandler implements Runnable 
 			}
 			else {
 				if (HttpServerOperations.log.isDebugEnabled()) {
+					ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+					HttpVersion version = channelOps instanceof HttpServerOperations ?
+							((HttpServerOperations) channelOps).version() : null;
 					HttpServerOperations.log.debug(
 							format(ctx.channel(), "Dropped HTTP content, since response has been sent already: {}"),
 							msg instanceof HttpObject ?
-									httpMessageLogFactory.debug(HttpMessageArgProviderFactory.create(msg)) : msg);
+									httpMessageLogFactory.debug(HttpMessageArgProviderFactory.create(msg, version)) : msg);
 				}
 				ReferenceCountUtil.release(msg);
 			}
@@ -434,10 +437,13 @@ final class HttpTrafficHandler extends ChannelDuplexHandler implements Runnable 
 		}
 		if (persistentConnection && pendingResponses == 0) {
 			if (HttpServerOperations.log.isDebugEnabled()) {
+				ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+				HttpVersion version = channelOps instanceof HttpServerOperations ?
+						((HttpServerOperations) channelOps).version() : null;
 				HttpServerOperations.log.debug(
 						format(ctx.channel(), "Dropped HTTP content, since response has been sent already: {}"),
 						msg instanceof HttpObject ?
-								httpMessageLogFactory.debug(HttpMessageArgProviderFactory.create(msg)) : msg);
+								httpMessageLogFactory.debug(HttpMessageArgProviderFactory.create(msg, version)) : msg);
 			}
 			ReferenceCountUtil.release(msg);
 			promise.setSuccess();
@@ -474,9 +480,12 @@ final class HttpTrafficHandler extends ChannelDuplexHandler implements Runnable 
 	void handleDefaultHttContent(DefaultHttpContent msg, ChannelPromise promise) {
 		if (persistentConnection && pendingResponses == 0) {
 			if (HttpServerOperations.log.isDebugEnabled()) {
+				ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+				HttpVersion version = channelOps instanceof HttpServerOperations ?
+						((HttpServerOperations) channelOps).version() : null;
 				HttpServerOperations.log.debug(
 						format(ctx.channel(), "Dropped HTTP content, since response has been sent already: {}"),
-								httpMessageLogFactory.debug(HttpMessageArgProviderFactory.create(msg)));
+								httpMessageLogFactory.debug(HttpMessageArgProviderFactory.create(msg, version)));
 			}
 			msg.release();
 			promise.setSuccess();

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
@@ -1393,6 +1393,32 @@ class HttpProtocolsTests extends BaseHttpTest {
 		      .verify(Duration.ofSeconds(5));
 	}
 
+	@ParameterizedCompatibleCombinationsTest
+	void testIssue3522(HttpServer server, HttpClient client) throws Exception {
+		disposableServer = server.handle((req, res) -> res.sendString(Mono.just("testIssue3522"))).bindNow();
+
+		HttpProtocol[] serverProtocols = server.configuration().protocols();
+		HttpProtocol[] clientProtocols = client.configuration().protocols();
+		boolean isHttp11 = (serverProtocols.length == 1 && serverProtocols[0] == HttpProtocol.HTTP11) ||
+				(clientProtocols.length == 1 && clientProtocols[0] == HttpProtocol.HTTP11);
+		String message = "HTTP/" + (isHttp11 ? "1.1" : "2.0") + " 200";
+		try (LogTracker logTracker = new LogTracker("reactor.netty.http.client.HttpClientOperations", message)) {
+			client.port(disposableServer.port())
+			      .get()
+			      .uri("/")
+			      .responseSingle((res, buf) -> buf.asString())
+			      .as(StepVerifier::create)
+			      .expectNext("testIssue3522")
+			      .expectComplete()
+			      .verify(Duration.ofSeconds(5));
+
+			assertThat(logTracker.latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+			assertThat(logTracker.actualMessages).hasSize(1);
+			assertThat(logTracker.actualMessages.get(0).getFormattedMessage()).contains(message);
+		}
+	}
+
 	static final class IdleTimeoutTestChannelInboundHandler extends ChannelInboundHandlerAdapter {
 
 		final CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
When using `HTTP/2` or `HTTP/3`, the logs were incorrectly showing `HTTP/1.1` instead of the actual negotiated protocol version.

Fixes #3522