### PR TITLE
Skip `SNI` lookup completion when the channel is already closed

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/SniProvider.java
@@ -133,6 +133,15 @@ final class SniProvider {
 
 		@Override
 		protected void onLookupComplete(ChannelHandlerContext ctx, String hostname, Future<SslProvider> future) {
+			if (!ctx.channel().isActive()) {
+				// The connection was closed before a complete TLS ClientHello was received (e.g. a bare
+				// TCP probe from a load balancer/health checker). Since Netty 4.2.14 the decoder cleanup
+				// path (channelInactive -> decodeLast -> decode -> select) reaches this method while the
+				// channel is already being torn down. There is nothing to match and nothing to configure,
+				// so short-circuit silently instead of propagating a misleading decode error.
+				return;
+			}
+
 			if (!future.isSuccess()) {
 				final Throwable cause = future.cause();
 				if (cause instanceof Error) {

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/SniProviderTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/SniProviderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.tcp;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
+import io.netty.util.AsyncMapping;
+import io.netty.util.concurrent.Promise;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SniProviderTest {
+
+	static final AsyncMapping<String, SslProvider> UNUSED_MAPPING = (input, promise) -> promise.setSuccess(null);
+
+	/**
+	 * Reproduces https://github.com/reactor/reactor-netty/issues/4229: when the connection is closed
+	 * (TCP FIN) before the SNI lookup completes, the lookup callback runs against an already inactive
+	 * channel. The handler must then short-circuit silently instead of propagating a misleading decode
+	 * error down the pipeline.
+	 */
+	@Test
+	void onLookupCompleteIsSilentWhenChannelInactive() {
+		SniProvider.SniHandler handler = new SniProvider(UNUSED_MAPPING, 0).newSniHandler();
+		EmbeddedChannel channel = new EmbeddedChannel(handler);
+		try {
+			ChannelHandlerContext ctx = channel.pipeline().context(handler);
+
+			channel.close();
+			assertThat(channel.isActive()).isFalse();
+
+			Promise<SslProvider> future = channel.eventLoop().newPromise();
+			future.setFailure(new DecoderException("failed to get the SslContext for example.com"));
+
+			assertThatCode(() -> handler.onLookupComplete(ctx, "example.com", future))
+					.doesNotThrowAnyException();
+		}
+		finally {
+			channel.finishAndReleaseAll();
+		}
+	}
+
+	@Test
+	void onLookupCompletePropagatesFailureWhenChannelActive() {
+		SniProvider.SniHandler handler = new SniProvider(UNUSED_MAPPING, 0).newSniHandler();
+		EmbeddedChannel channel = new EmbeddedChannel(handler);
+		try {
+			ChannelHandlerContext ctx = channel.pipeline().context(handler);
+			assertThat(channel.isActive()).isTrue();
+
+			Promise<SslProvider> future = channel.eventLoop().newPromise();
+			future.setFailure(new DecoderException(
+					"failed to get the SslContext for example.com: the SNI mapping returned null"));
+
+			assertThatThrownBy(() -> handler.onLookupComplete(ctx, "example.com", future))
+					.isInstanceOf(DecoderException.class)
+					.hasMessageContaining("the SNI mapping returned null");
+		}
+		finally {
+			channel.finishAndReleaseAll();
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4229