### PR TITLE
Document `TCP`/`UDP` metrics `remote.address` tag cardinality

### DIFF
--- a/docs/modules/ROOT/pages/tcp-client.adoc
+++ b/docs/modules/ROOT/pages/tcp-client.adoc
@@ -252,6 +252,9 @@ See xref:observability.adoc#observability-metrics-connect-time[Connect Time]
 See xref:observability.adoc#observability-metrics-hostname-resolution-time[Hostname Resolution Time]
 |=======
 
+:channel-metrics-prefix: reactor.netty.tcp.client
+include::partial$tcp-udp-metrics-remote-address-filter.adoc[]
+
 These additional metrics are also available:
 
 include::partial$conn-provider-metrics.adoc[]

--- a/docs/modules/ROOT/pages/tcp-server.adoc
+++ b/docs/modules/ROOT/pages/tcp-server.adoc
@@ -227,6 +227,9 @@ See xref:observability.adoc#observability-metrics-errors-count[Errors Count]
 See xref:observability.adoc#observability-metrics-tls-handshake-time[Tls Handshake Time]
 |=======
 
+:channel-metrics-prefix: reactor.netty.tcp.server
+include::partial$tcp-udp-metrics-remote-address-filter.adoc[]
+
 These additional metrics are also available:
 
 include::partial$alloc-metrics.adoc[]

--- a/docs/modules/ROOT/pages/udp-client.adoc
+++ b/docs/modules/ROOT/pages/udp-client.adoc
@@ -188,6 +188,9 @@ See xref:observability.adoc#observability-metrics-connect-time[Connect Time]
 See xref:observability.adoc#observability-metrics-hostname-resolution-time[Hostname Resolution Time]
 |=======
 
+:channel-metrics-prefix: reactor.netty.udp.client
+include::partial$tcp-udp-metrics-remote-address-filter.adoc[]
+
 These additional metrics are also available:
 
 include::partial$alloc-metrics.adoc[]

--- a/docs/modules/ROOT/pages/udp-server.adoc
+++ b/docs/modules/ROOT/pages/udp-server.adoc
@@ -178,6 +178,9 @@ See xref:observability.adoc#observability-metrics-data-sent[Data Sent]
 See xref:observability.adoc#observability-metrics-errors-count[Errors Count]
 |=======
 
+:channel-metrics-prefix: reactor.netty.udp.server
+include::partial$tcp-udp-metrics-remote-address-filter.adoc[]
+
 These additional metrics are also available:
 
 include::partial$alloc-metrics.adoc[]

--- a/docs/modules/ROOT/partials/tcp-udp-metrics-remote-address-filter.adoc
+++ b/docs/modules/ROOT/partials/tcp-udp-metrics-remote-address-filter.adoc
@@ -1,0 +1,15 @@
+NOTE: TCP and UDP channel metrics include a `remote.address` tag for the peer.
+Each distinct address adds time series, which can increase memory and CPU usage on the registry.
+As a best practice, configure an upper bound for that tag with https://micrometer.io/docs/concepts#_denyaccept_meters[`MeterFilter.maximumAllowableTags`], using this transport's metric name prefix and `reactor.netty.Metrics.REMOTE_ADDRESS` as the tag key.
+
+[source,java,subs=verbatim+attributes]
+----
+import io.micrometer.core.instrument.MeterFilter;
+import io.micrometer.core.instrument.Metrics;
+
+import static reactor.netty.Metrics.REMOTE_ADDRESS;
+
+Metrics.globalRegistry
+        .config()
+        .meterFilter(MeterFilter.maximumAllowableTags("{channel-metrics-prefix}", REMOTE_ADDRESS, 100, MeterFilter.deny()));
+----

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,11 @@ import static reactor.netty.Metrics.formatSocketAddress;
 
 /**
  * A {@link ChannelMetricsRecorder} implementation for integration with Micrometer.
+ * <p>Meters use a {@link reactor.netty.Metrics#REMOTE_ADDRESS remote.address} tag whose value is derived
+ * from each peer address. Applications should apply a {@link io.micrometer.core.instrument.config.MeterFilter}
+ * such as {@link io.micrometer.core.instrument.config.MeterFilter#maximumAllowableTags maximumAllowableTags}
+ * on the registry, scoped to the
+ * transport's metric name prefix and the {@code remote.address} tag key, to cap cardinality.
  *
  * @author Violeta Georgieva
  * @since 0.9

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClient.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,6 +236,22 @@ public abstract class TcpClient extends ClientTransport<TcpClient, TcpClientConf
 		return super.host(host);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * <p>When metrics are enabled with the default Micrometer {@link ChannelMetricsRecorder}, several meters use a
+	 * {@link reactor.netty.Metrics#REMOTE_ADDRESS remote.address} tag with one value per distinct peer. That cardinality can grow
+	 * without bound, so it is best practice to configure
+	 * {@link io.micrometer.core.instrument.config.MeterFilter#maximumAllowableTags maximumAllowableTags} on the registry
+	 * for {@link reactor.netty.Metrics#TCP_CLIENT_PREFIX} and {@link reactor.netty.Metrics#REMOTE_ADDRESS}. For example:
+	 * <pre class="code">
+	 * import io.micrometer.core.instrument.MeterFilter;
+	 * import io.micrometer.core.instrument.Metrics;
+	 *
+	 * Metrics.globalRegistry
+	 *        .config()
+	 *        .meterFilter(MeterFilter.maximumAllowableTags(TCP_CLIENT_PREFIX, REMOTE_ADDRESS, 100, MeterFilter.deny()));
+	 * </pre>
+	 */
 	@Override
 	public TcpClient metrics(boolean enable) {
 		return super.metrics(enable);

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServer.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,6 +121,22 @@ public abstract class TcpServer extends ServerTransport<TcpServer, TcpServerConf
 		return super.host(host);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * <p>When metrics are enabled with the default Micrometer {@link ChannelMetricsRecorder}, several meters use a
+	 * {@link reactor.netty.Metrics#REMOTE_ADDRESS remote.address} tag with one value per distinct peer. That cardinality can grow
+	 * without bound, so it is best practice to configure
+	 * {@link io.micrometer.core.instrument.config.MeterFilter#maximumAllowableTags maximumAllowableTags} on the registry
+	 * for {@link reactor.netty.Metrics#TCP_SERVER_PREFIX} and {@link reactor.netty.Metrics#REMOTE_ADDRESS}. For example:
+	 * <pre class="code">
+	 * import io.micrometer.core.instrument.MeterFilter;
+	 * import io.micrometer.core.instrument.Metrics;
+	 *
+	 * Metrics.globalRegistry
+	 *        .config()
+	 *        .meterFilter(MeterFilter.maximumAllowableTags(TCP_SERVER_PREFIX, REMOTE_ADDRESS, 100, MeterFilter.deny()));
+	 * </pre>
+	 */
 	@Override
 	public TcpServer metrics(boolean enable) {
 		return super.metrics(enable);

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,12 +123,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * {@link io.micrometer.core.instrument.Metrics#globalRegistry globalRegistry}.
 	 * Applications can separately register their own
 	 * {@link io.micrometer.core.instrument.config.MeterFilter filters}.
-	 * For example, to put an upper bound on the number of tags produced:
-	 * <pre class="code">
-	 * MeterFilter filter = ... ;
-	 * Metrics.globalRegistry.config().meterFilter(MeterFilter.maximumAllowableTags(prefix, 100, filter));
-	 * </pre>
-	 * <p>By default this is not enabled.
+	 * <p>By default, this is not enabled.
 	 *
 	 * @param enable true enables metrics collection; false disables it
 	 * @return a new {@link Transport} reference

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClient.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,6 +131,22 @@ public abstract class UdpClient extends ClientTransport<UdpClient, UdpClientConf
 		return super.host(host);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * <p>When metrics are enabled with the default Micrometer {@link ChannelMetricsRecorder}, several meters use a
+	 * {@link reactor.netty.Metrics#REMOTE_ADDRESS remote.address} tag with one value per distinct peer. That cardinality can grow
+	 * without bound, so it is best practice to configure
+	 * {@link io.micrometer.core.instrument.config.MeterFilter#maximumAllowableTags maximumAllowableTags} on the registry
+	 * for {@link reactor.netty.Metrics#UDP_CLIENT_PREFIX} and {@link reactor.netty.Metrics#REMOTE_ADDRESS}. For example:
+	 * <pre class="code">
+	 * import io.micrometer.core.instrument.MeterFilter;
+	 * import io.micrometer.core.instrument.Metrics;
+	 *
+	 * Metrics.globalRegistry
+	 *        .config()
+	 *        .meterFilter(MeterFilter.maximumAllowableTags(UDP_CLIENT_PREFIX, REMOTE_ADDRESS, 100, MeterFilter.deny()));
+	 * </pre>
+	 */
 	@Override
 	public final UdpClient metrics(boolean enable) {
 		return super.metrics(enable);

--- a/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServer.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/udp/UdpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -197,6 +197,22 @@ public abstract class UdpServer extends Transport<UdpServer, UdpServerConfig> {
 		return bindAddress(() -> AddressUtils.updateHost(configuration().bindAddress(), host));
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * <p>When metrics are enabled with the default Micrometer {@link ChannelMetricsRecorder}, several meters use a
+	 * {@link reactor.netty.Metrics#REMOTE_ADDRESS remote.address} tag with one value per distinct peer. That cardinality can grow
+	 * without bound, so it is best practice to configure
+	 * {@link io.micrometer.core.instrument.config.MeterFilter#maximumAllowableTags maximumAllowableTags} on the registry
+	 * for {@link reactor.netty.Metrics#UDP_SERVER_PREFIX} and {@link reactor.netty.Metrics#REMOTE_ADDRESS}. For example:
+	 * <pre class="code">
+	 * import io.micrometer.core.instrument.MeterFilter;
+	 * import io.micrometer.core.instrument.Metrics;
+	 *
+	 * Metrics.globalRegistry
+	 *        .config()
+	 *        .meterFilter(MeterFilter.maximumAllowableTags(UDP_SERVER_PREFIX, REMOTE_ADDRESS, 100, MeterFilter.deny()));
+	 * </pre>
+	 */
 	@Override
 	public final UdpServer metrics(boolean enable) {
 		return super.metrics(enable);


### PR DESCRIPTION
Recommend `MeterFilter.maximumAllowableTags` on the `Micrometer` registry scoped to each transport's metric prefix and `Metrics.REMOTE_ADDRESS`.