### PR TITLE
Add `Http2AllocationStrategy` documentation and improve javadoc

### DIFF
--- a/docs/modules/ROOT/partials/http-client-conn-provider.adoc
+++ b/docs/modules/ROOT/partials/http-client-conn-provider.adoc
@@ -82,6 +82,72 @@ If you need to disable the connection pool, you can apply the following configur
 include::{examples-dir}/pool/Application.java[lines=18..49]
 ----
 
+[[http2-connection-pool]]
+=== HTTP/2
+
+When the `HTTP` client is configured for `HTTP/2`, a specialized connection pool manages `HTTP/2` connections and their streams.
+By default, the pool opens new connections as needed for concurrent requests. Since `HTTP/2` supports multiplexing --
+multiple streams over a single connection -- you can fine-tune the connection pool behavior using
+{javadoc}/reactor/netty/http/client/Http2AllocationStrategy.html[`Http2AllocationStrategy`].
+
+The following table describes the available `Http2AllocationStrategy` configuration options:
+
+[width="100%",options="header"]
+|=======
+| Configuration name | Description
+| `maxConnections` | The maximum number of live connections to keep in the pool.
+Default: `Integer.MAX_VALUE` (no upper limit).
+| `minConnections` | The minimum number of live connections to keep in the pool (can be best effort).
+When configured with a value greater than zero, strict connection reuse is also enabled.
+Default: `0`.
+| `maxConcurrentStreams` | The maximum number of concurrent streams that can be opened to the remote peer.
+The minimum of this configuration and the remote peer configuration is used.
+Default: `-1` (use the remote peer configuration).
+| `strictConnectionReuse` | Whether the pool should avoid opening additional connections as long as existing
+connections have not reached their max concurrent streams limit. When enabled, the pool will maximize
+`HTTP/2` multiplexing. This is automatically enabled when `minConnections` is greater than zero.
+Default: `false`.
+|=======
+
+The following example shows how to configure the `HTTP/2` connection pool:
+
+{examples-link}/http2/pool/Application.java
+[%unbreakable]
+----
+include::{examples-dir}/http2/pool/Application.java[lines=18..55]
+----
+<1> Configures the maximum number of live connections to `20`.
+<2> Configures the minimum number of live connections to `5`. This also enables strict connection reuse.
+<3> Configures the maximum number of concurrent streams per connection to `50`.
+
+[[http2-strict-connection-reuse]]
+==== Strict Connection Reuse
+
+By default, when the `HTTP` client needs to open a new stream and there are concurrent acquire requests,
+the pool may allocate additional connections even though existing connections could still accept more streams.
+Enabling strict connection reuse changes this behavior so that the pool maximizes `HTTP/2` multiplexing by
+reusing existing connections before allocating new ones.
+
+This can be particularly beneficial when:
+
+* You want to minimize the number of connections to the remote peer.
+* Your workload benefits from `HTTP/2` multiplexing (many concurrent small requests).
+* You want to reduce connection establishment overhead (TCP + TLS handshakes).
+
+Strict connection reuse can be enabled in two ways:
+
+* Explicitly, by setting `strictConnectionReuse(true)`:
+
+{examples-link}/http2/pool/StrictReuseApplication.java
+[%unbreakable]
+----
+include::{examples-dir}/http2/pool/StrictReuseApplication.java[lines=18..54]
+----
+<1> Enables strict connection reuse. The pool will avoid opening additional connections as long as
+existing connections have not reached their max concurrent streams limit.
+
+* Implicitly, by configuring `minConnections` with a value greater than zero (see the example above).
+
 === Disposing Connection Pool
 
 - If you use the default `ConnectionProvider` provided by Reactor Netty, invoke

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/http2/pool/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/http2/pool/Application.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.client.http2.pool;
+
+import reactor.netty.http.HttpProtocol;
+import reactor.netty.http.client.Http2AllocationStrategy;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+public class Application {
+
+	public static void main(String[] args) {
+		ConnectionProvider provider =
+				ConnectionProvider.builder("custom")
+				                  .allocationStrategy(
+				                      Http2AllocationStrategy.builder()
+				                                             .maxConnections(20)                //<1>
+				                                             .minConnections(5)                 //<2>
+				                                             .maxConcurrentStreams(50)          //<3>
+				                                             .build())
+				                  .build();
+
+		HttpClient client =
+				HttpClient.create(provider)
+				          .protocol(HttpProtocol.H2)
+				          .secure();
+
+		String response =
+				client.get()
+				      .uri("https://example.com/")
+				      .responseContent()
+				      .aggregate()
+				      .asString()
+				      .block();
+
+		System.out.println("Response " + response);
+
+		provider.disposeLater()
+		        .block();
+	}
+}

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/http2/pool/StrictReuseApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/http2/pool/StrictReuseApplication.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.client.http2.pool;
+
+import reactor.netty.http.HttpProtocol;
+import reactor.netty.http.client.Http2AllocationStrategy;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+public class StrictReuseApplication {
+
+	public static void main(String[] args) {
+		ConnectionProvider provider =
+				ConnectionProvider.builder("custom")
+				                  .allocationStrategy(
+				                      Http2AllocationStrategy.builder()
+				                                             .maxConnections(20)
+				                                             .strictConnectionReuse(true) //<1>
+				                                             .build())
+				                  .build();
+
+		HttpClient client =
+				HttpClient.create(provider)
+				          .protocol(HttpProtocol.H2)
+				          .secure();
+
+		String response =
+				client.get()
+				      .uri("https://example.com/")
+				      .responseContent()
+				      .aggregate()
+				      .asString()
+				      .block();
+
+		System.out.println("Response " + response);
+
+		provider.disposeLater()
+		        .block();
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2AllocationStrategy.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2AllocationStrategy.java
@@ -61,9 +61,13 @@ public final class Http2AllocationStrategy implements ConnectionProvider.Allocat
 
 		/**
 		 * Configures the minimum number of live connections to keep in the pool (can be the best effort).
+		 * When configured with a value greater than zero, the pool will also enable
+		 * {@link #strictConnectionReuse(boolean) strict connection reuse}.
 		 * Default to {@code 0}.
 		 *
+		 * @param minConnections the minimum number of live connections to keep in the pool
 		 * @return {@code this}
+		 * @see #strictConnectionReuse(boolean)
 		 */
 		Builder minConnections(int minConnections);
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2AllocationStrategyTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2AllocationStrategyTest.java
@@ -35,12 +35,12 @@ class Http2AllocationStrategyTest {
 
 	@Test
 	void build() {
-		builder.maxConcurrentStreams(2).maxConnections(2).minConnections(1);
+		builder.maxConcurrentStreams(2).maxConnections(2).minConnections(1).strictConnectionReuse(true);
 		Http2AllocationStrategy strategy = builder.build();
 		assertThat(strategy.maxConcurrentStreams()).isEqualTo(2);
 		assertThat(strategy.permitMaximum()).isEqualTo(2);
 		assertThat(strategy.permitMinimum()).isEqualTo(1);
-		assertThat(strategy.strictConnectionReuse()).isEqualTo(DEFAULT_STRICT_CONNECTION_REUSE);
+		assertThat(strategy.strictConnectionReuse()).isTrue();
 	}
 
 	@Test
@@ -65,6 +65,9 @@ class Http2AllocationStrategyTest {
 	void strictConnectionReuse() {
 		builder.strictConnectionReuse(true);
 		Http2AllocationStrategy strategy = builder.build();
+		assertThat(strategy.maxConcurrentStreams()).isEqualTo(DEFAULT_MAX_CONCURRENT_STREAMS);
+		assertThat(strategy.permitMaximum()).isEqualTo(DEFAULT_MAX_CONNECTIONS);
+		assertThat(strategy.permitMinimum()).isEqualTo(DEFAULT_MIN_CONNECTIONS);
 		assertThat(strategy.strictConnectionReuse()).isTrue();
 	}
 
@@ -75,6 +78,7 @@ class Http2AllocationStrategyTest {
 		assertThat(strategy.maxConcurrentStreams()).isEqualTo(2);
 		assertThat(strategy.permitMaximum()).isEqualTo(DEFAULT_MAX_CONNECTIONS);
 		assertThat(strategy.permitMinimum()).isEqualTo(DEFAULT_MIN_CONNECTIONS);
+		assertThat(strategy.strictConnectionReuse()).isEqualTo(DEFAULT_STRICT_CONNECTION_REUSE);
 	}
 
 	@Test
@@ -91,6 +95,7 @@ class Http2AllocationStrategyTest {
 		assertThat(strategy.maxConcurrentStreams()).isEqualTo(DEFAULT_MAX_CONCURRENT_STREAMS);
 		assertThat(strategy.permitMaximum()).isEqualTo(2);
 		assertThat(strategy.permitMinimum()).isEqualTo(DEFAULT_MIN_CONNECTIONS);
+		assertThat(strategy.strictConnectionReuse()).isEqualTo(DEFAULT_STRICT_CONNECTION_REUSE);
 	}
 
 	@Test
@@ -107,6 +112,7 @@ class Http2AllocationStrategyTest {
 		assertThat(strategy.maxConcurrentStreams()).isEqualTo(DEFAULT_MAX_CONCURRENT_STREAMS);
 		assertThat(strategy.permitMaximum()).isEqualTo(DEFAULT_MAX_CONNECTIONS);
 		assertThat(strategy.permitMinimum()).isEqualTo(2);
+		assertThat(strategy.strictConnectionReuse()).isEqualTo(DEFAULT_STRICT_CONNECTION_REUSE);
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
@@ -151,17 +151,17 @@ class Http2PoolTest {
 
 		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
 				PoolBuilder.from(Mono.fromSupplier(() -> {
-							allocator.incrementAndGet();
-							EmbeddedChannel channel = new EmbeddedChannel(
-									new TestChannelId(),
-									Http2FrameCodecBuilder.forClient().build(),
-									new Http2MultiplexHandler(new ChannelHandlerAdapter() {}));
-							channels.add(channel);
-							return Connection.from(channel);
-						}))
-						.idleResourceReuseLruOrder()
-						.maxPendingAcquireUnbounded()
-						.sizeBetween(0, 2);
+				               allocator.incrementAndGet();
+				               EmbeddedChannel channel = new EmbeddedChannel(
+				                   new TestChannelId(),
+				                   Http2FrameCodecBuilder.forClient().build(),
+				                   new Http2MultiplexHandler(new ChannelHandlerAdapter() {}));
+				               channels.add(channel);
+				               return Connection.from(channel);
+				           }))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 2);
 		// Enable strict reuse so concurrent acquires do not allocate extra connections while a slot/allocation is in-flight.
 		Http2AllocationStrategy strategy = Http2AllocationStrategy.builder()
 				.maxConnections(2)


### PR DESCRIPTION
Add reference documentation for `Http2AllocationStrategy` configuration options including the new `strictConnectionReuse` setting. Document the `HTTP/2` connection pool behaviour and strict connection reuse in the connection provider section.

Improve `javadoc` for `minConnections` and `strictConnectionReuse` to accurately describe their relationship and avoid redundancy.