### PR TITLE
Expose forwarded header selection

### DIFF
--- a/docs/modules/ROOT/pages/http-server.adoc
+++ b/docs/modules/ROOT/pages/http-server.adoc
@@ -292,6 +292,17 @@ include::{examples-dir}/clientaddress/Application.java[tags=snippet-application]
 `HTTP` request headers, if possible.
 <2> Returns the address of the remote (client) peer.
 
+When both header formats can be present, you can choose to use only the `Forwarded` header or only the
+`X-Forwarded-*` headers:
+
+{examples-link}/clientaddress/ForwardedHeaderSelectionApplication.java
+[%unbreakable]
+----
+include::{examples-dir}/clientaddress/ForwardedHeaderSelectionApplication.java[tags=snippet-application]
+----
+<1> Specifies that information about the connection is to be obtained only from the `X-Forwarded-*` HTTP request headers.
+<2> Returns the address of the remote (client) peer.
+
 It is also possible to customize the behavior of the `Forwarded` or `X-Forwarded-*` header handler.
 The following example shows how to do so:
 

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/clientaddress/ForwardedHeaderSelectionApplication.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/clientaddress/ForwardedHeaderSelectionApplication.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.documentation.http.server.clientaddress;
+
+// tag::snippet-application[]
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.ForwardedHeaderMode;
+import reactor.netty.http.server.HttpServer;
+
+public class ForwardedHeaderSelectionApplication {
+
+	public static void main(String[] args) {
+		DisposableServer server =
+				HttpServer.create()
+				          .forwarded(ForwardedHeaderMode.X_FORWARDED) //<1>
+				          .route(routes ->
+				              routes.get("/clientip",
+				                  (request, response) ->
+				                      response.sendString(Mono.just(request.remoteAddress() //<2>
+				                                                           .getHostString()))))
+				          .bindNow();
+
+		server.onDispose()
+		      .block();
+	}
+}
+// end::snippet-application[]

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,12 @@ import static reactor.netty.http.server.ConnectionInfo.getDefaultHostPort;
  */
 final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> {
 
-	static final DefaultHttpForwardedHeaderHandler INSTANCE = new DefaultHttpForwardedHeaderHandler();
+	static final DefaultHttpForwardedHeaderHandler INSTANCE =
+			new DefaultHttpForwardedHeaderHandler(ForwardedHeaderMode.AUTO);
+	static final DefaultHttpForwardedHeaderHandler FORWARDED =
+			new DefaultHttpForwardedHeaderHandler(ForwardedHeaderMode.FORWARDED);
+	static final DefaultHttpForwardedHeaderHandler X_FORWARDED =
+			new DefaultHttpForwardedHeaderHandler(ForwardedHeaderMode.X_FORWARDED);
 
 	static final String  FORWARDED_HEADER         = "Forwarded";
 	static final String  X_FORWARDED_IP_HEADER    = "X-Forwarded-For";
@@ -61,13 +66,22 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 	static final boolean DEFAULT_FORWARDED_HEADER_VALIDATION =
 			Boolean.parseBoolean(System.getProperty(FORWARDED_HEADER_VALIDATION, "true"));
 
+	private final ForwardedHeaderMode forwardedHeaderMode;
+
+	private DefaultHttpForwardedHeaderHandler(ForwardedHeaderMode forwardedHeaderMode) {
+		this.forwardedHeaderMode = forwardedHeaderMode;
+	}
+
 	@Override
 	public ConnectionInfo apply(ConnectionInfo connectionInfo, HttpRequest request) {
-		String forwardedHeader = request.headers().get(FORWARDED_HEADER);
-		if (forwardedHeader != null) {
-			return parseForwardedInfo(connectionInfo, forwardedHeader);
+		if (forwardedHeaderMode != ForwardedHeaderMode.X_FORWARDED) {
+			String forwardedHeader = request.headers().get(FORWARDED_HEADER);
+			if (forwardedHeader != null) {
+				return parseForwardedInfo(connectionInfo, forwardedHeader);
+			}
 		}
-		return parseXForwardedInfo(connectionInfo, request);
+		return forwardedHeaderMode != ForwardedHeaderMode.FORWARDED ?
+				parseXForwardedInfo(connectionInfo, request) : connectionInfo;
 	}
 
 	@SuppressWarnings("NullAway")

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ForwardedHeaderMode.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ForwardedHeaderMode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+/**
+ * Specifies which forwarded request headers an {@link HttpServer} uses for deriving
+ * information about a connection.
+ *
+ * @author Arnab Nandy
+ * @since 1.4.0
+ */
+public enum ForwardedHeaderMode {
+
+	/**
+	 * Use the {@code "Forwarded"} header when present, otherwise use the
+	 * {@code "X-Forwarded-*"} headers.
+	 */
+	AUTO,
+
+	/**
+	 * Use only the {@code "Forwarded"} header.
+	 */
+	FORWARDED,
+
+	/**
+	 * Use only the {@code "X-Forwarded-*"} headers.
+	 */
+	X_FORWARDED
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -543,6 +543,35 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 			return dup;
 		}
 		return this;
+	}
+
+	/**
+	 * Specifies which forwarded HTTP request headers are used for deriving information
+	 * about the connection.
+	 *
+	 * @param forwardedHeaderMode the forwarded header mode
+	 * @return a new {@link HttpServer}
+	 * @since 1.4.0
+	 */
+	public final HttpServer forwarded(ForwardedHeaderMode forwardedHeaderMode) {
+		Objects.requireNonNull(forwardedHeaderMode, "forwardedHeaderMode");
+		DefaultHttpForwardedHeaderHandler handler;
+		switch (forwardedHeaderMode) {
+			case FORWARDED:
+				handler = DefaultHttpForwardedHeaderHandler.FORWARDED;
+				break;
+			case X_FORWARDED:
+				handler = DefaultHttpForwardedHeaderHandler.X_FORWARDED;
+				break;
+			default:
+				handler = DefaultHttpForwardedHeaderHandler.INSTANCE;
+		}
+		if (configuration().forwardedHeaderHandler == handler) {
+			return this;
+		}
+		HttpServer dup = duplicate();
+		dup.configuration().forwardedHeaderHandler = handler;
+		return dup;
 	}
 
 	/**

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,13 @@ class ConnectionInfoTests extends BaseHttpTest {
 				Arguments.of("https", false),
 				Arguments.of("wss", true),
 				Arguments.of("wss", false));
+	}
+
+	static Stream<Arguments> forwardedHeaderModeParams() {
+		return Stream.of(
+				Arguments.of(ForwardedHeaderMode.AUTO, "192.0.2.60"),
+				Arguments.of(ForwardedHeaderMode.FORWARDED, "192.0.2.60"),
+				Arguments.of(ForwardedHeaderMode.X_FORWARDED, "192.0.2.61"));
 	}
 
 	static @Nullable BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> getForwardedHandler(boolean useCustomForwardedHandler) {
@@ -830,6 +837,21 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.remoteAddress().getPort()).isPositive();
 					Assertions.assertThat(serverRequest.scheme()).isEqualTo("http");
 				});
+	}
+
+	@ParameterizedTest
+	@MethodSource("forwardedHeaderModeParams")
+	void forwardedHeaderMode(ForwardedHeaderMode forwardedHeaderMode, String expectedRemoteAddress) {
+		testClientRequest(
+				clientRequestHeaders -> {
+					clientRequestHeaders.add("Forwarded", "for=192.0.2.60");
+					clientRequestHeaders.add("X-Forwarded-For", "192.0.2.61");
+				},
+				serverRequest -> Assertions.assertThat(serverRequest.remoteAddress().getHostString())
+				                           .isEqualTo(expectedRemoteAddress),
+				Function.identity(),
+				httpServer -> httpServer.forwarded(forwardedHeaderMode),
+				false);
 	}
 
 	@Test


### PR DESCRIPTION
The default forwarded header handler always gives the standard `Forwarded` header precedence and only uses `X-Forwarded-*` headers when `Forwarded` is absent. Applications could not explicitly select one format without reimplementing the corresponding parsing logic in a custom handler.

Introduce `ForwardedHeaderMode` with the following modes:

- `AUTO` preserves the existing behavior.
- `FORWARDED` uses only the `Forwarded` header.
- `X_FORWARDED` uses only the `X-Forwarded-*` headers.

Add `HttpServer#forwarded(ForwardedHeaderMode)` while keeping `forwarded(true)` fully backward-compatible.

The reference documentation now includes a compiled example demonstrating explicit `X-Forwarded-*` selection. Parameterized tests use conflicting `Forwarded` and `X-Forwarded-For` values to verify each selection mode.

Resolves #4301

Validation:

- `ConnectionInfoTests`
- Reactor Netty examples compilation
- Spotless
- HTTP module Javadoc
- Antora resource generation