### PR TITLE
Remove deprecated `EventLoopGroup` checks from `supportGroup()`

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopEpoll.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopEpoll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollDomainDatagramChannel;
 import io.netty.channel.epoll.EpollDomainSocketChannel;
-import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollIoHandle;
 import io.netty.channel.epoll.EpollIoHandler;
 import io.netty.channel.epoll.EpollServerDomainSocketChannel;
@@ -98,13 +97,11 @@ final class DefaultLoopEpoll implements DefaultLoop {
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public boolean supportGroup(EventLoopGroup group) {
 		if (group instanceof ColocatedEventLoopGroup) {
 			group = ((ColocatedEventLoopGroup) group).get();
 		}
-		return (group instanceof IoEventLoopGroup && ((IoEventLoopGroup) group).isCompatible(EpollIoHandle.class)) ||
-				group instanceof EpollEventLoopGroup;
+		return group instanceof IoEventLoopGroup && ((IoEventLoopGroup) group).isCompatible(EpollIoHandle.class);
 	}
 
 	static final Logger log = Loggers.getLogger(DefaultLoopEpoll.class);

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopKQueue.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultLoopKQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueDatagramChannel;
 import io.netty.channel.kqueue.KQueueDomainDatagramChannel;
 import io.netty.channel.kqueue.KQueueDomainSocketChannel;
-import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.kqueue.KQueueIoHandle;
 import io.netty.channel.kqueue.KQueueIoHandler;
 import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
@@ -97,13 +96,11 @@ final class DefaultLoopKQueue implements DefaultLoop {
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public boolean supportGroup(EventLoopGroup group) {
 		if (group instanceof ColocatedEventLoopGroup) {
 			group = ((ColocatedEventLoopGroup) group).get();
 		}
-		return (group instanceof IoEventLoopGroup && ((IoEventLoopGroup) group).isCompatible(KQueueIoHandle.class)) ||
-				group instanceof KQueueEventLoopGroup;
+		return group instanceof IoEventLoopGroup && ((IoEventLoopGroup) group).isCompatible(KQueueIoHandle.class);
 	}
 
 	static final Logger log = Loggers.getLogger(DefaultLoopKQueue.class);

--- a/reactor-netty-core/src/test/java11/reactor/netty/resources/LoopResourcesTest.java
+++ b/reactor-netty-core/src/test/java11/reactor/netty/resources/LoopResourcesTest.java
@@ -29,27 +29,25 @@ import io.netty.channel.uring.IoUringIoHandler;
 import io.netty.channel.uring.IoUringServerSocketChannel;
 import io.netty.channel.uring.IoUringSocketChannel;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 class LoopResourcesTest {
 
 	@Test
 	@EnabledOnOs(OS.LINUX)
+	@EnabledIf("isIoUringTransport")
 	void testIoUringIsAvailable() {
-		assumeThat(System.getProperty("forceTransport")).isEqualTo("io_uring");
 		assertThat(IoUring.isAvailable()).isTrue();
 	}
 
 	@Test
 	@EnabledOnOs(OS.LINUX)
+	@EnabledIf("isIoUringAvailable")
 	void testOnChannelWithIoUringEventLoopGroup() throws Exception {
-		assumeThat(System.getProperty("forceTransport")).isEqualTo("io_uring");
-		assumeThat(IoUring.isAvailable()).isTrue();
-
 		EventLoopGroup ioUringGroup = new MultiThreadIoEventLoopGroup(1, IoUringIoHandler.newFactory());
 		try {
 			LoopResources loopResources = LoopResources.create("testOnChannelIoUring");
@@ -75,10 +73,8 @@ class LoopResourcesTest {
 
 	@Test
 	@EnabledOnOs(OS.LINUX)
+	@EnabledIf("isIoUringAvailable")
 	void testOnChannelClassWithIoUringEventLoopGroup() throws Exception {
-		assumeThat(System.getProperty("forceTransport")).isEqualTo("io_uring");
-		assumeThat(IoUring.isAvailable()).isTrue();
-
 		EventLoopGroup ioUringGroup = new MultiThreadIoEventLoopGroup(1, IoUringIoHandler.newFactory());
 		try {
 			LoopResources loopResources = LoopResources.create("testOnChannelClassIoUring");
@@ -100,5 +96,13 @@ class LoopResourcesTest {
 		finally {
 			ioUringGroup.shutdownGracefully().get(5, TimeUnit.SECONDS);
 		}
+	}
+
+	static boolean isIoUringTransport() {
+		return "io_uring".equals(System.getProperty("forceTransport"));
+	}
+
+	static boolean isIoUringAvailable() {
+		return isIoUringTransport() && IoUring.isAvailable();
 	}
 }


### PR DESCRIPTION
The `supportGroup()` methods in `DefaultLoopEpoll` and `DefaultLoopKQueue` no longer need explicit `instanceof` checks for deprecated `EventLoopGroup` classes (`EpollEventLoopGroup`, `KQueueEventLoopGroup`). The existing `IoEventLoopGroup.isCompatible()` check already handles both new `MultiThreadIoEventLoopGroup` and deprecated `EventLoopGroup` implementations.

Add parameterised tests to verify backward compatibility, ensuring that both new and deprecated `EventLoopGroup` implementations correctly select channel factories via `LoopResources.onChannel()` and `onChannelClass()`.