### PR TITLE
Evaluate the address supplier once in `AddressUtils.updatePort`

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/transport/AddressUtils.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/AddressUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -220,11 +220,11 @@ public final class AddressUtils {
 			throw new IllegalArgumentException("Cannot update DomainSocketAddress with post number [" + port + "].");
 		}
 
-		if (!(address.get() instanceof InetSocketAddress)) {
+		if (!(socketAddress instanceof InetSocketAddress)) {
 			return createUnresolved(NetUtil.LOCALHOST.getHostAddress(), port);
 		}
 
-		InetSocketAddress inet = (InetSocketAddress) address.get();
+		InetSocketAddress inet = (InetSocketAddress) socketAddress;
 
 		InetAddress addr = inet.getAddress();
 

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/AddressUtilsTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/AddressUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 package reactor.netty.transport;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 
@@ -274,6 +277,22 @@ class AddressUtilsTest {
 		assertThatExceptionOfType(IllegalArgumentException.class)
 				.isThrownBy(() -> AddressUtils.updatePort(null, -1))
 				.withMessage("port out of range:-1");
+	}
+
+	@Test
+	void updatePortEvaluatesSupplierOnce() {
+		AtomicInteger evaluations = new AtomicInteger();
+		Supplier<SocketAddress> supplier = () -> {
+			evaluations.incrementAndGet();
+			return AddressUtils.createUnresolved("example.com", 8080);
+		};
+
+		SocketAddress updated = AddressUtils.updatePort(supplier, 9090);
+
+		assertThat(evaluations).hasValue(1);
+		assertThat(updated).isInstanceOf(InetSocketAddress.class);
+		assertThat(((InetSocketAddress) updated).getHostString()).isEqualTo("example.com");
+		assertThat(((InetSocketAddress) updated).getPort()).isEqualTo(9090);
 	}
 
 	@Test


### PR DESCRIPTION
updatePort re-invoked the upstream supplier three times, re-running the whole host/port override chain (a fresh IP-literal parse each) per request on the event loop, and could observe an inconsistent snapshot from a dynamic supplier. Reuse the value captured on the first call.