### PR TITLE
Do not capture caller context into pool maintenance tasks

### DIFF
--- a/reactor-netty-core/src/contextPropagationTest/java/reactor/netty/PooledConnectionProviderContextPropagationTest.java
+++ b/reactor-netty-core/src/contextPropagationTest/java/reactor/netty/PooledConnectionProviderContextPropagationTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty;
+
+import io.micrometer.context.ContextRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Hooks;
+import reactor.netty.resources.ConnectionProvider;
+import reactor.netty.tcp.TcpClient;
+import reactor.netty.tcp.TcpServer;
+
+import java.lang.ref.WeakReference;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that connection pool maintenance tasks (background eviction and inactive
+ * pool disposal) do not capture and retain the scheduling caller's ThreadLocal state
+ * when automatic context propagation is enabled.
+ */
+class PooledConnectionProviderContextPropagationTest {
+
+	DisposableServer disposableServer;
+	ConnectionProvider provider;
+	ContextRegistry registry;
+
+	@BeforeEach
+	void setUp() {
+		registry = ContextRegistry.getInstance();
+		registry.registerThreadLocalAccessor(new TestThreadLocalAccessor());
+		Hooks.enableAutomaticContextPropagation();
+		disposableServer =
+				TcpServer.create()
+				         .handle((in, out) -> out.send(in.receive().retain()))
+				         .bindNow();
+	}
+
+	@AfterEach
+	void tearDown() {
+		Hooks.disableAutomaticContextPropagation();
+		TestThreadLocalHolder.reset();
+		registry.removeThreadLocalAccessor(TestThreadLocalAccessor.KEY);
+		if (provider != null) {
+			provider.disposeLater()
+			        .block(Duration.ofSeconds(30));
+		}
+		disposableServer.disposeNow();
+	}
+
+	@Test
+	void backgroundEvictionTaskDoesNotRetainCallerContext() throws Exception {
+		provider = ConnectionProvider.builder("evictionContextCapture")
+		                             .maxConnections(10)
+		                             .maxIdleTime(Duration.ofSeconds(30))
+		                             .evictInBackground(Duration.ofMillis(50))
+		                             .build();
+
+		// The pool is created lazily on the first acquire, i.e. on the "request" thread below,
+		// so the background eviction task is scheduled while the caller's ThreadLocal is set.
+		WeakReference<String> callerScope = runOnDedicatedThread(() -> {
+			Connection connection =
+					TcpClient.create(provider)
+					         .host("localhost")
+					         .port(disposableServer.port())
+					         .connectNow(Duration.ofSeconds(5));
+			connection.disposeNow();
+			return null;
+		});
+
+		assertScopeCollected(callerScope, "background eviction task");
+	}
+
+	@Test
+	void inactivePoolsDisposalTaskDoesNotRetainCallerContext() throws Exception {
+		// The disposal task is scheduled in the ConnectionProvider constructor,
+		// i.e. on the "request" thread below.
+		AtomicReference<ConnectionProvider> providerRef = new AtomicReference<>();
+		WeakReference<String> callerScope = runOnDedicatedThread(() -> {
+			providerRef.set(ConnectionProvider.builder("inactivePoolsContextCapture")
+			                                  .maxConnections(10)
+			                                  .disposeInactivePoolsInBackground(Duration.ofMillis(50), Duration.ofMillis(10))
+			                                  .build());
+			return null;
+		});
+		provider = providerRef.get();
+
+		assertScopeCollected(callerScope, "inactive pools disposal task");
+	}
+
+	/**
+	 * Runs the given action on a dedicated thread with a ThreadLocal value set, resets the
+	 * ThreadLocal and lets the thread terminate, so that afterwards no stack frame or
+	 * ThreadLocalMap entry can keep the value alive. Returns a {@link WeakReference} to
+	 * the value so tests can assert whether it is still strongly reachable elsewhere.
+	 */
+	static WeakReference<String> runOnDedicatedThread(Supplier<?> action) throws InterruptedException {
+		AtomicReference<WeakReference<String>> scopeRef = new AtomicReference<>();
+		AtomicReference<Throwable> error = new AtomicReference<>();
+		Thread thread = new Thread(() -> {
+			String callerScope = new String("caller-scope-value".toCharArray());
+			scopeRef.set(new WeakReference<>(callerScope));
+			TestThreadLocalHolder.value(callerScope);
+			try {
+				action.get();
+			}
+			catch (Throwable t) {
+				error.set(t);
+			}
+			finally {
+				TestThreadLocalHolder.reset();
+			}
+		}, "test-caller-thread");
+		thread.start();
+		thread.join();
+		assertThat(error.get()).isNull();
+		return scopeRef.get();
+	}
+
+	static void assertScopeCollected(WeakReference<String> callerScope, String taskDescription) throws InterruptedException {
+		for (int i = 0; i < 100; i++) {
+			System.gc();
+			if (callerScope.get() == null) {
+				return;
+			}
+			Thread.sleep(100);
+		}
+		assertThat(callerScope.get())
+				.as("caller ThreadLocal state should not be retained by the " + taskDescription)
+				.isNull();
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PoolMaintenanceScheduler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PoolMaintenanceScheduler.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.resources;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import reactor.core.Disposable;
+import reactor.core.Disposables;
+import reactor.core.scheduler.Scheduler;
+
+/**
+ * A minimal {@link Scheduler} dedicated to connection pool maintenance tasks: background
+ * eviction and inactive pool disposal.
+ *
+ * <p>Tasks are submitted directly to a shared single daemon thread and deliberately do
+ * NOT go through {@link reactor.core.scheduler.Schedulers} task decoration
+ * ({@code Schedulers.onSchedule(...)}). Maintenance tasks are library-internal,
+ * self-rescheduling and live as long as the application; decorating them with hooks such
+ * as the context-capture hook installed by
+ * {@code Hooks.enableAutomaticContextPropagation()} captures the scheduling caller's
+ * {@code ThreadLocal} state (typically a request scope, because pools are created lazily
+ * on request processing threads) into a pending task and re-captures it on every
+ * reschedule, retaining the caller's object graph for the lifetime of the pool.
+ */
+final class PoolMaintenanceScheduler implements Scheduler {
+
+	static final PoolMaintenanceScheduler INSTANCE = new PoolMaintenanceScheduler();
+
+	final ScheduledThreadPoolExecutor executor;
+
+	private PoolMaintenanceScheduler() {
+		ScheduledThreadPoolExecutor e = new ScheduledThreadPoolExecutor(1, r -> {
+			Thread t = new Thread(r, "reactor-netty-pool-maintenance");
+			t.setDaemon(true);
+			return t;
+		});
+		e.setRemoveOnCancelPolicy(true);
+		this.executor = e;
+	}
+
+	@Override
+	public Disposable schedule(Runnable task) {
+		return toDisposable(executor.submit(task));
+	}
+
+	@Override
+	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
+		return toDisposable(executor.schedule(task, delay, unit));
+	}
+
+	@Override
+	public Disposable schedulePeriodically(Runnable task, long initialDelay, long period, TimeUnit unit) {
+		return toDisposable(executor.scheduleAtFixedRate(task, initialDelay, period, unit));
+	}
+
+	@Override
+	public Worker createWorker() {
+		return new PoolMaintenanceWorker(this);
+	}
+
+	@Override
+	public void dispose() {
+		// shared infrastructure scheduler backed by a daemon thread, never disposed
+	}
+
+	static Disposable toDisposable(Future<?> future) {
+		return () -> future.cancel(false);
+	}
+
+	static final class PoolMaintenanceWorker implements Worker {
+
+		final PoolMaintenanceScheduler parent;
+		final Disposable.Composite tasks = Disposables.composite();
+
+		PoolMaintenanceWorker(PoolMaintenanceScheduler parent) {
+			this.parent = parent;
+		}
+
+		@Override
+		public Disposable schedule(Runnable task) {
+			return track(parent.schedule(task));
+		}
+
+		@Override
+		public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
+			return track(parent.schedule(task, delay, unit));
+		}
+
+		@Override
+		public Disposable schedulePeriodically(Runnable task, long initialDelay, long period, TimeUnit unit) {
+			return track(parent.schedulePeriodically(task, initialDelay, period, unit));
+		}
+
+		@Override
+		public void dispose() {
+			tasks.dispose();
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return tasks.isDisposed();
+		}
+
+		Disposable track(Disposable disposable) {
+			tasks.add(disposable);
+			return disposable;
+		}
+	}
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PoolMaintenanceScheduler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PoolMaintenanceScheduler.java
@@ -18,16 +18,18 @@ package reactor.netty.resources;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * A minimal {@link Scheduler} dedicated to connection pool maintenance tasks: background
  * eviction and inactive pool disposal.
  *
- * <p>Tasks are submitted directly to a shared single daemon thread and deliberately do
+ * <p>Tasks are submitted directly to a shared daemon thread and deliberately do
  * NOT go through {@link reactor.core.scheduler.Schedulers} task decoration
  * ({@code Schedulers.onSchedule(...)}). Maintenance tasks are library-internal,
  * self-rescheduling and live as long as the application; decorating them with hooks such
@@ -44,8 +46,9 @@ final class PoolMaintenanceScheduler implements Scheduler {
 	final ScheduledThreadPoolExecutor executor;
 
 	private PoolMaintenanceScheduler() {
-		ScheduledThreadPoolExecutor e = new ScheduledThreadPoolExecutor(1, r -> {
-			Thread t = new Thread(r, "reactor-netty-pool-maintenance");
+		AtomicLong counter = new AtomicLong();
+		ScheduledThreadPoolExecutor e = new ScheduledThreadPoolExecutor(Schedulers.DEFAULT_POOL_SIZE, r -> {
+			Thread t = new Thread(r, "reactor-netty-pool-maintenance-" + counter.incrementAndGet());
 			t.setDaemon(true);
 			return t;
 		});

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -28,7 +28,6 @@ import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
 import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
 import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
 import reactor.netty.ReactorNetty;
@@ -459,7 +458,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 
 	final void scheduleInactivePoolsDisposal() {
 		if (!inactivePoolDisposeInterval.isZero()) {
-			Schedulers.parallel()
+			PoolMaintenanceScheduler.INSTANCE
 			          .schedule(this::disposeInactivePoolsInBackground, inactivePoolDisposeInterval.toMillis(), TimeUnit.MILLISECONDS);
 		}
 	}
@@ -653,7 +652,7 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 				poolBuilder = poolBuilder.evictInBackground(evictionInterval, evictInBackgroundScheduler);
 			}
 			else {
-				poolBuilder = poolBuilder.evictInBackground(evictionInterval);
+				poolBuilder = poolBuilder.evictInBackground(evictionInterval, PoolMaintenanceScheduler.INSTANCE);
 			}
 
 			if (maxLifeTimeDuration != null) {


### PR DESCRIPTION
## What

`SimpleDequePool`'s background eviction task and `PooledConnectionProvider`'s inactive
pools disposal task are library-internal, self-rescheduling maintenance tasks that live as
long as the application. They were scheduled through `Schedulers.parallel()`, so every
scheduled `Runnable` goes through `Schedulers.onSchedule(...)` task decoration. When an
application enables `Hooks.enableAutomaticContextPropagation()` and registers a
`ThreadLocalAccessor` for a request-scoped object, that decoration wraps each task in a
Micrometer `ContextSnapshot` capturing the scheduling caller's ThreadLocals:

1. Connection pools are created lazily on first acquire — typically on a request
   processing thread — so the pool constructor's `scheduleEviction()` captures that
   request's context into the pending eviction task.
2. When the task runs, the snapshot is restored around `run()`, and the task re-schedules
   itself from inside that restored scope. The same long-dead request context is therefore
   re-captured into every subsequent task, indefinitely.

The result is permanent retention of the caller's object graph (437MB observed in
production for over 12 hours — see #4299 for the full analysis and a standalone
reproducer).

## Change

- Add a package-private `PoolMaintenanceScheduler`: a minimal `Scheduler` backed by a
  single shared daemon thread that submits tasks directly, deliberately bypassing
  `Schedulers.onSchedule` decoration.
- Background eviction: the default scheduler becomes `PoolMaintenanceScheduler.INSTANCE`;
  a scheduler explicitly supplied via `ConnectionProvider.Builder#evictInBackground(Duration, Scheduler)`
  (available since 1.3.2) is still honored.
- Inactive pools disposal: `Schedulers.parallel()` → `PoolMaintenanceScheduler.INSTANCE`.
- New tests in the `contextPropagationTest` source set reproducing both retention cases
  via `WeakReference` reachability; they fail before this change and pass after it.

Verified end-to-end: the standalone reproducer from #4299 leaks on 1.1.31, 1.2.18 and
1.3.6, and shows no leak against locally built `1.3.7-SNAPSHOT` and `1.2.19-SNAPSHOT`
builds containing this change.

Note: this also bypasses user-registered `onScheduleHook` decorators (e.g. MDC copying or
instrumentation) for these two internal tasks. I believe that is acceptable — these tasks
never execute user code — but it is a behavior change worth calling out.

## Alternatives considered

- A capture-exempt scheduling path in reactor-core would solve this class of problem for
  every library with internal periodic tasks (reactor-pool's eviction task affects direct
  reactor-pool users the same way). Happy to pursue that direction instead if preferred.
- Since 1.3.2, `ConnectionProvider.Builder#evictInBackground(Duration, Scheduler)` lets
  users supply their own scheduler, but any scheduler built via the `Schedulers` factory
  methods still applies the `onSchedule` decoration, so it cannot be used to opt out.

Fixes #4299.
