### PR TITLE
Expose pending acquire latencies to custom `MeterRegistrar`

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/ConnectionProvider.java
@@ -914,5 +914,31 @@ public interface ConnectionProvider extends Disposable {
 		 */
 		default void deRegisterMetrics(String poolName, String id, SocketAddress remoteAddress) {
 		}
+
+		/**
+		 * Invoked when a pending acquisition succeeds, i.e. when a connection/stream becomes available after the
+		 * acquisition had to wait. Default implementation is a no-op for backwards compatibility.
+		 *
+		 * @param poolName the pool name
+		 * @param id the pool id
+		 * @param remoteAddress the remote address
+		 * @param pendingAcquireTimeMillis the time, in milliseconds, the acquisition spent pending before succeeding
+		 * @since 1.3.7
+		 */
+		default void recordPendingAcquireSuccess(String poolName, String id, SocketAddress remoteAddress, long pendingAcquireTimeMillis) {
+		}
+
+		/**
+		 * Invoked when a pending acquisition fails, e.g. on timeout or when the pending acquire queue is full, after
+		 * the acquisition had to wait. Default implementation is a no-op for backwards compatibility.
+		 *
+		 * @param poolName the pool name
+		 * @param id the pool id
+		 * @param remoteAddress the remote address
+		 * @param pendingAcquireTimeMillis the time, in milliseconds, the acquisition spent pending before failing
+		 * @since 1.3.7
+		 */
+		default void recordPendingAcquireFailure(String poolName, String id, SocketAddress remoteAddress, long pendingAcquireTimeMillis) {
+		}
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultPooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/DefaultPooledConnectionProvider.java
@@ -48,6 +48,7 @@ import reactor.netty.channel.ChannelOperations;
 import reactor.netty.transport.TransportConfig;
 import reactor.netty.transport.TransportConnector;
 import reactor.pool.InstrumentedPool;
+import reactor.pool.PoolMetricsRecorder;
 import reactor.pool.PooledRef;
 import reactor.pool.PooledRefMetadata;
 import reactor.util.Logger;
@@ -105,7 +106,20 @@ final class DefaultPooledConnectionProvider extends PooledConnectionProvider<Def
 			PoolFactory<PooledConnection> poolFactory,
 			SocketAddress remoteAddress,
 			@Nullable AddressResolverGroup<?> resolverGroup) {
-		return new PooledConnectionAllocator(id, name, config, poolFactory, remoteAddress, resolverGroup).pool;
+		return new PooledConnectionAllocator(config, poolFactory, remoteAddress, resolverGroup,
+				new MicrometerPoolMetricsRecorder(id, name, remoteAddress)).pool;
+	}
+
+	@Override
+	protected InstrumentedPool<PooledConnection> createPool(
+			String id,
+			TransportConfig config,
+			PoolFactory<PooledConnection> poolFactory,
+			SocketAddress remoteAddress,
+			@Nullable AddressResolverGroup<?> resolverGroup,
+			MeterRegistrar registrar) {
+		return new PooledConnectionAllocator(config, poolFactory, remoteAddress, resolverGroup,
+				new MeterRegistrarPoolMetricsRecorder(registrar, name, id, remoteAddress)).pool;
 	}
 
 	static final Logger log = Loggers.getLogger(DefaultPooledConnectionProvider.class);
@@ -523,26 +537,21 @@ final class DefaultPooledConnectionProvider extends PooledConnectionProvider<Def
 				PoolFactory<PooledConnection> provider,
 				SocketAddress remoteAddress,
 				@Nullable AddressResolverGroup<?> resolver) {
-			this(null, null, config, provider, remoteAddress, resolver);
+			this(config, provider, remoteAddress, resolver, null);
 		}
 
-		@SuppressWarnings("NullAway")
 		PooledConnectionAllocator(
-				@Nullable String id,
-				@Nullable String name,
 				TransportConfig config,
 				PoolFactory<PooledConnection> provider,
 				SocketAddress remoteAddress,
-				@Nullable AddressResolverGroup<?> resolver) {
+				@Nullable AddressResolverGroup<?> resolver,
+				@Nullable PoolMetricsRecorder poolMetricsRecorder) {
 			this.config = config;
 			this.remoteAddress = remoteAddress;
 			this.resolver = resolver;
-			this.pool = id == null ?
+			this.pool = poolMetricsRecorder == null ?
 					provider.newPool(connectChannel(), null, DEFAULT_DESTROY_HANDLER, DEFAULT_EVICTION_PREDICATE) :
-					provider.newPool(connectChannel(), DEFAULT_DESTROY_HANDLER, DEFAULT_EVICTION_PREDICATE,
-							// Deliberately suppress "NullAway"
-							// With id != null, this means name != null
-							new MicrometerPoolMetricsRecorder(id, name, remoteAddress));
+					provider.newPool(connectChannel(), DEFAULT_DESTROY_HANDLER, DEFAULT_EVICTION_PREDICATE, poolMetricsRecorder);
 		}
 
 		Publisher<PooledConnection> connectChannel() {

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/MeterRegistrarPoolMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/MeterRegistrarPoolMetricsRecorder.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.resources;
+
+import reactor.netty.resources.ConnectionProvider.MeterRegistrar;
+import reactor.pool.PoolMetricsRecorder;
+
+import java.net.SocketAddress;
+
+/**
+ * A {@link PoolMetricsRecorder} that bridges pending acquisition latencies to a user-provided
+ * {@link MeterRegistrar}. This allows custom registrars to receive the {@code pending.connections.time}
+ * data that is otherwise only available to the built-in Micrometer integration.
+ *
+ * @author Violeta Georgieva
+ * @since 1.3.7
+ */
+final class MeterRegistrarPoolMetricsRecorder implements PoolMetricsRecorder {
+
+	final MeterRegistrar registrar;
+	final String poolName;
+	final String id;
+	final SocketAddress remoteAddress;
+
+	MeterRegistrarPoolMetricsRecorder(MeterRegistrar registrar, String poolName, String id, SocketAddress remoteAddress) {
+		this.registrar = registrar;
+		this.poolName = poolName;
+		this.id = id;
+		this.remoteAddress = remoteAddress;
+	}
+
+	@Override
+	public void recordAllocationSuccessAndLatency(long latencyMs) {
+		//noop
+	}
+
+	@Override
+	public void recordAllocationFailureAndLatency(long latencyMs) {
+		//noop
+	}
+
+	@Override
+	public void recordResetLatency(long latencyMs) {
+		//noop
+	}
+
+	@Override
+	public void recordDestroyLatency(long latencyMs) {
+		//noop
+	}
+
+	@Override
+	public void recordRecycled() {
+		//noop
+	}
+
+	@Override
+	public void recordLifetimeDuration(long millisecondsSinceAllocation) {
+		//noop
+	}
+
+	@Override
+	public void recordIdleTime(long millisecondsIdle) {
+		//noop
+	}
+
+	@Override
+	public void recordSlowPath() {
+		//noop
+	}
+
+	@Override
+	public void recordFastPath() {
+		//noop
+	}
+
+	@Override
+	public void recordPendingSuccessAndLatency(long latencyMs) {
+		registrar.recordPendingAcquireSuccess(poolName, id, remoteAddress, latencyMs);
+	}
+
+	@Override
+	public void recordPendingFailureAndLatency(long latencyMs) {
+		registrar.recordPendingAcquireFailure(poolName, id, remoteAddress, latencyMs);
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/MeterRegistrarPoolMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/MeterRegistrarPoolMetricsRecorder.java
@@ -25,7 +25,7 @@ import java.net.SocketAddress;
  * {@link MeterRegistrar}. This allows custom registrars to receive the {@code pending.connections.time}
  * data that is otherwise only available to the built-in Micrometer integration.
  *
- * @author Violeta Georgieva
+ * @author ejhnsn
  * @since 1.3.7
  */
 final class MeterRegistrarPoolMetricsRecorder implements PoolMetricsRecorder {

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -148,20 +148,34 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 
 				boolean metricsEnabled = poolFactory.metricsEnabled || config.metricsRecorder() != null;
 				String id = metricsEnabled ? poolKey.hashCode() + "" : null;
+				// Resolve the custom registrar (if any) once, so the same instance is used both for
+				// registerMetrics and for bridging the pending acquisition latencies to it.
+				MeterRegistrar registrar = metricsEnabled && poolFactory.registrar != null ? poolFactory.registrar.get() : null;
 
-				InstrumentedPool<T> newPool = metricsEnabled && poolFactory.registrar == null && Metrics.isMicrometerAvailable() ?
-						// Deliberately suppress "NullAway"
-						// With metricsEnabled == true, id is not null
-						createPool(id, config, poolFactory, remoteAddress, resolverGroup) :
-						createPool(config, poolFactory, remoteAddress, resolverGroup);
+				InstrumentedPool<T> newPool;
+				if (metricsEnabled && registrar != null) {
+					// A custom registrar is provided. Bridge the pending acquisition latencies to it so that
+					// it receives the same data the built-in Micrometer integration would collect.
+					// Deliberately suppress "NullAway"
+					// With metricsEnabled == true, id is not null
+					newPool = createPool(id, config, poolFactory, remoteAddress, resolverGroup, registrar);
+				}
+				else if (metricsEnabled && Metrics.isMicrometerAvailable()) {
+					// Deliberately suppress "NullAway"
+					// With metricsEnabled == true, id is not null
+					newPool = createPool(id, config, poolFactory, remoteAddress, resolverGroup);
+				}
+				else {
+					newPool = createPool(config, poolFactory, remoteAddress, resolverGroup);
+				}
 
 				if (metricsEnabled) {
 					// registrar is null when metrics are enabled on HttpClient level or
 					// with the `metrics(boolean metricsEnabled)` method on ConnectionProvider
-					if (poolFactory.registrar != null) {
+					if (registrar != null) {
 						// Deliberately suppress "NullAway"
 						// With metricsEnabled == true, id is not null
-						poolFactory.registrar.get().registerMetrics(
+						registrar.registerMetrics(
 								name, id, remoteAddress, delegateConnectionPoolMetrics(newPool.metrics()));
 					}
 					else if (Metrics.isMicrometerAvailable()) {
@@ -340,6 +354,30 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 			PoolFactory<T> poolFactory,
 			SocketAddress remoteAddress,
 			@Nullable AddressResolverGroup<?> resolverGroup) {
+		return createPool(config, poolFactory, remoteAddress, resolverGroup);
+	}
+
+	/**
+	 * Creates a connection pool whose pending acquisition latencies are bridged to the provided
+	 * {@link MeterRegistrar}. The default implementation does not bridge the latencies and is provided for
+	 * backwards compatibility; concrete providers override it to wire the bridging recorder into the pool.
+	 *
+	 * @param id the pool id
+	 * @param config the transport configuration
+	 * @param poolFactory the pool factory
+	 * @param remoteAddress the remote address
+	 * @param resolverGroup the address resolver group
+	 * @param registrar the custom registrar that should receive the pending acquisition latencies
+	 * @return a new connection pool
+	 * @since 1.3.7
+	 */
+	protected InstrumentedPool<T> createPool(
+			String id,
+			TransportConfig config,
+			PoolFactory<T> poolFactory,
+			SocketAddress remoteAddress,
+			@Nullable AddressResolverGroup<?> resolverGroup,
+			MeterRegistrar registrar) {
 		return createPool(config, poolFactory, remoteAddress, resolverGroup);
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
@@ -49,6 +49,7 @@ import reactor.netty.resources.PooledConnectionProvider;
 import reactor.netty.transport.ClientTransportConfig;
 import reactor.netty.transport.TransportConfig;
 import reactor.netty.internal.shaded.reactor.pool.InstrumentedPool;
+import reactor.netty.internal.shaded.reactor.pool.PoolMetricsRecorder;
 import reactor.netty.internal.shaded.reactor.pool.PooledRef;
 import reactor.netty.internal.shaded.reactor.pool.PooledRefMetadata;
 import reactor.util.Logger;
@@ -158,7 +159,20 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 			PooledConnectionProvider.PoolFactory<Connection> poolFactory,
 			SocketAddress remoteAddress,
 			@Nullable AddressResolverGroup<?> resolverGroup) {
-		return new PooledConnectionAllocator(id, name(), parent, config, poolFactory, remoteAddress, resolverGroup).pool;
+		return new PooledConnectionAllocator(parent, config, poolFactory, remoteAddress, resolverGroup,
+				new MicrometerPoolMetricsRecorder(id, name(), remoteAddress)).pool;
+	}
+
+	@Override
+	protected InstrumentedPool<Connection> createPool(
+			String id,
+			TransportConfig config,
+			PooledConnectionProvider.PoolFactory<Connection> poolFactory,
+			SocketAddress remoteAddress,
+			@Nullable AddressResolverGroup<?> resolverGroup,
+			MeterRegistrar registrar) {
+		return new PooledConnectionAllocator(parent, config, poolFactory, remoteAddress, resolverGroup,
+				new MeterRegistrarPoolMetricsRecorder(registrar, name(), id, remoteAddress)).pool;
 	}
 
 	@Override
@@ -628,18 +642,16 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 				PoolFactory<Connection> poolFactory,
 				SocketAddress remoteAddress,
 				@Nullable AddressResolverGroup<?> resolver) {
-			this(null, null, parent, config, poolFactory, remoteAddress, resolver);
+			this(parent, config, poolFactory, remoteAddress, resolver, null);
 		}
 
-		@SuppressWarnings("NullAway")
 		PooledConnectionAllocator(
-				@Nullable String id,
-				@Nullable String name,
 				ConnectionProvider parent,
 				TransportConfig config,
 				PoolFactory<Connection> poolFactory,
 				SocketAddress remoteAddress,
-				@Nullable AddressResolverGroup<?> resolver) {
+				@Nullable AddressResolverGroup<?> resolver,
+				@Nullable PoolMetricsRecorder poolMetricsRecorder) {
 			this.config = (HttpClientConfig) config;
 			Function<PoolConfig<Connection>, InstrumentedPool<Connection>> poolConfigFunction;
 			Http2SettingsSpec http2SettingsSpec = this.config.http2SettingsSpec();
@@ -657,12 +669,10 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 			}
 			this.remoteAddress = remoteAddress;
 			this.resolver = resolver;
-			this.pool = id == null ?
+			this.pool = poolMetricsRecorder == null ?
 					poolFactory.newPool(connectChannel(), null, DEFAULT_DESTROY_HANDLER, DEFAULT_EVICTION_PREDICATE, poolConfigFunction) :
 					poolFactory.newPool(connectChannel(), DEFAULT_DESTROY_HANDLER, DEFAULT_EVICTION_PREDICATE,
-							// Deliberately suppress "NullAway"
-							// With id != null, this means name != null
-							new MicrometerPoolMetricsRecorder(id, name, remoteAddress), poolConfigFunction);
+							poolMetricsRecorder, poolConfigFunction);
 		}
 
 		Publisher<Connection> connectChannel() {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http3ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http3ConnectionProvider.java
@@ -53,6 +53,7 @@ import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.resources.PooledConnectionProvider;
 import reactor.netty.transport.TransportConfig;
 import reactor.netty.internal.shaded.reactor.pool.InstrumentedPool;
+import reactor.netty.internal.shaded.reactor.pool.PoolMetricsRecorder;
 import reactor.netty.internal.shaded.reactor.pool.PooledRef;
 import reactor.netty.internal.shaded.reactor.pool.PooledRefMetadata;
 import reactor.util.Logger;
@@ -161,7 +162,20 @@ final class Http3ConnectionProvider extends PooledConnectionProvider<Connection>
 			PooledConnectionProvider.PoolFactory<Connection> poolFactory,
 			SocketAddress remoteAddress,
 			@Nullable AddressResolverGroup<?> resolverGroup) {
-		return new PooledConnectionAllocator(id, name(), parent, config, poolFactory, remoteAddress, resolverGroup).pool;
+		return new PooledConnectionAllocator(parent, config, poolFactory, remoteAddress, resolverGroup,
+				new MicrometerPoolMetricsRecorder(id, name(), remoteAddress)).pool;
+	}
+
+	@Override
+	protected InstrumentedPool<Connection> createPool(
+			String id,
+			TransportConfig config,
+			PooledConnectionProvider.PoolFactory<Connection> poolFactory,
+			SocketAddress remoteAddress,
+			@Nullable AddressResolverGroup<?> resolverGroup,
+			MeterRegistrar registrar) {
+		return new PooledConnectionAllocator(parent, config, poolFactory, remoteAddress, resolverGroup,
+				new MeterRegistrarPoolMetricsRecorder(registrar, name(), id, remoteAddress)).pool;
 	}
 
 	@Override
@@ -513,29 +527,25 @@ final class Http3ConnectionProvider extends PooledConnectionProvider<Connection>
 				PoolFactory<Connection> poolFactory,
 				SocketAddress remoteAddress,
 				@Nullable AddressResolverGroup<?> resolver) {
-			this(null, null, parent, config, poolFactory, remoteAddress, resolver);
+			this(parent, config, poolFactory, remoteAddress, resolver, null);
 		}
 
-		@SuppressWarnings("NullAway")
 		PooledConnectionAllocator(
-				@Nullable String id,
-				@Nullable String name,
 				ConnectionProvider parent,
 				TransportConfig config,
 				PoolFactory<Connection> poolFactory,
 				SocketAddress remoteAddress,
-				@Nullable AddressResolverGroup<?> resolver) {
+				@Nullable AddressResolverGroup<?> resolver,
+				@Nullable PoolMetricsRecorder poolMetricsRecorder) {
 			this.parent = parent;
 			this.config = (HttpClientConfig) config;
 			this.remoteAddress = remoteAddress;
 			this.resolver = resolver;
-			this.pool = id == null ?
+			this.pool = poolMetricsRecorder == null ?
 					poolFactory.newPool(connectChannel(), null, DEFAULT_DESTROY_HANDLER, DEFAULT_EVICTION_PREDICATE,
 							poolConfig -> new Http3Pool(poolConfig, poolFactory.allocationStrategy())) :
-					// Deliberately suppress "NullAway"
-					// With id != null, this means name != null
 					poolFactory.newPool(connectChannel(), DEFAULT_DESTROY_HANDLER, DEFAULT_EVICTION_PREDICATE,
-							new MicrometerPoolMetricsRecorder(id, name, remoteAddress),
+							poolMetricsRecorder,
 							poolConfig -> new Http3Pool(poolConfig, poolFactory.allocationStrategy()));
 		}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MeterRegistrarPoolMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MeterRegistrarPoolMetricsRecorder.java
@@ -25,7 +25,7 @@ import java.net.SocketAddress;
  * {@link MeterRegistrar}. This allows custom registrars to receive the {@code pending.streams.time}
  * data that is otherwise only available to the built-in Micrometer integration.
  *
- * @author Violeta Georgieva
+ * @author ejhnsn
  * @since 1.3.7
  */
 final class MeterRegistrarPoolMetricsRecorder implements PoolMetricsRecorder {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MeterRegistrarPoolMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MeterRegistrarPoolMetricsRecorder.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.client;
+
+import reactor.netty.internal.shaded.reactor.pool.PoolMetricsRecorder;
+import reactor.netty.resources.ConnectionProvider.MeterRegistrar;
+
+import java.net.SocketAddress;
+
+/**
+ * A {@link PoolMetricsRecorder} that bridges pending acquisition latencies to a user-provided
+ * {@link MeterRegistrar}. This allows custom registrars to receive the {@code pending.streams.time}
+ * data that is otherwise only available to the built-in Micrometer integration.
+ *
+ * @author Violeta Georgieva
+ * @since 1.3.7
+ */
+final class MeterRegistrarPoolMetricsRecorder implements PoolMetricsRecorder {
+
+	final MeterRegistrar registrar;
+	final String poolName;
+	final String id;
+	final SocketAddress remoteAddress;
+
+	MeterRegistrarPoolMetricsRecorder(MeterRegistrar registrar, String poolName, String id, SocketAddress remoteAddress) {
+		this.registrar = registrar;
+		this.poolName = poolName;
+		this.id = id;
+		this.remoteAddress = remoteAddress;
+	}
+
+	@Override
+	public void recordAllocationSuccessAndLatency(long latencyMs) {
+		//noop
+	}
+
+	@Override
+	public void recordAllocationFailureAndLatency(long latencyMs) {
+		//noop
+	}
+
+	@Override
+	public void recordResetLatency(long latencyMs) {
+		//noop
+	}
+
+	@Override
+	public void recordDestroyLatency(long latencyMs) {
+		//noop
+	}
+
+	@Override
+	public void recordRecycled() {
+		//noop
+	}
+
+	@Override
+	public void recordLifetimeDuration(long millisecondsSinceAllocation) {
+		//noop
+	}
+
+	@Override
+	public void recordIdleTime(long millisecondsIdle) {
+		//noop
+	}
+
+	@Override
+	public void recordSlowPath() {
+		//noop
+	}
+
+	@Override
+	public void recordFastPath() {
+		//noop
+	}
+
+	@Override
+	public void recordPendingSuccessAndLatency(long latencyMs) {
+		registrar.recordPendingAcquireSuccess(poolName, id, remoteAddress, latencyMs);
+	}
+
+	@Override
+	public void recordPendingFailureAndLatency(long latencyMs) {
+		registrar.recordPendingAcquireFailure(poolName, id, remoteAddress, latencyMs);
+	}
+}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PooledConnectionProviderCustomMetricsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PooledConnectionProviderCustomMetricsTest.java
@@ -25,6 +25,7 @@ import io.netty.pkitesting.X509Bundle;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.BaseHttpTest;
 import reactor.netty.NettyPipeline;
@@ -37,6 +38,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
@@ -163,6 +165,54 @@ class Http2PooledConnectionProviderCustomMetricsTest extends BaseHttpTest {
 	}
 
 	@Test
+	void measurePendingStreamsTimeSuccess() throws InterruptedException {
+		AtomicBoolean isRegistered = new AtomicBoolean();
+		AtomicBoolean isDeregistered = new AtomicBoolean();
+		AtomicReference<@Nullable HttpConnectionPoolMetrics> metrics = new AtomicReference<>();
+
+		disposableServer =
+				createServer()
+				        .protocol(H2)
+				        .secure(spec -> spec.sslContext(sslServer))
+				        .handle((req, resp) -> resp.sendString(Mono.delay(Duration.ofMillis(100)).then(Mono.just("test"))))
+				        .bindNow();
+
+		CustomHttp2MeterRegistrar registrar = new CustomHttp2MeterRegistrar(isRegistered, isDeregistered, metrics);
+		ConnectionProvider pool =
+				ConnectionProvider.builder("custom-pool")
+				                  .metrics(true, () -> registrar)
+				                  .maxConnections(1)
+				                  .pendingAcquireMaxCount(10)
+				                  .build();
+
+		HttpClient httpClient =
+				createClient(pool, disposableServer::address)
+				        .protocol(H2)
+				        .secure(spec -> spec.sslContext(sslClient))
+				        .http2Settings(builder -> {
+				            builder.maxStreams(1);
+				            builder.maxConcurrentStreams(1);
+				        });
+
+		try {
+			Flux.range(0, 5)
+			    .flatMapDelayError(i ->
+			        httpClient.get()
+			                  .uri("/")
+			                  .responseSingle((resp, bytes) -> bytes.asString()), 256, 32)
+			    .blockLast(Duration.ofSeconds(30));
+
+			assertThat(registrar.pendingAcquireSuccessLatch.await(30, TimeUnit.SECONDS))
+					.as("pending acquire success latch")
+					.isTrue();
+			assertThat(registrar.pendingAcquireSuccessCount.get()).isGreaterThanOrEqualTo(1);
+		}
+		finally {
+			pool.disposeLater().block(Duration.ofSeconds(5));
+		}
+	}
+
+	@Test
 	void testIssue3804() throws Exception {
 		disposableServer =
 				createServer()
@@ -214,6 +264,10 @@ class Http2PooledConnectionProviderCustomMetricsTest extends BaseHttpTest {
 		AtomicBoolean isRegistered;
 		AtomicBoolean isDeregistered;
 		AtomicReference<@Nullable HttpConnectionPoolMetrics> metrics;
+		final AtomicInteger pendingAcquireSuccessCount = new AtomicInteger();
+		final AtomicInteger pendingAcquireFailureCount = new AtomicInteger();
+		final CountDownLatch pendingAcquireSuccessLatch = new CountDownLatch(1);
+		final CountDownLatch pendingAcquireFailureLatch = new CountDownLatch(1);
 
 		CustomHttp2MeterRegistrar(
 				AtomicBoolean isRegistered,
@@ -234,6 +288,18 @@ class Http2PooledConnectionProviderCustomMetricsTest extends BaseHttpTest {
 		@Override
 		public void deRegisterMetrics(String poolName, String id, SocketAddress remoteAddress) {
 			isDeregistered.set(true);
+		}
+
+		@Override
+		public void recordPendingAcquireSuccess(String poolName, String id, SocketAddress remoteAddress, long pendingAcquireTimeMillis) {
+			pendingAcquireSuccessCount.incrementAndGet();
+			pendingAcquireSuccessLatch.countDown();
+		}
+
+		@Override
+		public void recordPendingAcquireFailure(String poolName, String id, SocketAddress remoteAddress, long pendingAcquireTimeMillis) {
+			pendingAcquireFailureCount.incrementAndGet();
+			pendingAcquireFailureLatch.countDown();
 		}
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
@@ -1062,10 +1062,99 @@ class DefaultPooledConnectionProviderTest extends BaseHttpTest {
 		}
 	}
 
+	@Test
+	void testIssue4235CustomRegistrarReceivesPendingAcquireSuccess() {
+		disposableServer =
+				createServer()
+				        .handle((req, res) -> res.sendString(Mono.just("testIssue4235")
+				                                                 .delayElement(Duration.ofMillis(100))))
+				        .bindNow();
+
+		MeterRegistrarImpl meterRegistrar = new MeterRegistrarImpl();
+		ConnectionProvider provider =
+				ConnectionProvider.builder("testIssue4235Success")
+				                  .maxConnections(1)
+				                  .pendingAcquireMaxCount(10)
+				                  .metrics(true, () -> meterRegistrar)
+				                  .build();
+
+		HttpClient client = createClient(provider, disposableServer.port());
+		try {
+			Flux.range(0, 2)
+			    .flatMapDelayError(i ->
+			        client.get()
+			              .uri("/")
+			              .responseContent()
+			              .aggregate()
+			              .asString(), 256, 32)
+			    .blockLast(Duration.ofSeconds(30));
+
+			assertThat(meterRegistrar.pendingAcquireSuccessLatch.await(30, TimeUnit.SECONDS))
+					.as("pending acquire success latch")
+					.isTrue();
+			assertThat(meterRegistrar.pendingAcquireSuccessCount.get()).isGreaterThanOrEqualTo(1);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException(e);
+		}
+		finally {
+			provider.disposeLater()
+			        .block(Duration.ofSeconds(5));
+		}
+	}
+
+	@Test
+	void testIssue4235CustomRegistrarReceivesPendingAcquireFailure() {
+		disposableServer =
+				createServer()
+				        .handle((req, res) -> res.sendString(Mono.just("testIssue4235")
+				                                                 .delayElement(Duration.ofMillis(500))))
+				        .bindNow();
+
+		MeterRegistrarImpl meterRegistrar = new MeterRegistrarImpl();
+		ConnectionProvider provider =
+				ConnectionProvider.builder("testIssue4235Failure")
+				                  .maxConnections(1)
+				                  .pendingAcquireTimeout(Duration.ofMillis(10))
+				                  .metrics(true, () -> meterRegistrar)
+				                  .build();
+
+		HttpClient client = createClient(provider, disposableServer.port());
+		try {
+			Flux.range(0, 3)
+			    .flatMapDelayError(i ->
+			        client.get()
+			              .uri("/")
+			              .responseContent()
+			              .aggregate()
+			              .asString(), 256, 32)
+			    .materialize()
+			    .blockLast(Duration.ofSeconds(30));
+
+			assertThat(meterRegistrar.pendingAcquireFailureLatch.await(30, TimeUnit.SECONDS))
+					.as("pending acquire failure latch")
+					.isTrue();
+			assertThat(meterRegistrar.pendingAcquireFailureCount.get()).isGreaterThanOrEqualTo(1);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException(e);
+		}
+		finally {
+			provider.disposeLater()
+			        .block(Duration.ofSeconds(5));
+		}
+	}
+
 	static final class MeterRegistrarImpl implements ConnectionProvider.MeterRegistrar {
 		AtomicBoolean registered = new AtomicBoolean();
 		AtomicBoolean deRegistered = new AtomicBoolean();
 		final CountDownLatch latch = new CountDownLatch(1);
+		final AtomicInteger pendingAcquireSuccessCount = new AtomicInteger();
+		final AtomicInteger pendingAcquireFailureCount = new AtomicInteger();
+		final CountDownLatch pendingAcquireSuccessLatch = new CountDownLatch(1);
+		final CountDownLatch pendingAcquireFailureLatch = new CountDownLatch(1);
 
 		MeterRegistrarImpl() {
 		}
@@ -1079,6 +1168,18 @@ class DefaultPooledConnectionProviderTest extends BaseHttpTest {
 		public void deRegisterMetrics(String poolName, String id, SocketAddress remoteAddress) {
 			deRegistered.compareAndSet(false, true);
 			latch.countDown();
+		}
+
+		@Override
+		public void recordPendingAcquireSuccess(String poolName, String id, SocketAddress remoteAddress, long pendingAcquireTimeMillis) {
+			pendingAcquireSuccessCount.incrementAndGet();
+			pendingAcquireSuccessLatch.countDown();
+		}
+
+		@Override
+		public void recordPendingAcquireFailure(String poolName, String id, SocketAddress remoteAddress, long pendingAcquireTimeMillis) {
+			pendingAcquireFailureCount.incrementAndGet();
+			pendingAcquireFailureLatch.countDown();
 		}
 	}
 }


### PR DESCRIPTION
## Motivation

Closes #4235.

A custom `ConnectionProvider.MeterRegistrar` receives `registerMetrics` / `deRegisterMetrics` callbacks, but never the `pending.connections.time` data. That latency is recorded through the `reactor-pool` `PoolMetricsRecorder`, and the recorder is only wired into the pool when the built-in Micrometer integration is active. So a user supplying their own registrar (e.g. to publish pending-acquire timing to a non-Micrometer backend) silently gets no pending-acquire data.

## Changes

- Add two `default` no-op methods to `ConnectionProvider.MeterRegistrar`: `recordPendingAcquireSuccess(...)` and `recordPendingAcquireFailure(...)` (source/binary compatible — verified with `japicmp`).
- Add a bridging `PoolMetricsRecorder` (`MeterRegistrarPoolMetricsRecorder`) that forwards `recordPendingSuccessAndLatency` / `recordPendingFailureAndLatency` to the registrar's new methods. All other recorder methods are no-ops.
- A bridge recorder is provided **per module** because `reactor-netty-http` uses the shaded `reactor.netty.internal.shaded.reactor.pool.PoolMetricsRecorder` while `reactor-netty-core` uses the unshaded `reactor.pool.PoolMetricsRecorder`.
- Add a `createPool(id, ..., MeterRegistrar registrar)` overload (`PooledConnectionProvider` + `Default`/`Http2`/`Http3`); allocators now take an explicit `PoolMetricsRecorder`. When a custom registrar is supplied, `acquire()` routes to this path so the pool is created with the bridge recorder. The existing Micrometer path is unchanged.

## Tests

- `DefaultPooledConnectionProviderTest#testIssue4235CustomRegistrarReceivesPendingAcquireSuccess` and `#...Failure` — HTTP/1.1 client exercising the core bridge under forced pending load (slow server, `maxConnections(1)`; failure path uses a short `pendingAcquireTimeout`).
- `Http2PooledConnectionProviderCustomMetricsTest#measurePendingStreamsTimeSuccess` — HTTP/2 client exercising the http (shaded) bridge under pending-stream load.

`spotlessCheck`, `checkstyle`, and `japicmp` are green for both modules.

Made with [Cursor](https://cursor.com)