### PR TITLE
Fix incorrect channel factory selection for custom `EventLoopGroups`

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNIO.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import java.util.concurrent.ThreadFactory;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.IoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandle;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
@@ -77,6 +79,9 @@ final class DefaultLoopNIO implements DefaultLoop {
 
 	@Override
 	public boolean supportGroup(EventLoopGroup group) {
-		return false;
+		if (group instanceof ColocatedEventLoopGroup) {
+			group = ((ColocatedEventLoopGroup) group).get();
+		}
+		return group instanceof IoEventLoopGroup && ((IoEventLoopGroup) group).isCompatible(NioIoHandle.class);
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNativeDetector.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopNativeDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package reactor.netty.resources;
 
+import io.netty.channel.EventLoopGroup;
+import org.jspecify.annotations.Nullable;
+
 /**
  * Provides an {@link DefaultLoop} instance based on the available transport.
  *
@@ -26,20 +29,58 @@ final class DefaultLoopNativeDetector {
 
 	static final DefaultLoop NIO;
 
+	@Nullable
+	static final DefaultLoop IO_URING;
+
+	@Nullable
+	static final DefaultLoop EPOLL;
+
+	@Nullable
+	static final DefaultLoop KQUEUE;
+
 	static {
 		NIO = new DefaultLoopNIO();
+		IO_URING = DefaultLoopIOUring.isIoUringAvailable ? new DefaultLoopIOUring() : null;
+		EPOLL = DefaultLoopEpoll.isEpollAvailable ? new DefaultLoopEpoll() : null;
+		KQUEUE = DefaultLoopKQueue.isKqueueAvailable ? new DefaultLoopKQueue() : null;
 
-		if (DefaultLoopIOUring.isIoUringAvailable) {
-			INSTANCE = new DefaultLoopIOUring();
+		if (IO_URING != null) {
+			INSTANCE = IO_URING;
 		}
-		else if (DefaultLoopEpoll.isEpollAvailable) {
-			INSTANCE = new DefaultLoopEpoll();
+		else if (EPOLL != null) {
+			INSTANCE = EPOLL;
 		}
-		else if (DefaultLoopKQueue.isKqueueAvailable) {
-			INSTANCE = new DefaultLoopKQueue();
+		else if (KQUEUE != null) {
+			INSTANCE = KQUEUE;
 		}
 		else {
 			INSTANCE = NIO;
 		}
+	}
+
+	/**
+	 * Finds the correct {@link DefaultLoop} for the given {@link EventLoopGroup}.
+	 * This method checks all available native transports to find one that supports
+	 * the provided group, falling back to NIO if none match.
+	 *
+	 * @param group the event loop group to find a matching channel factory for
+	 * @return the appropriate {@link DefaultLoop} for the group
+	 */
+	static DefaultLoop forGroup(EventLoopGroup group) {
+		// Check each available native transport in priority order
+		if (IO_URING != null && IO_URING.supportGroup(group)) {
+			return IO_URING;
+		}
+		if (EPOLL != null && EPOLL.supportGroup(group)) {
+			return EPOLL;
+		}
+		if (KQUEUE != null && KQUEUE.supportGroup(group)) {
+			return KQUEUE;
+		}
+		if (NIO.supportGroup(group)) {
+			return NIO;
+		}
+
+		throw new IllegalArgumentException("Unsupported event loop group: " + group);
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/LoopResources.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/LoopResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -235,12 +235,7 @@ public interface LoopResources extends Disposable {
 	 * @return a {@link Channel} instance
 	 */
 	default <CHANNEL extends Channel> CHANNEL onChannel(Class<CHANNEL> channelType, EventLoopGroup group) {
-		DefaultLoop channelFactory =
-				DefaultLoopNativeDetector.INSTANCE.supportGroup(group) ?
-						DefaultLoopNativeDetector.INSTANCE :
-						DefaultLoopNativeDetector.NIO;
-
-		return channelFactory.getChannel(channelType);
+		return DefaultLoopNativeDetector.forGroup(group).getChannel(channelType);
 	}
 
 	/**
@@ -252,12 +247,7 @@ public interface LoopResources extends Disposable {
 	 * @return a {@link Channel} class
 	 */
 	default <CHANNEL extends Channel> Class<? extends CHANNEL> onChannelClass(Class<CHANNEL> channelType, EventLoopGroup group) {
-		DefaultLoop channelFactory =
-				DefaultLoopNativeDetector.INSTANCE.supportGroup(group) ?
-						DefaultLoopNativeDetector.INSTANCE :
-						DefaultLoopNativeDetector.NIO;
-
-		return channelFactory.getChannelClass(channelType);
+		return DefaultLoopNativeDetector.forGroup(group).getChannelClass(channelType);
 	}
 
 	/**

--- a/reactor-netty-core/src/main/java17/reactor/netty/resources/DefaultLoopNIO.java
+++ b/reactor-netty-core/src/main/java17/reactor/netty/resources/DefaultLoopNIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import java.util.concurrent.ThreadFactory;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.IoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandle;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
@@ -87,6 +89,9 @@ final class DefaultLoopNIO implements DefaultLoop {
 
 	@Override
 	public boolean supportGroup(EventLoopGroup group) {
-		return false;
+		if (group instanceof ColocatedEventLoopGroup) {
+			group = ((ColocatedEventLoopGroup) group).get();
+		}
+		return group instanceof IoEventLoopGroup && ((IoEventLoopGroup) group).isCompatible(NioIoHandle.class);
 	}
 }

--- a/reactor-netty-core/src/test/java11/reactor/netty/resources/LoopResourcesTest.java
+++ b/reactor-netty-core/src/test/java11/reactor/netty/resources/LoopResourcesTest.java
@@ -15,7 +15,19 @@
  */
 package reactor.netty.resources;
 
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.uring.IoUring;
+import io.netty.channel.uring.IoUringDatagramChannel;
+import io.netty.channel.uring.IoUringIoHandler;
+import io.netty.channel.uring.IoUringServerSocketChannel;
+import io.netty.channel.uring.IoUringSocketChannel;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -30,5 +42,63 @@ class LoopResourcesTest {
 	void testIoUringIsAvailable() {
 		assumeThat(System.getProperty("forceTransport")).isEqualTo("io_uring");
 		assertThat(IoUring.isAvailable()).isTrue();
+	}
+
+	@Test
+	@EnabledOnOs(OS.LINUX)
+	void testOnChannelWithIoUringEventLoopGroup() throws Exception {
+		assumeThat(System.getProperty("forceTransport")).isEqualTo("io_uring");
+		assumeThat(IoUring.isAvailable()).isTrue();
+
+		EventLoopGroup ioUringGroup = new MultiThreadIoEventLoopGroup(1, IoUringIoHandler.newFactory());
+		try {
+			LoopResources loopResources = LoopResources.create("testOnChannelIoUring");
+			try {
+				// Verify onChannel returns correct io_uring channel instances (Java 11+)
+				SocketChannel socketChannel = loopResources.onChannel(SocketChannel.class, ioUringGroup);
+				assertThat(socketChannel).isInstanceOf(IoUringSocketChannel.class);
+
+				ServerSocketChannel serverSocketChannel = loopResources.onChannel(ServerSocketChannel.class, ioUringGroup);
+				assertThat(serverSocketChannel).isInstanceOf(IoUringServerSocketChannel.class);
+
+				DatagramChannel datagramChannel = loopResources.onChannel(DatagramChannel.class, ioUringGroup);
+				assertThat(datagramChannel).isInstanceOf(IoUringDatagramChannel.class);
+			}
+			finally {
+				loopResources.disposeLater().block(Duration.ofSeconds(5));
+			}
+		}
+		finally {
+			ioUringGroup.shutdownGracefully().get(5, TimeUnit.SECONDS);
+		}
+	}
+
+	@Test
+	@EnabledOnOs(OS.LINUX)
+	void testOnChannelClassWithIoUringEventLoopGroup() throws Exception {
+		assumeThat(System.getProperty("forceTransport")).isEqualTo("io_uring");
+		assumeThat(IoUring.isAvailable()).isTrue();
+
+		EventLoopGroup ioUringGroup = new MultiThreadIoEventLoopGroup(1, IoUringIoHandler.newFactory());
+		try {
+			LoopResources loopResources = LoopResources.create("testOnChannelClassIoUring");
+			try {
+				// Verify onChannelClass returns correct io_uring channel classes (Java 11+)
+				Class<? extends SocketChannel> socketChannelClass = loopResources.onChannelClass(SocketChannel.class, ioUringGroup);
+				assertThat(socketChannelClass).isEqualTo(IoUringSocketChannel.class);
+
+				Class<? extends ServerSocketChannel> serverSocketChannelClass = loopResources.onChannelClass(ServerSocketChannel.class, ioUringGroup);
+				assertThat(serverSocketChannelClass).isEqualTo(IoUringServerSocketChannel.class);
+
+				Class<? extends DatagramChannel> datagramChannelClass = loopResources.onChannelClass(DatagramChannel.class, ioUringGroup);
+				assertThat(datagramChannelClass).isEqualTo(IoUringDatagramChannel.class);
+			}
+			finally {
+				loopResources.disposeLater().block(Duration.ofSeconds(5));
+			}
+		}
+		finally {
+			ioUringGroup.shutdownGracefully().get(5, TimeUnit.SECONDS);
+		}
 	}
 }


### PR DESCRIPTION
`LoopResources.onChannel()` and `onChannelClass()` incorrectly selected channel factories when users provided custom `EventLoopGroups` via `runOn()`. The previous logic only checked if `DefaultLoopNativeDetector.INSTANCE` (the highest-priority available transport) supported the group, falling back to `NIO` otherwise.

This caused issues when, for example, `io_uring` was the default transport but a user explicitly provided an `Epoll` `EventLoopGroup` - the code would incorrectly return `NIO` channel factories instead of `Epoll` ones.

Changes:
  - Add `forGroup(EventLoopGroup)` method to `DefaultLoopNativeDetector` that checks all available transports (`io_uring`, `epoll`, `kqueue`, `nio`) to find the correct channel factory for any given `EventLoopGroup`
  - Fix `DefaultLoopNIO.supportGroup()` to properly detect `NIO` event loops using `isCompatible(NioIoHandle.class)`, matching the pattern used by other transports
  - Update `onChannel()` and `onChannelClass()` to use `forGroup()` instead of the previous INSTANCE-or-NIO logic