### PR TITLE
Fix `keep-alive` race when creating `HttpServerOperations`

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3ServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http3ServerOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2024-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,6 +83,11 @@ final class Http3ServerOperations extends HttpServerOperations {
 			return H3;
 		}
 		throw new IllegalStateException("request not parsed");
+	}
+
+	@Override
+	protected void afterInboundComplete() {
+		// noop
 	}
 
 	static final HttpVersion H3 = HttpVersion.valueOf("HTTP/3.0");

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperations.java
@@ -798,6 +798,13 @@ class HttpServerOperations extends HttpOperations<HttpServerRequest, HttpServerR
 	}
 
 	@Override
+	protected void afterInboundComplete() {
+		if (!isHttp2()) {
+			channel().pipeline().fireUserEventTriggered(HttpServerOperationsTerminatedEvent.INSTANCE);
+		}
+	}
+
+	@Override
 	protected void onInboundNext(ChannelHandlerContext ctx, Object msg) {
 		Class<?> msgClass = msg.getClass();
 		if (msgClass == DefaultHttpRequest.class) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperationsTerminatedEvent.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerOperationsTerminatedEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+/**
+ * A user event fired through the channel pipeline during
+ * {@code ChannelOperations#terminate()} via
+ * {@link HttpServerOperations#afterInboundComplete() afterInboundComplete()}.
+ * <p>
+ * This event signals that the previous {@link HttpServerOperations} has passed
+ * the channel rebind point and that keep-alive request handoff may resume.
+ *
+ * @since 1.2.18
+ */
+final class HttpServerOperationsTerminatedEvent {
+
+	static final HttpServerOperationsTerminatedEvent INSTANCE = new HttpServerOperationsTerminatedEvent();
+
+	private HttpServerOperationsTerminatedEvent() {
+	}
+
+	@Override
+	public String toString() {
+		return "HttpServerOperationsTerminatedEvent";
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -233,6 +233,16 @@ final class HttpTrafficHandler extends ChannelDuplexHandler implements Runnable 
 					return;
 				}
 
+				ChannelOperations<?, ?> existingOps = ChannelOperations.get(ctx.channel());
+				if (existingOps instanceof HttpServerOperations) {
+					if (HttpServerOperations.log.isDebugEnabled()) {
+						HttpServerOperations.log.debug(format(ctx.channel(), "Buffering keep-alive request, previous ops not yet terminated"));
+					}
+					overflow = true;
+					doPipeline(ctx, new HttpRequestHolder(request));
+					return;
+				}
+
 				HttpServerOperations ops;
 				ZonedDateTime timestamp = ZonedDateTime.now(ReactorNetty.ZONE_ID_SYSTEM);
 				ConnectionInfo connectionInfo = null;
@@ -511,6 +521,16 @@ final class HttpTrafficHandler extends ChannelDuplexHandler implements Runnable 
 		ctx.write(response, promise);
 	}
 
+	@Override
+	public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+		if (evt == HttpServerOperationsTerminatedEvent.INSTANCE) {
+			if (persistentConnection && ctx.channel().isActive()) {
+				resumeRead();
+			}
+		}
+		super.userEventTriggered(ctx, evt);
+	}
+
 	@SuppressWarnings("FutureReturnValueIgnored")
 	void handleLastHttpContent(Object msg, ChannelPromise promise) {
 		finalizingResponse = true;
@@ -546,6 +566,9 @@ final class HttpTrafficHandler extends ChannelDuplexHandler implements Runnable 
 			}
 		}
 
+	}
+
+	void resumeRead() {
 		if (pipelined != null && !pipelined.isEmpty()) {
 			if (HttpServerOperations.log.isDebugEnabled()) {
 				HttpServerOperations.log.debug(format(ctx.channel(), "Draining next pipelined " +

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -3926,4 +3926,86 @@ class HttpServerTests extends BaseHttpTest {
 		public void recordResponseTime(SocketAddress remoteAddress, String uri, String method, String status, Duration time) {
 		}
 	}
+
+	@Test
+	@Timeout(30)
+	void testIssue4188() throws Exception {
+		// https://github.com/reactor/reactor-netty/issues/4188
+		//
+		// Verifies the fix for a TOCTOU race condition in HttpTrafficHandler:
+		//
+		// Before the fix, when a keep-alive request arrived while the previous ops was
+		// still the current channel-bound ops, Connection.from(ctx.channel()) could
+		// return that request-scoped HttpServerOperations. If that ops later terminated,
+		// the new request could inherit an unstable parent chain.
+		//
+		// The fix buffers the next HTTP/1.1 keep-alive request while the previous ops
+		// is still channel-bound, and resumes read processing only after the previous
+		// ops reaches afterInboundComplete() inside terminate(), i.e. after the channel
+		// rebind point and before transition to DisposedConnection.
+
+		Field connectionField = ChannelOperations.class.getDeclaredField("connection");
+		connectionField.setAccessible(true);
+
+		int requestCount = 3;
+		List<Connection> parentConnections = new CopyOnWriteArrayList<>();
+		CountDownLatch latch = new CountDownLatch(requestCount);
+
+		disposableServer = createServer()
+				.doOnConnection(conn -> {
+					try {
+						Connection parent = (Connection) connectionField.get(conn);
+						parentConnections.add(parent);
+						latch.countDown();
+					}
+					catch (IllegalAccessException e) {
+						throw new RuntimeException(e);
+					}
+				})
+				.handle((req, res) -> {
+					// Send response immediately (Content-Length: 0), but delay chain
+					// completion. This keeps the current ops alive in the channel
+					// attribute when the next keep-alive request arrives via
+					// setAutoRead(true), which is the precondition for the TOCTOU race.
+					res.header(HttpHeaderNames.CONTENT_LENGTH, "0");
+					return res.then()
+					          .then(Mono.delay(Duration.ofMillis(200)).then());
+				})
+				.bindNow();
+
+		ConnectionProvider p = ConnectionProvider.create("testIssue4188", 1);
+
+		try {
+			Flux.range(0, requestCount)
+			    .concatMap(i ->
+			        createClient(p, disposableServer.port())
+			            .get()
+			            .uri("/")
+			            .responseSingle((r, bytes) -> {
+			                assertThat(r.status().code()).isEqualTo(200);
+			                return bytes.asString().defaultIfEmpty("");
+			            }))
+			    .blockLast(Duration.ofSeconds(20));
+		}
+		finally {
+			p.disposeLater().block(Duration.ofSeconds(5));
+		}
+
+		assertThat(latch.await(20, TimeUnit.SECONDS)).as("all requests processed").isTrue();
+		assertThat(parentConnections).hasSize(requestCount);
+
+		// All ops must share the same parent connection
+		Connection firstParent = parentConnections.get(0);
+		for (int i = 1; i < parentConnections.size(); i++) {
+			assertThat(parentConnections.get(i))
+					.as("ops[%d] parent connection should be the same stable initial connection", i)
+					.isSameAs(firstParent);
+		}
+
+		// The parent must NOT be a ChannelOperations (which can be terminated/disposed)
+		assertThat(firstParent)
+				.as("parent connection should not be a terminable ChannelOperations")
+				.isNotInstanceOf(ChannelOperations.class);
+	}
+
 }


### PR DESCRIPTION
  ## Summary

  Fixes #4188

  `HttpTrafficHandler` created new `HttpServerOperations` from `Connection.from(ctx.channel())`. On HTTP/1.1 keep-alive
  connections, that lookup could still return the previous request's `HttpServerOperations` instead of the stable channel-
  bound connection.

  This change captures the stable connection once in `handlerAdded()` and reuses it for subsequent request-scoped
  `HttpServerOperations`, including the pipelined path. That prevents a new request from inheriting a terminating
  `ChannelOperations` as its parent.

  ## Changes

  - capture the initial stable connection in `HttpTrafficHandler.handlerAdded()`
  - use that connection when creating `HttpServerOperations` in `channelRead()`
  - use the same connection in the pipelined request path in `run()`
  - add a regression test covering keep-alive reuse

  ## Testing

  - added `testKeepAliveNewOpsUsesStableParentConnection`
  - verified the test fails without the fix
  - verified the test passes with the fix