### PR TITLE
Lazily compute `HttpClientOperations#resourceUrl`

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -491,7 +491,6 @@ class HttpClientConnect extends HttpClient {
 		ProxyProvider                 proxyProvider;
 
 		volatile UriEndpoint        toURI;
-		volatile String             resourceUrl;
 		volatile UriEndpoint        fromURI;
 		volatile Supplier<String>[] redirectedFrom;
 		volatile boolean            shouldRetry;
@@ -539,7 +538,6 @@ class HttpClientConnect extends HttpClient {
 			else {
 				this.fromURI = this.toURI = uriEndpointFactory.createUriEndpoint(configuration.uri, configuration.websocketClientSpec != null);
 			}
-			this.resourceUrl = toURI.toExternalForm();
 		}
 
 		@Override
@@ -555,10 +553,10 @@ class HttpClientConnect extends HttpClient {
 		@SuppressWarnings("ReferenceEquality")
 		Publisher<Void> requestWithBody(HttpClientOperations ch) {
 			try {
-				ch.resourceUrl = this.resourceUrl;
 				ch.responseTimeout = responseTimeout;
 
 				UriEndpoint uri = toURI;
+				ch.uriEndpoint = uri;
 				HttpHeaders headers = ch.getNettyRequest()
 				                        .setUri(uri.getPathAndQuery())
 				                        .setMethod(method)
@@ -680,7 +678,7 @@ class HttpClientConnect extends HttpClient {
 				try {
 					URI redirectUri = new URI(to);
 					if (!redirectUri.isAbsolute()) {
-						URI requestUri = new URI(resourceUrl);
+						URI requestUri = new URI(from.toExternalForm());
 						redirectUri = requestUri.resolve(redirectUri);
 					}
 					toURITemp = uriEndpointFactory.createUriEndpoint(redirectUri, from.isWs());
@@ -693,7 +691,6 @@ class HttpClientConnect extends HttpClient {
 				toURITemp = UriEndpointFactory.createUriEndpoint(from, to, address);
 			}
 			toURI = toURITemp;
-			resourceUrl = toURITemp.toExternalForm();
 			this.redirectedFrom = addToRedirectedFromArray(redirectedFrom, from);
 		}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 	final HttpVersion            version;
 
 	Supplier<String>[]          redirectedFrom = EMPTY_REDIRECTIONS;
-	String                      resourceUrl;
+	UriEndpoint                 uriEndpoint;
 	String                      path;
 	Duration                    responseTimeout;
 
@@ -154,7 +154,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 		this.cookieEncoder = replaced.cookieEncoder;
 		this.cookieDecoder = replaced.cookieDecoder;
 		this.cookieList = replaced.cookieList;
-		this.resourceUrl = replaced.resourceUrl;
+		this.uriEndpoint = replaced.uriEndpoint;
 		this.path = replaced.path;
 		this.responseTimeout = replaced.responseTimeout;
 		this.is100Continue = replaced.is100Continue;
@@ -183,7 +183,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 		this.cookieEncoder = replaced.cookieEncoder;
 		this.cookieDecoder = replaced.cookieDecoder;
 		this.cookieList = replaced.cookieList;
-		this.resourceUrl = replaced.resourceUrl;
+		this.uriEndpoint = replaced.uriEndpoint;
 		this.path = replaced.path;
 		this.responseTimeout = replaced.responseTimeout;
 		this.is100Continue = replaced.is100Continue;
@@ -624,7 +624,7 @@ class HttpClientOperations extends HttpOperations<NettyInbound, NettyOutbound>
 	@Override
 	@Nullable
 	public String resourceUrl() {
-		return resourceUrl;
+		return uriEndpoint != null ? uriEndpoint.toExternalForm() : null;
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/UriEndpoint.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/UriEndpoint.java
@@ -41,6 +41,8 @@ final class UriEndpoint {
 	final Supplier<? extends SocketAddress> remoteAddressSupplier;
 	final String pathAndQuery;
 
+	String externalForm;
+
 	UriEndpoint(String scheme, String host, int port, SocketAddress remoteAddress, String pathAndQuery) {
 		this.host = host;
 		this.port = port;
@@ -80,8 +82,19 @@ final class UriEndpoint {
 	}
 
 	String toExternalForm() {
+		if (remoteAddressSupplier != null) {
+			return computeExternalForm(remoteAddressSupplier.get());
+		}
+		String result = externalForm;
+		if (result == null) {
+			result = computeExternalForm(remoteAddress);
+			externalForm = result;
+		}
+		return result;
+	}
+
+	private String computeExternalForm(SocketAddress address) {
 		StringBuilder sb = new StringBuilder();
-		SocketAddress address = getRemoteAddress();
 		if (isDomainSocketAddress(address)) {
 			sb.append(path(address));
 		}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientOperationsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -538,7 +538,7 @@ class HttpClientOperationsTest extends BaseHttpTest {
 		assertThat(req.cookieEncoder).isSameAs(res.cookieEncoder);
 		assertThat(req.cookieDecoder).isSameAs(res.cookieDecoder);
 		assertThat(req.cookieList).isSameAs(res.cookieList);
-		assertThat(req.resourceUrl).isSameAs(res.resourceUrl);
+		assertThat(req.uriEndpoint).isSameAs(res.uriEndpoint);
 		assertThat(req.path).isSameAs(res.path);
 		assertThat(req.responseTimeout).isSameAs(res.responseTimeout);
 		assertThat(req.is100Continue).isSameAs(res.is100Continue);

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -3816,7 +3816,7 @@ class HttpClientTest extends BaseHttpTest {
 			expectedUrl = "http://" + host + (uri != null ? uri : "/");
 		}
 
-		assertThat(handler.resourceUrl).isEqualTo(expectedUrl);
+		assertThat(handler.toURI.toExternalForm()).isEqualTo(expectedUrl);
 	}
 
 	static Object[][] baseUrlCombinations() {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/UriEndpointFactoryTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/UriEndpointFactoryTest.java
@@ -352,6 +352,14 @@ class UriEndpointFactoryTest {
 	}
 
 	@Test
+	void toExternalFormIsCached() {
+		UriEndpoint endpoint = this.builder.build().createUriEndpoint("http://localhost:8080/foo", false);
+		String first = endpoint.toExternalForm();
+		String second = endpoint.toExternalForm();
+		assertThat(first).isSameAs(second);
+	}
+
+	@Test
 	void toSocketAddressStringWithoutDefaultPortIPv4() {
 		SocketAddress addr80 = new InetSocketAddress("127.0.0.1", 80);
 		assertThat(toSocketAddressStringWithoutDefaultPort(addr80, false)).isEqualTo("127.0.0.1");


### PR DESCRIPTION
Based on the changes in #2700

Related to #829