### PR TITLE
Add `FlushConsolidationHandler` to `H2C` upgrade pipeline

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -934,7 +934,8 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 				http2MultiplexHandler = new Http2MultiplexHandler(H2InboundStreamHandler.INSTANCE,
 						new H2Codec(owner, obs, opsFactory, acceptGzip, metricsRecorder, proxyAddress, remoteAddress, uriTagValue));
 			}
-			pipeline.addAfter(ctx.name(), NettyPipeline.HttpCodec, http2FrameCodec)
+			pipeline.addAfter(ctx.name(), NettyPipeline.H2Flush, new FlushConsolidationHandler(1024, true))
+			        .addAfter(NettyPipeline.H2Flush, NettyPipeline.HttpCodec, http2FrameCodec)
 			        .addAfter(NettyPipeline.HttpCodec, NettyPipeline.H2MultiplexHandler, http2MultiplexHandler);
 			if (pipeline.get(NettyPipeline.HttpDecompressor) != null) {
 				pipeline.remove(NettyPipeline.HttpDecompressor);

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import reactor.core.publisher.Sinks;
 import reactor.core.scheduler.Schedulers;
 import reactor.netty.BaseHttpTest;
 import reactor.netty.ByteBufFlux;
+import reactor.netty.NettyPipeline;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.server.HttpServer;
 import reactor.netty.internal.shaded.reactor.pool.PoolAcquireTimeoutException;
@@ -908,5 +909,44 @@ class Http2Tests extends BaseHttpTest {
 			//no-op
 		}
 		return result;
+	}
+
+	@ParameterizedTest
+	@MethodSource("h2CompatibleCombinations")
+	@SuppressWarnings("deprecation")
+	void testFlushConsolidationHandlerH2(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols) {
+		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
+		Http2SslContextSpec clientCtx =
+				Http2SslContextSpec.forClient()
+				                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		doTestFlushConsolidationHandler(createServer().protocol(serverProtocols).secure(spec -> spec.sslContext(serverCtx)),
+				createClient(() -> disposableServer.address()).protocol(clientProtocols).secure(spec -> spec.sslContext(clientCtx)));
+	}
+
+	@ParameterizedTest
+	@MethodSource("h2cCompatibleCombinations")
+	void testFlushConsolidationHandlerH2C(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols) {
+		doTestFlushConsolidationHandler(createServer().protocol(serverProtocols),
+				createClient(() -> disposableServer.address()).protocol(clientProtocols));
+	}
+
+	private void doTestFlushConsolidationHandler(HttpServer server, HttpClient client) {
+		disposableServer =
+				server.handle((req, res) -> res.sendString(Mono.just("doTestFlushConsolidationHandler")))
+				      .bindNow();
+
+		AtomicBoolean handlerExists = new AtomicBoolean(false);
+		client.doOnResponse((res, conn) -> handlerExists.set(conn.channel().parent().pipeline().get(NettyPipeline.H2Flush) != null))
+		      .get()
+		      .uri("/")
+		      .responseContent()
+		      .aggregate()
+		      .asString()
+		      .as(StepVerifier::create)
+		      .expectNext("doTestFlushConsolidationHandler")
+		      .expectComplete()
+		      .verify(Duration.ofSeconds(5));
+
+		assertThat(handlerExists.get()).isTrue();
 	}
 }


### PR DESCRIPTION
When using `H2C` with `HTTP/1.1` fallback (`H2C`+`HTTP11`), the `H2C` upgrade pipeline was missing `FlushConsolidationHandler`. After a successful upgrade, `H2CleartextCodec.handlerAdded()` added `Http2FrameCodec` and `Http2MultiplexHandler` but not `FlushConsolidationHandler`, unlike the pure `H2C` path (`configureHttp2Pipeline`) which always included it.