### PR TITLE
Fix `WebSocket-over-HTTP/2` server metrics gauge accounting on close

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import reactor.netty.FutureMono;
 import reactor.netty.NettyOutbound;
 import reactor.netty.NettyPipeline;
 import reactor.netty.ReactorNetty;
+import reactor.netty.channel.ChannelOperations;
 import reactor.netty.http.HttpOperations;
 import reactor.netty.http.websocket.WebsocketInbound;
 import reactor.netty.http.websocket.WebsocketOutbound;
@@ -321,6 +322,13 @@ class WebsocketServerOperations extends HttpServerOperations
 			AtomicIntegerFieldUpdater.newUpdater(WebsocketServerOperations.class,
 					"closeSent");
 
+	/**
+	 * Replaces the {@code HttpMetricsHandler} slot after a WebSocket upgrade: it stops recording HTTP
+	 * request/response metrics (the exchange is over) while still carrying the connection/stream close
+	 * accounting via {@link #recordInactiveConnectionOrStream}. For the Micrometer recorder the
+	 * {@code ChannelMetricsHandler} is not present in the pipeline (see {@code HttpServerConfig}), so this
+	 * slot is the sole owner of that accounting.
+	 */
 	static final class WebsocketHttpServerMetricsHandler extends AbstractHttpServerMetricsHandler {
 
 		final HttpServerMetricsRecorder recorder;
@@ -347,11 +355,13 @@ class WebsocketServerOperations extends HttpServerOperations
 					recorder.recordServerConnectionClosed(ctx.channel().localAddress());
 				}
 
-				if (channelActivated) {
-					channelActivated = false;
-					// Always use the real connection local address without any proxy information
-					recorder.recordServerConnectionInactive(ctx.channel().localAddress());
+				// Dispatch on the channel type as the base handler does: an Http2StreamChannel close is a stream close.
+				ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
+				HttpServerOperations ops = null;
+				if (channelOps instanceof HttpServerOperations) {
+					ops = (HttpServerOperations) channelOps;
 				}
+				recordInactiveConnectionOrStream(ctx.channel(), ops);
 			}
 			catch (RuntimeException e) {
 				// Allow request-response exchange to continue, unaffected by metrics problem

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -787,6 +787,48 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		assertGauge(registry, SERVER_CONNECTIONS_ACTIVE, URI, HTTP, LOCAL_ADDRESS, address).hasValueEqualTo(0);
 	}
 
+	@Test
+	void testServerConnectionsWebsocketMicrometerHttp2() throws Exception {
+		// WebSocket-over-HTTP/2 server metrics gauge regression (#4290): the upgrade runs over an HTTP/2 stream, so
+		// after close streams.active must return to 0 while connections.active stays untouched.
+		// A fresh createServer() is required (not the shared httpServer): this path uses .handle(...) for the Extended
+		// CONNECT upgrade, which the shared .route(...) server would 404, and needs H2C + connectProtocolEnabled.
+		disposableServer =
+				createServer()
+						.channelGroup(group)
+						.host("127.0.0.1")
+						.protocol(HttpProtocol.H2C)
+						.http2Settings(spec -> spec.connectProtocolEnabled(true))
+						.metrics(true, Function.identity())
+						.handle((req, res) -> res.sendWebsocket((in, out) -> out.sendString(Mono.just("Hello World!"))))
+						.doOnConnection(cnx -> StreamCloseHandler.INSTANCE.register(cnx.channel()))
+						.bindNow();
+
+		String address = formatSocketAddress(disposableServer.address());
+
+		httpClient.protocol(HttpProtocol.H2C)
+		          .websocket()
+		          .uri("/ws")
+		          .handle((in, out) -> in.receive().aggregate().asString())
+		          .as(StepVerifier::create)
+		          .expectNext("Hello World!")
+		          .expectComplete()
+		          .verify(Duration.ofSeconds(30));
+
+		// make sure the client stream is closed on the server side (pass-through channelInactive ran)
+		// before checking server metrics
+		assertThat(StreamCloseHandler.INSTANCE.awaitClientClosedOnServer()).as("awaitClientClosedOnServer timeout").isTrue();
+
+		// streams.active back to 0; connections.active never recorded (only counted for a SocketChannel, so on this
+		// stream path it is never created - pre-fix the erroneous recordServerConnectionInactive created it at -1).
+		assertGauge(registry, SERVER_STREAMS_ACTIVE, URI, HTTP, LOCAL_ADDRESS, address).hasValueEqualTo(0);
+		assertGauge(registry, SERVER_CONNECTIONS_ACTIVE, URI, HTTP, LOCAL_ADDRESS, address)
+				.as("connections.active must not be recorded for a WebSocket-over-HTTP/2 stream close (pre-fix it was -1)")
+				.isNull();
+		// The stream close must not disturb the parent connection's total.
+		assertGauge(registry, SERVER_CONNECTIONS_TOTAL, URI, HTTP, LOCAL_ADDRESS, address).hasValueEqualTo(1);
+	}
+
 	@ParameterizedTest
 	@MethodSource("httpCompatibleProtocols")
 	void testServerConnectionsRecorder(HttpProtocol[] serverProtocols, HttpProtocol[] clientProtocols,


### PR DESCRIPTION
This fixes the server-side metrics gauge accounting when a WebSocket-over-HTTP/2 connection closes.

On an `Http2StreamChannel` the active unit is a *stream*: reading the upgrade request increments `reactor.netty.http.server.streams.active` (via `recordOpenStream`). On close, however, the pass-through `WebsocketHttpServerMetricsHandler#channelInactive` recorded a connection-inactive (`recordServerConnectionInactive`) regardless of the channel type. As a result:

- `streams.active` was never decremented and leaked by one per WebSocket-over-HTTP/2 connection;
- `connections.active` (only ever incremented for a `SocketChannel`) was spuriously decremented and went negative (`-1`).

The fix delegates `channelInactive` to the inherited `recordInactiveConnectionOrStream`, which dispatches on the channel type — recording a stream close for an `Http2StreamChannel` and a connection-inactive for a `SocketChannel` — so the pass-through stays consistent with the base handler. The channel's `HttpServerOperations` is looked up and passed through, the way every other call site of `recordInactiveConnectionOrStream` does, so the close is recorded at the same local address source the matching open used (`ops.connectionHostAddress()`) rather than relying on the two coinciding.

HTTP/1.1 is unaffected: for the WebSocket operations types `connectionHostAddress()` resolves to `channel().localAddress()`, so a `SocketChannel` still records a connection-inactive at exactly the address the previous inline code recorded.

The new `testServerConnectionsWebsocketMicrometerHttp2` in `HttpMetricsHandlerTests` exercises the `Http2StreamChannel` (stream) branch — the same branch taken by HTTP/2-over-TLS — while the existing `testServerConnectionsWebsocketMicrometer` exercises the `SocketChannel` (connection) branch. After the stream closes, the new test asserts that `streams.active` returns to `0`, `connections.active` is not recorded, and the parent connection's `connections.total` is left intact; the HTTP/1.1 sibling continues to pass.

Fixes #4290
