### PR TITLE
Add configurable `maxLifeTime` with per-resource variance

### DIFF
--- a/docs/modules/ROOT/partials/http-client-conn-provider.adoc
+++ b/docs/modules/ROOT/partials/http-client-conn-provider.adoc
@@ -24,12 +24,13 @@ When you need to change the default settings, you can configure the `ConnectionP
 {examples-link}/pool/config/Application.java
 [%unbreakable]
 ----
-include::{examples-dir}/pool/config/Application.java[lines=18..50]
+include::{examples-dir}/pool/config/Application.java[lines=18..51]
 ----
 <1> Configures the maximum time for a connection to stay idle to 20 seconds.
 <2> Configures the maximum time for a connection to stay alive to 60 seconds.
-<3> Configures the maximum time for the pending acquire operation to 60 seconds.
-<4> Every two minutes, the connection pool is regularly checked for connections that are applicable for removal.
+<3> Configures a 2.5% variance on the max lifetime, so connections expire between 58.5s and 60s.
+<4> Configures the maximum time for the pending acquire operation to 60 seconds.
+<5> Every two minutes, the connection pool is regularly checked for connections that are applicable for removal.
 
 NOTE: Notice that only the default `HttpClient` (`HttpClient.create()`) uses `500` as the maximum number of active channels. In the example above, when
 instantiating a custom `ConnectionProvider`, we are changing this value to `50` using `maxConnections`. Also, if you don't set this parameter the
@@ -62,6 +63,11 @@ the next acquire operation will get the `Most Recently Used` connection
 2 * available number of processors (but with a minimum value of 16).
 | `maxIdleTime` | The time after which the channel is eligible to be closed when idle (resolution: ms). Default: max idle time is not specified.
 | `maxLifeTime` | The total life time after which the channel is eligible to be closed (resolution: ms). Default: max life time is not specified.
+| `maxLifeTimeVariance` | A variance percentage for `maxLifeTime`, introducing per-connection jitter to prevent
+simultaneous expiry of connections created around the same time. The effective max lifetime for each connection will be
+in the range `[maxLifeTime * (1 - variance/100), maxLifeTime]`. For example, with a `maxLifeTime` of 60 seconds and a
+variance of 2.5%, connections would expire between 58.5s and 60s. Only meaningful when `maxLifeTime` is configured.
+Default: 0 (no variance).
 | `metrics` | Enables/disables built-in integration with Micrometer. `ConnectionProvider.MeterRegistrar` can be provided
 for integration with another metrics system. By default, metrics are not enabled.
 | `pendingAcquireMaxCount` | The maximum number of extra attempts at acquiring a connection to keep in a pending queue.

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -533,6 +533,7 @@ public interface ConnectionProvider extends Disposable {
 		Duration pendingAcquireTimeout  = Duration.ofMillis(DEFAULT_POOL_ACQUIRE_TIMEOUT);
 		@Nullable Duration maxIdleTime;
 		@Nullable Duration maxLifeTime;
+		double   maxLifeTimeVariance;
 		boolean  metricsEnabled;
 		String   leasingStrategy        = DEFAULT_POOL_LEASING_STRATEGY;
 		@Nullable Supplier<? extends ConnectionProvider.MeterRegistrar> registrar;
@@ -560,6 +561,7 @@ public interface ConnectionProvider extends Disposable {
 			this.pendingAcquireTimeout = copy.pendingAcquireTimeout;
 			this.maxIdleTime = copy.maxIdleTime;
 			this.maxLifeTime = copy.maxLifeTime;
+			this.maxLifeTimeVariance = copy.maxLifeTimeVariance;
 			this.metricsEnabled = copy.metricsEnabled;
 			this.leasingStrategy = copy.leasingStrategy;
 			this.registrar = copy.registrar;
@@ -654,6 +656,37 @@ public interface ConnectionProvider extends Disposable {
 		 */
 		public final SPEC maxLifeTime(Duration maxLifeTime) {
 			this.maxLifeTime = Objects.requireNonNull(maxLifeTime);
+			return get();
+		}
+
+		/**
+		 * Set a variance percentage for {@link #maxLifeTime(Duration)}, introducing per-connection
+		 * jitter to prevent simultaneous expiry of connections created around the same time.
+		 * <p>
+		 * The effective max lifetime for each connection will be in the range:
+		 * {@code [maxLifeTime * (1 - variance/100), maxLifeTime]}, spreading connection renewal over
+		 * a window instead of a single point in time.
+		 * <p>
+		 * For example, with a {@code maxLifeTime} of 60 seconds and a variance of 2.5%, connections
+		 * would expire between 58.5s and 60s.
+		 * <p>
+		 * Only meaningful when {@link #maxLifeTime(Duration)} is configured.
+		 * Defaults to 0 (no variance — all connections expire at exactly {@code maxLifeTime}).
+		 * <p><strong>Note:</strong> This configuration is not applicable for {@link reactor.netty.tcp.TcpClient}.
+		 * A TCP connection is always closed and never returned to the pool.
+		 *
+		 * @param variancePercent percentage of maxLifeTime to use as the variance range (0–100)
+		 * @return {@literal this}
+		 * @throws IllegalArgumentException if variancePercent is not between 0 and 100
+		 * @since 1.3.4
+		 * @see #maxLifeTime(Duration)
+		 */
+		public final SPEC maxLifeTimeVariance(double variancePercent) {
+			if (variancePercent < 0 || variancePercent > 100) {
+				throw new IllegalArgumentException(
+						"maxLifeTimeVariance must be between 0 and 100, was " + variancePercent);
+			}
+			this.maxLifeTimeVariance = variancePercent;
 			return get();
 		}
 

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -506,6 +506,8 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 		final int maxConnections;
 		final long maxIdleTime;
 		final long maxLifeTime;
+		final @Nullable Duration maxLifeTimeDuration;
+		final double maxLifeTimeVariance;
 		final boolean metricsEnabled;
 		final int pendingAcquireMaxCount;
 		final long pendingAcquireTimeout;
@@ -528,6 +530,8 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 			this.maxConnections = conf.maxConnections;
 			this.maxIdleTime = conf.maxIdleTime != null ? conf.maxIdleTime.toMillis() : -1;
 			this.maxLifeTime = conf.maxLifeTime != null ? conf.maxLifeTime.toMillis() : -1;
+			this.maxLifeTimeDuration = conf.maxLifeTime;
+			this.maxLifeTimeVariance = conf.maxLifeTimeVariance;
 			this.metricsEnabled = conf.metricsEnabled;
 			this.pendingAcquireMaxCount = conf.pendingAcquireMaxCount == PENDING_ACQUIRE_MAX_COUNT_NOT_SPECIFIED ?
 					2 * conf.maxConnections : conf.pendingAcquireMaxCount;
@@ -614,14 +618,18 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 				poolBuilder = poolBuilder.evictInBackground(evictionInterval);
 			}
 
+			if (maxLifeTimeDuration != null) {
+				poolBuilder = poolBuilder.maxLifeTime(maxLifeTimeDuration);
+				poolBuilder = poolBuilder.maxLifeTimeVariance(maxLifeTimeVariance);
+			}
+
 			if (this.evictionPredicate != null) {
 				poolBuilder = poolBuilder.evictionPredicate(
 						(poolable, meta) -> this.evictionPredicate.test(poolable, new PooledConnectionMetadata(meta)));
 			}
 			else {
 				poolBuilder = poolBuilder.evictionPredicate(defaultEvictionPredicate.or((poolable, meta) ->
-						(maxIdleTime != -1 && meta.idleTime() >= maxIdleTime)
-								|| (maxLifeTime != -1 && meta.lifeTime() >= maxLifeTime)));
+					maxIdleTime != -1 && meta.idleTime() >= maxIdleTime));
 			}
 
 			if (DEFAULT_POOL_GET_PERMITS_SAMPLING_RATE > 0d && DEFAULT_POOL_GET_PERMITS_SAMPLING_RATE <= 1d
@@ -687,6 +695,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 					", maxConnections=" + maxConnections +
 					", maxIdleTime=" + maxIdleTime +
 					", maxLifeTime=" + maxLifeTime +
+					", maxLifeTimeVariance=" + maxLifeTimeVariance +
 					", metricsEnabled=" + metricsEnabled +
 					", pendingAcquireMaxCount=" + pendingAcquireMaxCount +
 					", pendingAcquireTimeout=" + pendingAcquireTimeout +

--- a/reactor-netty-core/src/test/java/reactor/netty/resources/ConnectionProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/resources/ConnectionProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package reactor.netty.resources;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.Disposable;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -31,6 +33,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class ConnectionProviderTest {
 
@@ -88,12 +91,49 @@ class ConnectionProviderTest {
 		else if (BiPredicate.class == clazz) {
 			field.set(builder, TEST_BI_PREDICATE);
 		}
+		else if (double.class == clazz) {
+			field.setDouble(builder, 5.0);
+		}
 		else if (Scheduler.class == clazz) {
 			field.set(builder, Schedulers.parallel());
 		}
 		else {
 			throw new IllegalArgumentException("Unknown field type " + clazz);
 		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(doubles = {0, 2.5, 100})
+	void maxLifeTimeVariance(double maxLifeTimeVariance) {
+		ConnectionProvider provider =
+				ConnectionProvider.builder("maxLifeTimeVariance")
+				                  .maxLifeTime(Duration.ofSeconds(60))
+				                  .maxLifeTimeVariance(maxLifeTimeVariance)
+				                  .build();
+		try {
+			ConnectionProvider.Builder builder = provider.mutate();
+			assertThat(builder).isNotNull();
+			assertThat(builder.maxLifeTimeVariance).isEqualTo(maxLifeTimeVariance);
+		}
+		finally {
+			provider.disposeLater().block(Duration.ofSeconds(5));
+		}
+	}
+
+	@Test
+	void maxLifeTimeVarianceNegative() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> ConnectionProvider.builder("maxLifeTimeVarianceNegative")
+				                                    .maxLifeTimeVariance(-1))
+				.withMessageContaining("maxLifeTimeVariance must be between 0 and 100");
+	}
+
+	@Test
+	void maxLifeTimeVarianceAbove100() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> ConnectionProvider.builder("maxLifeTimeVarianceAbove100")
+				                                    .maxLifeTimeVariance(101))
+				.withMessageContaining("maxLifeTimeVariance must be between 0 and 100");
 	}
 
 	static final class TestAllocationStrategy implements ConnectionProvider.AllocationStrategy<TestAllocationStrategy> {

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/pool/config/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/client/pool/config/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,9 @@ public class Application {
 				                  .maxConnections(50)
 				                  .maxIdleTime(Duration.ofSeconds(20))           //<1>
 				                  .maxLifeTime(Duration.ofSeconds(60))           //<2>
-				                  .pendingAcquireTimeout(Duration.ofSeconds(60)) //<3>
-				                  .evictInBackground(Duration.ofSeconds(120))    //<4>
+				                  .maxLifeTimeVariance(2.5)                      //<3>
+				                  .pendingAcquireTimeout(Duration.ofSeconds(60)) //<4>
+				                  .evictInBackground(Duration.ofSeconds(120))    //<5>
 				                  .build();
 
 		HttpClient client = HttpClient.create(provider);

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
@@ -645,8 +645,7 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 			Http2SettingsSpec http2SettingsSpec = this.config.http2SettingsSpec();
 			if (poolFactory.evictionPredicate() == null && poolFactory.maxIdleTime() != -1 &&
 					http2SettingsSpec != null && http2SettingsSpec.pingAckTimeout() != null) {
-				Http11EvictionPredicate http11EvictionPredicate =
-						new Http11EvictionPredicate(poolFactory.maxIdleTime(), poolFactory.maxLifeTime());
+				Http11EvictionPredicate http11EvictionPredicate = new Http11EvictionPredicate(poolFactory.maxIdleTime());
 				Http2EvictionPredicate http2EvictionPredicate = new Http2EvictionPredicate(poolFactory.maxLifeTime());
 				this.parent = parent.mutate().evictionPredicate(http11EvictionPredicate).build();
 				poolConfigFunction = poolConfig -> new Http2Pool(poolConfig, poolFactory.allocationStrategy(),
@@ -678,11 +677,9 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 
 		static final class Http11EvictionPredicate implements BiPredicate<Connection, ConnectionMetadata> {
 			final long maxIdleTime;
-			final long maxLifeTime;
 
-			Http11EvictionPredicate(long maxIdleTime, long maxLifeTime) {
+			Http11EvictionPredicate(long maxIdleTime) {
 				this.maxIdleTime = maxIdleTime;
-				this.maxLifeTime = maxLifeTime;
 			}
 
 			@Override
@@ -694,8 +691,7 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 					ChannelHandlerContext frameCodec = http2PooledRef.slot.http2FrameCodecCtx();
 					isNotHttp2 = frameCodec == null;
 				}
-				return (isNotHttp2 && maxIdleTime != -1 && meta.idleTime() >= maxIdleTime)
-						|| (maxLifeTime != -1 && meta.lifeTime() >= maxLifeTime);
+				return isNotHttp2 && maxIdleTime != -1 && meta.idleTime() >= maxIdleTime;
 			}
 		}
 
@@ -708,7 +704,8 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 
 			@Override
 			public boolean test(Connection connection, PooledRefMetadata meta) {
-				return maxLifeTime != -1 && meta.lifeTime() >= maxLifeTime;
+				long effectiveMaxLifeTime = meta.maxLifeTimeMs() > 0 ? meta.maxLifeTimeMs() : maxLifeTime;
+				return effectiveMaxLifeTime > 0 && meta.lifeTime() >= effectiveMaxLifeTime;
 			}
 		}
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -308,7 +308,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 	}
 
 	Slot createSlot(Connection connection) {
-		return new Slot(this, connection);
+		return new Slot(this, connection, poolConfig.generateMaxLifeTimeMs());
 	}
 
 	Mono<Void> destroyPoolable(Http2PooledRef ref) {
@@ -1009,6 +1009,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		final long creationTimestamp;
 		final Http2Pool pool;
 		final @Nullable String applicationProtocol;
+		final long maxLifeTimeMs;
 
 		long idleTimestamp;
 		volatile long maxConcurrentStreams;
@@ -1017,10 +1018,11 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		volatile @Nullable ChannelHandlerContext http2MultiplexHandlerCtx;
 		volatile @Nullable ChannelHandlerContext h2cUpgradeHandlerCtx;
 
-		Slot(Http2Pool pool, Connection connection) {
+		Slot(Http2Pool pool, Connection connection, long maxLifeTimeMs) {
 			this.connection = connection;
 			this.creationTimestamp = pool.clock.millis();
 			this.pool = pool;
+			this.maxLifeTimeMs = maxLifeTimeMs;
 			SslHandler handler = connection.channel().pipeline().get(SslHandler.class);
 			if (handler != null) {
 				this.applicationProtocol = handler.applicationProtocol() != null ?
@@ -1177,6 +1179,11 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		@Override
 		public long allocationTimestamp() {
 			return creationTimestamp;
+		}
+
+		@Override
+		public long maxLifeTimeMs() {
+			return maxLifeTimeMs;
 		}
 
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http3Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http3Pool.java
@@ -45,7 +45,7 @@ final class Http3Pool extends Http2Pool {
 
 	@Override
 	Slot createSlot(Connection connection) {
-		return new Slot(this, connection);
+		return new Slot(this, connection, poolConfig.generateMaxLifeTimeMs());
 	}
 
 	@Override
@@ -74,8 +74,8 @@ final class Http3Pool extends Http2Pool {
 	static final class Slot extends Http2Pool.Slot {
 		volatile @Nullable ChannelHandlerContext http3ClientConnectionHandlerCtx;
 
-		Slot(Http2Pool pool, Connection connection) {
-			super(pool, connection);
+		Slot(Http2Pool pool, Connection connection, long maxLifeTimeMs) {
+			super(pool, connection, maxLifeTimeMs);
 		}
 
 		@Override

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
@@ -24,6 +24,8 @@ import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
@@ -1108,6 +1110,146 @@ class Http2PoolTest {
 			if (connection2 != null) {
 				((EmbeddedChannel) connection2.channel()).finishAndReleaseAll();
 				connection2.dispose();
+			}
+		}
+	}
+
+	@Test
+	void maxLifeTimeWithVariance() {
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> {
+				               Channel channel = new EmbeddedChannel(
+				                   new TestChannelId(),
+				                   Http2FrameCodecBuilder.forClient().build());
+				               return Connection.from(channel);
+				           }))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1)
+				           .maxLifeTime(Duration.ofMillis(100))
+				           .maxLifeTimeVariance(10);
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, null));
+
+		Connection connection1 = null;
+		try {
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
+			assertThat(acquired1).isNotNull();
+			assertThat(http2Pool.activeStreams()).isEqualTo(1);
+			connection1 = acquired1.poolable();
+
+			ConcurrentLinkedQueue<Http2Pool.Slot> connections = http2Pool.connections;
+			assertThat(connections).isNotNull();
+			assertThat(connections.size()).isEqualTo(1);
+			Http2Pool.Slot slot = connections.peek();
+			assertThat(slot).isNotNull();
+			assertThat(slot.maxLifeTimeMs).isBetween(90L, 100L);
+
+			acquired1.invalidate().block(Duration.ofSeconds(1));
+		}
+		finally {
+			if (connection1 != null) {
+				((EmbeddedChannel) connection1.channel()).finishAndReleaseAll();
+				connection1.dispose();
+			}
+		}
+	}
+
+	@Test
+	void maxLifeTimeWithVarianceEviction() throws Exception {
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> {
+				               Channel channel = new EmbeddedChannel(
+				                   new TestChannelId(),
+				                   Http2FrameCodecBuilder.forClient().build());
+				               return Connection.from(channel);
+				           }))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1)
+				           .maxLifeTime(Duration.ofMillis(50))
+				           .maxLifeTimeVariance(10);
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, null));
+
+		Connection connection1 = null;
+		Connection connection2 = null;
+		try {
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
+			assertThat(acquired1).isNotNull();
+			assertThat(http2Pool.activeStreams()).isEqualTo(1);
+			connection1 = acquired1.poolable();
+
+			ConcurrentLinkedQueue<Http2Pool.Slot> connections = http2Pool.connections;
+			assertThat(connections).isNotNull();
+			assertThat(connections.size()).isEqualTo(1);
+
+			Thread.sleep(60);
+
+			acquired1.invalidate().block(Duration.ofSeconds(1));
+
+			assertThat(http2Pool.activeStreams()).isEqualTo(0);
+			assertThat(connections.size()).isEqualTo(0);
+
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block(Duration.ofSeconds(1));
+			assertThat(acquired2).isNotNull();
+			assertThat(http2Pool.activeStreams()).isEqualTo(1);
+			connection2 = acquired2.poolable();
+
+			assertThat(connection1.channel().id()).isNotEqualTo(connection2.channel().id());
+
+			assertThat(connections.size()).isEqualTo(1);
+
+			acquired2.invalidate().block(Duration.ofSeconds(1));
+		}
+		finally {
+			if (connection1 != null) {
+				((EmbeddedChannel) connection1.channel()).finishAndReleaseAll();
+				connection1.dispose();
+			}
+			if (connection2 != null) {
+				((EmbeddedChannel) connection2.channel()).finishAndReleaseAll();
+				connection2.dispose();
+			}
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = {0, 60_000})
+	void slotMaxLifeTimeMsWithoutVariance(long maxLifeTimeMs) {
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> {
+				               Channel channel = new EmbeddedChannel(
+				                   new TestChannelId(),
+				                   Http2FrameCodecBuilder.forClient().build());
+				               return Connection.from(channel);
+				           }))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1);
+		if (maxLifeTimeMs > 0) {
+			poolBuilder = poolBuilder.maxLifeTime(Duration.ofMillis(maxLifeTimeMs));
+		}
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, null));
+
+		Connection connection = null;
+		try {
+			PooledRef<Connection> acquired = http2Pool.acquire().block(Duration.ofSeconds(1));
+			assertThat(acquired).isNotNull();
+			assertThat(http2Pool.activeStreams()).isEqualTo(1);
+			connection = acquired.poolable();
+
+			ConcurrentLinkedQueue<Http2Pool.Slot> connections = http2Pool.connections;
+			assertThat(connections).isNotNull();
+			assertThat(connections.size()).isEqualTo(1);
+			Http2Pool.Slot slot = connections.peek();
+			assertThat(slot).isNotNull();
+			assertThat(slot.maxLifeTimeMs).isEqualTo(maxLifeTimeMs);
+
+			acquired.invalidate().block(Duration.ofSeconds(1));
+		}
+		finally {
+			if (connection != null) {
+				((EmbeddedChannel) connection.channel()).finishAndReleaseAll();
+				connection.dispose();
 			}
 		}
 	}


### PR DESCRIPTION
This PR ports the feature from Reactor Pool and
makes it available for `Http2Pool` and `Http3Pool`
https://github.com/reactor/reactor-pool/pull/344