### PR TITLE
Fix `HTTP/3` connection pool drain when server replenishes streams to same level

### DIFF
--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -192,6 +192,7 @@ dependencies {
 	http3TestImplementation "io.projectreactor:reactor-test:$testAddonVersion"
 	http3TestImplementation "org.assertj:assertj-core:$assertJVersion"
 	http3TestImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
+	http3TestImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
 	http3TestImplementation "io.netty:netty-codec-native-quic:$nettyVersion$os_suffix"
 	http3TestImplementation "io.netty:netty-pkitesting:$nettyVersion"
 	http3TestRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"

--- a/reactor-netty-http/src/http3Test/java/reactor/netty/http/client/Http3PoolTest.java
+++ b/reactor-netty-http/src/http3Test/java/reactor/netty/http/client/Http3PoolTest.java
@@ -39,6 +39,8 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.internal.shaded.reactor.pool.PoolBuilder;
@@ -237,8 +239,9 @@ class Http3PoolTest {
 		}
 	}
 
-	@Test
-	void serverReplenishesStreams() {
+	@ParameterizedTest
+	@CsvSource({"1, 1, 1", "2, 2, 2"})
+	void serverReplenishesStreams(int streamsToRelease, int replenishedPeerAllowed, int expectedMaxConcurrentStreams) {
 		TestQuicChannel channel = new TestQuicChannel(2);
 
 		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
@@ -266,9 +269,12 @@ class Http3PoolTest {
 			assertThat(slot.canOpenStream()).isFalse();
 			assertThat(slot.maxConcurrentStreams).isEqualTo(2);
 
-			acquired.get(0).invalidate().block(Duration.ofSeconds(1));
+			for (int i = 0; i < streamsToRelease; i++) {
+				acquired.get(0).invalidate().block(Duration.ofSeconds(1));
+				acquired.remove(0);
+			}
 
-			assertThat(http3Pool.activeStreams()).isEqualTo(1);
+			assertThat(http3Pool.activeStreams()).isEqualTo(2 - streamsToRelease);
 			// In HTTP/3, releasing a stream does NOT replenish peerAllowedStreams.
 			// The peer budget is 0 (both used) and only the server can replenish via MAX_STREAMS.
 			assertThat(slot.canOpenStream()).isFalse();
@@ -280,17 +286,18 @@ class Http3PoolTest {
 			});
 			channel.runPendingTasks();
 
-			assertThat(acquired).hasSize(2);
+			int acquiredBeforeReplenish = acquired.size();
+			assertThat(acquiredBeforeReplenish).isEqualTo(2 - streamsToRelease);
 
 			// Simulate server replenishing streams via MAX_STREAMS
-			channel.setPeerAllowedStreams(QuicStreamType.BIDIRECTIONAL, 1);
+			channel.setPeerAllowedStreams(QuicStreamType.BIDIRECTIONAL, replenishedPeerAllowed);
 			slot.updateMaxConcurrentStreams(0);
 
 			channel.runPendingTasks();
 
-			assertThat(acquired).hasSize(3);
-			assertThat(http3Pool.activeStreams()).isEqualTo(2);
-			assertThat(slot.maxConcurrentStreams).isEqualTo(1);
+			assertThat(acquired).hasSize(acquiredBeforeReplenish + 1);
+			assertThat(http3Pool.activeStreams()).isEqualTo(2 - streamsToRelease + 1);
+			assertThat(slot.maxConcurrentStreams).isEqualTo(expectedMaxConcurrentStreams);
 
 			for (PooledRef<Connection> ref : acquired) {
 				ref.invalidate().block(Duration.ofSeconds(1));

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http3Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http3Pool.java
@@ -110,8 +110,10 @@ final class Http3Pool extends Http2Pool {
 			if (diff != 0) {
 				maxConcurrentStreams = newMaxConcurrentStreams;
 				TOTAL_MAX_CONCURRENT_STREAMS.addAndGet(this.pool, diff);
-				pool.drain();
 			}
+			// Always drain: even when maxConcurrentStreams hasn't changed, the server
+			// may have replenished peer-allowed streams, so pending borrowers must be woken up.
+			pool.drain();
 		}
 
 		private int peerAllowedMaxStreams() {


### PR DESCRIPTION
When the server sends a `MAX_STREAMS` frame that replenishes the stream limit back to the same value as the initial max, `updateMaxConcurrentStreams()` computes a diff of 0 and skips calling `pool.drain()`. This leave pending borrowers stuck waiting indefinitely, causing timeouts.

Move `pool.drain()` outside the diff check so it is always invoked on `QuicStreamLimitChangedEvent`, while `TOTAL_MAX_CONCURRENT_STREAMS` accounting remains conditional.