### PR TITLE
Handle IPv6 localhost in hosts resolver test

### DIFF
--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -300,7 +300,7 @@ class ClientTransportTest {
 				NameResolverProvider nameResolverProvider = NameResolverProvider.builder()
 						.hostsFileEntriesResolver((inetHost, resolvedAddressTypes) ->
 							// Returns only the first entry from the hosts file
-							addresses != null && !addresses.isEmpty() ? addresses.get(0) : null)
+							!addresses.isEmpty() ? addresses.get(0) : null)
 						.build();
 				config.defaultResolver.set(nameResolverProvider.newNameResolverGroup(config.loopResources, true));
 			}

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
@@ -37,6 +37,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -282,7 +283,17 @@ class ClientTransportTest {
 		TestClientTransportConfig config =
 				new TestClientTransportConfig(provider, Collections.emptyMap(), () -> null);
 		HostsFileEntriesProvider hostsFileEntriesProvider = HostsFileEntriesProvider.parser().parseSilently();
-		List<InetAddress> addresses = hostsFileEntriesProvider.ipv4Entries().get("localhost");
+		List<InetAddress> addresses = new ArrayList<>();
+
+		List<InetAddress> ipv4Addresses = hostsFileEntriesProvider.ipv4Entries().get("localhost");
+		if (ipv4Addresses != null) {
+			addresses.addAll(ipv4Addresses);
+		}
+
+		List<InetAddress> ipv6Addresses = hostsFileEntriesProvider.ipv6Entries().get("localhost");
+		if (ipv6Addresses != null) {
+			addresses.addAll(ipv6Addresses);
+		}
 		try {
 			config.loopResources = loop1;
 			if (customResolver) {


### PR DESCRIPTION
### Motivation

`ClientTransportTest#testDefaultHostsFileEntriesResolver` can fail on environments where `localhost` resolves to both IPv4 and IPv6 entries.

In my local environment, the resolver returned both:

- `localhost/127.0.0.1`
- `localhost/0:0:0:0:0:0:0:1`

while the test expected only one entry.

### Changes

This updates the test expectation to include both IPv4 and IPv6 `localhost` entries from `HostsFileEntriesProvider`.

### Testing

Ran:

```bash
./gradlew :reactor-netty-core:test --tests "reactor.netty.transport.ClientTransportTest.testDefaultHostsFileEntriesResolver"
./gradlew :reactor-netty-core:test --tests "reactor.netty.transport.ClientTransportTest"