### PR TITLE
Fix `HTTP/3` connection pool max streams handling

### DIFF
--- a/reactor-netty-http/src/http3Test/java/reactor/netty/http/Http3Tests.java
+++ b/reactor-netty-http/src/http3Test/java/reactor/netty/http/Http3Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2024-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ import reactor.netty.DisposableServer;
 import reactor.netty.LogTracker;
 import reactor.netty.NettyOutbound;
 import reactor.netty.NettyPipeline;
+import reactor.netty.http.client.Http2AllocationStrategy;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientRequest;
 import reactor.netty.http.client.HttpClientResponse;
@@ -537,18 +538,12 @@ class Http3Tests {
 
 	void doTestMaxActiveStreams(@Nullable ConnectionProvider provider, int maxActiveStreams, int expectedOnNext, int expectedOnError) throws Exception {
 		disposableServer =
-				createServer()
+				createServer(maxActiveStreams)
 				        .route(routes ->
 				                routes.post("/echo", (req, res) -> res.send(req.receive()
 				                                                               .aggregate()
 				                                                               .retain()
 				                                                               .delayElement(Duration.ofMillis(100)))))
-				        .http3Settings(spec -> spec.idleTimeout(Duration.ofSeconds(5))
-				                                   .maxData(10000000)
-				                                   .maxStreamDataBidirectionalLocal(1000000)
-				                                   .maxStreamDataBidirectionalRemote(1000000)
-				                                   .maxStreamsBidirectional(maxActiveStreams)
-				                                   .tokenHandler(InsecureQuicTokenHandler.INSTANCE))
 				        .bindNow();
 
 		HttpClient client = createClient(provider, disposableServer.port());
@@ -588,6 +583,84 @@ class Http3Tests {
 
 		assertThat(onNext).isEqualTo(expectedOnNext);
 		assertThat(onError).isEqualTo(expectedOnError);
+	}
+
+	@Test
+	void testMaxStreamsExceededServerReplenished() throws Exception {
+		ConnectionProvider provider = ConnectionProvider.create("testMaxStreamsExceededServerReplenished", 1);
+		try {
+			testMaxStreams(provider, 2, 1);
+		}
+		finally {
+			provider.disposeLater()
+			        .block(Duration.ofSeconds(5));
+		}
+	}
+
+	@Test
+	void testMaxStreamsMultipleConnectionsNeeded() throws Exception {
+		ConnectionProvider provider =
+				ConnectionProvider.builder("testMaxStreamsMultipleConnectionsNeeded")
+				                  .maxConnections(5)
+				                  .build();
+		try {
+			testMaxStreams(provider, 2, 5);
+		}
+		finally {
+			provider.disposeLater()
+			        .block(Duration.ofSeconds(5));
+		}
+	}
+
+	@Test
+	void testMaxStreamsWithCustomPool() throws Exception {
+		Http2AllocationStrategy strategy =
+				Http2AllocationStrategy.builder()
+				                       .maxConcurrentStreams(2)
+				                       .build();
+		ConnectionProvider provider =
+				ConnectionProvider.builder("testMaxStreamsWithCustomPool")
+				                  .maxConnections(1)
+				                  .allocationStrategy(strategy)
+				                  .build();
+		try {
+			testMaxStreams(provider, 100, 1);
+		}
+		finally {
+			provider.disposeLater()
+			        .block(Duration.ofSeconds(5));
+		}
+	}
+
+	private void testMaxStreams(ConnectionProvider provider, int serverMaxStreams, int expectedDistinctConnections) throws Exception {
+		int totalRequests = 6;
+
+		disposableServer =
+				createServer(serverMaxStreams)
+				        .handle((req, res) -> res.send(req.receive().retain()))
+				        .bindNow();
+
+		AtomicReference<List<Channel>> channels = new AtomicReference<>(new ArrayList<>());
+		HttpClient client =
+				createClient(provider, disposableServer.port())
+				        .doOnConnected(conn -> channels.get().add(conn.channel().parent()));
+
+		Flux.range(0, totalRequests)
+		    .flatMapDelayError(i ->
+		            client.post()
+		                  .uri("/")
+		                  .send(ByteBufFlux.fromString(Mono.just("msg-" + i)))
+		                  .responseContent()
+		                  .aggregate()
+		                  .asString(), 256, 32)
+		    .collectList()
+		    .as(StepVerifier::create)
+		    .assertNext(l -> assertThat(l).allMatch(s -> s.startsWith("msg-")))
+		    .expectComplete()
+		    .verify(Duration.ofSeconds(30));
+
+		long distinctConnections = channels.get().stream().distinct().count();
+		assertThat(distinctConnections).isLessThanOrEqualTo(expectedDistinctConnections);
 	}
 
 	@Test
@@ -1288,6 +1361,10 @@ class Http3Tests {
 	}
 
 	static HttpServer createServer() throws Exception {
+		return createServer(100);
+	}
+
+	static HttpServer createServer(int maxStreams) throws Exception {
 		Http3SslContextSpec serverCtx = Http3SslContextSpec.forServer(ssc.toTempPrivateKeyPem(), null, ssc.toTempCertChainPem());
 		return HttpServer.create()
 		                 .port(0)
@@ -1298,7 +1375,7 @@ class Http3Tests {
 		                                            .maxData(10000000)
 		                                            .maxStreamDataBidirectionalLocal(1000000)
 		                                            .maxStreamDataBidirectionalRemote(1000000)
-		                                            .maxStreamsBidirectional(100)
+		                                            .maxStreamsBidirectional(maxStreams)
 		                                            .tokenHandler(InsecureQuicTokenHandler.INSTANCE));
 	}
 

--- a/reactor-netty-http/src/http3Test/java/reactor/netty/http/client/Http3PoolTest.java
+++ b/reactor-netty-http/src/http3Test/java/reactor/netty/http/client/Http3PoolTest.java
@@ -1,0 +1,589 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.client;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelId;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.quic.QuicChannel;
+import io.netty.handler.codec.quic.QuicChannelConfig;
+import io.netty.handler.codec.quic.QuicConnectionAddress;
+import io.netty.handler.codec.quic.QuicConnectionPathStats;
+import io.netty.handler.codec.quic.QuicConnectionStats;
+import io.netty.handler.codec.quic.QuicStreamChannel;
+import io.netty.handler.codec.quic.QuicStreamType;
+import io.netty.handler.codec.quic.QuicTransportParameters;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.netty.Connection;
+import reactor.netty.internal.shaded.reactor.pool.PoolBuilder;
+import reactor.netty.internal.shaded.reactor.pool.PoolConfig;
+import reactor.netty.internal.shaded.reactor.pool.PooledRef;
+
+import javax.net.ssl.SSLEngine;
+import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Http3PoolTest {
+
+	@Test
+	void evictClosedConnection() {
+		TestQuicChannel channel1 = new TestQuicChannel(5);
+		TestQuicChannel channel2 = new TestQuicChannel(5);
+		List<TestQuicChannel> channels = Arrays.asList(channel1, channel2);
+		int[] idx = {0};
+
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> Connection.from(channels.get(idx[0]++))))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 2);
+		Http3Pool http3Pool = poolBuilder.build(config -> new Http3Pool(config, null));
+
+		try {
+			List<PooledRef<Connection>> acquired = new ArrayList<>();
+			http3Pool.acquire().subscribe(conn -> {
+				acquired.add(conn);
+				channel1.decrementPeerAllowedStreams(QuicStreamType.BIDIRECTIONAL);
+			});
+			channel1.runPendingTasks();
+
+			assertThat(acquired).hasSize(1);
+			assertThat(http3Pool.activeStreams()).isEqualTo(1);
+
+			Connection conn1 = acquired.get(0).poolable();
+
+			channel1.finishAndReleaseAll();
+			conn1.dispose();
+
+			acquired.get(0).invalidate().block(Duration.ofSeconds(1));
+
+			assertThat(http3Pool.activeStreams()).isEqualTo(0);
+
+			http3Pool.acquire().subscribe(conn -> {
+				acquired.add(conn);
+				channel2.decrementPeerAllowedStreams(QuicStreamType.BIDIRECTIONAL);
+			});
+			channel2.runPendingTasks();
+
+			assertThat(acquired).hasSize(2);
+			Connection conn2 = acquired.get(1).poolable();
+			assertThat(conn1.channel().id()).isNotEqualTo(conn2.channel().id());
+
+			acquired.get(1).invalidate().block(Duration.ofSeconds(1));
+		}
+		finally {
+			for (TestQuicChannel ch : channels) {
+				ch.finishAndReleaseAll();
+				Connection.from(ch).dispose();
+			}
+		}
+	}
+
+	@Test
+	void canOpenStreamWithMaxConcurrentStreamsRespected() {
+		canOpenStream(10, 3);
+	}
+
+	@Test
+	void canOpenStreamWithPeerMaxStreamsNoAllocationStrategy() {
+		canOpenStream(3, 0);
+	}
+
+	@Test
+	void canOpenStreamWithPeerMaxStreamsRespected() {
+		canOpenStream(3, 10);
+	}
+
+	private static void canOpenStream(int peerMaxStreams, int maxConcurrentStreams) {
+		TestQuicChannel channel = new TestQuicChannel(peerMaxStreams);
+
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.just(Connection.from(channel)))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1);
+		Http2AllocationStrategy strategy = maxConcurrentStreams == 0 ? null :
+				Http2AllocationStrategy.builder()
+						.maxConnections(1)
+						.maxConcurrentStreams(maxConcurrentStreams)
+						.build();
+		Http3Pool http3Pool = poolBuilder.build(config -> new Http3Pool(config, strategy));
+
+		int effectiveLimit = maxConcurrentStreams == 0 ? peerMaxStreams : Math.min(peerMaxStreams, maxConcurrentStreams);
+		try {
+			List<PooledRef<Connection>> acquired = new ArrayList<>();
+
+			for (int i = 0; i < 3; i++) {
+				http3Pool.acquire().subscribe(conn -> {
+					acquired.add(conn);
+					channel.decrementPeerAllowedStreams(QuicStreamType.BIDIRECTIONAL);
+				});
+				channel.runPendingTasks();
+			}
+
+			assertThat(acquired).hasSize(effectiveLimit);
+			assertThat(http3Pool.activeStreams()).isEqualTo(effectiveLimit);
+
+			Http2Pool.Slot slot = ((Http2Pool.Http2PooledRef) acquired.get(0)).slot;
+
+			assertThat(slot.canOpenStream()).isFalse();
+
+			for (PooledRef<Connection> ref : acquired) {
+				ref.invalidate().block(Duration.ofSeconds(1));
+			}
+
+			assertThat(http3Pool.activeStreams()).isEqualTo(0);
+		}
+		finally {
+			channel.finishAndReleaseAll();
+			Connection.from(channel).dispose();
+		}
+	}
+
+	@Test
+	void maxStreamsCausesNewAllocation() {
+		TestQuicChannel channel1 = new TestQuicChannel(2);
+		TestQuicChannel channel2 = new TestQuicChannel(2);
+		List<TestQuicChannel> channels = Arrays.asList(channel1, channel2);
+		int[] idx = {0};
+
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.fromSupplier(() -> Connection.from(channels.get(idx[0]++))))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 2);
+		Http3Pool http3Pool = poolBuilder.build(config -> new Http3Pool(config, null));
+
+		try {
+			List<PooledRef<Connection>> acquired = new ArrayList<>();
+
+			for (int i = 0; i < 2; i++) {
+				http3Pool.acquire().subscribe(conn -> {
+					acquired.add(conn);
+					channel1.decrementPeerAllowedStreams(QuicStreamType.BIDIRECTIONAL);
+				});
+				channel1.runPendingTasks();
+			}
+
+			assertThat(acquired).hasSize(2);
+			assertThat(http3Pool.activeStreams()).isEqualTo(2);
+
+			Http2Pool.Slot slot1 = ((Http2Pool.Http2PooledRef) acquired.get(0)).slot;
+			Http2Pool.Slot slot2 = ((Http2Pool.Http2PooledRef) acquired.get(1)).slot;
+			assertThat(slot2).isSameAs(slot1);
+
+			assertThat(slot1.maxConcurrentStreams).isEqualTo(2);
+			assertThat(slot1.canOpenStream()).isFalse();
+
+			http3Pool.acquire().subscribe(conn -> {
+				acquired.add(conn);
+				channel2.decrementPeerAllowedStreams(QuicStreamType.BIDIRECTIONAL);
+			});
+			channel2.runPendingTasks();
+
+			assertThat(acquired).hasSize(3);
+			assertThat(http3Pool.activeStreams()).isEqualTo(3);
+
+			Http2Pool.Slot slot3 = ((Http2Pool.Http2PooledRef) acquired.get(2)).slot;
+			assertThat(slot3).isNotSameAs(slot1);
+
+			assertThat(slot3.maxConcurrentStreams).isEqualTo(2);
+			assertThat(slot3.canOpenStream()).isTrue();
+
+			for (PooledRef<Connection> ref : acquired) {
+				ref.invalidate().block(Duration.ofSeconds(1));
+			}
+		}
+		finally {
+			for (TestQuicChannel ch : channels) {
+				ch.finishAndReleaseAll();
+				Connection.from(ch).dispose();
+			}
+		}
+	}
+
+	@Test
+	void serverReplenishesStreams() {
+		TestQuicChannel channel = new TestQuicChannel(2);
+
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.just(Connection.from(channel)))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1);
+		Http3Pool http3Pool = poolBuilder.build(config -> new Http3Pool(config, null));
+
+		try {
+			List<PooledRef<Connection>> acquired = new ArrayList<>();
+
+			for (int i = 0; i < 2; i++) {
+				http3Pool.acquire().subscribe(conn -> {
+					acquired.add(conn);
+					channel.decrementPeerAllowedStreams(QuicStreamType.BIDIRECTIONAL);
+				});
+				channel.runPendingTasks();
+			}
+
+			assertThat(acquired).hasSize(2);
+			assertThat(http3Pool.activeStreams()).isEqualTo(2);
+
+			Http2Pool.Slot slot = ((Http2Pool.Http2PooledRef) acquired.get(0)).slot;
+			assertThat(slot.canOpenStream()).isFalse();
+			assertThat(slot.maxConcurrentStreams).isEqualTo(2);
+
+			acquired.get(0).invalidate().block(Duration.ofSeconds(1));
+
+			assertThat(http3Pool.activeStreams()).isEqualTo(1);
+			// In HTTP/3, releasing a stream does NOT replenish peerAllowedStreams.
+			// The peer budget is 0 (both used) and only the server can replenish via MAX_STREAMS.
+			assertThat(slot.canOpenStream()).isFalse();
+
+			// A new acquire should not succeed (no peer budget, no new connection possible)
+			http3Pool.acquire().subscribe(conn -> {
+				acquired.add(conn);
+				channel.decrementPeerAllowedStreams(QuicStreamType.BIDIRECTIONAL);
+			});
+			channel.runPendingTasks();
+
+			assertThat(acquired).hasSize(2);
+
+			// Simulate server replenishing streams via MAX_STREAMS
+			channel.setPeerAllowedStreams(QuicStreamType.BIDIRECTIONAL, 1);
+			slot.updateMaxConcurrentStreams(0);
+
+			channel.runPendingTasks();
+
+			assertThat(acquired).hasSize(3);
+			assertThat(http3Pool.activeStreams()).isEqualTo(2);
+			assertThat(slot.maxConcurrentStreams).isEqualTo(1);
+
+			for (PooledRef<Connection> ref : acquired) {
+				ref.invalidate().block(Duration.ofSeconds(1));
+			}
+
+			assertThat(http3Pool.activeStreams()).isEqualTo(0);
+		}
+		finally {
+			channel.finishAndReleaseAll();
+			Connection.from(channel).dispose();
+		}
+	}
+
+	static final class TestChannelId implements ChannelId {
+
+		static final Random rndm = new Random();
+		final String id;
+
+		TestChannelId() {
+			byte[] array = new byte[8];
+			rndm.nextBytes(array);
+			this.id = new String(array, StandardCharsets.UTF_8);
+		}
+
+		@Override
+		public String asShortText() {
+			return id;
+		}
+
+		@Override
+		public String asLongText() {
+			return id;
+		}
+
+		@Override
+		public int compareTo(ChannelId o) {
+			if (this == o) {
+				return 0;
+			}
+			return this.asShortText().compareTo(o.asShortText());
+		}
+	}
+
+	static final class TestQuicChannel extends EmbeddedChannel implements QuicChannel {
+		private final Map<QuicStreamType, Long> peerAllowedStreams = new EnumMap<>(QuicStreamType.class);
+		private TestQuicChannelConfig config;
+
+		TestQuicChannel(long initialMaxStreamsBidi) {
+			super(new TestChannelId());
+			this.peerAllowedStreams.put(QuicStreamType.BIDIRECTIONAL, initialMaxStreamsBidi);
+			this.peerAllowedStreams.put(QuicStreamType.UNIDIRECTIONAL, 0L);
+		}
+
+		void setPeerAllowedStreams(QuicStreamType type, long value) {
+			this.peerAllowedStreams.put(type, value);
+		}
+
+		void decrementPeerAllowedStreams(QuicStreamType type) {
+			this.peerAllowedStreams.compute(type, (k, v) -> v == null ? 0L : Math.max(0, v - 1));
+		}
+
+		@Override
+		public @Nullable QuicConnectionAddress localAddress() {
+			return null;
+		}
+
+		@Override
+		public @Nullable QuicConnectionAddress remoteAddress() {
+			return null;
+		}
+
+		@Override
+		public @Nullable SocketAddress localSocketAddress() {
+			return null;
+		}
+
+		@Override
+		public @Nullable SocketAddress remoteSocketAddress() {
+			return null;
+		}
+
+		@Override
+		public boolean isTimedOut() {
+			return false;
+		}
+
+		@Override
+		public @Nullable SSLEngine sslEngine() {
+			return null;
+		}
+
+		@Override
+		public QuicChannelConfig config() {
+			if (config == null) {
+				config = new TestQuicChannelConfig(super.config());
+			}
+			return config;
+		}
+
+		@Override
+		public QuicChannel flush() {
+			super.flush();
+			return this;
+		}
+
+		@Override
+		public QuicChannel read() {
+			super.read();
+			return this;
+		}
+
+		@Override
+		public long peerAllowedStreams(QuicStreamType type) {
+			return peerAllowedStreams.getOrDefault(type, 0L);
+		}
+
+		@Override
+		public Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler,
+				Promise<QuicStreamChannel> promise) {
+			return promise.setFailure(new UnsupportedOperationException("Not implemented for test"));
+		}
+
+		@Override
+		public ChannelFuture close(boolean applicationClose, int error, ByteBuf reason, ChannelPromise promise) {
+			reason.release();
+			return close(promise);
+		}
+
+		@Override
+		public Future<QuicConnectionStats> collectStats(Promise<QuicConnectionStats> promise) {
+			return promise.setFailure(new UnsupportedOperationException("Not implemented for test"));
+		}
+
+		@Override
+		public Future<QuicConnectionPathStats> collectPathStats(int i, Promise<QuicConnectionPathStats> promise) {
+			return promise.setFailure(new UnsupportedOperationException("Not implemented for test"));
+		}
+
+		@Override
+		public @Nullable QuicTransportParameters peerTransportParameters() {
+			return null;
+		}
+	}
+
+	static final class TestQuicChannelConfig implements QuicChannelConfig {
+
+		final ChannelConfig delegate;
+
+		TestQuicChannelConfig(ChannelConfig delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public Map<ChannelOption<?>, Object> getOptions() {
+			return delegate.getOptions();
+		}
+
+		@Override
+		public boolean setOptions(Map<ChannelOption<?>, ?> map) {
+			return delegate.setOptions(map);
+		}
+
+		@Override
+		public <T> T getOption(ChannelOption<T> option) {
+			return delegate.getOption(option);
+		}
+
+		@Override
+		public <T> boolean setOption(ChannelOption<T> option, T value) {
+			return delegate.setOption(option, value);
+		}
+
+		@Override
+		public int getConnectTimeoutMillis() {
+			return delegate.getConnectTimeoutMillis();
+		}
+
+		@Override
+		public QuicChannelConfig setConnectTimeoutMillis(int ms) {
+			delegate.setConnectTimeoutMillis(ms);
+			return this;
+		}
+
+		@Override
+		@Deprecated
+		public int getMaxMessagesPerRead() {
+			return delegate.getMaxMessagesPerRead();
+		}
+
+		@Override
+		@Deprecated
+		public QuicChannelConfig setMaxMessagesPerRead(int max) {
+			delegate.setMaxMessagesPerRead(max);
+			return this;
+		}
+
+		@Override
+		public int getWriteSpinCount() {
+			return delegate.getWriteSpinCount();
+		}
+
+		@Override
+		public QuicChannelConfig setWriteSpinCount(int count) {
+			delegate.setWriteSpinCount(count);
+			return this;
+		}
+
+		@Override
+		public ByteBufAllocator getAllocator() {
+			return delegate.getAllocator();
+		}
+
+		@Override
+		public QuicChannelConfig setAllocator(ByteBufAllocator alloc) {
+			delegate.setAllocator(alloc);
+			return this;
+		}
+
+		@Override
+		public <T extends RecvByteBufAllocator> T getRecvByteBufAllocator() {
+			return delegate.getRecvByteBufAllocator();
+		}
+
+		@Override
+		public QuicChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator alloc) {
+			delegate.setRecvByteBufAllocator(alloc);
+			return this;
+		}
+
+		@Override
+		public boolean isAutoRead() {
+			return delegate.isAutoRead();
+		}
+
+		@Override
+		public QuicChannelConfig setAutoRead(boolean autoRead) {
+			delegate.setAutoRead(autoRead);
+			return this;
+		}
+
+		@Override
+		public boolean isAutoClose() {
+			return delegate.isAutoClose();
+		}
+
+		@Override
+		public QuicChannelConfig setAutoClose(boolean autoClose) {
+			delegate.setAutoClose(autoClose);
+			return this;
+		}
+
+		@Override
+		public int getWriteBufferHighWaterMark() {
+			return delegate.getWriteBufferHighWaterMark();
+		}
+
+		@Override
+		public QuicChannelConfig setWriteBufferHighWaterMark(int mark) {
+			delegate.setWriteBufferHighWaterMark(mark);
+			return this;
+		}
+
+		@Override
+		public int getWriteBufferLowWaterMark() {
+			return delegate.getWriteBufferLowWaterMark();
+		}
+
+		@Override
+		public QuicChannelConfig setWriteBufferLowWaterMark(int mark) {
+			delegate.setWriteBufferLowWaterMark(mark);
+			return this;
+		}
+
+		@Override
+		public MessageSizeEstimator getMessageSizeEstimator() {
+			return delegate.getMessageSizeEstimator();
+		}
+
+		@Override
+		public QuicChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
+			delegate.setMessageSizeEstimator(estimator);
+			return this;
+		}
+
+		@Override
+		public WriteBufferWaterMark getWriteBufferWaterMark() {
+			return delegate.getWriteBufferWaterMark();
+		}
+
+		@Override
+		public QuicChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark mark) {
+			delegate.setWriteBufferWaterMark(mark);
+			return this;
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http3ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http3ConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2024-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,11 @@ package reactor.netty.http.client;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
+import io.netty.handler.codec.quic.QuicStreamLimitChangedEvent;
+import io.netty.handler.codec.quic.QuicStreamType;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.codec.http3.Http3;
 import io.netty.handler.codec.http3.Http3ClientConnectionHandler;
@@ -62,6 +66,7 @@ import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 
@@ -609,7 +614,7 @@ final class Http3ConnectionProvider extends PooledConnectionProvider<Connection>
 				MonoSink<Connection> sink) {
 			QuicChannelBootstrap bootstrap =
 					QuicChannel.newBootstrap(channel)
-					           .handler(handler)
+					           .handler(new Http3ConnectionInitializer(handler, sink))
 					           .remoteAddress(remoteAddress);
 			attributes(bootstrap, config.attributes());
 			channelOptions(bootstrap, config.options());
@@ -619,9 +624,6 @@ final class Http3ConnectionProvider extends PooledConnectionProvider<Connection>
 			             if (!f.isSuccess()) {
 			                 sink.error(f.cause());
 			             }
-			             else {
-			                 sink.success(Connection.from((Channel) f.get()));
-			             }
 			         });
 		}
 
@@ -629,5 +631,90 @@ final class Http3ConnectionProvider extends PooledConnectionProvider<Connection>
 				(connection, metadata) -> false;
 
 		static final Function<Connection, Publisher<Void>> DEFAULT_DESTROY_HANDLER = connection -> Mono.empty();
+
+		static final class Http3ConnectionInitializer extends ChannelInitializer<Channel> {
+
+			final ChannelHandler handler;
+			final MonoSink<Connection> sink;
+
+			Http3ConnectionInitializer(ChannelHandler handler, MonoSink<Connection> sink) {
+				this.handler = handler;
+				this.sink = sink;
+			}
+
+			@Override
+			protected void initChannel(Channel ch) {
+				ch.pipeline().addLast(handler, new PooledConnectionAllocator.Http3MaxStreamsHandler(sink));
+			}
+
+			@Override
+			public boolean isSharable() {
+				return true;
+			}
+		}
+
+		static final class Http3MaxStreamsHandler extends ChannelInboundHandlerAdapter {
+
+			volatile int configured;
+			static final AtomicIntegerFieldUpdater<Http3MaxStreamsHandler> CONFIGURED_UPDATER =
+					AtomicIntegerFieldUpdater.newUpdater(Http3MaxStreamsHandler.class, "configured");
+
+			final MonoSink<Connection> sink;
+
+			Http3MaxStreamsHandler(MonoSink<Connection> sink) {
+				this.sink = sink;
+			}
+
+			@Override
+			public void channelInactive(ChannelHandlerContext ctx) {
+				if (CONFIGURED_UPDATER.compareAndSet(this, 0, 1)) {
+					sink.error(new IOException("Connection closed before receiving MAX_STREAMS limit"));
+				}
+				ctx.fireChannelInactive();
+			}
+
+			@Override
+			public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+				if (CONFIGURED_UPDATER.compareAndSet(this, 0, 1)) {
+					sink.error(cause);
+				}
+				ctx.fireExceptionCaught(cause);
+			}
+
+			@Override
+			public boolean isSharable() {
+				return false;
+			}
+
+			@Override
+			public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+				if (evt instanceof QuicStreamLimitChangedEvent) {
+					if (CONFIGURED_UPDATER.compareAndSet(this, 0, 1)) {
+						// Wait to receive the first max stream limit from the server, only then emit the Connection
+						sink.success(Connection.from(ctx.channel()));
+					}
+					else {
+						ConnectionObserver owner = ctx.channel().attr(Http3ConnectionProvider.OWNER).get();
+						if (owner instanceof Http3ConnectionProvider.DisposableAcquire) {
+							Http3ConnectionProvider.DisposableAcquire da = (Http3ConnectionProvider.DisposableAcquire) owner;
+							if (da.pooledRef != null) {
+								Http2Pool.Http2PooledRef ref = Http2ConnectionProvider.http2PooledRef(da.pooledRef);
+								ref.slot.updateMaxConcurrentStreams(0);
+								if (log.isDebugEnabled()) {
+									log.debug(format(ctx.channel(),
+											"Received QuicStreamLimitChangedEvent, updated max streams to [{}]"), ref.slot.maxConcurrentStreams);
+								}
+							}
+						}
+						else if (log.isDebugEnabled()) {
+							log.debug(format(ctx.channel(),
+									"Received QuicStreamLimitChangedEvent, owner is [{}]"),
+									owner != null ? owner.getClass().getSimpleName() : "null");
+						}
+					}
+				}
+				ctx.fireUserEventTriggered(evt);
+			}
+		}
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http3ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http3ConnectionProvider.java
@@ -22,7 +22,6 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.codec.quic.QuicStreamLimitChangedEvent;
-import io.netty.handler.codec.quic.QuicStreamType;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.codec.http3.Http3;
 import io.netty.handler.codec.http3.Http3ClientConnectionHandler;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http3Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http3Pool.java
@@ -18,10 +18,14 @@ package reactor.netty.http.client;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http3.Http3ClientConnectionHandler;
+import io.netty.handler.codec.quic.QuicChannel;
+import io.netty.handler.codec.quic.QuicStreamType;
 import org.jspecify.annotations.Nullable;
 import reactor.netty.Connection;
 import reactor.netty.internal.shaded.reactor.pool.PoolConfig;
 import reactor.netty.resources.ConnectionProvider;
+
+import static reactor.netty.ReactorNetty.format;
 
 /**
  * <p>This class is intended to be used only as {@code HTTP/3} connection pool. It doesn't have generic purpose.
@@ -79,18 +83,44 @@ final class Http3Pool extends Http2Pool {
 		}
 
 		@Override
+		int availableStreams(int concurrency) {
+			int peerAllowed = peerAllowedMaxStreams();
+			if (pool.maxConcurrentStreams != -1) {
+				return Math.min(peerAllowed, Math.max(0, pool.maxConcurrentStreams - concurrency));
+			}
+			return peerAllowed;
+		}
+
+		@Override
 		void initMaxConcurrentStreams() {
-			this.maxConcurrentStreams = pool.maxConcurrentStreams;
+			int peerAllowed = peerAllowedMaxStreams();
+			int newMaxConcurrentStreams = pool.maxConcurrentStreams == -1 ?
+					peerAllowed : Math.min(pool.maxConcurrentStreams, peerAllowed);
+			this.maxConcurrentStreams = newMaxConcurrentStreams;
+			log.debug(format(connection.channel(), "Max streams for this channel [{}]"), newMaxConcurrentStreams);
+			TOTAL_MAX_CONCURRENT_STREAMS.addAndGet(this.pool, newMaxConcurrentStreams);
 		}
 
 		@Override
-		boolean canOpenStream() {
-			return true;
+		void updateMaxConcurrentStreams(@SuppressWarnings("unused") long remoteMaxConcurrentStreams) {
+			int peerAllowed = peerAllowedMaxStreams();
+			int newMaxConcurrentStreams = pool.maxConcurrentStreams == -1 ?
+					peerAllowed : Math.min(pool.maxConcurrentStreams, peerAllowed);
+			int diff = newMaxConcurrentStreams - maxConcurrentStreams;
+			if (diff != 0) {
+				maxConcurrentStreams = newMaxConcurrentStreams;
+				TOTAL_MAX_CONCURRENT_STREAMS.addAndGet(this.pool, diff);
+				pool.drain();
+			}
 		}
 
-		@Override
-		boolean canOpenStream(int concurrency) {
-			return true;
+		private int peerAllowedMaxStreams() {
+			Channel ch = connection.channel();
+			if (ch instanceof QuicChannel) {
+				long allowed = ((QuicChannel) ch).peerAllowedStreams(QuicStreamType.BIDIRECTIONAL);
+				return (int) Math.min(allowed, Integer.MAX_VALUE);
+			}
+			return 0;
 		}
 
 		@Override

--- a/reactor-netty-http/src/main/resources/META-INF/native-image/io.projectreactor.netty/reactor-netty-http/reflect-config.json
+++ b/reactor-netty-http/src/main/resources/META-INF/native-image/io.projectreactor.netty/reactor-netty-http/reflect-config.json
@@ -57,6 +57,20 @@
 	},
 	{
 		"condition": {
+			"typeReachable": "reactor.netty.http.client.Http3ConnectionProvider$PooledConnectionAllocator$Http3ConnectionInitializer"
+		},
+		"name": "reactor.netty.http.client.Http3ConnectionProvider$PooledConnectionAllocator$Http3ConnectionInitializer",
+		"queryAllPublicMethods": true
+	},
+	{
+		"condition": {
+			"typeReachable": "reactor.netty.http.client.Http3ConnectionProvider$PooledConnectionAllocator$Http3MaxStreamsHandler"
+		},
+		"name": "reactor.netty.http.client.Http3ConnectionProvider$PooledConnectionAllocator$Http3MaxStreamsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"condition": {
 			"typeReachable": "reactor.netty.http.client.Http3Codec"
 		},
 		"name": "reactor.netty.http.client.Http3Codec",


### PR DESCRIPTION
With this change `HTTP/3` connection pool starts to respect the server's `MAX_STREAMS` frames