### PR TITLE
Require choice between `Forwarded` and `X-Forwarded` headers

### DIFF
--- a/docs/modules/ROOT/pages/http-server.adoc
+++ b/docs/modules/ROOT/pages/http-server.adoc
@@ -280,7 +280,17 @@ has to be checked. Also note that enabling this property effectively ignores `ma
 In addition to the metadata that you can obtain from the request, you can also receive the
 `host (server)` address, the `remote (client)` address and the `scheme`. Depending on the
 chosen factory method, you can retrieve the information directly from the channel or by
-using the `Forwarded` or `X-Forwarded-*` `HTTP` request headers.
+using the standard `Forwarded` `HTTP` request header or the `X-Forwarded-*` alternative
+`HTTP` request headers.
+
+WARNING: An application cannot know if forwarded headers were added by a trusted proxy or by
+a malicious client. It is imperative that a proxy at the edge of trust is configured to drop
+forwarded headers from the outside, including both the standard `Forwarded` header and the
+`X-Forwarded-*` alternative headers.
+
+Proxies are typically configured to support either the standard `Forwarded` header or the
+`X-Forwarded-*` header. Accordingly, an application must indicate which of the two
+alternatives it expects. Support for `X-Forwarded-Prefix` is enabled separately.
 The following example shows how to do so:
 
 {examples-link}/clientaddress/Application.java
@@ -288,8 +298,8 @@ The following example shows how to do so:
 ----
 include::{examples-dir}/clientaddress/Application.java[tags=snippet-application]
 ----
-<1> Specifies that the information about the connection is to be obtained from the `Forwarded` and `X-Forwarded-*`
-`HTTP` request headers, if possible.
+<1> Specifies that the information about the connection is to be obtained from the `X-Forwarded-*`
+alternative `HTTP` request headers, if possible, and that `X-Forwarded-Prefix` is not used.
 <2> Returns the address of the remote (client) peer.
 
 It is also possible to customize the behavior of the `Forwarded` or `X-Forwarded-*` header handler.

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/clientaddress/Application.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/documentation/http/server/clientaddress/Application.java
@@ -25,7 +25,7 @@ public class Application {
 	public static void main(String[] args) {
 		DisposableServer server =
 				HttpServer.create()
-				          .forwarded(true) //<1>
+				          .forwarded(false, false) //<1>
 				          .route(routes ->
 				              routes.get("/clientip",
 				                  (request, response) ->

--- a/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpServerDecoratorTest.java
+++ b/reactor-netty-http-brave/src/test/java/reactor/netty/http/brave/ITTracingHttpServerDecoratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ public class ITTracingHttpServerDecoratorTest extends ITHttpServer {
 				HttpServer.create()
 				          .port(0)
 				          .wiretap(true)
-				          .forwarded(true)
+				          .forwarded(false, false)
 				          .channelGroup(group)
 				          .handle(routes)).bindNow();
 	}

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -211,7 +211,6 @@ jar {
 
 japicmp {
 	methodExcludes = [
-			'reactor.netty.http.server.HttpServer#forwarded(boolean)'
 	]
 }
 

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -211,6 +211,7 @@ jar {
 
 japicmp {
 	methodExcludes = [
+			'reactor.netty.http.server.HttpServer#forwarded(boolean)'
 	]
 }
 

--- a/reactor-netty-http/src/http3Test/java/reactor/netty/http/Http3Tests.java
+++ b/reactor-netty-http/src/http3Test/java/reactor/netty/http/Http3Tests.java
@@ -284,7 +284,7 @@ class Http3Tests {
 				            });
 				            return resp.send();
 				        })
-				        .forwarded(true)
+				        .forwarded(true, false)
 				        .accessLog(true, args -> {
 				            ConnectionInformation connectionInformation = args.connectionInformation();
 				            return connectionInformation != null ?

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
@@ -41,6 +41,16 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 	static final DefaultHttpForwardedHeaderHandler X_FORWARDED = new DefaultHttpForwardedHeaderHandler(false, false);
 	static final DefaultHttpForwardedHeaderHandler X_FORWARDED_WITH_PREFIX = new DefaultHttpForwardedHeaderHandler(false, true);
 
+	/**
+	 * Handles the standard {@code Forwarded} header when it is present, otherwise falls back to the
+	 * {@code X-Forwarded-*} alternative headers, {@code X-Forwarded-Prefix} included.
+	 *
+	 * @deprecated as of 1.4.0. This instance exists only for {@link HttpServer#forwarded(boolean)}
+	 * and will be removed in version 1.5.0.
+	 */
+	@Deprecated
+	static final DefaultHttpForwardedHeaderHandler LEGACY = new DefaultHttpForwardedHeaderHandler(true, true, true);
+
 	static final String  FORWARDED_HEADER         = "Forwarded";
 	static final String  X_FORWARDED_IP_HEADER    = "X-Forwarded-For";
 	static final String  X_FORWARDED_HOST_HEADER  = "X-Forwarded-Host";
@@ -70,9 +80,20 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 
 	final boolean useForwardedPrefix;
 
+	/**
+	 * Whether both alternatives are handled, the standard {@code Forwarded} header taking precedence.
+	 * Used only by {@link #LEGACY}, it will be removed in version 1.5.0.
+	 */
+	final boolean legacy;
+
 	private DefaultHttpForwardedHeaderHandler(boolean useStandardHeader, boolean useForwardedPrefix) {
+		this(useStandardHeader, useForwardedPrefix, false);
+	}
+
+	private DefaultHttpForwardedHeaderHandler(boolean useStandardHeader, boolean useForwardedPrefix, boolean legacy) {
 		this.useStandardHeader = useStandardHeader;
 		this.useForwardedPrefix = useForwardedPrefix;
+		this.legacy = legacy;
 	}
 
 	static DefaultHttpForwardedHeaderHandler instance(boolean useStandardHeader, boolean useForwardedPrefix) {
@@ -84,6 +105,13 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 
 	@Override
 	public ConnectionInfo apply(ConnectionInfo connectionInfo, HttpRequest request) {
+		if (legacy) {
+			String forwardedHeader = request.headers().get(FORWARDED_HEADER);
+			if (forwardedHeader != null) {
+				return parseForwardedInfo(connectionInfo, forwardedHeader);
+			}
+			return parseForwardedPrefixInfo(parseXForwardedInfo(connectionInfo, request), request);
+		}
 		if (useStandardHeader) {
 			String forwardedHeader = request.headers().get(FORWARDED_HEADER);
 			if (forwardedHeader != null) {
@@ -94,10 +122,7 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 			connectionInfo = parseXForwardedInfo(connectionInfo, request);
 		}
 		if (useForwardedPrefix) {
-			String prefixHeader = request.headers().get(X_FORWARDED_PREFIX_HEADER);
-			if (prefixHeader != null) {
-				connectionInfo = connectionInfo.withForwardedPrefix(parseForwardedPrefix(prefixHeader));
-			}
+			connectionInfo = parseForwardedPrefixInfo(connectionInfo, request);
 		}
 		return connectionInfo;
 	}
@@ -165,6 +190,14 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 			}
 		}
 
+		return connectionInfo;
+	}
+
+	private static ConnectionInfo parseForwardedPrefixInfo(ConnectionInfo connectionInfo, HttpRequest request) {
+		String prefixHeader = request.headers().get(X_FORWARDED_PREFIX_HEADER);
+		if (prefixHeader != null) {
+			return connectionInfo.withForwardedPrefix(parseForwardedPrefix(prefixHeader));
+		}
 		return connectionInfo;
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultHttpForwardedHeaderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,14 +27,19 @@ import reactor.netty.transport.AddressUtils;
 import static reactor.netty.http.server.ConnectionInfo.getDefaultHostPort;
 
 /**
- * Default implementation for handling {@code X-Forwarded}/{@code Forwarded} headers.
+ * Default implementation for handling the standard {@code Forwarded} header or the
+ * {@code X-Forwarded-*} alternative headers. Support for {@code X-Forwarded-Prefix} is
+ * enabled separately.
  *
  * @author Andrey Shlykov
  * @since 0.9.12
  */
 final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> {
 
-	static final DefaultHttpForwardedHeaderHandler INSTANCE = new DefaultHttpForwardedHeaderHandler();
+	static final DefaultHttpForwardedHeaderHandler FORWARDED = new DefaultHttpForwardedHeaderHandler(true, false);
+	static final DefaultHttpForwardedHeaderHandler FORWARDED_WITH_PREFIX = new DefaultHttpForwardedHeaderHandler(true, true);
+	static final DefaultHttpForwardedHeaderHandler X_FORWARDED = new DefaultHttpForwardedHeaderHandler(false, false);
+	static final DefaultHttpForwardedHeaderHandler X_FORWARDED_WITH_PREFIX = new DefaultHttpForwardedHeaderHandler(false, true);
 
 	static final String  FORWARDED_HEADER         = "Forwarded";
 	static final String  X_FORWARDED_IP_HEADER    = "X-Forwarded-For";
@@ -61,13 +66,40 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 	static final boolean DEFAULT_FORWARDED_HEADER_VALIDATION =
 			Boolean.parseBoolean(System.getProperty(FORWARDED_HEADER_VALIDATION, "true"));
 
+	final boolean useStandardHeader;
+
+	final boolean useForwardedPrefix;
+
+	private DefaultHttpForwardedHeaderHandler(boolean useStandardHeader, boolean useForwardedPrefix) {
+		this.useStandardHeader = useStandardHeader;
+		this.useForwardedPrefix = useForwardedPrefix;
+	}
+
+	static DefaultHttpForwardedHeaderHandler instance(boolean useStandardHeader, boolean useForwardedPrefix) {
+		if (useStandardHeader) {
+			return useForwardedPrefix ? FORWARDED_WITH_PREFIX : FORWARDED;
+		}
+		return useForwardedPrefix ? X_FORWARDED_WITH_PREFIX : X_FORWARDED;
+	}
+
 	@Override
 	public ConnectionInfo apply(ConnectionInfo connectionInfo, HttpRequest request) {
-		String forwardedHeader = request.headers().get(FORWARDED_HEADER);
-		if (forwardedHeader != null) {
-			return parseForwardedInfo(connectionInfo, forwardedHeader);
+		if (useStandardHeader) {
+			String forwardedHeader = request.headers().get(FORWARDED_HEADER);
+			if (forwardedHeader != null) {
+				connectionInfo = parseForwardedInfo(connectionInfo, forwardedHeader);
+			}
 		}
-		return parseXForwardedInfo(connectionInfo, request);
+		else {
+			connectionInfo = parseXForwardedInfo(connectionInfo, request);
+		}
+		if (useForwardedPrefix) {
+			String prefixHeader = request.headers().get(X_FORWARDED_PREFIX_HEADER);
+			if (prefixHeader != null) {
+				connectionInfo = connectionInfo.withForwardedPrefix(parseForwardedPrefix(prefixHeader));
+			}
+		}
+		return connectionInfo;
 	}
 
 	@SuppressWarnings("NullAway")
@@ -133,10 +165,6 @@ final class DefaultHttpForwardedHeaderHandler implements BiFunction<ConnectionIn
 			}
 		}
 
-		String prefixHeader = request.headers().get(X_FORWARDED_PREFIX_HEADER);
-		if (prefixHeader != null) {
-			connectionInfo = connectionInfo.withForwardedPrefix(parseForwardedPrefix(prefixHeader));
-		}
 		return connectionInfo;
 	}
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -519,6 +519,45 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	}
 
 	/**
+	 * Specifies whether support for the {@code "Forwarded"} and {@code "X-Forwarded-*"}
+	 * HTTP request headers for deriving information about the connection is enabled.
+	 * <p>An application cannot know if forwarded headers were added by a trusted proxy or by
+	 * a malicious client. It is imperative that a proxy at the edge of trust is configured to
+	 * drop forwarded headers from the outside, including both the standard {@code "Forwarded"}
+	 * header and the {@code "X-Forwarded-*"} alternative headers.
+	 * <p>When enabled, the standard {@code "Forwarded"} header takes precedence and the
+	 * {@code "X-Forwarded-*"} alternative headers, {@code "X-Forwarded-Prefix"} included,
+	 * are used only when the standard header is absent.
+	 *
+	 * @param forwardedEnabled if true support for the {@code "Forwarded"} and {@code "X-Forwarded-*"}
+	 * HTTP request headers for deriving information about the connection is enabled,
+	 * otherwise disabled.
+	 * @return a new {@link HttpServer}
+	 * @since 0.9.7
+	 * @deprecated as of 1.4.0. Prefer using {@link #forwarded(boolean, boolean)} in order to select
+	 * explicitly between the standard {@code "Forwarded"} header and the {@code "X-Forwarded-*"}
+	 * alternative headers, or {@link #noForwarded()} in order to disable the support.
+	 * This method will be removed in version 1.5.0.
+	 */
+	@Deprecated
+	public final HttpServer forwarded(boolean forwardedEnabled) {
+		if (forwardedEnabled) {
+			if (configuration().forwardedHeaderHandler == DefaultHttpForwardedHeaderHandler.LEGACY) {
+				return this;
+			}
+			HttpServer dup = duplicate();
+			dup.configuration().forwardedHeaderHandler = DefaultHttpForwardedHeaderHandler.LEGACY;
+			return dup;
+		}
+		else if (configuration().forwardedHeaderHandler != null) {
+			HttpServer dup = duplicate();
+			dup.configuration().forwardedHeaderHandler = null;
+			return dup;
+		}
+		return this;
+	}
+
+	/**
 	 * Specifies whether to use the standard {@code "Forwarded"} HTTP request header or the
 	 * {@code "X-Forwarded-*"} alternative HTTP request headers for deriving information
 	 * about the connection.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -519,30 +519,35 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 	}
 
 	/**
-	 * Specifies whether support for the {@code "Forwarded"} and {@code "X-Forwarded-*"}
-	 * HTTP request headers for deriving information about the connection is enabled.
+	 * Specifies whether to use the standard {@code "Forwarded"} HTTP request header or the
+	 * {@code "X-Forwarded-*"} alternative HTTP request headers for deriving information
+	 * about the connection.
+	 * <p>An application cannot know if forwarded headers were added by a trusted proxy or by
+	 * a malicious client. It is imperative that a proxy at the edge of trust is configured to
+	 * drop forwarded headers from the outside, including both the standard {@code "Forwarded"}
+	 * header and the {@code "X-Forwarded-*"} alternative headers.
+	 * <p>Proxies are typically configured to support either the standard {@code "Forwarded"}
+	 * header or the {@code "X-Forwarded-*"} header. Accordingly, an application must indicate
+	 * which of the two alternatives it expects.
+	 * <p>Support for {@code "X-Forwarded-Prefix"} is enabled separately via
+	 * {@code useForwardedPrefix}.
 	 *
-	 * @param forwardedEnabled if true support for the {@code "Forwarded"} and {@code "X-Forwarded-*"}
-	 * HTTP request headers for deriving information about the connection is enabled,
-	 * otherwise disabled.
+	 * @param useStandardHeader whether to use the standard {@code "Forwarded"} header
+	 * (true), or the {@code "X-Forwarded-*"} alternative headers (false)
+	 * @param useForwardedPrefix whether to use {@code "X-Forwarded-Prefix"}. By default,
+	 * this is set to false in which case the header is ignored.
 	 * @return a new {@link HttpServer}
-	 * @since 0.9.7
+	 * @since 1.4.0
 	 */
-	public final HttpServer forwarded(boolean forwardedEnabled) {
-		if (forwardedEnabled) {
-			if (configuration().forwardedHeaderHandler == DefaultHttpForwardedHeaderHandler.INSTANCE) {
-				return this;
-			}
-			HttpServer dup = duplicate();
-			dup.configuration().forwardedHeaderHandler = DefaultHttpForwardedHeaderHandler.INSTANCE;
-			return dup;
+	public final HttpServer forwarded(boolean useStandardHeader, boolean useForwardedPrefix) {
+		DefaultHttpForwardedHeaderHandler handler =
+				DefaultHttpForwardedHeaderHandler.instance(useStandardHeader, useForwardedPrefix);
+		if (configuration().forwardedHeaderHandler == handler) {
+			return this;
 		}
-		else if (configuration().forwardedHeaderHandler != null) {
-			HttpServer dup = duplicate();
-			dup.configuration().forwardedHeaderHandler = null;
-			return dup;
-		}
-		return this;
+		HttpServer dup = duplicate();
+		dup.configuration().forwardedHeaderHandler = handler;
+		return dup;
 	}
 
 	/**
@@ -932,6 +937,21 @@ public abstract class HttpServer extends ServerTransport<HttpServer, HttpServerC
 		else {
 			return this;
 		}
+	}
+
+	/**
+	 * Removes any previously applied forwarded header handling configuration.
+	 *
+	 * @return a new {@link HttpServer}
+	 * @since 1.4.0
+	 */
+	public final HttpServer noForwarded() {
+		if (configuration().forwardedHeaderHandler != null) {
+			HttpServer dup = duplicate();
+			dup.configuration().forwardedHeaderHandler = null;
+			return dup;
+		}
+		return this;
 	}
 
 	/**

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpServerConfig.java
@@ -194,11 +194,13 @@ public final class HttpServerConfig extends ServerTransportConfig<HttpServerConf
 	}
 
 	/**
-	 * Returns whether that {@link HttpServer} supports the {@code "Forwarded"} and {@code "X-Forwarded-*"}
-	 * HTTP request headers for deriving information about the connection.
+	 * Returns whether that {@link HttpServer} supports the standard {@code "Forwarded"} HTTP request
+	 * header or the {@code "X-Forwarded-*"} alternative HTTP request headers for deriving information
+	 * about the connection.
 	 *
-	 * @return true if that {@link HttpServer} supports the {@code "Forwarded"} and {@code "X-Forwarded-*"}
-	 * HTTP request headers for deriving information about the connection
+	 * @return true if that {@link HttpServer} supports the standard {@code "Forwarded"} HTTP request
+	 * header or the {@code "X-Forwarded-*"} alternative HTTP request headers for deriving information
+	 * about the connection
 	 */
 	public boolean isForwarded() {
 		return forwardedHeaderHandler != null;

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -673,7 +673,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 					ServerCloseHandler.INSTANCE.register(cnx.channel());
 				});
 
-		disposableServer = server.forwarded(true).bindNow();
+		disposableServer = server.forwarded(false, false).bindNow();
 
 		AtomicReference<SocketAddress> clientAddress = new AtomicReference<>();
 		httpClient = httpClient
@@ -1202,9 +1202,11 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 		}
 
 		AtomicReference<SocketAddress> clientSA = new AtomicReference<>();
-		disposableServer = bindServer.apply(customizeServerOptions(httpServer, serverCtx, serverProtocols))
-				.metrics(true, () -> contextAware ? ContextAwareServerRecorderBadUri.INSTANCE : ServerRecorderBadUri.INSTANCE, Function.identity())
-				.forwarded(xForwardedFor != null || xForwardedPort != -1)
+		HttpServer localServer = bindServer.apply(customizeServerOptions(httpServer, serverCtx, serverProtocols))
+				.metrics(true, () -> contextAware ? ContextAwareServerRecorderBadUri.INSTANCE : ServerRecorderBadUri.INSTANCE, Function.identity());
+		localServer = xForwardedFor != null || xForwardedPort != -1 ?
+				localServer.forwarded(false, false) : localServer.noForwarded();
+		disposableServer = localServer
 				.childObserve((conn, state) -> {
 					if (state == ConnectionObserver.State.CONNECTED) {
 						if (xForwardedFor != null && xForwardedPort != -1) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -449,7 +449,7 @@ class HttpProtocolsTests extends BaseHttpTest {
 				          });
 				          return resp.send();
 				      })
-				      .forwarded(true)
+				      .forwarded(true, false)
 				      .accessLog(true, args -> {
 				          ConnectionInformation connectionInformation = args.connectionInformation();
 				          return connectionInformation != null ?

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -629,6 +629,68 @@ class ConnectionInfoTests extends BaseHttpTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
+	void deprecatedForwardedEnabledStandardHeaderTakesPrecedence() {
+		testClientRequest(
+				clientRequestHeaders -> {
+					clientRequestHeaders.add("Forwarded", "host=a.example.com:8080;proto=https;for=192.0.2.60");
+					clientRequestHeaders.add("X-Forwarded-Host", "b.example.com");
+					clientRequestHeaders.add("X-Forwarded-Port", "9090");
+					clientRequestHeaders.add("X-Forwarded-Prefix", "/test-prefix");
+				},
+				serverRequest -> {
+					Assertions.assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("a.example.com");
+					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(8080);
+					Assertions.assertThat(serverRequest.remoteAddress().getHostString()).isEqualTo("192.0.2.60");
+					Assertions.assertThat(serverRequest.scheme()).isEqualTo("https");
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isNull();
+				},
+				Function.identity(), httpServer -> httpServer.forwarded(true), false);
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	void deprecatedForwardedEnabledFallsBackToXForwardedHeaders() {
+		testClientRequest(
+				clientRequestHeaders -> {
+					clientRequestHeaders.add("X-Forwarded-For", "192.0.2.60");
+					clientRequestHeaders.add("X-Forwarded-Host", "b.example.com");
+					clientRequestHeaders.add("X-Forwarded-Port", "9090");
+					clientRequestHeaders.add("X-Forwarded-Proto", "https");
+					clientRequestHeaders.add("X-Forwarded-Prefix", "/test-prefix");
+				},
+				serverRequest -> {
+					Assertions.assertThat(serverRequest.hostAddress().getHostString()).isEqualTo("b.example.com");
+					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(9090);
+					Assertions.assertThat(serverRequest.remoteAddress().getHostString()).isEqualTo("192.0.2.60");
+					Assertions.assertThat(serverRequest.scheme()).isEqualTo("https");
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("/test-prefix");
+				},
+				Function.identity(), httpServer -> httpServer.forwarded(true), false);
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	void deprecatedForwardedDisabled() {
+		testClientRequest(
+				clientRequestHeaders -> {
+					clientRequestHeaders.add("Forwarded", "host=a.example.com:8080;proto=wss;for=192.0.2.60");
+					clientRequestHeaders.add("X-Forwarded-Host", "b.example.com");
+					clientRequestHeaders.add("X-Forwarded-Prefix", "/test-prefix");
+				},
+				serverRequest -> {
+					Assertions.assertThat(serverRequest.hostAddress().getHostString())
+					          .containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
+					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(this.disposableServer.port());
+					Assertions.assertThat(serverRequest.remoteAddress().getHostString())
+					          .containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
+					Assertions.assertThat(serverRequest.scheme()).isEqualTo(expectedScheme());
+					Assertions.assertThat(serverRequest.forwardedPrefix()).isNull();
+				},
+				Function.identity(), httpServer -> httpServer.forwarded(false), false);
+	}
+
+	@Test
 	void customForwardedHandlerForMultipleHost() {
 		testClientRequest(
 				clientRequestHeaders ->

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -333,6 +333,8 @@ class ConnectionInfoTests extends BaseHttpTest {
 				httpClient -> httpClient,
 				httpServer -> httpServer.port(8080),
 				false,
+				true,
+				false,
 				true);
 	}
 
@@ -421,7 +423,9 @@ class ConnectionInfoTests extends BaseHttpTest {
 				getForwardedHandler(useCustomForwardedHandler),
 				httpClient -> httpClient,
 				httpServer -> httpServer.port(8080),
-				false);
+				false,
+				false,
+				true);
 	}
 
 	@ParameterizedTest
@@ -442,6 +446,8 @@ class ConnectionInfoTests extends BaseHttpTest {
 				getForwardedHandler(useCustomForwardedHandler),
 				httpClient -> httpClient,
 				httpServer -> httpServer.port(8080),
+				false,
+				true,
 				false,
 				true);
 	}
@@ -536,6 +542,8 @@ class ConnectionInfoTests extends BaseHttpTest {
 				getForwardedHandler(useCustomForwardedHandler),
 				httpClient -> httpClient.secure(ssl -> ssl.sslContext(clientSslContext)),
 				httpServer -> httpServer.secure(ssl -> ssl.sslContext(serverSslContext)),
+				true,
+				false,
 				true);
 	}
 
@@ -557,6 +565,60 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.forwardedPrefix()).isNull();
 				},
 				useCustomForwardedHandler);
+	}
+
+	@Test
+	void xForwardedPrefixNotEnabled() {
+		testClientRequest(
+				clientRequestHeaders -> clientRequestHeaders.add("X-Forwarded-Prefix", "/test-prefix"),
+				serverRequest -> Assertions.assertThat(serverRequest.forwardedPrefix()).isNull(),
+				false, false);
+	}
+
+	@Test
+	void xForwardedPrefixWithStandardHeader() {
+		testClientRequest(
+				clientRequestHeaders -> clientRequestHeaders.add("X-Forwarded-Prefix", "/test-prefix"),
+				serverRequest -> Assertions.assertThat(serverRequest.forwardedPrefix()).isEqualTo("/test-prefix"),
+				true, true);
+	}
+
+	@Test
+	void forwardedHeaderIgnoredWhenXForwardedHeadersUsed() {
+		testClientRequest(
+				clientRequestHeaders -> clientRequestHeaders.add("Forwarded",
+						"host=a.example.com:443;proto=https;for=192.0.2.60"),
+				serverRequest -> {
+					Assertions.assertThat(serverRequest.hostAddress().getHostString())
+					          .containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
+					Assertions.assertThat(serverRequest.hostName()).containsPattern("^\\[::1\\]|127.0.0.1$");
+					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(this.disposableServer.port());
+					Assertions.assertThat(serverRequest.remoteAddress().getHostString())
+					          .containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
+					Assertions.assertThat(serverRequest.scheme()).isEqualTo("http");
+				},
+				false, false);
+	}
+
+	@Test
+	void xForwardedHeadersIgnoredWhenForwardedHeaderUsed() {
+		testClientRequest(
+				clientRequestHeaders -> {
+					clientRequestHeaders.add("X-Forwarded-For", "192.0.2.60");
+					clientRequestHeaders.add("X-Forwarded-Host", "a.example.com");
+					clientRequestHeaders.add("X-Forwarded-Port", "8080");
+					clientRequestHeaders.add("X-Forwarded-Proto", "https");
+				},
+				serverRequest -> {
+					Assertions.assertThat(serverRequest.hostAddress().getHostString())
+					          .containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
+					Assertions.assertThat(serverRequest.hostName()).containsPattern("^\\[::1\\]|127.0.0.1$");
+					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(this.disposableServer.port());
+					Assertions.assertThat(serverRequest.remoteAddress().getHostString())
+					          .containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
+					Assertions.assertThat(serverRequest.scheme()).isEqualTo("http");
+				},
+				true, false);
 	}
 
 	@Test
@@ -846,18 +908,28 @@ class ConnectionInfoTests extends BaseHttpTest {
 	                               Consumer<HttpServerRequest> serverRequestConsumer,
 	                               boolean useCustomForwardedHandler) {
 		testClientRequest(clientRequestHeadersConsumer, serverRequestConsumer, getForwardedHandler(useCustomForwardedHandler),
-				Function.identity(), Function.identity(), false);
+				Function.identity(), Function.identity(), false, false, true);
 	}
 
 	private void testClientRequest(Consumer<HttpHeaders> clientRequestHeadersConsumer,
 			Consumer<HttpServerRequest> serverRequestConsumer) {
-		testClientRequest(clientRequestHeadersConsumer, serverRequestConsumer, null, Function.identity(), Function.identity(), false);
+		testClientRequest(clientRequestHeadersConsumer, serverRequestConsumer, null,
+				Function.identity(), Function.identity(), false, true, false);
+	}
+
+	private void testClientRequest(Consumer<HttpHeaders> clientRequestHeadersConsumer,
+			Consumer<HttpServerRequest> serverRequestConsumer,
+			boolean useStandardHeader,
+			boolean useForwardedPrefix) {
+		testClientRequest(clientRequestHeadersConsumer, serverRequestConsumer, null,
+				Function.identity(), Function.identity(), false, useStandardHeader, useForwardedPrefix);
 	}
 
 	private void testClientRequest(Consumer<HttpHeaders> clientRequestHeadersConsumer,
 			Consumer<HttpServerRequest> serverRequestConsumer,
 			BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> forwardedHeaderHandler) {
-		testClientRequest(clientRequestHeadersConsumer, serverRequestConsumer, forwardedHeaderHandler, Function.identity(), Function.identity(), false);
+		testClientRequest(clientRequestHeadersConsumer, serverRequestConsumer, forwardedHeaderHandler,
+				Function.identity(), Function.identity(), false, false, true);
 	}
 
 	private void testClientRequest(Consumer<HttpHeaders> clientRequestHeadersConsumer,
@@ -865,7 +937,8 @@ class ConnectionInfoTests extends BaseHttpTest {
 			Function<HttpClient, HttpClient> clientConfigFunction,
 			Function<HttpServer, HttpServer> serverConfigFunction,
 			boolean useHttps) {
-		testClientRequest(clientRequestHeadersConsumer, serverRequestConsumer, null, clientConfigFunction, serverConfigFunction, useHttps);
+		testClientRequest(clientRequestHeadersConsumer, serverRequestConsumer, null, clientConfigFunction,
+				serverConfigFunction, useHttps, false, false);
 	}
 
 	private void testClientRequest(Consumer<HttpHeaders> clientRequestHeadersConsumer,
@@ -873,9 +946,11 @@ class ConnectionInfoTests extends BaseHttpTest {
 			@Nullable BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> forwardedHeaderHandler,
 			Function<HttpClient, HttpClient> clientConfigFunction,
 			Function<HttpServer, HttpServer> serverConfigFunction,
-			boolean useHttps) {
+			boolean useHttps,
+			boolean useStandardHeader,
+			boolean useForwardedPrefix) {
 		testClientRequest(clientRequestHeadersConsumer, serverRequestConsumer, forwardedHeaderHandler,
-				clientConfigFunction, serverConfigFunction, useHttps, false);
+				clientConfigFunction, serverConfigFunction, useHttps, false, useStandardHeader, useForwardedPrefix);
 	}
 
 	private void testClientRequest(Consumer<HttpHeaders> clientRequestHeadersConsumer,
@@ -884,9 +959,11 @@ class ConnectionInfoTests extends BaseHttpTest {
 				Function<HttpClient, HttpClient> clientConfigFunction,
 				Function<HttpServer, HttpServer> serverConfigFunction,
 				boolean useHttps,
-				boolean is400BadRequest) {
+				boolean is400BadRequest,
+				boolean useStandardHeader,
+				boolean useForwardedPrefix) {
 
-		HttpServer server = createServer().forwarded(true);
+		HttpServer server = createServer().forwarded(useStandardHeader, useForwardedPrefix);
 		if (forwardedHeaderHandler != null) {
 			server = server.forwarded(forwardedHeaderHandler);
 		}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/ConnectionInfoTests.java
@@ -78,6 +78,13 @@ class ConnectionInfoTests extends BaseHttpTest {
 		return httpServer;
 	}
 
+	/**
+	 * Returns the scheme as derived from the channel, that is when no forwarded headers are applied.
+	 */
+	protected String expectedScheme() {
+		return "http";
+	}
+
 	@BeforeAll
 	static void createSelfSignedCertificate() throws Exception {
 		ssc = new CertificateBuilder().subject("CN=localhost").setIsCertificateAuthority(true).buildSelfSigned();
@@ -587,7 +594,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 	void forwardedHeaderIgnoredWhenXForwardedHeadersUsed() {
 		testClientRequest(
 				clientRequestHeaders -> clientRequestHeaders.add("Forwarded",
-						"host=a.example.com:443;proto=https;for=192.0.2.60"),
+						"host=a.example.com:443;proto=wss;for=192.0.2.60"),
 				serverRequest -> {
 					Assertions.assertThat(serverRequest.hostAddress().getHostString())
 					          .containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
@@ -595,7 +602,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(this.disposableServer.port());
 					Assertions.assertThat(serverRequest.remoteAddress().getHostString())
 					          .containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
-					Assertions.assertThat(serverRequest.scheme()).isEqualTo("http");
+					Assertions.assertThat(serverRequest.scheme()).isEqualTo(expectedScheme());
 				},
 				false, false);
 	}
@@ -607,7 +614,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					clientRequestHeaders.add("X-Forwarded-For", "192.0.2.60");
 					clientRequestHeaders.add("X-Forwarded-Host", "a.example.com");
 					clientRequestHeaders.add("X-Forwarded-Port", "8080");
-					clientRequestHeaders.add("X-Forwarded-Proto", "https");
+					clientRequestHeaders.add("X-Forwarded-Proto", "wss");
 				},
 				serverRequest -> {
 					Assertions.assertThat(serverRequest.hostAddress().getHostString())
@@ -616,7 +623,7 @@ class ConnectionInfoTests extends BaseHttpTest {
 					Assertions.assertThat(serverRequest.hostPort()).isEqualTo(this.disposableServer.port());
 					Assertions.assertThat(serverRequest.remoteAddress().getHostString())
 					          .containsPattern("^0:0:0:0:0:0:0:1(%\\w*)?|127.0.0.1$");
-					Assertions.assertThat(serverRequest.scheme()).isEqualTo("http");
+					Assertions.assertThat(serverRequest.scheme()).isEqualTo(expectedScheme());
 				},
 				true, false);
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/Http2ConnectionInfoTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/Http2ConnectionInfoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,11 @@ class Http2ConnectionInfoTests extends ConnectionInfoTests {
 		catch (Exception e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	@Override
+	protected String expectedScheme() {
+		return "https";
 	}
 
 	@Override


### PR DESCRIPTION
This commit introduces `HttpServer#forwarded(boolean, boolean)` to select whether to use the standard `Forwarded` header or the `X-Forwarded-*` alternative headers. The headers of the alternative that is not selected are ignored. A separate parameter enables support for `X-Forwarded-Prefix`.

`HttpServer#forwarded(boolean)` is removed, this is a breaking change.
`HttpServer#noForwarded()` is added as a replacement for `forwarded(false)`.

Fixes #4301