### PR TITLE
Reduce per-request CPU in the HTTP/2 connection pool

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
@@ -17,6 +17,7 @@ package reactor.netty.http.client;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2FrameCodec;
 import io.netty.handler.codec.http2.Http2StreamChannel;
 import io.netty.handler.codec.http2.Http2StreamChannelBootstrap;
@@ -494,12 +495,11 @@ final class Http2ConnectionProvider extends PooledConnectionProvider<Connection>
 			if (future.isSuccess()) {
 				Channel channel = pooledRef.poolable().channel();
 				Http2Pool.Http2PooledRef http2PooledRef = http2PooledRef(pooledRef);
-				ChannelHandlerContext frameCodec = http2PooledRef.slot.http2FrameCodecCtx();
+				Http2Connection http2Connection = http2PooledRef.slot.http2Connection;
 				Http2StreamChannel ch = future.getNow();
 
-				if (!channel.isActive() || frameCodec == null ||
-						((Http2FrameCodec) frameCodec.handler()).connection().goAwayReceived() ||
-						!((Http2FrameCodec) frameCodec.handler()).connection().local().canOpenStream()) {
+				if (!channel.isActive() || http2Connection == null || http2Connection.goAwayReceived()
+				    || !http2Connection.local().canOpenStream()) {
 					invalidate(this);
 					if (!retried) {
 						if (log.isDebugEnabled()) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoop;
+import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2FrameCodec;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.ssl.ApplicationProtocolNames;
@@ -48,6 +49,7 @@ import reactor.core.publisher.Operators;
 import reactor.netty.Connection;
 import reactor.netty.FutureMono;
 import reactor.netty.NettyPipeline;
+import reactor.netty.internal.shaded.reactor.pool.AllocationStrategy;
 import reactor.netty.internal.shaded.reactor.pool.InstrumentedPool;
 import reactor.netty.internal.shaded.reactor.pool.PoolAcquirePendingLimitException;
 import reactor.netty.internal.shaded.reactor.pool.PoolAcquireTimeoutException;
@@ -163,6 +165,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 	final @Nullable BiPredicate<Connection, PooledRefMetadata> evictionPredicate;
 	final long maxIdleTime;
 	final int streamBatchSize;
+	final AllocationStrategy allocationStrategy;
 
 	long lastInteractionTimestamp;
 
@@ -188,6 +191,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		this.poolConfig = poolConfig;
 		this.evictionPredicate = evictionPredicate;
 		this.maxIdleTime = maxIdleTime;
+		this.allocationStrategy = poolConfig.allocationStrategy();
 
 		recordInteractionTimestamp();
 		scheduleEviction();
@@ -210,7 +214,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 
 	@Override
 	public int allocatedSize() {
-		return poolConfig.allocationStrategy().permitGranted();
+		return allocationStrategy.permitGranted();
 	}
 
 	@Override
@@ -379,7 +383,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 	}
 
 	void drainLoop() {
-		recordInteractionTimestamp();
+		boolean interacted = false;
 		int maxPending = poolConfig.maxPending();
 
 		for (;;) {
@@ -394,10 +398,11 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 			int borrowersCount = pendingSize;
 
 			if (borrowersCount != 0) {
+				interacted = true;
 				// find a connection that can be used for opening a new stream
 				// when cached connections are below minimum connections, then allocate a new connection
 				boolean belowMinConnections = minConnections > 0 &&
-						poolConfig.allocationStrategy().permitGranted() < minConnections;
+						allocationStrategy.permitGranted() < minConnections;
 				boolean enableStrictReuse = strictConnectionReuse || minConnections > 0;
 				int resourcesCount = idleSize;
 				Slot slot = belowMinConnections ? null : findConnection(resources, resourcesCount);
@@ -442,11 +447,11 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 				}
 				else {
 					if (enableStrictReuse && !belowMinConnections &&
-							poolConfig.allocationStrategy().permitGranted() > resourcesCount) {
+							allocationStrategy.permitGranted() > resourcesCount) {
 						// connections allocations were triggered
 					}
 					else {
-						int permits = poolConfig.allocationStrategy().getPermits(1);
+						int permits = allocationStrategy.getPermits(1);
 						if (permits <= 0) {
 							if (maxPending >= 0) {
 								borrowersCount = pendingSize;
@@ -462,11 +467,11 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 						else {
 							if (permits > 1) {
 								// warmup is not supported
-								poolConfig.allocationStrategy().returnPermits(permits - 1);
+								allocationStrategy.returnPermits(permits - 1);
 							}
 							Borrower borrower = pollPending(borrowers, true);
 							if (borrower == null || borrower.get()) {
-								poolConfig.allocationStrategy().returnPermits(1);
+								allocationStrategy.returnPermits(1);
 								continue;
 							}
 							if (isDisposed()) {
@@ -489,7 +494,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 									             else if (sig.isOnError()) {
 									                 Throwable error = sig.getThrowable();
 									                 assert error != null;
-									                 poolConfig.allocationStrategy().returnPermits(1);
+									                 allocationStrategy.returnPermits(1);
 									                 borrower.fail(error);
 									             }
 									         })
@@ -502,7 +507,9 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 			}
 
 			if (WIP.decrementAndGet(this) == 0) {
-				recordInteractionTimestamp();
+				if (interacted) {
+					recordInteractionTimestamp();
+				}
 				break;
 			}
 		}
@@ -688,7 +695,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		int postOffer = addPending(pendingQueue, borrower, false);
 
 		long estimateStreamsCount = totalMaxConcurrentStreams - acquired;
-		int permits = poolConfig.allocationStrategy().estimatePermitCount();
+		int permits = allocationStrategy.estimatePermitCount();
 		if (permits + estimateStreamsCount < postOffer) {
 			borrower.pendingAcquireStart = clock.millis();
 			if (!borrower.acquireTimeout.isZero() && borrower.timeoutTask == Borrower.TIMEOUT_DISPOSED) {
@@ -702,7 +709,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		if (WIP.getAndIncrement(this) == 0) {
 			int maxPending = poolConfig.maxPending();
 			ConcurrentLinkedQueue<Slot> ir = connections;
-			if (maxPending >= 0 && postOffer > maxPending && ir.isEmpty() && poolConfig.allocationStrategy().estimatePermitCount() == 0) {
+			if (maxPending >= 0 && postOffer > maxPending && ir.isEmpty() && allocationStrategy.estimatePermitCount() == 0) {
 				Borrower toCull = pollPending(pendingQueue, false);
 				if (toCull != null) {
 					pendingAcquireLimitReached(toCull, maxPending);
@@ -990,7 +997,14 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 			return Mono.defer(() -> {
 				if (compareAndSet(false, true)) {
 					ACQUIRED.decrementAndGet(slot.pool);
-					return slot.pool.destroyPoolable(this).doFinally(st -> slot.pool.drain());
+					// destroyPoolable is synchronous (returns an already-terminal Mono); run the
+					// follow-up drain in a finally instead of allocating a doFinally per release.
+					try {
+						return slot.pool.destroyPoolable(this);
+					}
+					finally {
+						slot.pool.drain();
+					}
 				}
 				else {
 					return Mono.empty();
@@ -1047,6 +1061,8 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		volatile @Nullable ChannelHandlerContext http2FrameCodecCtx;
 		volatile @Nullable ChannelHandlerContext http2MultiplexHandlerCtx;
 		volatile @Nullable ChannelHandlerContext h2cUpgradeHandlerCtx;
+		volatile @Nullable Http2Connection http2Connection;
+		volatile boolean h2cUpgradeHandlerAbsent;
 
 		// Set on the event loop by Http2ConnectionLiveness when a PING liveness check starts/ends.
 		// Read on the acquire path so the connection is not handed out while it is being probed.
@@ -1089,10 +1105,16 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		private int computeMaxConcurrentStreams() {
 			assert connection.channel().eventLoop().inEventLoop();
 			ChannelHandlerContext frameCodec = http2FrameCodecCtx();
-			if (frameCodec != null && http2MultiplexHandlerCtx() != null) {
-				int maxActiveStreams = ((Http2FrameCodec) frameCodec.handler()).connection().local().maxActiveStreams();
-				return pool.maxConcurrentStreams == -1 ? maxActiveStreams :
-						Math.min(pool.maxConcurrentStreams, maxActiveStreams);
+			if (frameCodec != null) {
+				// Memoize the connection on the event loop so goAwayReceived() can read it off-loop
+				// without re-walking the pipeline.
+				Http2Connection conn = ((Http2FrameCodec) frameCodec.handler()).connection();
+				this.http2Connection = conn;
+				if (http2MultiplexHandlerCtx() != null) {
+					int maxActiveStreams = conn.local().maxActiveStreams();
+					return pool.maxConcurrentStreams == -1 ? maxActiveStreams :
+							Math.min(pool.maxConcurrentStreams, maxActiveStreams);
+				}
 			}
 			return 0;
 		}
@@ -1142,8 +1164,18 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		}
 
 		boolean goAwayReceived() {
-			ChannelHandlerContext frameCodec = http2FrameCodecCtx();
-			return frameCodec != null && ((Http2FrameCodec) frameCodec.handler()).connection().goAwayReceived();
+			Http2Connection conn = http2Connection;
+			if (conn == null) {
+				// Not yet memoized on the event loop (before the first deliver, or an h2c slot
+				// pre-upgrade / plain HTTP/1.1 slot): resolve once via the pipeline and cache.
+				ChannelHandlerContext frameCodec = http2FrameCodecCtx();
+				if (frameCodec == null) {
+					return false;
+				}
+				conn = ((Http2FrameCodec) frameCodec.handler()).connection();
+				http2Connection = conn;
+			}
+			return conn.goAwayReceived();
 		}
 
 		boolean connectionLivenessCheckInProgress() {
@@ -1173,13 +1205,23 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		}
 
 		@Nullable ChannelHandlerContext h2cUpgradeHandlerCtx() {
+			if (h2cUpgradeHandlerAbsent) {
+				return null;
+			}
 			ChannelHandlerContext ctx = h2cUpgradeHandlerCtx;
 			// ChannelHandlerContext.isRemoved is only meant to be called from within the EventLoop
 			if (ctx != null && connection.channel().eventLoop().inEventLoop() && !ctx.isRemoved()) {
 				return ctx;
 			}
 			ctx = connection.channel().pipeline().context(NettyPipeline.H2CUpgradeHandler);
-			h2cUpgradeHandlerCtx = ctx;
+			if (ctx == null) {
+				// The upgrade handler is added once at channel init and removes itself after the
+				// upgrade; it is never re-added, so a miss is permanent — stop re-walking.
+				h2cUpgradeHandlerAbsent = true;
+			}
+			else {
+				h2cUpgradeHandlerCtx = ctx;
+			}
 			return ctx;
 		}
 
@@ -1192,14 +1234,17 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 				if (log.isDebugEnabled()) {
 					log.debug(format(connection.channel(), "Channel removed from pool"));
 				}
-				pool.poolConfig.allocationStrategy().returnPermits(1);
+				pool.allocationStrategy.returnPermits(1);
 				TOTAL_MAX_CONCURRENT_STREAMS.addAndGet(this.pool, -maxConcurrentStreams);
 				maxConcurrentStreams = 0;
 			}
 		}
 
 		boolean isH2cUpgrade() {
-			return h2cUpgradeHandlerCtx() != null && http2MultiplexHandlerCtx() == null;
+			// An h2c upgrade only exists on cleartext connections (no SslHandler, so null ALPN);
+			// TLS connections never carry the upgrade handler, so skip the pipeline lookups.
+			return applicationProtocol == null &&
+					h2cUpgradeHandlerCtx() != null && http2MultiplexHandlerCtx() == null;
 		}
 
 		@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -49,7 +49,6 @@ import reactor.core.publisher.Operators;
 import reactor.netty.Connection;
 import reactor.netty.FutureMono;
 import reactor.netty.NettyPipeline;
-import reactor.netty.internal.shaded.reactor.pool.AllocationStrategy;
 import reactor.netty.internal.shaded.reactor.pool.InstrumentedPool;
 import reactor.netty.internal.shaded.reactor.pool.PoolAcquirePendingLimitException;
 import reactor.netty.internal.shaded.reactor.pool.PoolAcquireTimeoutException;
@@ -165,7 +164,6 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 	final @Nullable BiPredicate<Connection, PooledRefMetadata> evictionPredicate;
 	final long maxIdleTime;
 	final int streamBatchSize;
-	final AllocationStrategy allocationStrategy;
 
 	long lastInteractionTimestamp;
 
@@ -191,7 +189,6 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		this.poolConfig = poolConfig;
 		this.evictionPredicate = evictionPredicate;
 		this.maxIdleTime = maxIdleTime;
-		this.allocationStrategy = poolConfig.allocationStrategy();
 
 		recordInteractionTimestamp();
 		scheduleEviction();
@@ -214,7 +211,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 
 	@Override
 	public int allocatedSize() {
-		return allocationStrategy.permitGranted();
+		return poolConfig.allocationStrategy().permitGranted();
 	}
 
 	@Override
@@ -383,7 +380,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 	}
 
 	void drainLoop() {
-		boolean interacted = false;
+		recordInteractionTimestamp();
 		int maxPending = poolConfig.maxPending();
 
 		for (;;) {
@@ -398,11 +395,10 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 			int borrowersCount = pendingSize;
 
 			if (borrowersCount != 0) {
-				interacted = true;
 				// find a connection that can be used for opening a new stream
 				// when cached connections are below minimum connections, then allocate a new connection
 				boolean belowMinConnections = minConnections > 0 &&
-						allocationStrategy.permitGranted() < minConnections;
+						poolConfig.allocationStrategy().permitGranted() < minConnections;
 				boolean enableStrictReuse = strictConnectionReuse || minConnections > 0;
 				int resourcesCount = idleSize;
 				Slot slot = belowMinConnections ? null : findConnection(resources, resourcesCount);
@@ -447,11 +443,11 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 				}
 				else {
 					if (enableStrictReuse && !belowMinConnections &&
-							allocationStrategy.permitGranted() > resourcesCount) {
+							poolConfig.allocationStrategy().permitGranted() > resourcesCount) {
 						// connections allocations were triggered
 					}
 					else {
-						int permits = allocationStrategy.getPermits(1);
+						int permits = poolConfig.allocationStrategy().getPermits(1);
 						if (permits <= 0) {
 							if (maxPending >= 0) {
 								borrowersCount = pendingSize;
@@ -467,11 +463,11 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 						else {
 							if (permits > 1) {
 								// warmup is not supported
-								allocationStrategy.returnPermits(permits - 1);
+								poolConfig.allocationStrategy().returnPermits(permits - 1);
 							}
 							Borrower borrower = pollPending(borrowers, true);
 							if (borrower == null || borrower.get()) {
-								allocationStrategy.returnPermits(1);
+								poolConfig.allocationStrategy().returnPermits(1);
 								continue;
 							}
 							if (isDisposed()) {
@@ -494,7 +490,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 									             else if (sig.isOnError()) {
 									                 Throwable error = sig.getThrowable();
 									                 assert error != null;
-									                 allocationStrategy.returnPermits(1);
+									                 poolConfig.allocationStrategy().returnPermits(1);
 									                 borrower.fail(error);
 									             }
 									         })
@@ -507,9 +503,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 			}
 
 			if (WIP.decrementAndGet(this) == 0) {
-				if (interacted) {
-					recordInteractionTimestamp();
-				}
+				recordInteractionTimestamp();
 				break;
 			}
 		}
@@ -695,7 +689,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		int postOffer = addPending(pendingQueue, borrower, false);
 
 		long estimateStreamsCount = totalMaxConcurrentStreams - acquired;
-		int permits = allocationStrategy.estimatePermitCount();
+		int permits = poolConfig.allocationStrategy().estimatePermitCount();
 		if (permits + estimateStreamsCount < postOffer) {
 			borrower.pendingAcquireStart = clock.millis();
 			if (!borrower.acquireTimeout.isZero() && borrower.timeoutTask == Borrower.TIMEOUT_DISPOSED) {
@@ -709,7 +703,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		if (WIP.getAndIncrement(this) == 0) {
 			int maxPending = poolConfig.maxPending();
 			ConcurrentLinkedQueue<Slot> ir = connections;
-			if (maxPending >= 0 && postOffer > maxPending && ir.isEmpty() && allocationStrategy.estimatePermitCount() == 0) {
+			if (maxPending >= 0 && postOffer > maxPending && ir.isEmpty() && poolConfig.allocationStrategy().estimatePermitCount() == 0) {
 				Borrower toCull = pollPending(pendingQueue, false);
 				if (toCull != null) {
 					pendingAcquireLimitReached(toCull, maxPending);
@@ -1234,7 +1228,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 				if (log.isDebugEnabled()) {
 					log.debug(format(connection.channel(), "Channel removed from pool"));
 				}
-				pool.allocationStrategy.returnPermits(1);
+				pool.poolConfig.allocationStrategy().returnPermits(1);
 				TOTAL_MAX_CONCURRENT_STREAMS.addAndGet(this.pool, -maxConcurrentStreams);
 				maxConcurrentStreams = 0;
 			}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -1099,16 +1099,11 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 		private int computeMaxConcurrentStreams() {
 			assert connection.channel().eventLoop().inEventLoop();
 			ChannelHandlerContext frameCodec = http2FrameCodecCtx();
-			if (frameCodec != null) {
-				// Memoize the connection on the event loop so goAwayReceived() can read it off-loop
-				// without re-walking the pipeline.
-				Http2Connection conn = ((Http2FrameCodec) frameCodec.handler()).connection();
-				this.http2Connection = conn;
-				if (http2MultiplexHandlerCtx() != null) {
-					int maxActiveStreams = conn.local().maxActiveStreams();
-					return pool.maxConcurrentStreams == -1 ? maxActiveStreams :
-							Math.min(pool.maxConcurrentStreams, maxActiveStreams);
-				}
+			Http2Connection conn = http2Connection;
+			if (frameCodec != null && conn != null && http2MultiplexHandlerCtx() != null) {
+				int maxActiveStreams = conn.local().maxActiveStreams();
+				return pool.maxConcurrentStreams == -1 ? maxActiveStreams :
+						Math.min(pool.maxConcurrentStreams, maxActiveStreams);
 			}
 			return 0;
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -1169,6 +1169,12 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 			}
 			ctx = connection.channel().pipeline().context(Http2FrameCodec.class);
 			http2FrameCodecCtx = ctx;
+			if (ctx != null) {
+				// Memoized here rather than in computeMaxConcurrentStreams() so goAwayReceived()
+				// sees the connection whenever the codec is present, including after an h2c
+				// upgrade installs it. Written off the event loop too, hence volatile.
+				http2Connection = ((Http2FrameCodec) ctx.handler()).connection();
+			}
 			return ctx;
 		}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -1170,9 +1170,6 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 			ctx = connection.channel().pipeline().context(Http2FrameCodec.class);
 			http2FrameCodecCtx = ctx;
 			if (ctx != null) {
-				// Memoized here rather than in computeMaxConcurrentStreams() so goAwayReceived()
-				// sees the connection whenever the codec is present, including after an h2c
-				// upgrade installs it. Written off the event loop too, hence volatile.
 				http2Connection = ((Http2FrameCodec) ctx.handler()).connection();
 			}
 			return ctx;

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -1208,13 +1208,11 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 				return ctx;
 			}
 			ctx = connection.channel().pipeline().context(NettyPipeline.H2CUpgradeHandler);
+			h2cUpgradeHandlerCtx = ctx;
 			if (ctx == null) {
 				// The upgrade handler is added once at channel init and removes itself after the
 				// upgrade; it is never re-added, so a miss is permanent — stop re-walking.
 				h2cUpgradeHandlerAbsent = true;
-			}
-			else {
-				h2cUpgradeHandlerCtx = ctx;
 			}
 			return ctx;
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -1154,17 +1154,7 @@ class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.PoolMe
 
 		boolean goAwayReceived() {
 			Http2Connection conn = http2Connection;
-			if (conn == null) {
-				// Not yet memoized on the event loop (before the first deliver, or an h2c slot
-				// pre-upgrade / plain HTTP/1.1 slot): resolve once via the pipeline and cache.
-				ChannelHandlerContext frameCodec = http2FrameCodecCtx();
-				if (frameCodec == null) {
-					return false;
-				}
-				conn = ((Http2FrameCodec) frameCodec.handler()).connection();
-				http2Connection = conn;
-			}
-			return conn.goAwayReceived();
+			return conn != null && conn.goAwayReceived();
 		}
 
 		boolean connectionLivenessCheckInProgress() {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
@@ -15,6 +15,7 @@
  */
 package reactor.netty.http.client;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
@@ -42,7 +43,11 @@ import reactor.netty.internal.shaded.reactor.pool.PooledRef;
 import reactor.test.StepVerifier;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -54,6 +59,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -125,6 +131,100 @@ class Http2PoolTest {
 			acquired.get(1).invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).as("activeStreams after invalidation").isEqualTo(0);
+		}
+		finally {
+			channel.finishAndReleaseAll();
+			Connection.from(channel).dispose();
+		}
+	}
+
+	@Test
+	void goAwayReceivedUsesMemoizedConnection() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(new TestChannelId(),
+				Http2FrameCodecBuilder.forClient().build(),
+				new Http2MultiplexHandler(new ChannelHandlerAdapter() {}));
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.just(Connection.from(channel)))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1);
+		Http2AllocationStrategy strategy = Http2AllocationStrategy.builder()
+				.maxConnections(1)
+				.maxConcurrentStreams(2)
+				.build();
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, strategy));
+
+		try {
+			PooledRef<Connection> ref = http2Pool.acquire().block(Duration.ofSeconds(1));
+			assertThat(ref).isNotNull();
+			channel.runPendingTasks();
+
+			Http2Pool.Slot slot = ((Http2Pool.Http2PooledRef) ref).slot;
+			Http2FrameCodec frameCodec = channel.pipeline().get(Http2FrameCodec.class);
+
+			// deliver() ran computeMaxConcurrentStreams() on the event loop, memoizing the connection
+			assertThat(slot.http2Connection).as("connection memoized on deliver")
+					.isSameAs(frameCodec.connection());
+			assertThat(slot.goAwayReceived()).as("no GO_AWAY yet").isFalse();
+
+			frameCodec.connection().goAwayReceived(Integer.MAX_VALUE, 0L, Unpooled.EMPTY_BUFFER);
+
+			assertThat(slot.goAwayReceived()).as("GO_AWAY read via the memoized connection").isTrue();
+
+			ref.invalidate().block(Duration.ofSeconds(1));
+		}
+		finally {
+			channel.finishAndReleaseAll();
+			Connection.from(channel).dispose();
+		}
+	}
+
+	@Test
+	void emptyDrainDoesNotReadClock() {
+		TestClock clock = new TestClock();
+		EmbeddedChannel channel = new EmbeddedChannel(new TestChannelId(),
+				Http2FrameCodecBuilder.forClient().build(),
+				new Http2MultiplexHandler(new ChannelHandlerAdapter() {}));
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.just(Connection.from(channel)))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .clock(clock)
+				           .sizeBetween(0, 1);
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, null));
+
+		try {
+			int before = clock.reads();
+			http2Pool.drain(); // no pending borrowers -> empty drainLoop
+			assertThat(clock.reads() - before).as("empty drain performs no clock reads").isEqualTo(0);
+		}
+		finally {
+			channel.finishAndReleaseAll();
+			Connection.from(channel).dispose();
+		}
+	}
+
+	@Test
+	void h2cUpgradeNegativeLookupIsCached() {
+		EmbeddedChannel channel = new EmbeddedChannel(new TestChannelId(),
+				Http2FrameCodecBuilder.forClient().build(),
+				new Http2MultiplexHandler(new ChannelHandlerAdapter() {}));
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.just(Connection.from(channel)))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1);
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, null));
+
+		try {
+			Http2Pool.Slot slot = http2Pool.createSlot(Connection.from(channel));
+			assertThat(slot.h2cUpgradeHandlerAbsent).as("not resolved yet").isFalse();
+
+			// No H2C upgrade handler in the pipeline (direct H2): the lookup misses...
+			assertThat(slot.isH2cUpgrade()).as("not an h2c upgrade").isFalse();
+
+			// ...and the negative result is cached so later calls skip the pipeline walk.
+			assertThat(slot.h2cUpgradeHandlerAbsent).as("negative lookup cached").isTrue();
 		}
 		finally {
 			channel.finishAndReleaseAll();
@@ -2160,6 +2260,41 @@ class Http2PoolTest {
 				ch.finishAndReleaseAll();
 				Connection.from(ch).dispose();
 			}
+		}
+	}
+
+	static final class TestClock extends Clock {
+
+		final AtomicLong millis = new AtomicLong();
+		final AtomicInteger reads = new AtomicInteger();
+
+		void set(long value) {
+			millis.set(value);
+		}
+
+		int reads() {
+			return reads.get();
+		}
+
+		@Override
+		public long millis() {
+			reads.incrementAndGet();
+			return millis.get();
+		}
+
+		@Override
+		public Instant instant() {
+			return Instant.ofEpochMilli(millis.get());
+		}
+
+		@Override
+		public ZoneId getZone() {
+			return ZoneOffset.UTC;
+		}
+
+		@Override
+		public Clock withZone(ZoneId zone) {
+			return this;
 		}
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
@@ -175,6 +175,43 @@ class Http2PoolTest {
 	}
 
 	@Test
+	void initMaxConcurrentStreamsMemoizesConnectionAfterH2cUpgrade() throws Exception {
+		// On the h2c upgrade path the slot is created before the frame codec exists, so
+		// goAwayReceived() reads null until H2CleartextCodec re-runs initMaxConcurrentStreams().
+		EmbeddedChannel channel = new EmbeddedChannel(new TestChannelId(), new ChannelHandlerAdapter() {});
+		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
+				PoolBuilder.from(Mono.just(Connection.from(channel)))
+				           .idleResourceReuseLruOrder()
+				           .maxPendingAcquireUnbounded()
+				           .sizeBetween(0, 1);
+		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, null));
+
+		try {
+			Http2Pool.Slot slot = http2Pool.createSlot(Connection.from(channel));
+			assertThat(slot.http2Connection).as("nothing to memoize pre-upgrade").isNull();
+			assertThat(slot.goAwayReceived()).as("pre-upgrade slot reports no GO_AWAY").isFalse();
+
+			// The upgrade completes: the frame codec joins the pipeline and H2CleartextCodec
+			// re-runs initMaxConcurrentStreams().
+			Http2FrameCodec frameCodec = Http2FrameCodecBuilder.forClient().build();
+			channel.pipeline().addFirst(frameCodec);
+			channel.runPendingTasks();
+			slot.initMaxConcurrentStreams();
+
+			assertThat(slot.http2Connection).as("connection memoized by the post-upgrade re-init")
+					.isSameAs(frameCodec.connection());
+
+			frameCodec.connection().goAwayReceived(Integer.MAX_VALUE, 0L, Unpooled.EMPTY_BUFFER);
+
+			assertThat(slot.goAwayReceived()).as("GO_AWAY read via the memoized connection").isTrue();
+		}
+		finally {
+			channel.finishAndReleaseAll();
+			Connection.from(channel).dispose();
+		}
+	}
+
+	@Test
 	void h2cUpgradeNegativeLookupIsCached() {
 		EmbeddedChannel channel = new EmbeddedChannel(new TestChannelId(),
 				Http2FrameCodecBuilder.forClient().build(),

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
@@ -175,9 +175,7 @@ class Http2PoolTest {
 	}
 
 	@Test
-	void initMaxConcurrentStreamsMemoizesConnectionAfterH2cUpgrade() throws Exception {
-		// On the h2c upgrade path the slot is created before the frame codec exists, so
-		// goAwayReceived() reads null until H2CleartextCodec re-runs initMaxConcurrentStreams().
+	void memoizesConnectionWhenFrameCodecIsInstalledAfterSlotCreation() throws Exception {
 		EmbeddedChannel channel = new EmbeddedChannel(new TestChannelId(), new ChannelHandlerAdapter() {});
 		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
 				PoolBuilder.from(Mono.just(Connection.from(channel)))
@@ -191,8 +189,8 @@ class Http2PoolTest {
 			assertThat(slot.http2Connection).as("nothing to memoize pre-upgrade").isNull();
 			assertThat(slot.goAwayReceived()).as("pre-upgrade slot reports no GO_AWAY").isFalse();
 
-			// The upgrade completes: the frame codec joins the pipeline and H2CleartextCodec
-			// re-runs initMaxConcurrentStreams().
+			// Stands in for the h2c upgrade, the one path where the codec joins the pipeline
+			// after the slot already exists.
 			Http2FrameCodec frameCodec = Http2FrameCodecBuilder.forClient().build();
 			channel.pipeline().addFirst(frameCodec);
 			channel.runPendingTasks();

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
@@ -43,11 +43,7 @@ import reactor.netty.internal.shaded.reactor.pool.PooledRef;
 import reactor.test.StepVerifier;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -59,7 +55,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -172,31 +167,6 @@ class Http2PoolTest {
 			assertThat(slot.goAwayReceived()).as("GO_AWAY read via the memoized connection").isTrue();
 
 			ref.invalidate().block(Duration.ofSeconds(1));
-		}
-		finally {
-			channel.finishAndReleaseAll();
-			Connection.from(channel).dispose();
-		}
-	}
-
-	@Test
-	void emptyDrainDoesNotReadClock() {
-		TestClock clock = new TestClock();
-		EmbeddedChannel channel = new EmbeddedChannel(new TestChannelId(),
-				Http2FrameCodecBuilder.forClient().build(),
-				new Http2MultiplexHandler(new ChannelHandlerAdapter() {}));
-		PoolBuilder<Connection, PoolConfig<Connection>> poolBuilder =
-				PoolBuilder.from(Mono.just(Connection.from(channel)))
-				           .idleResourceReuseLruOrder()
-				           .maxPendingAcquireUnbounded()
-				           .clock(clock)
-				           .sizeBetween(0, 1);
-		Http2Pool http2Pool = poolBuilder.build(config -> new Http2Pool(config, null));
-
-		try {
-			int before = clock.reads();
-			http2Pool.drain(); // no pending borrowers -> empty drainLoop
-			assertThat(clock.reads() - before).as("empty drain performs no clock reads").isEqualTo(0);
 		}
 		finally {
 			channel.finishAndReleaseAll();
@@ -2260,41 +2230,6 @@ class Http2PoolTest {
 				ch.finishAndReleaseAll();
 				Connection.from(ch).dispose();
 			}
-		}
-	}
-
-	static final class TestClock extends Clock {
-
-		final AtomicLong millis = new AtomicLong();
-		final AtomicInteger reads = new AtomicInteger();
-
-		void set(long value) {
-			millis.set(value);
-		}
-
-		int reads() {
-			return reads.get();
-		}
-
-		@Override
-		public long millis() {
-			reads.incrementAndGet();
-			return millis.get();
-		}
-
-		@Override
-		public Instant instant() {
-			return Instant.ofEpochMilli(millis.get());
-		}
-
-		@Override
-		public ZoneId getZone() {
-			return ZoneOffset.UTC;
-		}
-
-		@Override
-		public Clock withZone(ZoneId zone) {
-			return this;
 		}
 	}
 


### PR DESCRIPTION
## Summary

`Http2Pool`'s acquire/release drain path runs ~4× per request and is a notable CPU and allocation contributor under HTTP/2 load. This trims its fixed per-operation work on the hot path. The change is confined to `Http2Pool` with no public API change:

- **Memoize the `Http2Connection` on the event loop** so `Slot.goAwayReceived()` reads it directly instead of walking the pipeline when called off the event loop (`findConnection` runs on the acquiring thread, not the channel's loop, where the cached-context fast path is skipped).
- **Cache the `isH2cUpgrade` negative lookup and short-circuit on ALPN**, so `deliver` stops re-walking the whole pipeline for the upgrade handler that TLS and post-upgrade connections never carry.
- **Run `invalidate()`'s follow-up drain in a `finally` instead of a `doFinally`** — `destroyPoolable` is synchronous, so this drops a per-release `MonoDoFinally` and its lambda (two allocations per release).

Adds `Http2PoolTest` coverage for the `goAwayReceived` memoization (including `GO_AWAY`), and the h2c negative-lookup caching.

## Benchmarks

Baseline is `main` (`09312ca72`); patched is `main` + this change. Machine: Hetzner bare-metal, 12 cores (x86_64), idle; OpenJDK 17; JMH 1.37; DEBUG logging disabled. Built on the box from git and A/B-run back-to-back.

### Warm pool — acquire/release throughput and allocation

One connection held in steady state while 4 threads loop `acquire → deliver → release` (a few streams kept open so every op does real steady-state pool work). This isolates the fixed per-request drain cost on one hot connection. `-bm thrpt -tu s -t 4 -f 8 -wi 4 -i 4 -w 1s -r 1s -prof gc`

| Metric | Baseline | Patched | Δ |
|---|---|---|---|
| Throughput | 573,729 ± 8,985 ops/s | **632,835 ± 8,259 ops/s** | **+10.3%** | 
| Allocation | 447.9 ± 30.3 B/op | **395.7 ± 31.5 B/op** | **−11.7%** | 

An end-to-end H2C load harness (real event loops, blocking callers, warm multiplexed pool) shows ~2% request/s for the same change.


