### PR TITLE
Fix `HttpClient#proxyWhen` to use `NoopAddressResolverGroup`

### DIFF
--- a/docs/modules/ROOT/partials/http-client-proxy.adoc
+++ b/docs/modules/ROOT/partials/http-client-proxy.adoc
@@ -11,6 +11,13 @@ Sometimes this might be the reason for not being able to connect to the proxy. C
 whether it supports or needs an additional configuration in order to support `CONNECT` method.
 // end::proxy-connect-method[]
 
+NOTE: When a proxy is configured and no custom DNS resolver has been specified, Reactor Netty automatically uses
+{nettyjavadoc}/io/netty/resolver/NoopAddressResolverGroup.html[`NoopAddressResolverGroup`] to skip client-side DNS
+resolution and delegate it to the proxy. If a custom DNS resolver is explicitly configured (e.g. the JVM built-in resolver
+via `DefaultAddressResolverGroup.INSTANCE` or via the `resolver(...)` method), Reactor Netty respects that configuration
+and does not override it. In that case, the configured resolver must be able to resolve the target hostname on the client side,
+even when using a proxy.
+
 The following example uses `ProxyProvider`:
 
 {examples-link}/proxy/Application.java

--- a/docs/modules/ROOT/partials/tcp-client-proxy.adoc
+++ b/docs/modules/ROOT/partials/tcp-client-proxy.adoc
@@ -11,6 +11,13 @@ Sometimes this might be the reason for not being able to connect to the proxy. C
 whether it supports or needs an additional configuration in order to support `CONNECT` method.
 // end::proxy-connect-method[]
 
+NOTE: When a proxy is configured and no custom DNS resolver has been specified, Reactor Netty automatically uses
+{nettyjavadoc}/io/netty/resolver/NoopAddressResolverGroup.html[`NoopAddressResolverGroup`] to skip client-side DNS
+resolution and delegate it to the proxy. If a custom DNS resolver is explicitly configured (e.g. the JVM built-in resolver
+via `DefaultAddressResolverGroup.INSTANCE` or via the `resolver(...)` method), Reactor Netty respects that configuration
+and does not override it. In that case, the configured resolver must be able to resolve the target hostname on the client side,
+even when using a proxy.
+
 The following example uses `ProxyProvider`:
 
 {examples-link}/proxy/Application.java

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -247,6 +247,9 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 
 	/**
 	 * Remove any previously applied Proxy configuration customization.
+	 * <p>
+	 * If the resolver was automatically set to {@link NoopAddressResolverGroup#INSTANCE}
+	 * when the proxy was configured, it is reset to {@code null} so that the default resolver is used.
 	 *
 	 * @return a new {@link ClientTransport} reference
 	 */
@@ -277,9 +280,18 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 
 	/**
 	 * Apply a proxy configuration.
+	 * <p>
+	 * When a proxy is configured and no custom {@link AddressResolverGroup} has been set via
+	 * {@link #resolver(AddressResolverGroup)} or {@link #resolver(Consumer)},
+	 * {@link NoopAddressResolverGroup#INSTANCE} is used automatically to skip client-side DNS resolution
+	 * and delegate it to the proxy. If a custom {@link AddressResolverGroup} has already been configured,
+	 * it is not overridden and the configured resolver must be able to resolve the target hostname
+	 * on the client side.
 	 *
 	 * @param proxyOptions the proxy configuration callback
 	 * @return a new {@link ClientTransport} reference
+	 * @see #resolver(AddressResolverGroup)
+	 * @see #resolver(Consumer)
 	 */
 	public T proxy(Consumer<? super ProxyProvider.TypeSpec> proxyOptions) {
 		Objects.requireNonNull(proxyOptions, "proxyOptions");
@@ -316,8 +328,16 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * instance returned by this method behaves as if there is no proxy settings,
 	 * regardless of configuration of the original {@link ClientTransport} instance.
 	 * <p>
+	 * When a proxy is configured and no custom {@link AddressResolverGroup} has been set,
+	 * {@link NoopAddressResolverGroup#INSTANCE} is used automatically to skip client-side DNS resolution
+	 * and delegate it to the proxy. If a custom {@link AddressResolverGroup} has already been configured,
+	 * it is not overridden and the configured resolver must be able to resolve the target hostname
+	 * on the client side.
+	 *
 	 * @return a new {@link ClientTransport} reference
 	 * @since 1.0.8
+	 * @see #resolver(AddressResolverGroup)
+	 * @see #resolver(Consumer)
 	 */
 	public final T proxyWithSystemProperties() {
 		return proxyWithSystemProperties(System.getProperties());
@@ -363,6 +383,12 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 
 	/**
 	 * Assign an {@link AddressResolverGroup}.
+	 * <p>
+	 * <strong>Note:</strong> When a proxy is configured (via {@link #proxy(Consumer)} or
+	 * {@link #proxyWithSystemProperties()}), the resolver set by this method will be used as-is
+	 * and will not be replaced by {@link NoopAddressResolverGroup#INSTANCE}. This means the
+	 * configured resolver must be able to resolve the target hostname on the client side,
+	 * even when using a proxy.
 	 *
 	 * @param resolver the new {@link AddressResolverGroup}
 	 * @return a new {@link ClientTransport} reference
@@ -377,6 +403,12 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 
 	/**
 	 * Apply a name resolver configuration.
+	 * <p>
+	 * <strong>Note:</strong> When a proxy is configured (via {@link #proxy(Consumer)} or
+	 * {@link #proxyWithSystemProperties()}), the resolver set by this method will be used as-is
+	 * and will not be replaced by {@link NoopAddressResolverGroup#INSTANCE}. This means the
+	 * configured resolver must be able to resolve the target hostname on the client side,
+	 * even when using a proxy.
 	 *
 	 * @param nameResolverSpec the name resolver callback
 	 * @return a new {@link ClientTransport} reference

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransportConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -242,6 +242,10 @@ public abstract class ClientTransportConfig<CONF extends TransportConfig> extend
 
 	protected void proxyProviderSupplier(Supplier<ProxyProvider> proxyProviderSupplier) {
 		this.proxyProviderSupplier = proxyProviderSupplier;
+	}
+
+	protected void resolver(AddressResolverGroup<?> resolver) {
+		this.resolver = resolver;
 	}
 
 	protected AddressResolverGroup<?> resolverInternal() {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,8 @@ import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.NoopAddressResolverGroup;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.publisher.Flux;
@@ -1646,10 +1648,18 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * <p>When proxyWhen(...) is set, calls to proxy(...) and noProxy() methods are ignored.</p>
 	 * <p>This method allows dynamic determination of proxy settings, applying or skipping the proxy based on the configured conditions.</p>
+	 * <p>When a proxy is configured and no custom {@link AddressResolverGroup} has been set via
+	 * {@link #resolver(AddressResolverGroup)} or {@link #resolver(Consumer)},
+	 * {@link NoopAddressResolverGroup#INSTANCE} is used automatically to skip client-side DNS resolution
+	 * and delegate it to the proxy. If a custom {@link AddressResolverGroup} has already been configured,
+	 * it is not overridden and the configured resolver must be able to resolve the target hostname
+	 * on the client side.</p>
 	 *
 	 * @param proxyBuilder a deferred builder for proxy configuration
 	 * @return a new {@link HttpClient} reference
 	 * @since 1.2.3
+	 * @see #resolver(AddressResolverGroup)
+	 * @see #resolver(Consumer)
 	 */
 	public final HttpClient proxyWhen(
 			BiFunction<HttpClientConfig, ? super ProxyProvider.TypeSpec, Mono<? extends ProxyProvider.Builder>> proxyBuilder) {
@@ -1663,6 +1673,9 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 
 			return mono.map(builder -> {
 				config.proxyProvider(builder.build());
+				if (config.resolver() == null) {
+					config.resolver(NoopAddressResolverGroup.INSTANCE);
+				}
 				return config;
 			});
 		});

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -517,6 +517,11 @@ public final class HttpClientConfig extends ClientTransportConfig<HttpClientConf
 	}
 
 	@Override
+	protected void resolver(AddressResolverGroup<?> resolver) {
+		super.resolver(resolver);
+	}
+
+	@Override
 	protected AddressResolverGroup<?> resolverInternal() {
 		return super.resolverInternal();
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientProxyTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -550,6 +550,47 @@ class HttpClientProxyTest extends BaseHttpTest {
 
 		assertThat(resolver.get()).isNotNull();
 		assertThat(resolver.get()).isInstanceOf(NoopAddressResolverGroup.class);
+	}
+
+	@Test
+	void proxyWhenShouldUseNoopAddressResolverGroup(Hoverfly hoverfly) {
+		AtomicReference<AddressResolverGroup<?>> resolver = new AtomicReference<>();
+		HttpClient.create()
+		          .proxyWhen((config, spec) ->
+		                  Mono.just(spec.type(ProxyProvider.Proxy.HTTP)
+		                                .host("localhost")
+		                                .port(hoverfly.getHoverflyConfig().getProxyPort()))
+		                      .doFinally(signalType -> resolver.set(config.resolver())))
+		          .get()
+		          .uri("http://localhost:" + port + "/")
+		          .responseContent()
+		          .aggregate()
+		          .asString()
+		          .block(Duration.ofSeconds(30));
+
+		assertThat(resolver.get()).isNotNull()
+			.isEqualTo(NoopAddressResolverGroup.INSTANCE);
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	void proxyWhenShouldNotResolveTargetHostname(Hoverfly hoverfly) {
+		Http11SslContextSpec clientCtx =
+				Http11SslContextSpec.forClient()
+				                    .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+		HttpClient.create()
+		          .secure(spec -> spec.sslContext(clientCtx))
+		          .proxyWhen((config, spec) ->
+		                  Mono.just(spec.type(ProxyProvider.Proxy.HTTP)
+		                                .host("localhost")
+		                                .port(hoverfly.getHoverflyConfig().getProxyPort())))
+		          .get()
+		          .uri(LOCALLY_NOT_RESOLVABLE_ADDRESS)
+		          .responseSingle((response, body) -> body.asString())
+		          .as(StepVerifier::create)
+		          .expectNextMatches(("Hi from " + LOCALLY_NOT_RESOLVABLE_ADDRESS)::equals)
+		          .expectComplete()
+		          .verify(Duration.ofSeconds(30));
 	}
 
 	@Test


### PR DESCRIPTION
When a proxy is configured via `proxy()` or `proxyWithSystemProperties()`, `NoopAddressResolverGroup` is automatically used to skip client-side `DNS` resolution and delegate it to the proxy. `HttpClient#proxyWhen` was missing this behaviour.
Document proxy/resolver interaction.

Related to #4103