### PR TITLE
Add  `Http2AllocationStrategy#streamBatchSize` for batched stream dispatching

### DIFF
--- a/docs/modules/ROOT/partials/http-client-conn-provider.adoc
+++ b/docs/modules/ROOT/partials/http-client-conn-provider.adoc
@@ -113,6 +113,12 @@ Default: `-1` (use the remote peer configuration).
 connections have not reached their max concurrent streams limit. When enabled, the pool will maximize
 `HTTP/2` multiplexing. This is automatically enabled when `minConnections` is greater than zero.
 Default: `false`.
+| `streamBatchSize` | The maximum number of streams that can be opened at once when a suitable connection
+is found in the pool. Instead of opening only one stream and then re-evaluating the available connections,
+the pool will attempt to open up to `streamBatchSize` streams on that connection, limited by the connection's
+available capacity. This setting only takes effect when strict connection reuse is active
+(either by enabling `strictConnectionReuse(true)` or by setting `minConnections` to a value greater than zero).
+Default: `1` (open one stream at a time).
 |=======
 
 The following example shows how to configure the `HTTP/2` connection pool:

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2AllocationStrategy.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2AllocationStrategy.java
@@ -89,6 +89,28 @@ public final class Http2AllocationStrategy implements ConnectionProvider.Allocat
 		default Builder strictConnectionReuse(boolean strictConnectionReuse) {
 			return this;
 		}
+
+		/**
+		 * Configures the maximum number of streams that can be opened at once when a suitable connection
+		 * is found in the pool. When the pool finds a connection that can be used for opening a stream,
+		 * instead of opening only one stream and then re-evaluating the available connections,
+		 * the pool will attempt to open up to {@code streamBatchSize} streams on that connection
+		 * (limited by the connection's available capacity, i.e. max concurrent streams minus current active streams).
+		 * <p>
+		 * This setting takes effect when strict connection reuse is active, either by enabling
+		 * {@code strictConnectionReuse(true)} or by setting {@code minConnections} to a value greater than zero.
+		 * <p>
+		 * Default to {@code 1} - open one stream at a time.
+		 *
+		 * @param streamBatchSize the maximum number of streams to open at once per connection
+		 * @return {@code this}
+		 * @since 1.3.4
+		 * @see #strictConnectionReuse(boolean)
+		 * @see #minConnections(int)
+		 */
+		default Builder streamBatchSize(int streamBatchSize) {
+			return this;
+		}
 	}
 
 	/**
@@ -136,6 +158,16 @@ public final class Http2AllocationStrategy implements ConnectionProvider.Allocat
 	}
 
 	/**
+	 * Returns the configured stream batch size.
+	 *
+	 * @return the configured stream batch size
+	 * @since 1.3.4
+	 */
+	public int streamBatchSize() {
+		return streamBatchSize;
+	}
+
+	/**
 	 * Returns whether strict HTTP/2 connection reuse (multiplexing) is enabled.
 	 *
 	 * @return whether strict connection reuse is enabled
@@ -177,6 +209,7 @@ public final class Http2AllocationStrategy implements ConnectionProvider.Allocat
 	final long maxConcurrentStreams;
 	final int maxConnections;
 	final int minConnections;
+	final int streamBatchSize;
 	final boolean strictConnectionReuse;
 
 	volatile int permits;
@@ -186,6 +219,7 @@ public final class Http2AllocationStrategy implements ConnectionProvider.Allocat
 		this.maxConcurrentStreams = build.maxConcurrentStreams;
 		this.maxConnections = build.maxConnections;
 		this.minConnections = build.minConnections;
+		this.streamBatchSize = build.streamBatchSize;
 		this.strictConnectionReuse = build.strictConnectionReuse;
 		PERMITS.lazySet(this, this.maxConnections);
 	}
@@ -194,6 +228,7 @@ public final class Http2AllocationStrategy implements ConnectionProvider.Allocat
 		this.maxConcurrentStreams = copy.maxConcurrentStreams;
 		this.maxConnections = copy.maxConnections;
 		this.minConnections = copy.minConnections;
+		this.streamBatchSize = copy.streamBatchSize;
 		this.strictConnectionReuse = copy.strictConnectionReuse;
 		PERMITS.lazySet(this, this.maxConnections);
 	}
@@ -202,11 +237,13 @@ public final class Http2AllocationStrategy implements ConnectionProvider.Allocat
 		static final long DEFAULT_MAX_CONCURRENT_STREAMS = -1;
 		static final int DEFAULT_MAX_CONNECTIONS = Integer.MAX_VALUE;
 		static final int DEFAULT_MIN_CONNECTIONS = 0;
+		static final int DEFAULT_STREAM_BATCH_SIZE = 1;
 		static final boolean DEFAULT_STRICT_CONNECTION_REUSE = false;
 
 		long maxConcurrentStreams = DEFAULT_MAX_CONCURRENT_STREAMS;
 		int maxConnections = DEFAULT_MAX_CONNECTIONS;
 		int minConnections = DEFAULT_MIN_CONNECTIONS;
+		int streamBatchSize = DEFAULT_STREAM_BATCH_SIZE;
 		boolean strictConnectionReuse = DEFAULT_STRICT_CONNECTION_REUSE;
 
 		@Override
@@ -242,6 +279,15 @@ public final class Http2AllocationStrategy implements ConnectionProvider.Allocat
 				throw new IllegalArgumentException("minConnections must be positive or zero");
 			}
 			this.minConnections = minConnections;
+			return this;
+		}
+
+		@Override
+		public Builder streamBatchSize(int streamBatchSize) {
+			if (streamBatchSize < 1) {
+				throw new IllegalArgumentException("streamBatchSize must be strictly positive");
+			}
+			this.streamBatchSize = streamBatchSize;
 			return this;
 		}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.Http2FrameCodec;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.ssl.ApplicationProtocolNames;
@@ -155,12 +156,13 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 			AtomicIntegerFieldUpdater.newUpdater(Http2Pool.class, "wip");
 
 	final Clock clock;
-	final Long maxConcurrentStreams;
+	final int maxConcurrentStreams;
 	final boolean strictConnectionReuse;
 	final int minConnections;
 	final PoolConfig<Connection> poolConfig;
 	final @Nullable BiPredicate<Connection, PooledRefMetadata> evictionPredicate;
 	final long maxIdleTime;
+	final int streamBatchSize;
 
 	long lastInteractionTimestamp;
 
@@ -176,7 +178,9 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		this.connections = new ConcurrentLinkedQueue<>();
 		this.lastInteractionTimestamp = clock.millis();
 		this.maxConcurrentStreams = allocationStrategy instanceof Http2AllocationStrategy ?
-				((Http2AllocationStrategy) allocationStrategy).maxConcurrentStreams() : -1;
+				(int) Math.min(((Http2AllocationStrategy) allocationStrategy).maxConcurrentStreams(), Integer.MAX_VALUE) : -1;
+		this.streamBatchSize = allocationStrategy instanceof Http2AllocationStrategy ?
+				((Http2AllocationStrategy) allocationStrategy).streamBatchSize() : 1;
 		this.strictConnectionReuse = allocationStrategy instanceof Http2AllocationStrategy &&
 				((Http2AllocationStrategy) allocationStrategy).strictConnectionReuse();
 		this.minConnections = allocationStrategy == null ? 0 : allocationStrategy.permitMinimum();
@@ -398,28 +402,40 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 				int resourcesCount = idleSize;
 				Slot slot = belowMinConnections ? null : findConnection(resources, resourcesCount);
 				if (slot != null) {
-					Borrower borrower = pollPending(borrowers, true);
-					if (borrower == null || borrower.get()) {
+					int available = slot.availableStreams();
+					int batchSize = enableStrictReuse ? Math.min(streamBatchSize, available) : 1;
+					EventLoop eventLoop = slot.connection.channel().eventLoop();
+					int dispatched = 0;
+
+					while (dispatched < batchSize) {
+						Borrower borrower = pollPending(borrowers, true);
+						if (borrower == null) {
+							break;
+						}
+						if (borrower.get()) {
+							continue;
+						}
+						if (isDisposed()) {
+							borrower.fail(new PoolShutdownException());
+							return;
+						}
+						dispatched++;
+						eventLoop.execute(() -> borrower.deliver(new Http2PooledRef(slot), enableStrictReuse));
+					}
+
+					if (dispatched == 0) {
 						offerSlot(resources, slot);
 						continue;
 					}
-					if (isDisposed()) {
-						borrower.fail(new PoolShutdownException());
-						return;
-					}
 					if (log.isDebugEnabled()) {
-						log.debug(format(slot.connection.channel(), "Channel activated"));
+						log.debug(format(slot.connection.channel(), "Channel activated, batch size: {}"), dispatched);
 					}
-					ACQUIRED.incrementAndGet(this);
+					ACQUIRED.addAndGet(this, dispatched);
 					if (enableStrictReuse) {
-						// Reserve concurrency and re-offer the slot before async deliver so concurrent acquires can reuse the connection
-						slot.incrementConcurrencyAndGet();
+						slot.addConcurrencyAndGet(dispatched);
 						slot.deactivate();
 					}
-					slot.connection.channel().eventLoop().execute(() -> {
-						borrower.deliver(new Http2PooledRef(slot), enableStrictReuse);
-						drain();
-					});
+					eventLoop.execute(this::drain);
 				}
 				else {
 					if (enableStrictReuse && !belowMinConnections &&
@@ -1012,7 +1028,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		final long maxLifeTimeMs;
 
 		long idleTimestamp;
-		volatile long maxConcurrentStreams;
+		volatile int maxConcurrentStreams;
 
 		volatile @Nullable ChannelHandlerContext http2FrameCodecCtx;
 		volatile @Nullable ChannelHandlerContext http2MultiplexHandlerCtx;
@@ -1035,45 +1051,56 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		}
 
 		void initMaxConcurrentStreams() {
-			long newMaxConcurrentStreams = computeMaxConcurrentStreams();
+			int newMaxConcurrentStreams = computeMaxConcurrentStreams();
 			this.maxConcurrentStreams = newMaxConcurrentStreams;
 			TOTAL_MAX_CONCURRENT_STREAMS.addAndGet(this.pool, newMaxConcurrentStreams);
 		}
 
 		void updateMaxConcurrentStreams(long remoteMaxConcurrentStreams) {
-			long maxActiveStreams = Math.min(remoteMaxConcurrentStreams, Integer.MAX_VALUE);
-			long newMaxConcurrentStreams = pool.maxConcurrentStreams == -1 ?
+			int maxActiveStreams = (int) Math.min(remoteMaxConcurrentStreams, Integer.MAX_VALUE);
+			int newMaxConcurrentStreams = pool.maxConcurrentStreams == -1 ?
 					maxActiveStreams : Math.min(pool.maxConcurrentStreams, maxActiveStreams);
-			long diff = newMaxConcurrentStreams - maxConcurrentStreams;
+			int diff = newMaxConcurrentStreams - maxConcurrentStreams;
 			if (diff != 0) {
 				maxConcurrentStreams = newMaxConcurrentStreams;
 				TOTAL_MAX_CONCURRENT_STREAMS.addAndGet(this.pool, diff);
 			}
 		}
 
-		private long computeMaxConcurrentStreams() {
+		private int computeMaxConcurrentStreams() {
 			assert connection.channel().eventLoop().inEventLoop();
 			ChannelHandlerContext frameCodec = http2FrameCodecCtx();
 			if (frameCodec != null && http2MultiplexHandlerCtx() != null) {
-				long maxActiveStreams = ((Http2FrameCodec) frameCodec.handler()).connection().local().maxActiveStreams();
+				int maxActiveStreams = ((Http2FrameCodec) frameCodec.handler()).connection().local().maxActiveStreams();
 				return pool.maxConcurrentStreams == -1 ? maxActiveStreams :
 						Math.min(pool.maxConcurrentStreams, maxActiveStreams);
 			}
 			return 0;
 		}
 
+		int availableStreams() {
+			return availableStreams(this.concurrency);
+		}
+
+		int availableStreams(int concurrency) {
+			int max = this.maxConcurrentStreams;
+			// For non-HTTP/2 connections (max == 0), allow opening a stream if concurrency is 0
+			if (max == 0) {
+				return concurrency == 0 ? 1 : 0;
+			}
+			// For HTTP/2 connections, return the number of remaining available streams.
+			// Concurrency can be negative when a stream completes between the reservation
+			// in drainLoop and the delivery check. In that case max - concurrency > max,
+			// which is correct since there is clearly capacity available.
+			return Math.max(0, max - concurrency);
+		}
+
 		boolean canOpenStream() {
-			return canOpenStream(this.concurrency);
+			return availableStreams() > 0;
 		}
 
 		boolean canOpenStream(int concurrency) {
-			if (concurrency < 0) {
-				return false;
-			}
-			long max = this.maxConcurrentStreams;
-			// For non-HTTP/2 connections (max == 0), allow opening a stream if concurrency is 0
-			// For HTTP/2 connections, check that we haven't reached max concurrent streams
-			return max == 0 ? concurrency == 0 : concurrency < max;
+			return availableStreams(concurrency) > 0;
 		}
 
 		int concurrency() {
@@ -1135,6 +1162,10 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 
 		void incrementConcurrencyAndGet() {
 			CONCURRENCY.incrementAndGet(this);
+		}
+
+		void addConcurrencyAndGet(int delta) {
+			CONCURRENCY.addAndGet(this, delta);
 		}
 
 		void invalidate() {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
@@ -1147,9 +1147,9 @@ class Http2Tests extends BaseHttpTest {
 
 			assertThat(results).isNotNull().hasSize(2);
 
-			long successCount = results.stream().filter(Signal::isOnNext).count();
+			long successCount = results.stream().filter(s -> s.isOnNext()).count();
 			long errorCount = results.stream()
-			        .filter(Signal::isOnError)
+			        .filter(s -> s.isOnError())
 			        .filter(s -> s.getThrowable() instanceof PoolAcquireTimeoutException)
 			        .count();
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2AllocationStrategyTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2AllocationStrategyTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static reactor.netty.http.client.Http2AllocationStrategy.Build.DEFAULT_MAX_CONCURRENT_STREAMS;
 import static reactor.netty.http.client.Http2AllocationStrategy.Build.DEFAULT_MAX_CONNECTIONS;
 import static reactor.netty.http.client.Http2AllocationStrategy.Build.DEFAULT_MIN_CONNECTIONS;
+import static reactor.netty.http.client.Http2AllocationStrategy.Build.DEFAULT_STREAM_BATCH_SIZE;
 import static reactor.netty.http.client.Http2AllocationStrategy.Build.DEFAULT_STRICT_CONNECTION_REUSE;
 
 class Http2AllocationStrategyTest {
@@ -35,11 +36,16 @@ class Http2AllocationStrategyTest {
 
 	@Test
 	void build() {
-		builder.maxConcurrentStreams(2).maxConnections(2).minConnections(1).strictConnectionReuse(true);
+		builder.maxConcurrentStreams(2)
+				.maxConnections(2)
+				.minConnections(1)
+				.streamBatchSize(5)
+				.strictConnectionReuse(true);
 		Http2AllocationStrategy strategy = builder.build();
 		assertThat(strategy.maxConcurrentStreams()).isEqualTo(2);
 		assertThat(strategy.permitMaximum()).isEqualTo(2);
 		assertThat(strategy.permitMinimum()).isEqualTo(1);
+		assertThat(strategy.streamBatchSize()).isEqualTo(5);
 		assertThat(strategy.strictConnectionReuse()).isTrue();
 	}
 
@@ -52,12 +58,17 @@ class Http2AllocationStrategyTest {
 
 	@Test
 	void copy() {
-		builder.maxConcurrentStreams(2).maxConnections(2).minConnections(1).strictConnectionReuse(true);
+		builder.maxConcurrentStreams(2)
+				.maxConnections(2)
+				.minConnections(1)
+				.streamBatchSize(5)
+				.strictConnectionReuse(true);
 		Http2AllocationStrategy strategy = builder.build();
 		Http2AllocationStrategy copy = strategy.copy();
 		assertThat(copy.maxConcurrentStreams()).isEqualTo(strategy.maxConcurrentStreams());
 		assertThat(copy.permitMaximum()).isEqualTo(strategy.permitMaximum());
 		assertThat(copy.permitMinimum()).isEqualTo(strategy.permitMinimum());
+		assertThat(copy.streamBatchSize()).isEqualTo(strategy.streamBatchSize());
 		assertThat(copy.strictConnectionReuse()).isEqualTo(strategy.strictConnectionReuse());
 	}
 
@@ -68,6 +79,7 @@ class Http2AllocationStrategyTest {
 		assertThat(strategy.maxConcurrentStreams()).isEqualTo(DEFAULT_MAX_CONCURRENT_STREAMS);
 		assertThat(strategy.permitMaximum()).isEqualTo(DEFAULT_MAX_CONNECTIONS);
 		assertThat(strategy.permitMinimum()).isEqualTo(DEFAULT_MIN_CONNECTIONS);
+		assertThat(strategy.streamBatchSize()).isEqualTo(DEFAULT_STREAM_BATCH_SIZE);
 		assertThat(strategy.strictConnectionReuse()).isTrue();
 	}
 
@@ -78,6 +90,7 @@ class Http2AllocationStrategyTest {
 		assertThat(strategy.maxConcurrentStreams()).isEqualTo(2);
 		assertThat(strategy.permitMaximum()).isEqualTo(DEFAULT_MAX_CONNECTIONS);
 		assertThat(strategy.permitMinimum()).isEqualTo(DEFAULT_MIN_CONNECTIONS);
+		assertThat(strategy.streamBatchSize()).isEqualTo(DEFAULT_STREAM_BATCH_SIZE);
 		assertThat(strategy.strictConnectionReuse()).isEqualTo(DEFAULT_STRICT_CONNECTION_REUSE);
 	}
 
@@ -95,6 +108,7 @@ class Http2AllocationStrategyTest {
 		assertThat(strategy.maxConcurrentStreams()).isEqualTo(DEFAULT_MAX_CONCURRENT_STREAMS);
 		assertThat(strategy.permitMaximum()).isEqualTo(2);
 		assertThat(strategy.permitMinimum()).isEqualTo(DEFAULT_MIN_CONNECTIONS);
+		assertThat(strategy.streamBatchSize()).isEqualTo(DEFAULT_STREAM_BATCH_SIZE);
 		assertThat(strategy.strictConnectionReuse()).isEqualTo(DEFAULT_STRICT_CONNECTION_REUSE);
 	}
 
@@ -112,6 +126,7 @@ class Http2AllocationStrategyTest {
 		assertThat(strategy.maxConcurrentStreams()).isEqualTo(DEFAULT_MAX_CONCURRENT_STREAMS);
 		assertThat(strategy.permitMaximum()).isEqualTo(DEFAULT_MAX_CONNECTIONS);
 		assertThat(strategy.permitMinimum()).isEqualTo(2);
+		assertThat(strategy.streamBatchSize()).isEqualTo(DEFAULT_STREAM_BATCH_SIZE);
 		assertThat(strategy.strictConnectionReuse()).isEqualTo(DEFAULT_STRICT_CONNECTION_REUSE);
 	}
 
@@ -120,5 +135,26 @@ class Http2AllocationStrategyTest {
 		assertThatExceptionOfType(IllegalArgumentException.class)
 				.isThrownBy(() -> builder.minConnections(-1))
 				.withMessage("minConnections must be positive or zero");
+	}
+
+	@Test
+	void streamBatchSize() {
+		builder.streamBatchSize(10);
+		Http2AllocationStrategy strategy = builder.build();
+		assertThat(strategy.maxConcurrentStreams()).isEqualTo(DEFAULT_MAX_CONCURRENT_STREAMS);
+		assertThat(strategy.permitMaximum()).isEqualTo(DEFAULT_MAX_CONNECTIONS);
+		assertThat(strategy.permitMinimum()).isEqualTo(DEFAULT_MIN_CONNECTIONS);
+		assertThat(strategy.streamBatchSize()).isEqualTo(10);
+		assertThat(strategy.strictConnectionReuse()).isEqualTo(DEFAULT_STRICT_CONNECTION_REUSE);
+	}
+
+	@Test
+	void streamBatchSizeBadValues() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> builder.streamBatchSize(0))
+				.withMessage("streamBatchSize must be strictly positive");
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> builder.streamBatchSize(-1))
+				.withMessage("streamBatchSize must be strictly positive");
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
@@ -132,6 +132,26 @@ class Http2PoolTest {
 
 	@Test
 	void acquiredCountCorrectWhenDeliverRejectedStrictReuse() {
+		acquiredCountCorrectWhenDeliverRejected(
+				Http2AllocationStrategy.builder()
+				                       .maxConnections(1)
+				                       .maxConcurrentStreams(2)
+				                       .strictConnectionReuse(true)
+				                       .build(), 2);
+	}
+
+	@Test
+	void acquiredCountCorrectWhenDeliverRejectedStreamBatchSize() {
+		acquiredCountCorrectWhenDeliverRejected(
+				Http2AllocationStrategy.builder()
+				                       .maxConnections(1)
+				                       .maxConcurrentStreams(3)
+				                       .strictConnectionReuse(true)
+				                       .streamBatchSize(3)
+				                       .build(), 3);
+	}
+
+	private static void acquiredCountCorrectWhenDeliverRejected(Http2AllocationStrategy strategy, int concurrentAcquires) {
 		EmbeddedChannel channel = new EmbeddedChannel(new TestChannelId(),
 				Http2FrameCodecBuilder.forClient().build(),
 				new Http2MultiplexHandler(new ChannelHandlerAdapter() {}));
@@ -140,11 +160,6 @@ class Http2PoolTest {
 				           .idleResourceReuseLruOrder()
 				           .maxPendingAcquireUnbounded()
 				           .sizeBetween(0, 1);
-		Http2AllocationStrategy strategy = Http2AllocationStrategy.builder()
-				.maxConnections(1)
-				.maxConcurrentStreams(2)
-				.strictConnectionReuse(true)
-				.build();
 		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, strategy));
 
 		try {
@@ -158,47 +173,44 @@ class Http2PoolTest {
 			warm.release().block(Duration.ofSeconds(1));
 			assertThat(slot.concurrency()).as("concurrency after release").isEqualTo(0);
 
-			// Submit two concurrent acquires. With strict reuse and maxConcurrentStreams=2,
-			// drainLoop() will pre-reserve concurrency for both and increment ACQUIRED by 2.
-			// Both deliver() tasks are queued on the event loop.
+			// Submit "concurrentAcquires" concurrent acquires.
+			// drainLoop() will pre-reserve concurrency for all of them and increment ACQUIRED by "concurrentAcquires".
+			// All deliver() tasks are queued on the event loop.
 			List<PooledRef<Connection>> acquired = new ArrayList<>();
-			http2Pool.acquire().subscribe(acquired::add);
-			http2Pool.acquire().subscribe(acquired::add);
+			for (int i = 0; i < concurrentAcquires; i++) {
+				http2Pool.acquire().subscribe(acquired::add);
+			}
 
 			assertThat(acquired).as("deliver() tasks should not have run yet").isEmpty();
-			assertThat(http2Pool.activeStreams()).as("ACQUIRED pre-reserved for 2 borrowers").isEqualTo(2);
-			// Concurrency was pre-reserved for both borrowers
-			assertThat(slot.concurrency()).as("concurrency pre-reserved for 2 borrowers").isEqualTo(2);
+			assertThat(http2Pool.activeStreams()).as("ACQUIRED pre-reserved for concurrentAcquires borrowers").isEqualTo(concurrentAcquires);
+			assertThat(slot.concurrency()).as("concurrency pre-reserved for concurrentAcquires borrowers").isEqualTo(concurrentAcquires);
 
 			// Simulate the remote peer lowering max concurrent streams to 1 (via SETTINGS frame)
 			// BEFORE the deliver() tasks run on the event loop.
-			Http2FrameCodec frameCodec = channel.pipeline().get(Http2FrameCodec.class);
-			frameCodec.connection().local().maxActiveStreams(1);
 			slot.updateMaxConcurrentStreams(1);
 
-			// Run pending tasks - first deliver() is rejected, second deliver() succeeds
 			channel.runPendingTasks();
 
 			// Only one borrower should have been served
 			assertThat(acquired).as("only one borrower should be served").hasSize(1);
 			// ACQUIRED must be 1 - the rejected deliver() must have rolled back its pre-reserved increment
-			assertThat(http2Pool.activeStreams()).as("activeStreams: 1 served, 1 rolled back").isEqualTo(1);
+			assertThat(http2Pool.activeStreams()).as("activeStreams: 1 served, the others are rolled back").isEqualTo(1);
 			// Concurrency must be 1 - the rejected deliver() must have rolled back its pre-reserved concurrency
-			assertThat(slot.concurrency()).as("concurrency: 1 served, 1 rolled back").isEqualTo(1);
+			assertThat(slot.concurrency()).as("concurrency: 1 served, the others are rolled back").isEqualTo(1);
 
 			// Release the successfully acquired stream to bring concurrency down to 0
-			acquired.get(0).invalidate().block(Duration.ofSeconds(1));
+			acquired.forEach(a -> a.invalidate().block(Duration.ofSeconds(1)));
 
 			channel.runPendingTasks();
 
 			// The rejected borrower was re-added to pending and drain() was triggered.
 			// deliver() runs and serves the borrower.
-			assertThat(acquired).as("both borrowers should now be served").hasSize(2);
+			assertThat(acquired).as("2 borrowers should now be served").hasSize(2);
 			assertThat(http2Pool.activeStreams()).as("activeStreams after second served").isEqualTo(1);
 
-			acquired.get(1).invalidate().block(Duration.ofSeconds(1));
+			acquired.forEach(a -> a.invalidate().block(Duration.ofSeconds(1)));
 
-			assertThat(http2Pool.activeStreams()).as("activeStreams after invalidation").isEqualTo(0);
+			assertThat(http2Pool.activeStreams()).as("activeStreams after invalidation").isEqualTo(concurrentAcquires - 2);
 		}
 		finally {
 			channel.finishAndReleaseAll();
@@ -1708,6 +1720,195 @@ class Http2PoolTest {
 		finally {
 			channel.finishAndReleaseAll();
 			Connection.from(channel).dispose();
+		}
+	}
+
+	@Test
+	void streamBatchSizeDefault() {
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> {
+				               EmbeddedChannel ch = new EmbeddedChannel(
+				                   new TestChannelId(),
+				                   Http2FrameCodecBuilder.forClient().build(),
+				                   new Http2MultiplexHandler(new ChannelHandlerAdapter() {}));
+				               return Connection.from(ch);
+				           }))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(2, 2);
+		Http2AllocationStrategy strategy = Http2AllocationStrategy.builder()
+				.maxConnections(2)
+				.minConnections(2)
+				.build();
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, strategy));
+
+		List<PooledRef<Connection>> warmup = new ArrayList<>();
+		try {
+			Flux.range(1, 2)
+			    .flatMap(i -> http2Pool.acquire().doOnNext(warmup::add))
+			    .blockLast(Duration.ofSeconds(1));
+
+			assertThat(warmup).hasSize(2);
+			assertThat(warmup.get(0).poolable()).isNotSameAs(warmup.get(1).poolable());
+			warmup.get(0).release().block(Duration.ofSeconds(1));
+			warmup.get(1).release().block(Duration.ofSeconds(1));
+
+			List<PooledRef<Connection>> acquired = new ArrayList<>();
+			for (int i = 0; i < 4; i++) {
+				http2Pool.acquire()
+				         .doOnSubscribe(s -> warmup.forEach(ref -> ((EmbeddedChannel) ref.poolable().channel()).runPendingTasks()))
+				         .subscribe(acquired::add);
+			}
+			warmup.forEach(ref -> ((EmbeddedChannel) ref.poolable().channel()).runPendingTasks());
+
+			assertThat(acquired).hasSize(4);
+			assertThat(http2Pool.activeStreams()).isEqualTo(4);
+			Connection conn0 = acquired.get(0).poolable();
+			Connection conn1 = acquired.get(1).poolable();
+			assertThat(conn0).as("streams 0 and 1 should be on different connections").isNotSameAs(conn1);
+			assertThat(acquired.get(2).poolable()).as("stream 2 same as stream 0").isSameAs(conn0);
+			assertThat(acquired.get(3).poolable()).as("stream 3 same as stream 1").isSameAs(conn1);
+
+			for (PooledRef<Connection> ref : acquired) {
+				ref.invalidate().block(Duration.ofSeconds(1));
+			}
+
+			assertThat(http2Pool.activeStreams()).isEqualTo(0);
+		}
+		finally {
+			for (PooledRef<Connection> ref : warmup) {
+				EmbeddedChannel ch = (EmbeddedChannel) ref.poolable().channel();
+				ch.finishAndReleaseAll();
+				Connection.from(ch).dispose();
+			}
+		}
+	}
+
+	@Test
+	void streamBatchSizeLimitedByMaxConcurrentStreams() {
+		streamBatchSize(
+				Http2AllocationStrategy.builder()
+				                       .maxConnections(2)
+				                       .minConnections(2)
+				                       .maxConcurrentStreams(2)
+				                       .streamBatchSize(3)
+				                       .build());
+	}
+
+	@Test
+	void streamBatchSizeOpenMultipleStreamsOnSameConnection() {
+		streamBatchSize(
+				Http2AllocationStrategy.builder()
+				                       .maxConnections(2)
+				                       .minConnections(2)
+				                       .streamBatchSize(2)
+				                       .build());
+	}
+
+	private static void streamBatchSize(Http2AllocationStrategy strategy) {
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> {
+				               EmbeddedChannel ch = new EmbeddedChannel(
+				                   new TestChannelId(),
+				                   Http2FrameCodecBuilder.forClient().build(),
+				                   new Http2MultiplexHandler(new ChannelHandlerAdapter() {}));
+				               return Connection.from(ch);
+				           }))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(2, 2);
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, strategy));
+
+		List<PooledRef<Connection>> warmup = new ArrayList<>();
+		try {
+			Flux.range(1, 2)
+			    .flatMap(i -> http2Pool.acquire().doOnNext(warmup::add))
+			    .blockLast(Duration.ofSeconds(1));
+
+			assertThat(warmup).hasSize(2);
+			assertThat(warmup.get(0).poolable()).isNotSameAs(warmup.get(1).poolable());
+			warmup.get(0).release().block(Duration.ofSeconds(1));
+			warmup.get(1).release().block(Duration.ofSeconds(1));
+
+			List<PooledRef<Connection>> acquired = new ArrayList<>();
+			for (int i = 0; i < 4; i++) {
+				http2Pool.acquire().subscribe(acquired::add);
+			}
+			warmup.forEach(ref -> ((EmbeddedChannel) ref.poolable().channel()).runPendingTasks());
+
+			assertThat(acquired).hasSize(4);
+			assertThat(http2Pool.activeStreams()).isEqualTo(4);
+			Connection conn0 = acquired.get(0).poolable();
+			Connection conn2 = acquired.get(2).poolable();
+			assertThat(conn0).as("streams 0 and 2 should be on different connections").isNotSameAs(conn2);
+			assertThat(acquired.get(1).poolable()).as("stream 1 same as stream 0").isSameAs(conn0);
+			assertThat(acquired.get(3).poolable()).as("stream 3 same as stream 2").isSameAs(conn2);
+
+			for (PooledRef<Connection> ref : acquired) {
+				ref.invalidate().block(Duration.ofSeconds(1));
+			}
+
+			assertThat(http2Pool.activeStreams()).isEqualTo(0);
+		}
+		finally {
+			for (PooledRef<Connection> ref : warmup) {
+				EmbeddedChannel ch = (EmbeddedChannel) ref.poolable().channel();
+				ch.finishAndReleaseAll();
+				Connection.from(ch).dispose();
+			}
+		}
+	}
+
+	@Test
+	void streamBatchSizeWithStrictReuse() {
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> {
+				               EmbeddedChannel ch = new EmbeddedChannel(
+				                   new TestChannelId(),
+				                   Http2FrameCodecBuilder.forClient().build(),
+				                   new Http2MultiplexHandler(new ChannelHandlerAdapter() {}));
+				               return Connection.from(ch);
+				           }))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 5);
+		Http2AllocationStrategy strategy = Http2AllocationStrategy.builder()
+				.maxConnections(5)
+				.strictConnectionReuse(true)
+				.streamBatchSize(4)
+				.build();
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, strategy));
+
+		EmbeddedChannel ch = null;
+		try {
+			PooledRef<Connection> warm = http2Pool.acquire().block(Duration.ofSeconds(1));
+			assertThat(warm).isNotNull();
+			warm.release().block(Duration.ofSeconds(1));
+
+			ch = (EmbeddedChannel) warm.poolable().channel();
+
+			List<PooledRef<Connection>> acquired = new ArrayList<>();
+			for (int i = 0; i < 4; i++) {
+				http2Pool.acquire().subscribe(acquired::add);
+			}
+
+			ch.runPendingTasks();
+
+			assertThat(acquired).hasSize(4);
+			Connection firstConnection = acquired.get(0).poolable();
+			for (PooledRef<Connection> ref : acquired) {
+				assertThat(ref.poolable()).isSameAs(firstConnection);
+			}
+
+			for (PooledRef<Connection> ref : acquired) {
+				ref.release().block(Duration.ofSeconds(1));
+			}
+		}
+		finally {
+			if (ch != null) {
+				ch.finishAndReleaseAll();
+				Connection.from(ch).dispose();
+			}
 		}
 	}
 


### PR DESCRIPTION
When strict connection reuse is active, the `HTTP/2` pool can now open multiple streams at once on a single connection instead of dispatching one stream per drain loop iteration.