### PR TITLE
Throw `DecoderException` with hostname when `SNI` AsyncMapping resolves to null

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
@@ -26,6 +26,7 @@ import io.netty.util.DomainWildcardMappingBuilder;
 import io.netty.util.Mapping;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.PlatformDependent;
 import reactor.netty.NettyPipeline;
@@ -112,7 +113,22 @@ final class SniProvider {
 
 		@Override
 		protected Future<SslProvider> lookup(ChannelHandlerContext ctx, String hostname) {
-			return mappings.map(hostname, ctx.executor().newPromise());
+			Promise<SslProvider> promise = ctx.executor().newPromise();
+			mappings.map(hostname, ctx.executor().newPromise())
+			        .addListener((FutureListener<SslProvider>) future -> {
+			            Throwable cause = future.cause();
+			            if (cause != null) {
+			                promise.setFailure(cause);
+			            }
+			            else if (future.getNow() == null) {
+			                promise.setFailure(new DecoderException("failed to get the SslContext for " + hostname
+			                        + ": the SNI mapping returned null"));
+			            }
+			            else {
+			                promise.setSuccess(future.getNow());
+			            }
+			        });
+			return promise;
 		}
 
 		@Override
@@ -122,14 +138,15 @@ final class SniProvider {
 				if (cause instanceof Error) {
 					throw (Error) cause;
 				}
+				// The lookup already builds a descriptive DecoderException (e.g. the SNI mapping
+				// returned null), so propagate it as-is instead of wrapping it once more.
+				if (cause instanceof DecoderException) {
+					throw (DecoderException) cause;
+				}
 				throw new DecoderException("failed to get the SslContext for " + hostname, cause);
 			}
 
 			SslProvider sslProvider = future.getNow();
-			if (sslProvider == null) {
-				throw new DecoderException("failed to get the SslContext for " + hostname
-						+ ": the SNI mapping returned null");
-			}
 			SslHandler sslHandler = null;
 			try {
 				sslHandler = sslProvider.getSslContext().newHandler(ctx.alloc());

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
@@ -126,6 +126,10 @@ final class SniProvider {
 			}
 
 			SslProvider sslProvider = future.getNow();
+			if (sslProvider == null) {
+				throw new DecoderException("failed to get the SslContext for " + hostname
+						+ ": the SNI mapping returned null");
+			}
 			SslHandler sslHandler = null;
 			try {
 				sslHandler = sslProvider.getSslContext().newHandler(ctx.alloc());

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -199,6 +199,10 @@ public final class SslProvider {
 		 * <p><strong>Note:</strong> This method is an alternative of {@link #addSniMapping(String, Consumer)},
 		 * {@link #addSniMappings(Map)} and {@link #setSniMappings(Map)}.
 		 * <p><strong>Note:</strong> This configuration is applicable only when configuring the server.
+		 * <p><strong>Note:</strong> The supplied {@link AsyncMapping} must resolve to a non-null
+		 * {@link SslProvider} when it completes successfully. Completing the lookup successfully
+		 * with a {@code null} value causes the SNI handshake to fail with an
+		 * {@link io.netty.handler.codec.DecoderException}.
 		 *
 		 * @param mappings mappings of domain names to {@link SslProvider}
 		 * @return {@literal this}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -67,6 +67,7 @@ import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
@@ -2433,6 +2434,58 @@ class HttpServerTests extends BaseHttpTest {
 
 		assertThat(hostname.get()).isNotNull();
 		assertThat(hostname.get()).isEqualTo("test.com");
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	void testSniSupportAsyncMappingsReturningNull() throws Exception {
+		Http11SslContextSpec defaultSslContextBuilder =
+				Http11SslContextSpec.forServer(ssc.toTempCertChainPem(), ssc.toTempPrivateKeyPem());
+
+		Http11SslContextSpec clientSslContextBuilder =
+				Http11SslContextSpec.forClient()
+				                    .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+
+		Sinks.One<Throwable> error = Sinks.one();
+		AtomicReference<String> mappedHostname = new AtomicReference<>();
+		disposableServer =
+				createServer()
+				        .secure(spec -> spec.sslContext(defaultSslContextBuilder)
+				                            .setSniAsyncMappings((input, promise) -> {
+				                                mappedHostname.set(input);
+				                                return promise.setSuccess(null);
+				                            }))
+				        .doOnChannelInit((obs, ch, addr) ->
+				                ch.pipeline().addBefore(NettyPipeline.ReactiveBridge, "testSniSupportAsyncMappingsReturningNull",
+				                        new ChannelInboundHandlerAdapter() {
+
+				                            @Override
+				                            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+				                                error.tryEmitValue(cause);
+				                                ctx.fireExceptionCaught(cause);
+				                            }
+				                        }))
+				        .handle((req, res) -> res.sendString(Mono.just("testSniSupport")))
+				        .bindNow();
+
+		createClient(disposableServer::address)
+		        .secure(spec -> spec.sslContext(clientSslContextBuilder)
+		                            .serverNames(new SNIHostName("test.com")))
+		        .get()
+		        .uri("/")
+		        .responseContent()
+		        .aggregate()
+		        .as(StepVerifier::create)
+		        .expectError()
+		        .verify(Duration.ofSeconds(10));
+
+		StepVerifier.create(error.asMono())
+		            .expectNextMatches(t -> t instanceof DecoderException
+		                    && t.getMessage() != null
+		                    && t.getMessage().contains(String.valueOf(mappedHostname.get()))
+		                    && t.getMessage().contains("the SNI mapping returned null"))
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(10));
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -2447,6 +2447,7 @@ class HttpServerTests extends BaseHttpTest {
 				                    .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
 
 		Sinks.One<Throwable> error = Sinks.one();
+		Sinks.One<SniCompletionEvent> sniCompletionEvent = Sinks.one();
 		AtomicReference<String> mappedHostname = new AtomicReference<>();
 		disposableServer =
 				createServer()
@@ -2458,6 +2459,14 @@ class HttpServerTests extends BaseHttpTest {
 				        .doOnChannelInit((obs, ch, addr) ->
 				                ch.pipeline().addBefore(NettyPipeline.ReactiveBridge, "testSniSupportAsyncMappingsReturningNull",
 				                        new ChannelInboundHandlerAdapter() {
+
+				                            @Override
+				                            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+				                                if (evt instanceof SniCompletionEvent) {
+				                                    sniCompletionEvent.tryEmitValue((SniCompletionEvent) evt);
+				                                }
+				                                ctx.fireUserEventTriggered(evt);
+				                            }
 
 				                            @Override
 				                            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
@@ -2484,6 +2493,14 @@ class HttpServerTests extends BaseHttpTest {
 		                    && t.getMessage() != null
 		                    && t.getMessage().contains(String.valueOf(mappedHostname.get()))
 		                    && t.getMessage().contains("the SNI mapping returned null"))
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(10));
+
+		StepVerifier.create(sniCompletionEvent.asMono())
+		            .expectNextMatches(evt -> !evt.isSuccess()
+		                    && evt.cause() instanceof DecoderException
+		                    && evt.cause().getMessage() != null
+		                    && evt.cause().getMessage().contains("the SNI mapping returned null"))
 		            .expectComplete()
 		            .verify(Duration.ofSeconds(10));
 	}


### PR DESCRIPTION
If the `AsyncMapping` configured via `SslProvider.Builder.setSniAsyncMappings` resolves successfully with a `null` `SslProvider`, `SniProvider.SniHandler.onLookupComplete` produces a bare `NullPointerException` without the offending hostname.

This change throws a `DecoderException` carrying the hostname instead.

Fixes #4210