### PR TITLE
Add regression test for stale dispose closing reused connection

### DIFF
--- a/docs/modules/ROOT/pages/faq.adoc
+++ b/docs/modules/ROOT/pages/faq.adoc
@@ -120,16 +120,6 @@ Issues related to TCP keep-alive configuration on various load balancers were re
 *** https://github.com/reactor/reactor-netty/issues/764#issuecomment-1011373248
 *** https://github.com/reactor/reactor-netty/issues/1510
 *** https://github.com/reactor/reactor-netty/issues/1843
-* Be aware of a stale cancel signal from a previous request disposing a reused connection.
-** This can occur in a gateway/proxy scenario (e.g. Spring Cloud Gateway) where a client (browser) cancels
-a request while the gateway is still waiting for a response from the upstream server.
-** When the upstream response has already been received and the connection has been returned to the pool and
-reused by a new request, a delayed cancel signal from the previous request may incorrectly call
-`channel().close()` on the channel already in use by the new request, resulting in
-`Connection prematurely closed BEFORE response`.
-** This issue affects reactor-netty versions prior to `1.1.24`.
-It was implicitly fixed in `1.1.24` by https://github.com/reactor/reactor-netty/pull/3459[PR #3459].
-** Consider upgrading to reactor-netty `1.1.24+` (Spring Boot `3.3.x` or later).
 * Check the target server.
 ** Are there configurations related to any of the following?
 *** idle timeout (the connection is closed when there is no incoming data for a certain period of time)


### PR DESCRIPTION
## Summary

When a previous request's cancel signal is processed after the connection has been
returned to the pool and reused by a new request, the delayed `dispose()` call
may incorrectly close the channel currently in use, resulting in
`PrematureCloseException: Connection prematurely closed BEFORE response`.

### Environment (where this was observed)

- reactor-netty: `1.1.13`
- JVM: `17`
- Spring Boot: `3.0.13`
- Spring Cloud Gateway: `4.0.9`
- Envoy proxy + pod-to-pod communication

### Scenario

This was observed in a Spring Cloud Gateway environment:

```
T1: Request A — upstream response completed
    → ops_A.terminate() → pool.release()

T2: Request B — same connection acquired from pool
    → ops_B.bind() → channel.attr(CONNECTION) = ops_B

T3: Browser sends TCP FIN for Request A
    → HttpServerOperations.terminate()
    → OUTBOUND_CLOSE.cancel() → Reactor chain cancel propagates upstream
    → ops_A.dispose() fires

T4: ops_A.dispose() → connection.dispose() → channel().close()
    ← closes the channel already in use by Request B!

T5: Request B → PrematureCloseException
```

### Root Cause

`ChannelOperations.dispose()` calls `connection.dispose()` → `channel().close()`
without verifying that the current ops instance still owns the channel.
By the time the stale cancel fires, `channel.attr(CONNECTION)` has already been
replaced by `ops_B.bind()`.

### Fix Status

This issue is **implicitly fixed in reactor-netty 1.1.24+** as a side effect of
[PR #3459](https://github.com/reactor/reactor-netty/pull/3459), which replaces the
`connection` field with `DisposedConnection` after `terminate()`.
`DisposedChannel.close()` is a no-op, preventing the stale cancel from closing
the reused channel.

This PR adds:
1. A regression test `staleDisposeAfterConnectionReuseDoseNotCloseActiveChannel()`
   that deterministically reproduces the race condition using `doOnConnected` hook
2. A FAQ entry describing this scenario for users on older versions

## Changes

- `reactor-netty-http/.../HttpClientTest.java`
  - `staleDisposeAfterConnectionReuseDoseNotCloseActiveChannel()`: deterministic
    regression test — captures `ops_A`, waits for `ops_B.bind()` via `doOnConnected`,
    then synchronously calls `ops_A.dispose()` while Request B is still waiting for
    the response
- `docs/modules/ROOT/pages/faq.adoc`
  - Document the stale cancel scenario under
    "How can I debug Connection prematurely closed BEFORE response?"

## Affected Versions

| Version | Status |
|————|————|
| Prior to 1.1.24 | Bug present |
| 1.1.24+ (Spring Boot 3.3.x+) | Implicitly fixed via PR #3459 |