### PR TITLE
Fix `Http2Pool` `ACQUIRED` counter not rolled back when deliver is rejected

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -857,6 +857,8 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 				else {
 					poolSlot.slot.deactivate();
 				}
+				// ACQUIRED was incremented in drainLoop, rollback
+				ACQUIRED.decrementAndGet(pool);
 				pool.addPending(pool.pending, this, true);
 				return;
 			}


### PR DESCRIPTION
When `drainLoop()` finds a reusable connection, it increments the `ACQUIRED` counter and schedules a `deliver()` task on the event loop. If the remote peer lowers max concurrent streams (via `SETTINGS` frame) between the `drainLoop()` check and the `deliver()` execution, `deliver()` rejects the borrower and re-adds it to the pending queue. However, the `ACQUIRED` counter was never decremented, causing it to be permanently over-counted.