### PR TITLE
Add SSL support for HTTP proxy connections

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/NettyPipeline.java
@@ -114,6 +114,9 @@ public interface NettyPipeline {
 	String OnChannelReadIdle     = LEFT + "onChannelReadIdle";
 	String OnChannelWriteIdle    = LEFT + "onChannelWriteIdle";
 	String ProxyHandler          = LEFT + "proxyHandler";
+	String ProxySslHandler       = LEFT + "proxySslHandler";
+	String ProxySslLoggingHandler = LEFT + "proxySslLoggingHandler";
+	String ProxySslReader        = LEFT + "proxySslReader";
 	/**
 	 * Use to register a special handler which ensures that any {@link io.netty.channel.VoidChannelPromise}
 	 * will be converted to "unvoided" promises.

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelMetricsHandler.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.handler.ssl.SniCompletionEvent;
 import io.netty.handler.ssl.SslHandler;
 import org.jspecify.annotations.Nullable;
+import reactor.netty.NettyPipeline;
 
 import java.net.SocketAddress;
 import java.time.Duration;
@@ -151,7 +152,7 @@ public class ChannelMetricsHandler extends AbstractChannelMetricsHandler {
 
 		private void addListener(ChannelHandlerContext ctx) {
 			if (!listenerAdded) {
-				SslHandler sslHandler = ctx.pipeline().get(SslHandler.class);
+				SslHandler sslHandler = (SslHandler) ctx.pipeline().get(NettyPipeline.SslHandler);
 				if (sslHandler != null) {
 					listenerAdded = true;
 					long tlsHandshakeTimeStart = System.nanoTime();

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsHandler.java
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.handler.ssl.SniCompletionEvent;
 import io.netty.handler.ssl.SslHandler;
 import org.jspecify.annotations.Nullable;
+import reactor.netty.NettyPipeline;
 import reactor.netty.ReactorNetty;
 import reactor.netty.observability.ReactorNettyHandlerContext;
 import reactor.util.context.ContextView;
@@ -352,7 +353,7 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 
 		private void addListener(ChannelHandlerContext ctx) {
 			if (!listenerAdded) {
-				SslHandler sslHandler = ctx.pipeline().get(SslHandler.class);
+				SslHandler sslHandler = (SslHandler) ctx.pipeline().get(NettyPipeline.SslHandler);
 				if (sslHandler != null) {
 					listenerAdded = true;
 					SocketAddress rAddr = remoteAddress != null ? remoteAddress : ctx.channel().remoteAddress();

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SslProvider.java
@@ -472,6 +472,41 @@ public final class SslProvider {
 		addSslReadHandler(pipeline, sslDebug);
 	}
 
+	public void addProxySslHandler(Channel channel, @Nullable SocketAddress remoteAddress, boolean sslDebug) {
+		Objects.requireNonNull(channel, "channel");
+
+		SslHandler sslHandler;
+
+		if (remoteAddress instanceof InetSocketAddress) {
+			InetSocketAddress sniInfo = (InetSocketAddress) remoteAddress;
+			sslHandler = getSslContext()
+					.newHandler(channel.alloc(), sniInfo.getHostString(), sniInfo.getPort());
+
+			if (log.isDebugEnabled()) {
+				log.debug(format(channel, "Proxy SSL enabled using engine {} and SNI {}"), sslHandler.engine(), sniInfo);
+			}
+		}
+		else {
+			sslHandler = getSslContext().newHandler(channel.alloc());
+
+			if (log.isDebugEnabled()) {
+				log.debug(format(channel, "Proxy SSL enabled using engine {}"), sslHandler.engine());
+			}
+		}
+
+		configure(sslHandler);
+
+		ChannelPipeline pipeline = channel.pipeline();
+		if (pipeline.get(NettyPipeline.ProxyHandler) != null) {
+			pipeline.addBefore(NettyPipeline.ProxyHandler, NettyPipeline.ProxySslHandler, sslHandler);
+		}
+		else {
+			pipeline.addFirst(NettyPipeline.ProxySslHandler, sslHandler);
+		}
+
+		addProxySslReadHandler(pipeline, sslDebug);
+	}
+
 	@Override
 	public String toString() {
 		return "SslProvider {" +
@@ -507,6 +542,53 @@ public final class SslProvider {
 		}
 		else {
 			pipeline.addAfter(NettyPipeline.SslHandler, NettyPipeline.SslReader, new SslReadHandler());
+		}
+	}
+
+	static void addProxySslReadHandler(ChannelPipeline pipeline, boolean sslDebug) {
+		pipeline.addAfter(NettyPipeline.ProxySslHandler, NettyPipeline.ProxySslReader, new ProxySslReadHandler());
+		if (sslDebug) {
+			pipeline.addBefore(NettyPipeline.ProxySslHandler, NettyPipeline.ProxySslLoggingHandler, LOGGING_HANDLER);
+		}
+	}
+
+	static final class ProxySslReadHandler extends ChannelInboundHandlerAdapter {
+
+		boolean handshakeDone;
+
+		@Override
+		public void channelActive(ChannelHandlerContext ctx) {
+			ctx.read();
+		}
+
+		@Override
+		public void channelReadComplete(ChannelHandlerContext ctx) {
+			if (!handshakeDone) {
+				ctx.read();
+			}
+			ctx.fireChannelReadComplete();
+		}
+
+		@Override
+		public boolean isSharable() {
+			return false;
+		}
+
+		@Override
+		public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+			if (evt instanceof SslHandshakeCompletionEvent) {
+				handshakeDone = true;
+				if (ctx.pipeline().context(this) != null) {
+					ctx.pipeline().remove(this);
+				}
+
+				SslHandshakeCompletionEvent handshake = (SslHandshakeCompletionEvent) evt;
+				if (!handshake.isSuccess()) {
+					ctx.fireExceptionCaught(handshake.cause());
+				}
+				return;
+			}
+			ctx.fireUserEventTriggered(evt);
 		}
 	}
 

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ProxyProvider.java
@@ -41,7 +41,9 @@ import io.netty.handler.proxy.Socks4ProxyHandler;
 import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.util.internal.StringUtil;
 import org.jspecify.annotations.Nullable;
+import reactor.netty.ReactorNetty;
 import reactor.netty.NettyPipeline;
+import reactor.netty.tcp.SslProvider;
 import reactor.netty.transport.logging.AdvancedByteBufFormat;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.PROXY_AUTHORIZATION;
@@ -69,6 +71,7 @@ public final class ProxyProvider {
 	final @Nullable HttpHeaders httpHeaders;
 	final @Nullable HttpHeaders httpHeadersNoProxyAuthorization;
 	final @Nullable Integer proxyAuthorizationHeaderUID;
+	final @Nullable SslProvider sslProvider;
 	final Proxy type;
 	final long connectTimeoutMillis;
 
@@ -112,6 +115,7 @@ public final class ProxyProvider {
 			throw new IllegalArgumentException("Proxy type is not specified");
 		}
 		this.connectTimeoutMillis = builder.connectTimeoutMillis;
+		this.sslProvider = builder.sslProvider;
 	}
 
 	/**
@@ -219,6 +223,9 @@ public final class ProxyProvider {
 		Objects.requireNonNull(channel, "channel");
 		ChannelPipeline pipeline = channel.pipeline();
 		pipeline.addFirst(NettyPipeline.ProxyHandler, newProxyHandler());
+		if (sslProvider != null) {
+			sslProvider.addProxySslHandler(channel, address, PROXY_SSL_DEBUG);
+		}
 		// For SOCKS proxy, the netty SOCKS handlers may register listeners in channel promises, so we need to register a
 		// special handler which ensures that any VoidPromise will be converted to "unvoided" promises (for support of listeners).
 		// Note: an example of a VoidPromise which does not support listeners is the MonoSendMany.SendManyInner promise.
@@ -303,6 +310,8 @@ public final class ProxyProvider {
 	static final LoggingHandler LOGGING_HANDLER =
 			AdvancedByteBufFormat.HEX_DUMP
 					.toLoggingHandler("reactor.netty.proxy", LogLevel.DEBUG, Charset.defaultCharset());
+	static final boolean PROXY_SSL_DEBUG =
+			Boolean.parseBoolean(System.getProperty(ReactorNetty.SSL_CLIENT_DEBUG, "false"));
 
 	static final String HTTP_PROXY_HOST = "http.proxyHost";
 	static final String HTTP_PROXY_PORT = "http.proxyPort";
@@ -440,6 +449,7 @@ public final class ProxyProvider {
 		@Nullable String password;
 		@Nullable Function<? super String, ? extends String> passwordFunction;
 		@Nullable String host;
+		@Nullable SslProvider sslProvider;
 		int port;
 		@Nullable Supplier<? extends SocketAddress> address;
 		Predicate<SocketAddress> nonProxyHostPredicate = ALWAYS_PROXY;
@@ -553,6 +563,21 @@ public final class ProxyProvider {
 		@Override
 		public Builder connectTimeoutMillis(long connectTimeoutMillis) {
 			this.connectTimeoutMillis = connectTimeoutMillis;
+			return this;
+		}
+
+		@Override
+		public Builder secure(Consumer<? super SslProvider.SslContextSpec> sslProviderBuilder) {
+			Objects.requireNonNull(sslProviderBuilder, "sslProviderBuilder");
+			SslProvider.SslContextSpec builder = SslProvider.builder();
+			sslProviderBuilder.accept(builder);
+			this.sslProvider = ((SslProvider.Builder) builder).build();
+			return this;
+		}
+
+		@Override
+		public Builder secure(SslProvider sslProvider) {
+			this.sslProvider = Objects.requireNonNull(sslProvider, "sslProvider");
 			return this;
 		}
 
@@ -788,6 +813,22 @@ public final class ProxyProvider {
 		 * @return {@code this}
 		 */
 		Builder connectTimeoutMillis(long connectTimeoutMillis);
+
+		/**
+		 * Apply SSL configuration customization options for the proxy connection.
+		 *
+		 * @param sslProviderBuilder builder callback for further customization of SslContext
+		 * @return {@code this}
+		 */
+		Builder secure(Consumer<? super SslProvider.SslContextSpec> sslProviderBuilder);
+
+		/**
+		 * Apply an SSL configuration via the passed {@link SslProvider} for the proxy connection.
+		 *
+		 * @param sslProvider the SSL provider
+		 * @return {@code this}
+		 */
+		Builder secure(SslProvider sslProvider);
 
 		/**
 		 * Builds new ProxyProvider.

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ProxyProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ProxyProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package reactor.netty.transport;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -24,9 +25,12 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.proxy.HttpProxyHandler;
 import io.netty.handler.proxy.ProxyHandler;
+import reactor.netty.NettyPipeline;
+import reactor.netty.tcp.TcpSslContextSpec;
 import io.netty.handler.proxy.Socks5ProxyHandler;
 import org.junit.jupiter.api.Test;
 
@@ -688,6 +692,39 @@ class ProxyProviderTest {
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> ProxyProvider.createFrom(properties))
 				.withMessage("only socks versions 4 and 5 supported but got 42");
+	}
+
+	@Test
+	void addProxyHandlerAddsProxySslHandlerBeforeProxyHandler() {
+		ProxyProvider proxyProvider =
+				ProxyProvider.builder()
+				             .type(ProxyProvider.Proxy.HTTP)
+				             .host("localhost")
+				             .port(8080)
+				             .secure(spec -> spec.sslContext(TcpSslContextSpec.forClient()))
+				             .build();
+
+		EmbeddedChannel channel = new EmbeddedChannel();
+
+		proxyProvider.addProxyHandler(channel);
+
+		List<String> names = channel.pipeline().names();
+
+		assertThat(channel.pipeline().get(NettyPipeline.ProxySslHandler))
+				.as("Pipeline names: %s", names)
+				.isNotNull();
+
+		assertThat(channel.pipeline().get(NettyPipeline.ProxySslReader))
+				.as("Pipeline names: %s", names)
+				.isNotNull();
+
+		assertThat(names)
+				.as("Pipeline names: %s", names)
+				.anyMatch(name -> name.contains("HttpProxyHandler"));
+
+		assertThat(names.indexOf(NettyPipeline.ProxySslHandler))
+				.as("Pipeline names: %s", names)
+				.isLessThan(names.indexOf(NettyPipeline.ProxySslReader));
 	}
 
 	private static ProxyProvider createProxy(InetSocketAddress address, Function<String, String> passwordFunc) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -1043,7 +1043,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 			this.creationTimestamp = pool.clock.millis();
 			this.pool = pool;
 			this.maxLifeTimeMs = maxLifeTimeMs;
-			SslHandler handler = connection.channel().pipeline().get(SslHandler.class);
+			SslHandler handler = (SslHandler) connection.channel().pipeline().get(NettyPipeline.SslHandler);
 			if (handler != null) {
 				this.applicationProtocol = handler.applicationProtocol() != null ?
 						handler.applicationProtocol() : ApplicationProtocolNames.HTTP_1_1;


### PR DESCRIPTION
### Motivation

This adds support for connecting to an HTTP proxy over SSL/TLS.

The target scenario is:

```text
HttpClient --TLS--> HTTPS proxy --plain HTTP--> backend
```

This is related to #2348, where the proxy endpoint itself is HTTPS while the backend resource can still be plain HTTP.

### Changes

* Adds proxy-level SSL configuration to `ProxyProvider`
* Adds dedicated proxy SSL pipeline handlers
* Ensures proxy SSL is inserted before the proxy handler
* Adds unit coverage for proxy SSL pipeline ordering

### Testing

Ran:

```bash
./gradlew :reactor-netty-core:compileJava
./gradlew :reactor-netty-core:test --tests "reactor.netty.transport.ProxyProviderTest"
```

### TODO

* Add end-to-end HTTP client test for HTTPS proxy -> HTTP backend
