### PR TITLE
Add WebSocket server metrics

### DIFF
--- a/docs/modules/ROOT/pages/http-server.adoc
+++ b/docs/modules/ROOT/pages/http-server.adoc
@@ -723,6 +723,57 @@ include::{examples-dir}/metrics/custom/Application.java[tags=snippet-application
 ----
 <1> Enables HTTP server metrics and provides {javadoc}/reactor/netty/http/server/HttpServerMetricsRecorder.html[`HttpServerMetricsRecorder`] implementation.
 
+[[websocket-metrics]]
+=== WebSocket Metrics
+When the connection is upgraded to a `WebSocket`, the HTTP server metrics handler stops recording the HTTP
+request/response metrics (it keeps recording the connection and stream metrics), and a dedicated
+`WebSocket` server metrics handler is installed alongside it. From that point on, the `WebSocket` traffic is
+exposed with a prefix of `reactor.netty.websocket.server`.
+
+The following table provides information for the `WebSocket` server metrics:
+
+[width="100%",options="header"]
+|=======
+| metric name | type | tags | description
+| reactor.netty.websocket.server.handshake.time | Timer | `uri`, `status` | Time spent for the `WebSocket` opening handshake.
+| reactor.netty.websocket.server.connection.duration | Timer | `uri` | Time spent for the lifetime of the `WebSocket` connection.
+| reactor.netty.websocket.server.data.received | DistributionSummary | `uri` | Amount of the data received, in bytes.
+| reactor.netty.websocket.server.data.sent | DistributionSummary | `uri` | Amount of the data sent, in bytes.
+| reactor.netty.websocket.server.data.received.time | Timer | `uri` | Time spent in consuming incoming data.
+| reactor.netty.websocket.server.data.sent.time | Timer | `uri` | Time spent in sending outgoing data.
+| reactor.netty.websocket.server.errors | Counter | `uri` | Number of errors that occurred, both pipeline exceptions (for example, protocol/codec errors reaching `exceptionCaught`) and application errors raised while sending the `WebSocket` outbound (for example, an error signal from the handler's outbound `Publisher`).
+|=======
+
+The four `data.*` meters are recorded once per message, when its final frame is processed. Control frames
+(Close, Ping, Pong) are excluded from all four.
+
+The `status` tag on `handshake.time` takes one of three values: `101` (a successful HTTP/1.1 upgrade),
+`200` (a successful HTTP/2 upgrade per RFC 8441 Extended CONNECT), or `ERROR` (the handshake failed
+after the `WebSocket` metrics handler was installed, see the note below). A handshake success-rate query
+must match both `101` and `200` to account for both protocols.
+
+The `connection.duration` meter is recorded from the installation of the `WebSocket` metrics handler, which
+happens before the handshake runs, until the handler is removed from the pipeline. A handshake that fails
+after that point is therefore also recorded, and as this meter has no `status` tag it is not distinguishable
+from an established session.
+
+NOTE: Pre-upgrade rejections, such as an unsupported `WebSocket` version on HTTP/1.1 or an invalid
+Extended CONNECT request on HTTP/2, are answered before the `WebSocket` metrics handler is installed.
+They are therefore not reflected in any `reactor.netty.websocket.server` meter.
+
+NOTE: As with the `HTTP` server metrics above, the `uri` tag value is produced by the configured `uriTagValue` mapper
+(see the `metrics(...)` example in the metrics section above). Convert real URIs to templated URIs whenever possible and
+apply an upper limit for the meters with `uri` tags, to avoid a memory and CPU overhead from unbounded tag cardinality.
+A `MeterFilter` that caps the `HTTP` server prefix does not cover these meters, so add one for
+`reactor.netty.websocket.server` as well.
+
+The same recorder customization applies: when an integration with a system other than `Micrometer` is needed,
+provide your own {javadoc}/reactor/netty/http/server/WebSocketServerMetricsRecorder.html[`WebSocketServerMetricsRecorder`] implementation.
+A recorder that implements only
+{javadoc}/reactor/netty/http/server/HttpServerMetricsRecorder.html[`HttpServerMetricsRecorder`] still receives the
+`WebSocket` data and error recordings through the methods it inherits from it, so that traffic is reported with the
+`WebSocket` `uri`, while the handshake and connection duration are not reported at all.
+
 [[tracing]]
 == Tracing
 The HTTP server supports built-in integration with https://micrometer.io/docs/tracing[`Micrometer Tracing`].

--- a/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
@@ -70,6 +70,14 @@ public class Metrics {
 	public static final String WEBSOCKET_CLIENT_PREFIX = "reactor.netty.websocket.client";
 
 	/**
+	 * Name prefix that will be used for the WebSocket server's metrics
+	 * registered in Micrometer's global registry.
+	 *
+	 * @since 1.3.7
+	 */
+	public static final String WEBSOCKET_SERVER_PREFIX = "reactor.netty.websocket.server";
+
+	/**
 	 * Name prefix that will be used for the TCP server's metrics
 	 * registered in Micrometer's global registry.
 	 */

--- a/reactor-netty-core/src/testFixtures/java/reactor/netty/micrometer/CounterAssert.java
+++ b/reactor-netty-core/src/testFixtures/java/reactor/netty/micrometer/CounterAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2024-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,15 @@ public final class CounterAssert extends AbstractAssert<CounterAssert, Counter> 
 
 	public static CounterAssert assertCounter(MeterRegistry registry, String name, String... tags) {
 		return new CounterAssert(registry.find(name).tags(tags).counter(), CounterAssert.class);
+	}
+
+	public CounterAssert hasCountEqualTo(double expected) {
+		isNotNull();
+		double count = actual.count();
+		if (count != expected) {
+			failWithMessage("%nExpecting count:%n  %s%nto be equal to:%n  %s", count, expected);
+		}
+		return this;
 	}
 
 	public CounterAssert hasCountGreaterThanOrEqualTo(double expected) {

--- a/reactor-netty-core/src/testFixtures/java/reactor/netty/micrometer/DistributionSummaryAssert.java
+++ b/reactor-netty-core/src/testFixtures/java/reactor/netty/micrometer/DistributionSummaryAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2024-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,15 @@ public final class DistributionSummaryAssert extends AbstractAssert<Distribution
 		long count = actual.count();
 		if (count != expected) {
 			failWithMessage("%nExpecting count:%n  %s%nto be equal to:%n  %s", count, expected);
+		}
+		return this;
+	}
+
+	public DistributionSummaryAssert hasTotalAmountEqualTo(double expected) {
+		isNotNull();
+		double totalAmount = actual.totalAmount();
+		if (totalAmount != expected) {
+			failWithMessage("%nExpecting total amount:%n  %s%nto be equal to:%n  %s", totalAmount, expected);
 		}
 		return this;
 	}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractWebSocketServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractWebSocketServerMetricsHandler.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import reactor.util.context.ContextView;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+import static reactor.netty.ReactorNetty.format;
+
+/**
+ * {@link ChannelDuplexHandler} for handling WebSocket {@link HttpServer} metrics.
+ *
+ * @author LivingLikeKrillin
+ * @since 1.3.7
+ */
+abstract class AbstractWebSocketServerMetricsHandler extends ChannelDuplexHandler {
+
+	private static final Logger log = Loggers.getLogger(AbstractWebSocketServerMetricsHandler.class);
+
+	final String method;
+	final SocketAddress remoteAddress;
+
+	final String path;
+
+	final ContextView contextView;
+
+	long dataReceived;
+
+	long dataSent;
+
+	long dataReceivedTime;
+
+	long dataSentTime;
+
+	long connectionStartTime;
+
+	long handshakeStartTime;
+
+	volatile int handshakeFinalized;
+
+	protected AbstractWebSocketServerMetricsHandler(SocketAddress remoteAddress, String path, ContextView contextView,
+			String method) {
+		this.method = method;
+		this.path = path;
+		this.contextView = contextView;
+		this.remoteAddress = remoteAddress;
+	}
+
+	@Override
+	public boolean isSharable() {
+		return false;
+	}
+
+	@Override
+	public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+		super.handlerAdded(ctx);
+		connectionStartTime = System.nanoTime();
+	}
+
+	@Override
+	public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+		try {
+			if (connectionStartTime > 0) {
+				recordConnectionClosed();
+			}
+		}
+		catch (RuntimeException e) {
+			if (log.isWarnEnabled()) {
+				log.warn(format(ctx.channel(), "Exception caught while recording metrics."), e);
+			}
+		}
+		super.handlerRemoved(ctx);
+	}
+
+	void startHandshake(Channel channel) {
+		handshakeStartTime = System.nanoTime();
+	}
+
+	void recordHandshakeComplete(Channel channel, String status) {
+		if (HANDSHAKE_FINALIZED.getAndSet(this, 1) != 0) {
+			return;
+		}
+		Duration time = Duration.ofNanos(System.nanoTime() - handshakeStartTime);
+		recorder().recordWebSocketHandshakeTime(remoteAddress, path, status, time);
+	}
+
+	void recordHandshakeFailure(Channel channel) {
+		if (HANDSHAKE_FINALIZED.getAndSet(this, 1) != 0) {
+			return;
+		}
+		Duration time = Duration.ofNanos(System.nanoTime() - handshakeStartTime);
+		recorder().recordWebSocketHandshakeTime(remoteAddress, path, "ERROR", time);
+	}
+
+	@Override
+	@SuppressWarnings("FutureReturnValueIgnored")
+	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+		try {
+			if (msg instanceof WebSocketFrame) {
+				WebSocketFrame frame = (WebSocketFrame) msg;
+				if (isDataFrame(frame)) {
+					if (dataSentTime == 0) {
+						dataSentTime = System.nanoTime();
+					}
+					dataSent += extractProcessedDataFromBuffer(frame);
+
+					if (frame.isFinalFragment()) {
+						// Snapshot and reset the shared accumulators BEFORE registering the
+						// asynchronous write-completion listener. Otherwise, a subsequent message
+						// written before this listener fires mutates dataSent/dataSentTime and
+						// corrupts this message's byte/time attribution.
+						long sentBytes = dataSent;
+						long sentTimeNanos = dataSentTime;
+						dataSent = 0;
+						dataSentTime = 0;
+						// VoidChannelPromise does not support addListener, unvoid to ensure the listener fires
+						promise = promise.unvoid();
+						promise.addListener(f -> {
+							try {
+								recordWrite(remoteAddress, sentBytes, sentTimeNanos);
+							}
+							catch (RuntimeException e) {
+								if (log.isWarnEnabled()) {
+									log.warn(format(ctx.channel(), "Exception caught while recording metrics."), e);
+								}
+							}
+						});
+					}
+				}
+			}
+		}
+		catch (RuntimeException e) {
+			if (log.isWarnEnabled()) {
+				log.warn(format(ctx.channel(), "Exception caught while recording metrics."), e);
+			}
+		}
+
+		//"FutureReturnValueIgnored" this is deliberate
+		ctx.write(msg, promise);
+	}
+
+	@Override
+	public void channelRead(ChannelHandlerContext ctx, Object msg) {
+		try {
+			if (msg instanceof WebSocketFrame) {
+				WebSocketFrame frame = (WebSocketFrame) msg;
+				if (isDataFrame(frame)) {
+					if (dataReceivedTime == 0) {
+						dataReceivedTime = System.nanoTime();
+					}
+					dataReceived += extractProcessedDataFromBuffer(frame);
+
+					if (frame.isFinalFragment()) {
+						// dataReceived is reset inside recordRead
+						recordRead(remoteAddress);
+						dataReceivedTime = 0;
+					}
+				}
+			}
+		}
+		catch (RuntimeException e) {
+			if (log.isWarnEnabled()) {
+				log.warn(format(ctx.channel(), "Exception caught while recording metrics."), e);
+			}
+		}
+
+		ctx.fireChannelRead(msg);
+	}
+
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+		try {
+			recordException();
+		}
+		catch (RuntimeException e) {
+			if (log.isWarnEnabled()) {
+				log.warn(format(ctx.channel(), "Exception caught while recording metrics."), e);
+			}
+		}
+
+		ctx.fireExceptionCaught(cause);
+	}
+
+	static boolean isDataFrame(WebSocketFrame msg) {
+		return !(msg instanceof CloseWebSocketFrame) &&
+				!(msg instanceof PingWebSocketFrame) &&
+				!(msg instanceof PongWebSocketFrame);
+	}
+
+	private static long extractProcessedDataFromBuffer(WebSocketFrame msg) {
+		return msg.content().readableBytes();
+	}
+
+	protected abstract WebSocketServerMetricsRecorder recorder();
+
+	protected void recordConnectionClosed() {
+		Duration duration = Duration.ofNanos(System.nanoTime() - connectionStartTime);
+		recorder().recordWebSocketConnectionDuration(remoteAddress, path, duration);
+	}
+
+	protected void recordException() {
+		recorder().incrementErrorsCount(remoteAddress, path);
+	}
+
+	protected void recordRead(SocketAddress address) {
+		Duration duration = Duration.ofNanos(System.nanoTime() - dataReceivedTime);
+		recorder().recordDataReceivedTime(path, method, duration);
+
+		recorder().recordDataReceived(address, path, dataReceived);
+		dataReceived = 0;
+	}
+
+	protected void recordWrite(SocketAddress address, long sentBytes, long sentTimeNanos) {
+		Duration duration = Duration.ofNanos(System.nanoTime() - sentTimeNanos);
+		recorder().recordDataSentTime(path, method, "n/a", duration);
+
+		recorder().recordDataSent(address, path, sentBytes);
+	}
+
+	static final AtomicIntegerFieldUpdater<AbstractWebSocketServerMetricsHandler> HANDSHAKE_FINALIZED =
+			AtomicIntegerFieldUpdater.newUpdater(AbstractWebSocketServerMetricsHandler.class, "handshakeFinalized");
+
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareWebSocketServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareWebSocketServerMetricsHandler.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.netty.channel.Channel;
+import reactor.util.context.ContextView;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+
+/**
+ * {@link AbstractWebSocketServerMetricsHandler} that propagates
+ * {@link reactor.util.context.ContextView}.
+ *
+ * @author LivingLikeKrillin
+ * @since 1.3.7
+ */
+final class ContextAwareWebSocketServerMetricsHandler extends AbstractWebSocketServerMetricsHandler {
+
+	final ContextAwareWebSocketServerMetricsRecorder recorder;
+
+	ContextAwareWebSocketServerMetricsHandler(ContextAwareWebSocketServerMetricsRecorder recorder,
+			SocketAddress remoteAddress,
+			String path,
+			ContextView contextView,
+			String method) {
+		super(remoteAddress, path, contextView, method);
+		this.recorder = recorder;
+	}
+
+	@Override
+	protected ContextAwareWebSocketServerMetricsRecorder recorder() {
+		return recorder;
+	}
+
+	@Override
+	void recordHandshakeComplete(Channel channel, String status) {
+		if (HANDSHAKE_FINALIZED.getAndSet(this, 1) != 0) {
+			return;
+		}
+		Duration time = Duration.ofNanos(System.nanoTime() - handshakeStartTime);
+		recorder.recordWebSocketHandshakeTime(contextView, remoteAddress, path, status, time);
+	}
+
+	@Override
+	void recordHandshakeFailure(Channel channel) {
+		if (HANDSHAKE_FINALIZED.getAndSet(this, 1) != 0) {
+			return;
+		}
+		Duration time = Duration.ofNanos(System.nanoTime() - handshakeStartTime);
+		recorder.recordWebSocketHandshakeTime(contextView, remoteAddress, path, "ERROR", time);
+	}
+
+	@Override
+	protected void recordConnectionClosed() {
+		Duration duration = Duration.ofNanos(System.nanoTime() - connectionStartTime);
+		recorder.recordWebSocketConnectionDuration(contextView, remoteAddress, path, duration);
+	}
+
+	@Override
+	protected void recordException() {
+		recorder().incrementErrorsCount(contextView, remoteAddress, path);
+	}
+
+	@Override
+	protected void recordWrite(SocketAddress address, long sentBytes, long sentTimeNanos) {
+		Duration duration = Duration.ofNanos(System.nanoTime() - sentTimeNanos);
+		recorder.recordDataSentTime(contextView, path, method, "n/a", duration);
+
+		recorder.recordDataSent(contextView, address, path, sentBytes);
+	}
+
+	@Override
+	protected void recordRead(SocketAddress address) {
+		Duration duration = Duration.ofNanos(System.nanoTime() - dataReceivedTime);
+		recorder.recordDataReceivedTime(contextView, path, method, duration);
+
+		recorder.recordDataReceived(contextView, address, path, dataReceived);
+		dataReceived = 0;
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareWebSocketServerMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareWebSocketServerMetricsRecorder.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+
+/**
+ * {@link ContextView} aware class for collecting metrics on WebSocket server level.
+ *
+ * @author LivingLikeKrillin
+ * @since 1.3.7
+ */
+public abstract class ContextAwareWebSocketServerMetricsRecorder extends ContextAwareHttpServerMetricsRecorder
+		implements WebSocketServerMetricsRecorder {
+
+	/**
+	 * Records the time that is spent for the WebSocket handshake.
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux
+	 * @param remoteAddress The remote peer
+	 * @param uri the requested URI
+	 * @param status the WebSocket handshake status
+	 * @param time the time in nanoseconds that is spent for the handshake
+	 */
+	public abstract void recordWebSocketHandshakeTime(ContextView contextView, SocketAddress remoteAddress, String uri,
+			String status, Duration time);
+
+	@Override
+	public void recordWebSocketHandshakeTime(SocketAddress remoteAddress, String uri, String status, Duration time) {
+		recordWebSocketHandshakeTime(Context.empty(), remoteAddress, uri, status, time);
+	}
+
+	/**
+	 * Records the duration of the WebSocket connection.
+	 *
+	 * @param contextView The current {@link ContextView} associated with the Mono/Flux
+	 * @param remoteAddress The remote peer
+	 * @param uri the requested URI
+	 * @param time the duration of the connection
+	 */
+	public abstract void recordWebSocketConnectionDuration(ContextView contextView, SocketAddress remoteAddress,
+			String uri, Duration time);
+
+	@Override
+	public void recordWebSocketConnectionDuration(SocketAddress remoteAddress, String uri, Duration time) {
+		recordWebSocketConnectionDuration(Context.empty(), remoteAddress, uri, time);
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultContextAwareWebSocketServerMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultContextAwareWebSocketServerMetricsRecorder.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import reactor.util.context.ContextView;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+
+/**
+ * {@link ContextAwareWebSocketServerMetricsRecorder} that delegates to a {@link ContextAwareHttpServerMetricsRecorder}.
+ *
+ * @author LivingLikeKrillin
+ * @since 1.3.7
+ */
+final class DefaultContextAwareWebSocketServerMetricsRecorder extends ContextAwareWebSocketServerMetricsRecorder {
+
+	final ContextAwareHttpServerMetricsRecorder recorder;
+
+	DefaultContextAwareWebSocketServerMetricsRecorder(ContextAwareHttpServerMetricsRecorder recorder) {
+		this.recorder = recorder;
+	}
+
+	@Override
+	public void recordWebSocketHandshakeTime(ContextView contextView, SocketAddress remoteAddress, String uri,
+			String status, Duration time) {
+	}
+
+	@Override
+	public void recordWebSocketConnectionDuration(ContextView contextView, SocketAddress remoteAddress,
+			String uri, Duration time) {
+	}
+
+	@Override
+	public void recordDataReceivedTime(ContextView contextView, String uri, String method, Duration time) {
+		recorder.recordDataReceivedTime(contextView, uri, method, time);
+	}
+
+	@Override
+	public void recordDataSentTime(ContextView contextView, String uri, String method, String status, Duration time) {
+		recorder.recordDataSentTime(contextView, uri, method, status, time);
+	}
+
+	@Override
+	public void recordResponseTime(ContextView contextView, String uri, String method, String status, Duration time) {
+		recorder.recordResponseTime(contextView, uri, method, status, time);
+	}
+
+	@Override
+	public void recordServerConnectionActive(SocketAddress localAddress) {
+		recorder.recordServerConnectionActive(localAddress);
+	}
+
+	@Override
+	public void recordServerConnectionInactive(SocketAddress localAddress) {
+		recorder.recordServerConnectionInactive(localAddress);
+	}
+
+	@Override
+	public void recordStreamOpened(SocketAddress localAddress) {
+		recorder.recordStreamOpened(localAddress);
+	}
+
+	@Override
+	public void recordStreamClosed(SocketAddress localAddress) {
+		recorder.recordStreamClosed(localAddress);
+	}
+
+	@Override
+	public void incrementErrorsCount(ContextView contextView, SocketAddress remoteAddress, String uri) {
+		recorder.incrementErrorsCount(contextView, remoteAddress, uri);
+	}
+
+	@Override
+	public void recordDataReceived(ContextView contextView, SocketAddress remoteAddress, String uri, long bytes) {
+		recorder.recordDataReceived(contextView, remoteAddress, uri, bytes);
+	}
+
+	@Override
+	public void recordDataSent(ContextView contextView, SocketAddress remoteAddress, String uri, long bytes) {
+		recorder.recordDataSent(contextView, remoteAddress, uri, bytes);
+	}
+
+	@Override
+	public void incrementErrorsCount(ContextView contextView, SocketAddress remoteAddress) {
+		recorder.incrementErrorsCount(contextView, remoteAddress);
+	}
+
+	@Override
+	public void incrementErrorsCount(ContextView contextView, SocketAddress remoteAddress, SocketAddress proxyAddress) {
+		recorder.incrementErrorsCount(contextView, remoteAddress, proxyAddress);
+	}
+
+	@Override
+	public void recordConnectTime(ContextView contextView, SocketAddress remoteAddress, Duration time, String status) {
+		recorder.recordConnectTime(contextView, remoteAddress, time, status);
+	}
+
+	@Override
+	public void recordConnectTime(ContextView contextView, SocketAddress remoteAddress, SocketAddress proxyAddress,
+			Duration time, String status) {
+		recorder.recordConnectTime(contextView, remoteAddress, proxyAddress, time, status);
+	}
+
+	@Override
+	public void recordDataReceived(ContextView contextView, SocketAddress remoteAddress, long bytes) {
+		recorder.recordDataReceived(contextView, remoteAddress, bytes);
+	}
+
+	@Override
+	public void recordDataReceived(ContextView contextView, SocketAddress remoteAddress, SocketAddress proxyAddress, long bytes) {
+		recorder.recordDataReceived(contextView, remoteAddress, proxyAddress, bytes);
+	}
+
+	@Override
+	public void recordDataSent(ContextView contextView, SocketAddress remoteAddress, long bytes) {
+		recorder.recordDataSent(contextView, remoteAddress, bytes);
+	}
+
+	@Override
+	public void recordDataSent(ContextView contextView, SocketAddress remoteAddress, SocketAddress proxyAddress, long bytes) {
+		recorder.recordDataSent(contextView, remoteAddress, proxyAddress, bytes);
+	}
+
+	@Override
+	public void recordTlsHandshakeTime(ContextView contextView, SocketAddress remoteAddress, Duration time, String status) {
+		recorder.recordTlsHandshakeTime(contextView, remoteAddress, time, status);
+	}
+
+	@Override
+	public void recordTlsHandshakeTime(ContextView contextView, SocketAddress remoteAddress, SocketAddress proxyAddress,
+			Duration time, String status) {
+		recorder.recordTlsHandshakeTime(contextView, remoteAddress, proxyAddress, time, status);
+	}
+
+	@Override
+	public void recordResolveAddressTime(SocketAddress remoteAddress, Duration time, String status) {
+		recorder.recordResolveAddressTime(remoteAddress, time, status);
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultWebSocketServerMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/DefaultWebSocketServerMetricsRecorder.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+
+/**
+ * {@link WebSocketServerMetricsRecorder} that delegates to a {@link HttpServerMetricsRecorder}.
+ *
+ * @author LivingLikeKrillin
+ * @since 1.3.7
+ */
+final class DefaultWebSocketServerMetricsRecorder implements WebSocketServerMetricsRecorder {
+
+	final HttpServerMetricsRecorder recorder;
+
+	DefaultWebSocketServerMetricsRecorder(HttpServerMetricsRecorder recorder) {
+		this.recorder = recorder;
+	}
+
+	@Override
+	public void recordWebSocketHandshakeTime(SocketAddress remoteAddress, String uri, String status, Duration time) {
+	}
+
+	@Override
+	public void recordWebSocketConnectionDuration(SocketAddress remoteAddress, String uri, Duration time) {
+	}
+
+	@Override
+	public void recordDataReceivedTime(String uri, String method, Duration time) {
+		recorder.recordDataReceivedTime(uri, method, time);
+	}
+
+	@Override
+	public void recordDataSentTime(String uri, String method, String status, Duration time) {
+		recorder.recordDataSentTime(uri, method, status, time);
+	}
+
+	@Override
+	public void recordResponseTime(String uri, String method, String status, Duration time) {
+		recorder.recordResponseTime(uri, method, status, time);
+	}
+
+	@Override
+	public void recordServerConnectionActive(SocketAddress localAddress) {
+		recorder.recordServerConnectionActive(localAddress);
+	}
+
+	@Override
+	public void recordServerConnectionInactive(SocketAddress localAddress) {
+		recorder.recordServerConnectionInactive(localAddress);
+	}
+
+	@Override
+	public void recordStreamOpened(SocketAddress localAddress) {
+		recorder.recordStreamOpened(localAddress);
+	}
+
+	@Override
+	public void recordStreamClosed(SocketAddress localAddress) {
+		recorder.recordStreamClosed(localAddress);
+	}
+
+	@Override
+	public void recordDataReceived(SocketAddress remoteAddress, String uri, long bytes) {
+		recorder.recordDataReceived(remoteAddress, uri, bytes);
+	}
+
+	@Override
+	public void recordDataSent(SocketAddress remoteAddress, String uri, long bytes) {
+		recorder.recordDataSent(remoteAddress, uri, bytes);
+	}
+
+	@Override
+	public void incrementErrorsCount(SocketAddress remoteAddress, String uri) {
+		recorder.incrementErrorsCount(remoteAddress, uri);
+	}
+
+	@Override
+	public void incrementErrorsCount(SocketAddress remoteAddress) {
+		recorder.incrementErrorsCount(remoteAddress);
+	}
+
+	@Override
+	public void incrementErrorsCount(SocketAddress remoteAddress, SocketAddress proxyAddress) {
+		recorder.incrementErrorsCount(remoteAddress, proxyAddress);
+	}
+
+	@Override
+	public void recordConnectTime(SocketAddress remoteAddress, Duration time, String status) {
+		recorder.recordConnectTime(remoteAddress, time, status);
+	}
+
+	@Override
+	public void recordConnectTime(SocketAddress remoteAddress, SocketAddress proxyAddress, Duration time, String status) {
+		recorder.recordConnectTime(remoteAddress, proxyAddress, time, status);
+	}
+
+	@Override
+	public void recordDataReceived(SocketAddress remoteAddress, long bytes) {
+		recorder.recordDataReceived(remoteAddress, bytes);
+	}
+
+	@Override
+	public void recordDataReceived(SocketAddress remoteAddress, SocketAddress proxyAddress, long bytes) {
+		recorder.recordDataReceived(remoteAddress, proxyAddress, bytes);
+	}
+
+	@Override
+	public void recordDataSent(SocketAddress remoteAddress, long bytes) {
+		recorder.recordDataSent(remoteAddress, bytes);
+	}
+
+	@Override
+	public void recordDataSent(SocketAddress remoteAddress, SocketAddress proxyAddress, long bytes) {
+		recorder.recordDataSent(remoteAddress, proxyAddress, bytes);
+	}
+
+	@Override
+	public void recordTlsHandshakeTime(SocketAddress remoteAddress, Duration time, String status) {
+		recorder.recordTlsHandshakeTime(remoteAddress, time, status);
+	}
+
+	@Override
+	public void recordTlsHandshakeTime(SocketAddress remoteAddress, SocketAddress proxyAddress, Duration time, String status) {
+		recorder.recordTlsHandshakeTime(remoteAddress, proxyAddress, time, status);
+	}
+
+	@Override
+	public void recordResolveAddressTime(SocketAddress remoteAddress, Duration time, String status) {
+		recorder.recordResolveAddressTime(remoteAddress, time, status);
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2WebsocketServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2WebsocketServerOperations.java
@@ -122,6 +122,7 @@ final class Http2WebsocketServerOperations extends WebsocketServerOperations {
 			if (handler != null) {
 				replaceHandler(NettyPipeline.HttpMetricsHandler,
 						new WebsocketHttpServerMetricsHandler((AbstractHttpServerMetricsHandler) handler));
+				swapMetricsHandler((AbstractHttpServerMetricsHandler) handler, replaced);
 			}
 
 			HttpRequest request = new DefaultHttpRequest(replaced.version(), replaced.method(), replaced.uri());
@@ -152,6 +153,7 @@ final class Http2WebsocketServerOperations extends WebsocketServerOperations {
 			}
 
 			handshakerHttp2 = new WebsocketServerHandshaker(wsUrl, websocketServerSpec);
+			recordHandshakeStart(channel);
 			handshakerHttp2.handshake(channel, request, responseHeaders.remove(HttpHeaderNames.TRANSFER_ENCODING), handshakerResult)
 			               .addListener(f -> {
 			                   if (replaced.rebind(this)) {
@@ -161,6 +163,12 @@ final class Http2WebsocketServerOperations extends WebsocketServerOperations {
 			                   }
 			                   else if (log.isDebugEnabled()) {
 			                       log.debug(format(channel, "Cannot bind Http2WebsocketServerOperations after the handshake."));
+			                   }
+			                   if (f.isSuccess()) {
+			                       recordHandshakeComplete(channel, "200");
+			                   }
+			                   else {
+			                       recordHandshakeFailure(channel);
 			                   }
 			               });
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerWebSocketServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerWebSocketServerMetricsHandler.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.transport.RequestReplyReceiverContext;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import org.jspecify.annotations.Nullable;
+import reactor.netty.observability.ReactorNettyHandlerContext;
+import reactor.util.context.ContextView;
+
+import java.net.SocketAddress;
+import java.util.function.Supplier;
+
+import static reactor.netty.Metrics.HANDSHAKE_TIME;
+import static reactor.netty.Metrics.OBSERVATION_REGISTRY;
+import static reactor.netty.Metrics.UNKNOWN;
+import static reactor.netty.Metrics.updateChannelContext;
+import static reactor.netty.ReactorNetty.setChannelContext;
+import static reactor.netty.http.server.WebSocketServerObservations.HandshakeTimeHighCardinalityTags.HTTP_STATUS_CODE;
+import static reactor.netty.http.server.WebSocketServerObservations.HandshakeTimeHighCardinalityTags.HTTP_URL;
+import static reactor.netty.http.server.WebSocketServerObservations.HandshakeTimeHighCardinalityTags.REACTOR_NETTY_TYPE;
+import static reactor.netty.http.server.WebSocketServerObservations.HandshakeTimeLowCardinalityTags.STATUS;
+import static reactor.netty.http.server.WebSocketServerObservations.HandshakeTimeLowCardinalityTags.URI;
+
+/**
+ * {@link AbstractWebSocketServerMetricsHandler} for Reactor Netty built-in integration with Micrometer.
+ *
+ * @author LivingLikeKrillin
+ * @since 1.3.7
+ */
+final class MicrometerWebSocketServerMetricsHandler extends AbstractWebSocketServerMetricsHandler {
+	final MicrometerWebSocketServerMetricsRecorder recorder;
+
+	@SuppressWarnings("NullAway")
+	// Deliberately suppress "NullAway"
+	// This is a lazy initialization
+	HandshakeTimeHandlerContext handshakeTimeHandlerContext;
+	@SuppressWarnings("NullAway")
+	// Deliberately suppress "NullAway"
+	// This is a lazy initialization
+	Observation handshakeTimeObservation;
+	@Nullable ContextView parentContextView;
+
+	MicrometerWebSocketServerMetricsHandler(MicrometerWebSocketServerMetricsRecorder recorder,
+			SocketAddress remoteAddress,
+			String path,
+			ContextView contextView,
+			String method) {
+		super(remoteAddress, path, contextView, method);
+		this.recorder = recorder;
+	}
+
+	@Override
+	protected WebSocketServerMetricsRecorder recorder() {
+		return recorder;
+	}
+
+	@Override
+	void startHandshake(Channel channel) {
+		super.startHandshake(channel);
+		handshakeTimeHandlerContext = new HandshakeTimeHandlerContext(recorder, path);
+		handshakeTimeObservation = Observation.createNotStarted(
+				recorder.name() + HANDSHAKE_TIME, handshakeTimeHandlerContext, OBSERVATION_REGISTRY);
+		parentContextView = updateChannelContext(channel, handshakeTimeObservation);
+		handshakeTimeObservation.start();
+	}
+
+	@Override
+	void recordHandshakeComplete(Channel channel, String status) {
+		if (HANDSHAKE_FINALIZED.getAndSet(this, 1) != 0) {
+			return;
+		}
+		if (handshakeTimeHandlerContext != null) {
+			handshakeTimeHandlerContext.status = status;
+		}
+		// Cannot invoke the recorder anymore:
+		// 1. The recorder is one instance only, it is invoked for all requests that can happen
+		// 2. The recorder does not have knowledge about request lifecycle
+		//
+		// Move the implementation from the recorder here
+		if (handshakeTimeObservation != null) {
+			handshakeTimeObservation.stop();
+		}
+		setChannelContext(channel, parentContextView);
+	}
+
+	@Override
+	void recordHandshakeFailure(Channel channel) {
+		if (HANDSHAKE_FINALIZED.getAndSet(this, 1) != 0) {
+			return;
+		}
+		if (handshakeTimeHandlerContext != null) {
+			handshakeTimeHandlerContext.status = "ERROR";
+		}
+		if (handshakeTimeObservation != null) {
+			handshakeTimeObservation.stop();
+		}
+		setChannelContext(channel, parentContextView);
+	}
+
+	/*
+	 * Requirements for WebSocket servers
+	 * Following OpenTelemetry semantic conventions for HTTP servers, adapted for WebSocket.
+	 */
+	static final class HandshakeTimeHandlerContext extends RequestReplyReceiverContext<HttpRequest, HttpResponse>
+			implements ReactorNettyHandlerContext, Supplier<Observation.Context> {
+		static final String TYPE = "server";
+
+		final String path;
+		final MicrometerWebSocketServerMetricsRecorder recorder;
+
+		String status = UNKNOWN;
+
+		HandshakeTimeHandlerContext(MicrometerWebSocketServerMetricsRecorder recorder, String path) {
+			super((carrier, key) -> null);
+			this.recorder = recorder;
+			this.path = path;
+			setContextualName("websocket " + path);
+		}
+
+		@Override
+		public Observation.Context get() {
+			return this;
+		}
+
+		@Override
+		public @Nullable Timer getTimer() {
+			return recorder.getHandshakeTimeTimer(recorder.name() + HANDSHAKE_TIME, path, status);
+		}
+
+		@Override
+		public KeyValues getHighCardinalityKeyValues() {
+			return KeyValues.of(REACTOR_NETTY_TYPE.asString(), TYPE,
+					HTTP_URL.asString(), path, HTTP_STATUS_CODE.asString(), status);
+		}
+
+		@Override
+		public KeyValues getLowCardinalityKeyValues() {
+			return KeyValues.of(STATUS.asString(), status, URI.asString(), path);
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerWebSocketServerMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerWebSocketServerMetricsRecorder.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Timer;
+import org.jspecify.annotations.Nullable;
+import reactor.netty.channel.ChannelMeters;
+import reactor.netty.channel.MeterKey;
+import reactor.netty.http.MicrometerHttpMetricsRecorder;
+import reactor.netty.internal.util.MapUtils;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static reactor.netty.Metrics.CONNECTION_DURATION;
+import static reactor.netty.Metrics.DATA_RECEIVED;
+import static reactor.netty.Metrics.DATA_RECEIVED_TIME;
+import static reactor.netty.Metrics.DATA_SENT;
+import static reactor.netty.Metrics.DATA_SENT_TIME;
+import static reactor.netty.Metrics.ERRORS;
+import static reactor.netty.Metrics.HANDSHAKE_TIME;
+import static reactor.netty.Metrics.REGISTRY;
+import static reactor.netty.Metrics.WEBSOCKET_SERVER_PREFIX;
+
+/**
+ * {@link WebSocketServerMetricsRecorder} for Reactor Netty built-in integration with Micrometer.
+ *
+ * @author LivingLikeKrillin
+ * @since 1.3.7
+ */
+final class MicrometerWebSocketServerMetricsRecorder extends MicrometerHttpMetricsRecorder implements WebSocketServerMetricsRecorder {
+
+	static final MicrometerWebSocketServerMetricsRecorder INSTANCE = new MicrometerWebSocketServerMetricsRecorder();
+
+	private final ConcurrentMap<MeterKey, Timer> handshakeTimeCache = new ConcurrentHashMap<>();
+
+	private final ConcurrentMap<MeterKey, DistributionSummary> dataReceivedCache = new ConcurrentHashMap<>();
+
+	private final ConcurrentMap<MeterKey, DistributionSummary> dataSentCache = new ConcurrentHashMap<>();
+
+	private final ConcurrentMap<MeterKey, Timer> connectionDurationCache = new ConcurrentHashMap<>();
+
+	private final ConcurrentMap<MeterKey, Counter> errorsCache = new ConcurrentHashMap<>();
+
+	private MicrometerWebSocketServerMetricsRecorder() {
+		super(WEBSOCKET_SERVER_PREFIX, "websocket", true);
+	}
+
+	@Override
+	public void recordWebSocketHandshakeTime(SocketAddress remoteAddress, String uri, String status, Duration time) {
+		Timer handshakeTime = getHandshakeTimeTimer(name() + HANDSHAKE_TIME, uri, status);
+		if (handshakeTime != null) {
+			handshakeTime.record(time);
+		}
+	}
+
+	@Nullable Timer getHandshakeTimeTimer(String name, String uri, String status) {
+		MeterKey meterKey = new MeterKey(uri, null, null, null, status);
+		return MapUtils.computeIfAbsent(handshakeTimeCache, meterKey,
+				key -> filter(Timer.builder(name)
+				                   .tags(WebSocketServerMeters.HandshakeTimeTags.URI.asString(), uri,
+				                         WebSocketServerMeters.HandshakeTimeTags.STATUS.asString(), status)
+				                   .register(REGISTRY)));
+	}
+
+	@Override
+	public void recordWebSocketConnectionDuration(SocketAddress remoteAddress, String uri, Duration time) {
+		MeterKey meterKey = new MeterKey(uri, null, null, null, null);
+		Timer connectionDuration = MapUtils.computeIfAbsent(connectionDurationCache, meterKey,
+				key -> filter(Timer.builder(name() + CONNECTION_DURATION)
+				                   .tags(WebSocketServerMeters.ConnectionDurationTags.URI.asString(), uri)
+				                   .register(REGISTRY)));
+		if (connectionDuration != null) {
+			connectionDuration.record(time);
+		}
+	}
+
+	@Override
+	public void recordDataReceivedTime(String uri, String method, Duration time) {
+		MeterKey meterKey = new MeterKey(uri, null, null, null, null);
+		Timer dataReceivedTime = MapUtils.computeIfAbsent(dataReceivedTimeCache, meterKey,
+				key -> filter(Timer.builder(name() + DATA_RECEIVED_TIME)
+				                   .tags(WebSocketServerMeters.DataReceivedTimeTags.URI.asString(), uri)
+				                   .register(REGISTRY)));
+		if (dataReceivedTime != null) {
+			dataReceivedTime.record(time);
+		}
+	}
+
+	@Override
+	public void recordDataSentTime(String uri, String method, String status, Duration time) {
+		MeterKey meterKey = new MeterKey(uri, null, null, null, null);
+		Timer dataSentTime = MapUtils.computeIfAbsent(dataSentTimeCache, meterKey,
+				key -> filter(Timer.builder(name() + DATA_SENT_TIME)
+				                   .tags(WebSocketServerMeters.DataSentTimeTags.URI.asString(), uri)
+				                   .register(REGISTRY)));
+		if (dataSentTime != null) {
+			dataSentTime.record(time);
+		}
+	}
+
+	@Override
+	public void recordResponseTime(String uri, String method, String status, Duration time) {
+	}
+
+	@Override
+	public void recordDataReceived(SocketAddress remoteAddress, String uri, long bytes) {
+		MeterKey meterKey = new MeterKey(uri, null, null, null, null);
+		DistributionSummary dataReceived = MapUtils.computeIfAbsent(dataReceivedCache, meterKey,
+				key -> filter(DistributionSummary.builder(name() + DATA_RECEIVED)
+				                                 .baseUnit(ChannelMeters.DATA_RECEIVED.getBaseUnit())
+				                                 .tags(ChannelMeters.ChannelMetersTags.URI.asString(), uri)
+				                                 .register(REGISTRY)));
+		if (dataReceived != null) {
+			dataReceived.record(bytes);
+		}
+	}
+
+	@Override
+	public void recordDataSent(SocketAddress remoteAddress, String uri, long bytes) {
+		MeterKey meterKey = new MeterKey(uri, null, null, null, null);
+		DistributionSummary dataSent = MapUtils.computeIfAbsent(dataSentCache, meterKey,
+				key -> filter(DistributionSummary.builder(name() + DATA_SENT)
+				                                 .baseUnit(ChannelMeters.DATA_SENT.getBaseUnit())
+				                                 .tags(ChannelMeters.ChannelMetersTags.URI.asString(), uri)
+				                                 .register(REGISTRY)));
+		if (dataSent != null) {
+			dataSent.record(bytes);
+		}
+	}
+
+	@Override
+	public void incrementErrorsCount(SocketAddress remoteAddress, String uri) {
+		MeterKey meterKey = new MeterKey(uri, null, null, null, null);
+		Counter errors = MapUtils.computeIfAbsent(errorsCache, meterKey,
+				key -> filter(Counter.builder(name() + ERRORS)
+				                     .tags(ChannelMeters.ChannelMetersTags.URI.asString(), uri)
+				                     .register(REGISTRY)));
+		if (errors != null) {
+			errors.increment();
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/WebSocketServerMeters.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/WebSocketServerMeters.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.docs.MeterDocumentation;
+
+/**
+ * WebSocket {@link HttpServer} meters.
+ *
+ * @author LivingLikeKrillin
+ * @since 1.3.7
+ */
+enum WebSocketServerMeters implements MeterDocumentation {
+
+	/**
+	 * Time spent for the WebSocket handshake on the server.
+	 */
+	WEBSOCKET_SERVER_HANDSHAKE_TIME {
+		@Override
+		public String getName() {
+			return "reactor.netty.websocket.server.handshake.time";
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return HandshakeTimeTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.TIMER;
+		}
+	},
+
+	/**
+	 * Time spent in consuming incoming data on the WebSocket server.
+	 */
+	WEBSOCKET_SERVER_DATA_RECEIVED_TIME {
+		@Override
+		public String getName() {
+			return "reactor.netty.websocket.server.data.received.time";
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return DataReceivedTimeTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.TIMER;
+		}
+	},
+
+	/**
+	 * Time spent in sending outgoing data from the WebSocket server.
+	 */
+	WEBSOCKET_SERVER_DATA_SENT_TIME {
+		@Override
+		public String getName() {
+			return "reactor.netty.websocket.server.data.sent.time";
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return DataSentTimeTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.TIMER;
+		}
+	},
+
+	/**
+	 * Duration of the WebSocket connection on the server.
+	 */
+	WEBSOCKET_SERVER_CONNECTION_DURATION {
+		@Override
+		public String getName() {
+			return "reactor.netty.websocket.server.connection.duration";
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return ConnectionDurationTags.values();
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.TIMER;
+		}
+	};
+
+	enum HandshakeTimeTags implements KeyName {
+
+		/**
+		 * STATUS.
+		 */
+		STATUS {
+			@Override
+			public String asString() {
+				return "status";
+			}
+		},
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String asString() {
+				return "uri";
+			}
+		}
+	}
+
+	enum DataReceivedTimeTags implements KeyName {
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String asString() {
+				return "uri";
+			}
+		}
+	}
+
+	enum DataSentTimeTags implements KeyName {
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String asString() {
+				return "uri";
+			}
+		}
+	}
+
+	enum ConnectionDurationTags implements KeyName {
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String asString() {
+				return "uri";
+			}
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/WebSocketServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/WebSocketServerMetricsHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import reactor.util.context.ContextView;
+
+import java.net.SocketAddress;
+
+/**
+ * {@link AbstractWebSocketServerMetricsHandler} for collecting metrics on WebSocket {@link HttpServer} level.
+ *
+ * @author LivingLikeKrillin
+ * @since 1.3.7
+ */
+final class WebSocketServerMetricsHandler extends AbstractWebSocketServerMetricsHandler {
+
+	final WebSocketServerMetricsRecorder recorder;
+
+	WebSocketServerMetricsHandler(WebSocketServerMetricsRecorder recorder,
+			SocketAddress remoteAddress,
+			String path,
+			ContextView contextView,
+			String method) {
+		super(remoteAddress, path, contextView, method);
+		this.recorder = recorder;
+	}
+
+	@Override
+	protected WebSocketServerMetricsRecorder recorder() {
+		return recorder;
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/WebSocketServerMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/WebSocketServerMetricsRecorder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+
+/**
+ * Interface for collecting metrics on WebSocket server level.
+ *
+ * @author LivingLikeKrillin
+ * @since 1.3.7
+ */
+public interface WebSocketServerMetricsRecorder extends HttpServerMetricsRecorder {
+
+	/**
+	 * Records the time that is spent for the WebSocket handshake.
+	 *
+	 * @param remoteAddress The remote peer
+	 * @param uri the requested URI
+	 * @param status the WebSocket handshake status
+	 * @param time the time that is spent for the handshake
+	 */
+	void recordWebSocketHandshakeTime(SocketAddress remoteAddress, String uri, String status, Duration time);
+
+	/**
+	 * Records the duration of the WebSocket connection.
+	 *
+	 * @param remoteAddress The remote peer
+	 * @param uri the requested URI
+	 * @param time the duration of the connection
+	 */
+	void recordWebSocketConnectionDuration(SocketAddress remoteAddress, String uri, Duration time);
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/WebSocketServerObservations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/WebSocketServerObservations.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http.server;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.docs.ObservationDocumentation;
+
+/**
+ * WebSocket {@link HttpServer} observations.
+ *
+ * @author LivingLikeKrillin
+ * @since 1.3.7
+ */
+enum WebSocketServerObservations implements ObservationDocumentation {
+
+	/**
+	 * WebSocket handshake metric.
+	 */
+	WEBSOCKET_SERVER_HANDSHAKE_TIME {
+		@Override
+		public KeyName[] getHighCardinalityKeyNames() {
+			return HandshakeTimeHighCardinalityTags.values();
+		}
+
+		@Override
+		public KeyName[] getLowCardinalityKeyNames() {
+			return HandshakeTimeLowCardinalityTags.values();
+		}
+
+		@Override
+		public String getName() {
+			return "reactor.netty.websocket.server.handshake.time";
+		}
+	};
+
+	/**
+	 * Handshake Time High Cardinality Tags.
+	 */
+	enum HandshakeTimeHighCardinalityTags implements KeyName {
+
+		/**
+		 * Status code.
+		 */
+		HTTP_STATUS_CODE {
+			@Override
+			public String asString() {
+				return "http.status_code";
+			}
+		},
+
+		/**
+		 * URL.
+		 */
+		HTTP_URL {
+			@Override
+			public String asString() {
+				return "http.url";
+			}
+		},
+
+		/**
+		 * Reactor Netty type (always server).
+		 */
+		REACTOR_NETTY_TYPE {
+			@Override
+			public String asString() {
+				return "reactor.netty.type";
+			}
+		}
+	}
+
+	/**
+	 * Handshake Time Low Cardinality Tags.
+	 */
+	enum HandshakeTimeLowCardinalityTags implements KeyName {
+
+		/**
+		 * STATUS.
+		 */
+		STATUS {
+			@Override
+			public String asString() {
+				return "status";
+			}
+		},
+
+		/**
+		 * URI.
+		 */
+		URI {
+			@Override
+			public String asString() {
+				return "uri";
+			}
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/WebsocketServerOperations.java
@@ -15,6 +15,7 @@
  */
 package reactor.netty.http.server;
 
+import java.net.SocketAddress;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import io.netty.buffer.ByteBuf;
@@ -66,6 +67,7 @@ import static reactor.netty.ReactorNetty.format;
  *
  * @author Stephane Maldini
  * @author Simon Baslé
+ * @author LivingLikeKrillin
  */
 class WebsocketServerOperations extends HttpServerOperations
 		implements WebsocketInbound, WebsocketOutbound {
@@ -74,6 +76,8 @@ class WebsocketServerOperations extends HttpServerOperations
 	ChannelPromise                            handshakerResult;
 	final Sinks.One<WebSocketCloseStatus>     onCloseState;
 	final boolean                             proxyPing;
+
+	@Nullable AbstractWebSocketServerMetricsHandler micrometerWsHandler;
 
 	volatile int closeSent;
 
@@ -107,6 +111,7 @@ class WebsocketServerOperations extends HttpServerOperations
 			if (handler != null) {
 				replaceHandler(NettyPipeline.HttpMetricsHandler,
 						new WebsocketHttpServerMetricsHandler((AbstractHttpServerMetricsHandler) handler));
+				swapMetricsHandler((AbstractHttpServerMetricsHandler) handler, replaced);
 			}
 
 			handshakerResult = channel.newPromise();
@@ -150,6 +155,7 @@ class WebsocketServerOperations extends HttpServerOperations
 				}
 			}
 
+			recordHandshakeStart(channel);
 			handshakerHttp11.handshake(channel,
 			                     request,
 			                     replaced.responseHeaders
@@ -163,6 +169,12 @@ class WebsocketServerOperations extends HttpServerOperations
 			              }
 			              else if (log.isDebugEnabled()) {
 			                  log.debug(format(channel, "Cannot bind WebsocketServerOperations after the handshake."));
+			              }
+			              if (f.isSuccess()) {
+			                  recordHandshakeComplete(channel, "101");
+			              }
+			              else {
+			                  recordHandshakeFailure(channel);
 			              }
 			          });
 		}
@@ -218,6 +230,10 @@ class WebsocketServerOperations extends HttpServerOperations
 			if (log.isDebugEnabled()) {
 				log.debug(format(channel(), "Outbound error happened"), err);
 			}
+			// An application error flowing through Reactor (WebsocketSubscriber.onError ->
+			// ChannelOperations.onError -> this method) never reaches exceptionCaught, so it would
+			// otherwise never be counted by the errors meter. Record it here, once, before closing.
+			recordOutboundError(channel());
 			sendCloseNow(new CloseWebSocketFrame(WebSocketCloseStatus.PROTOCOL_ERROR),
 					f -> terminate());
 		}
@@ -316,6 +332,116 @@ class WebsocketServerOperations extends HttpServerOperations
 
 	Subscriber<Void> websocketSubscriber(ContextView contextView) {
 		return new WebsocketSubscriber(this, Context.of(contextView));
+	}
+
+	void swapMetricsHandler(AbstractHttpServerMetricsHandler handler, HttpServerOperations replaced) {
+		Channel channel = channel();
+
+		String rawPath = resolvePath(this);
+		String resolvedPath = handler.uriTagValue != null ? handler.uriTagValue.apply(rawPath) : rawPath;
+		ContextView ctxView = currentContext();
+		SocketAddress remoteAddress = channel.remoteAddress();
+		String httpMethod = replaced.method().name();
+
+		AbstractWebSocketServerMetricsHandler wsHandler;
+		if (handler instanceof MicrometerHttpServerMetricsHandler) {
+			wsHandler = new MicrometerWebSocketServerMetricsHandler(
+					MicrometerWebSocketServerMetricsRecorder.INSTANCE, remoteAddress, resolvedPath, ctxView, httpMethod);
+		}
+		else if (handler instanceof ContextAwareHttpServerMetricsHandler) {
+			ContextAwareHttpServerMetricsHandler ctxHandler = (ContextAwareHttpServerMetricsHandler) handler;
+			ContextAwareWebSocketServerMetricsRecorder wsRecorder;
+			if (ctxHandler.recorder instanceof ContextAwareWebSocketServerMetricsRecorder) {
+				wsRecorder = (ContextAwareWebSocketServerMetricsRecorder) ctxHandler.recorder;
+			}
+			else {
+				wsRecorder = new DefaultContextAwareWebSocketServerMetricsRecorder(ctxHandler.recorder);
+			}
+			wsHandler = new ContextAwareWebSocketServerMetricsHandler(
+					wsRecorder, remoteAddress, resolvedPath, ctxView, httpMethod);
+		}
+		else if (handler instanceof HttpServerMetricsHandler) {
+			HttpServerMetricsHandler plainHandler = (HttpServerMetricsHandler) handler;
+			WebSocketServerMetricsRecorder wsRecorder;
+			if (plainHandler.recorder instanceof WebSocketServerMetricsRecorder) {
+				wsRecorder = (WebSocketServerMetricsRecorder) plainHandler.recorder;
+			}
+			else {
+				wsRecorder = new DefaultWebSocketServerMetricsRecorder(plainHandler.recorder);
+			}
+			wsHandler = new WebSocketServerMetricsHandler(
+					wsRecorder, remoteAddress, resolvedPath, ctxView, httpMethod);
+		}
+		else {
+			return;
+		}
+		this.micrometerWsHandler = wsHandler;
+		channel.pipeline().addBefore(NettyPipeline.ReactiveBridge, NettyPipeline.WsMetricsHandler, wsHandler);
+	}
+
+	void recordHandshakeStart(Channel channel) {
+		if (micrometerWsHandler == null) {
+			return;
+		}
+		try {
+			micrometerWsHandler.startHandshake(channel);
+		}
+		catch (RuntimeException e) {
+			if (log.isWarnEnabled()) {
+				log.warn(format(channel, "Exception caught while recording metrics."), e);
+			}
+		}
+	}
+
+	void recordHandshakeComplete(Channel channel, String status) {
+		if (micrometerWsHandler == null) {
+			return;
+		}
+		try {
+			micrometerWsHandler.recordHandshakeComplete(channel, status);
+		}
+		catch (RuntimeException e) {
+			if (log.isWarnEnabled()) {
+				log.warn(format(channel, "Exception caught while recording metrics."), e);
+			}
+		}
+	}
+
+	void recordHandshakeFailure(Channel channel) {
+		if (micrometerWsHandler == null) {
+			return;
+		}
+		try {
+			micrometerWsHandler.recordHandshakeFailure(channel);
+		}
+		catch (RuntimeException e) {
+			if (log.isWarnEnabled()) {
+				log.warn(format(channel, "Exception caught while recording metrics."), e);
+			}
+		}
+	}
+
+	void recordOutboundError(Channel channel) {
+		if (micrometerWsHandler == null) {
+			return;
+		}
+		try {
+			micrometerWsHandler.recordException();
+		}
+		catch (RuntimeException e) {
+			if (log.isWarnEnabled()) {
+				log.warn(format(channel, "Exception caught while recording metrics."), e);
+			}
+		}
+	}
+
+	static String resolvePath(HttpServerOperations ops) {
+		try {
+			return ops.fullPath();
+		}
+		catch (Exception e) {
+			return "/bad-request";
+		}
 	}
 
 	static final AtomicIntegerFieldUpdater<WebsocketServerOperations> CLOSE_SENT =

--- a/reactor-netty-http/src/main/resources/META-INF/native-image/io.projectreactor.netty/reactor-netty-http/reflect-config.json
+++ b/reactor-netty-http/src/main/resources/META-INF/native-image/io.projectreactor.netty/reactor-netty-http/reflect-config.json
@@ -183,9 +183,23 @@
 	},
 	{
 		"condition": {
+			"typeReachable": "reactor.netty.http.server.AbstractWebSocketServerMetricsHandler"
+		},
+		"name": "reactor.netty.http.server.AbstractWebSocketServerMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"condition": {
 			"typeReachable": "reactor.netty.http.server.ContextAwareHttpServerMetricsHandler"
 		},
 		"name": "reactor.netty.http.server.ContextAwareHttpServerMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"condition": {
+			"typeReachable": "reactor.netty.http.server.ContextAwareWebSocketServerMetricsHandler"
+		},
+		"name": "reactor.netty.http.server.ContextAwareWebSocketServerMetricsHandler",
 		"queryAllPublicMethods": true
 	},
 	{
@@ -323,6 +337,13 @@
 	},
 	{
 		"condition": {
+			"typeReachable": "reactor.netty.http.server.MicrometerWebSocketServerMetricsHandler"
+		},
+		"name": "reactor.netty.http.server.MicrometerWebSocketServerMetricsHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"condition": {
 			"typeReachable": "reactor.netty.http.server.NonSslRedirectDetector"
 		},
 		"name": "reactor.netty.http.server.NonSslRedirectDetector",
@@ -340,6 +361,13 @@
 			"typeReachable": "reactor.netty.http.server.SimpleCompressionHandler"
 		},
 		"name": "reactor.netty.http.server.SimpleCompressionHandler",
+		"queryAllPublicMethods": true
+	},
+	{
+		"condition": {
+			"typeReachable": "reactor.netty.http.server.WebSocketServerMetricsHandler"
+		},
+		"name": "reactor.netty.http.server.WebSocketServerMetricsHandler",
 		"queryAllPublicMethods": true
 	},
 	{

--- a/reactor-netty-http/src/test/java/reactor/netty/http/WebSocketServerMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/WebSocketServerMetricsHandlerTests.java
@@ -1,0 +1,548 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.http;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.websocketx.ContinuationWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http2.Http2StreamChannel;
+import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.netty.BaseHttpTest;
+import reactor.netty.NettyPipeline;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static reactor.netty.Metrics.CONNECTION_DURATION;
+import static reactor.netty.Metrics.DATA_RECEIVED;
+import static reactor.netty.Metrics.DATA_RECEIVED_TIME;
+import static reactor.netty.Metrics.DATA_SENT;
+import static reactor.netty.Metrics.DATA_SENT_TIME;
+import static reactor.netty.Metrics.ERRORS;
+import static reactor.netty.Metrics.HANDSHAKE_TIME;
+import static reactor.netty.Metrics.STATUS;
+import static reactor.netty.Metrics.URI;
+import static reactor.netty.Metrics.WEBSOCKET_SERVER_PREFIX;
+import static reactor.netty.micrometer.CounterAssert.assertCounter;
+import static reactor.netty.micrometer.DistributionSummaryAssert.assertDistributionSummary;
+import static reactor.netty.micrometer.TimerAssert.assertTimer;
+
+/**
+ * WebSocket server metrics tests.
+ * <p>Each test binds its own server, because the configuration under test differs per case
+ * ({@code uriTagValue} mapper, {@code HTTP/2}, an injected handler that fails the handshake write).
+ *
+ * @author LivingLikeKrillin
+ * @since 1.3.7
+ */
+class WebSocketServerMetricsHandlerTests extends BaseHttpTest {
+
+	static final String WS_SERVER_HANDSHAKE_TIME = WEBSOCKET_SERVER_PREFIX + HANDSHAKE_TIME;
+	static final String WS_SERVER_CONNECTION_DURATION = WEBSOCKET_SERVER_PREFIX + CONNECTION_DURATION;
+	static final String WS_SERVER_DATA_SENT_TIME = WEBSOCKET_SERVER_PREFIX + DATA_SENT_TIME;
+	static final String WS_SERVER_DATA_RECEIVED_TIME = WEBSOCKET_SERVER_PREFIX + DATA_RECEIVED_TIME;
+	static final String WS_SERVER_DATA_SENT = WEBSOCKET_SERVER_PREFIX + DATA_SENT;
+	static final String WS_SERVER_DATA_RECEIVED = WEBSOCKET_SERVER_PREFIX + DATA_RECEIVED;
+	static final String WS_SERVER_ERRORS = WEBSOCKET_SERVER_PREFIX + ERRORS;
+
+	private ConnectionProvider provider;
+	private HttpClient httpClient;
+	private MeterRegistry registry;
+	private final ServerCloseHandler serverCloseHandler = new ServerCloseHandler();
+
+	@BeforeEach
+	void setUp() {
+		provider = ConnectionProvider.create("WebSocketServerMetricsHandlerTests", 1);
+		httpClient = createClient(provider, () -> disposableServer.address())
+				.metrics(true, Function.identity());
+
+		registry = new SimpleMeterRegistry();
+		Metrics.addRegistry(registry);
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (!provider.isDisposed()) {
+			provider.disposeLater()
+			        .block(Duration.ofSeconds(30));
+		}
+
+		Metrics.removeRegistry(registry);
+		registry.clear();
+		registry.close();
+
+		if (disposableServer != null) {
+			disposableServer.disposeNow();
+			disposableServer = null;
+		}
+	}
+
+	@Test
+	void testServerWebSocketHandshakeTimeMicrometer() {
+		disposableServer =
+				createServer().host("127.0.0.1")
+				              .metrics(true, Function.identity())
+				              .handle((req, res) -> res.sendWebsocket((in, out) -> out.sendString(Mono.just("Hello World!"))))
+				              .bindNow();
+
+		httpClient.websocket()
+		          .uri("/ws")
+		          .handle((in, out) -> in.receive().aggregate().asString())
+		          .as(StepVerifier::create)
+		          .expectNext("Hello World!")
+		          .expectComplete()
+		          .verify(Duration.ofSeconds(30));
+
+		assertTimer(registry, WS_SERVER_HANDSHAKE_TIME, URI, "/ws", STATUS, "101")
+				.hasCountEqualTo(1)
+				.hasTotalTimeGreaterThan(0);
+	}
+
+	@Test
+	void testServerWebSocketHandshakeTimeMicrometerHttp2() {
+		disposableServer =
+				createServer().host("127.0.0.1")
+				              .protocol(HttpProtocol.H2C)
+				              .http2Settings(spec -> spec.connectProtocolEnabled(true))
+				              .metrics(true, Function.identity())
+				              .handle((req, res) -> res.sendWebsocket((in, out) -> out.sendString(Mono.just("Hello World!"))))
+				              .bindNow();
+
+		HttpClient client = httpClient.protocol(HttpProtocol.H2C);
+
+		client.websocket()
+		      .uri("/ws")
+		      .handle((in, out) -> in.receive().aggregate().asString())
+		      .as(StepVerifier::create)
+		      .expectNext("Hello World!")
+		      .expectComplete()
+		      .verify(Duration.ofSeconds(30));
+
+		assertTimer(registry, WS_SERVER_HANDSHAKE_TIME, URI, "/ws", STATUS, "200")
+				.hasCountEqualTo(1)
+				.hasTotalTimeGreaterThan(0);
+	}
+
+	@Test
+	void testServerWebSocketHandshakeFailureMicrometer() {
+		// Fail the write of the handshake response so that the handshake future completes exceptionally
+		// after the WebSocket metrics handler has been installed. On the HTTP/1.1 path this is the only
+		// way the ERROR status is reached: a request that cannot be upgraded at all is rejected before
+		// the handler is there.
+		disposableServer =
+				createServer().host("127.0.0.1")
+				              .metrics(true, Function.identity())
+				              .doOnConnection(cnx -> cnx.channel().pipeline().addAfter(NettyPipeline.HttpCodec,
+				                      "failHandshakeWrite",
+				                      new ChannelDuplexHandler() {
+				                          @Override
+				                          public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+				                              if (msg instanceof HttpResponse &&
+				                                      ((HttpResponse) msg).status().code() == 101) {
+				                                  ReferenceCountUtil.release(msg);
+				                                  promise.setFailure(new IOException("Simulated handshake write failure"));
+				                                  ctx.close();
+				                              }
+				                              else {
+				                                  ctx.write(msg, promise);
+				                              }
+				                          }
+				                      }))
+				              .handle((req, res) -> res.sendWebsocket((in, out) -> out.sendString(Mono.just("Hello World!"))))
+				              .bindNow();
+
+		httpClient.websocket()
+		          .uri("/ws")
+		          .handle((in, out) -> in.receive().aggregate().asString())
+		          .as(StepVerifier::create)
+		          .expectError()
+		          .verify(Duration.ofSeconds(30));
+
+		await().atMost(5, TimeUnit.SECONDS)
+		       .pollInterval(50, TimeUnit.MILLISECONDS)
+		       .untilAsserted(() -> {
+		           assertTimer(registry, WS_SERVER_HANDSHAKE_TIME, URI, "/ws", STATUS, "ERROR")
+		                   .hasCountEqualTo(1)
+		                   .hasTotalTimeGreaterThan(0);
+
+		           // The handler is installed before the handshake runs, so the duration of the
+		           // failed attempt is recorded as well
+		           assertTimer(registry, WS_SERVER_CONNECTION_DURATION, URI, "/ws")
+		                   .hasCountEqualTo(1)
+		                   .hasTotalTimeGreaterThan(0);
+		       });
+	}
+
+	@Test
+	void testServerWebSocketUriTagValueFunctionMicrometer() {
+		disposableServer =
+				createServer().host("127.0.0.1")
+				              .metrics(true, s -> "/normalized")
+				              .handle((req, res) -> res.sendWebsocket((in, out) -> out.sendString(Mono.just("Hello World!"))))
+				              .bindNow();
+
+		httpClient.websocket()
+		          .uri("/ws")
+		          .handle((in, out) -> in.receive().aggregate().asString())
+		          .as(StepVerifier::create)
+		          .expectNext("Hello World!")
+		          .expectComplete()
+		          .verify(Duration.ofSeconds(30));
+
+		assertTimer(registry, WS_SERVER_HANDSHAKE_TIME, URI, "/normalized", STATUS, "101")
+				.hasCountEqualTo(1)
+				.hasTotalTimeGreaterThan(0);
+	}
+
+	@Test
+	void testServerWebSocketConnectionDurationMicrometer() throws Exception {
+		disposableServer =
+				createServer().host("127.0.0.1")
+				              .metrics(true, Function.identity())
+				              .doOnConnection(cnx -> serverCloseHandler.register(cnx.channel()))
+				              .handle((req, res) -> res.sendWebsocket((in, out) -> out.sendString(Mono.just("Hello World!"))))
+				              .bindNow();
+
+		httpClient.websocket()
+		          .uri("/ws")
+		          .handle((in, out) -> in.receive().aggregate().asString())
+		          .as(StepVerifier::create)
+		          .expectNext("Hello World!")
+		          .expectComplete()
+		          .verify(Duration.ofSeconds(30));
+
+		// connection.duration is recorded when the WS metrics handler is removed from the pipeline,
+		// which happens on connection close; make sure that has happened server-side first
+		assertThat(serverCloseHandler.awaitClientClosedOnServer()).as("awaitClientClosedOnServer timeout").isTrue();
+
+		await().atMost(5, TimeUnit.SECONDS)
+		       .pollInterval(50, TimeUnit.MILLISECONDS)
+		       .untilAsserted(() ->
+		               assertTimer(registry, WS_SERVER_CONNECTION_DURATION, URI, "/ws")
+		                       .hasCountEqualTo(1)
+		                       .hasTotalTimeGreaterThan(0));
+	}
+
+	@Test
+	void testServerWebSocketDataMetricsMicrometer() {
+		disposableServer =
+				createServer().host("127.0.0.1")
+				              .metrics(true, Function.identity())
+				              .handle((req, res) -> res.sendWebsocket((in, out) ->
+				                      // Send and receive concurrently so that both a data.sent and a
+				                      // data.received final data frame are recorded on the server side.
+				                      out.sendString(Mono.just("Hello World!"))
+				                         .then()
+				                         .and(in.receive().asString().take(1).then())))
+				              .bindNow();
+
+		httpClient.websocket()
+		          .uri("/ws")
+		          .handle((in, out) -> out.sendString(Mono.just("ping"))
+		                                  .then()
+		                                  .thenMany(in.receive().asString().take(1)))
+		          .as(StepVerifier::create)
+		          .expectNext("Hello World!")
+		          .expectComplete()
+		          .verify(Duration.ofSeconds(30));
+
+		await().atMost(5, TimeUnit.SECONDS)
+		       .pollInterval(50, TimeUnit.MILLISECONDS)
+		       .untilAsserted(() -> {
+		           assertTimer(registry, WS_SERVER_DATA_SENT_TIME, URI, "/ws")
+		                   .hasCountEqualTo(1)
+		                   .hasTotalTimeGreaterThan(0);
+
+		           assertTimer(registry, WS_SERVER_DATA_RECEIVED_TIME, URI, "/ws")
+		                   .hasCountEqualTo(1)
+		                   .hasTotalTimeGreaterThan(0);
+
+		           // "Hello World!" out, "ping" in; exact totals also guard against a frame being counted twice
+		           assertDistributionSummary(registry, WS_SERVER_DATA_SENT, URI, "/ws")
+		                   .hasCountEqualTo(1)
+		                   .hasTotalAmountEqualTo(12);
+
+		           assertDistributionSummary(registry, WS_SERVER_DATA_RECEIVED, URI, "/ws")
+		                   .hasCountEqualTo(1)
+		                   .hasTotalAmountEqualTo(4);
+		       });
+	}
+
+	@Test
+	void testServerWebSocketMultipleMessagesSentMicrometer() {
+		int messageCount = 16;
+		String message = "abcde";
+		int messageSize = message.getBytes(CharsetUtil.UTF_8).length;
+
+		disposableServer =
+				createServer().host("127.0.0.1")
+				              .metrics(true, Function.identity())
+				              .handle((req, res) -> res.sendWebsocket((in, out) -> out.sendObject(
+				                      Flux.range(0, messageCount).map(i -> new TextWebSocketFrame(message)))
+				                                                                       .then()))
+				              .bindNow();
+
+		httpClient.websocket()
+		          .uri("/ws")
+		          .handle((in, out) -> in.receive().asString().take(messageCount).then())
+		          .as(StepVerifier::create)
+		          .expectComplete()
+		          .verify(Duration.ofSeconds(30));
+
+		// Each message must be recorded as its own data.sent record. The write path snapshots the
+		// per-message accumulators before the write listener runs; if it read them inside the listener
+		// instead, a following message would corrupt this message's byte and time attribution.
+		await().atMost(5, TimeUnit.SECONDS)
+		       .pollInterval(50, TimeUnit.MILLISECONDS)
+		       .untilAsserted(() -> {
+		           assertDistributionSummary(registry, WS_SERVER_DATA_SENT, URI, "/ws")
+		                   .hasCountEqualTo(messageCount)
+		                   .hasTotalAmountEqualTo((double) messageSize * messageCount);
+
+		           assertTimer(registry, WS_SERVER_DATA_SENT_TIME, URI, "/ws")
+		                   .hasCountEqualTo(messageCount)
+		                   .hasTotalTimeGreaterThan(0);
+		       });
+
+		// Per-message attribution must be exact: no single record may carry more than one message
+		DistributionSummary dataSent = registry.find(WS_SERVER_DATA_SENT).tag(URI, "/ws").summary();
+		assertThat(dataSent).isNotNull();
+		assertThat(dataSent.max()).isLessThanOrEqualTo(messageSize);
+
+		// And no send time may be a garbage 'now - 0' duration
+		Timer dataSentTime = registry.find(WS_SERVER_DATA_SENT_TIME).tag(URI, "/ws").timer();
+		assertThat(dataSentTime).isNotNull();
+		assertThat(dataSentTime.max(TimeUnit.SECONDS)).isLessThan(10d);
+	}
+
+	@Test
+	void testServerWebSocketMultipleMessagesReceivedMicrometer() {
+		int messageCount = 16;
+		String message = "abcde";
+		int messageSize = message.getBytes(CharsetUtil.UTF_8).length;
+
+		disposableServer =
+				createServer().host("127.0.0.1")
+				              .metrics(true, Function.identity())
+				              .handle((req, res) -> res.sendWebsocket((in, out) ->
+				                      in.receive().asString().take(messageCount).then()))
+				              .bindNow();
+
+		// Space the messages out so that a per-message duration and a duration accumulated since the
+		// first message differ by orders of magnitude rather than by microseconds.
+		Duration gap = Duration.ofMillis(20);
+
+		httpClient.websocket()
+		          .uri("/ws")
+		          .handle((in, out) -> out.sendObject(
+		                  Flux.range(0, messageCount)
+		                      .delayElements(gap)
+		                      .map(i -> new TextWebSocketFrame(message)))
+		                                  .then())
+		          .as(StepVerifier::create)
+		          .expectComplete()
+		          .verify(Duration.ofSeconds(30));
+
+		// Each message must be recorded as its own data.received record with its own duration. The read
+		// path resets the per-message clock after every message; if it did not, every record after the
+		// first would measure from the first message and the durations would grow without bound.
+		await().atMost(5, TimeUnit.SECONDS)
+		       .pollInterval(50, TimeUnit.MILLISECONDS)
+		       .untilAsserted(() -> {
+		           assertDistributionSummary(registry, WS_SERVER_DATA_RECEIVED, URI, "/ws")
+		                   .hasCountEqualTo(messageCount)
+		                   .hasTotalAmountEqualTo((double) messageSize * messageCount);
+
+		           assertTimer(registry, WS_SERVER_DATA_RECEIVED_TIME, URI, "/ws")
+		                   .hasCountEqualTo(messageCount)
+		                   .hasTotalTimeGreaterThan(0);
+		       });
+
+		// A per-message duration is the time to process one frame, far below the gap between messages.
+		// A duration accumulated since the first message would be a multiple of that gap.
+		Timer dataReceivedTime = registry.find(WS_SERVER_DATA_RECEIVED_TIME).tag(URI, "/ws").timer();
+		assertThat(dataReceivedTime).isNotNull();
+		assertThat(dataReceivedTime.max(TimeUnit.MILLISECONDS))
+				.as("per-message receive durations must not accumulate")
+				.isLessThan((double) gap.toMillis());
+	}
+
+	@Test
+	void testServerWebSocketControlFramesExcludedFromDataMetricsMicrometer() {
+		disposableServer =
+				createServer().host("127.0.0.1")
+				              .metrics(true, Function.identity())
+				              .handle((req, res) -> res.sendWebsocket((in, out) ->
+				                      in.receive().asString().take(1).then()))
+				              .bindNow();
+
+		httpClient.websocket()
+		          .uri("/ws")
+		          .handle((in, out) -> out.sendObject(Flux.just(new PingWebSocketFrame(),
+		                                                        new TextWebSocketFrame("data")))
+		                                  .then())
+		          .as(StepVerifier::create)
+		          .expectComplete()
+		          .verify(Duration.ofSeconds(30));
+
+		await().atMost(5, TimeUnit.SECONDS)
+		       .pollInterval(50, TimeUnit.MILLISECONDS)
+		       .untilAsserted(() -> {
+		           // Only the 4-byte text frame is counted; the Ping and the Close frame are not
+		           assertDistributionSummary(registry, WS_SERVER_DATA_RECEIVED, URI, "/ws")
+		                   .hasCountEqualTo(1)
+		                   .hasTotalAmountEqualTo(4);
+
+		           // The server sends no data frame here, only the automatic Pong and the Close frame,
+		           // so nothing is recorded on the outbound side either. The meter is not registered
+		           // at all unless something was recorded, hence the null-tolerant read.
+		           DistributionSummary dataSent = registry.find(WS_SERVER_DATA_SENT).tag(URI, "/ws").summary();
+		           assertThat(dataSent == null ? 0 : dataSent.count())
+		                   .as("server WS data.sent must not record control frames")
+		                   .isZero();
+		       });
+	}
+
+	@Test
+	void testServerWebSocketFragmentedDataReceivedMicrometer() {
+		disposableServer =
+				createServer().host("127.0.0.1")
+				              .metrics(true, Function.identity())
+				              .handle((req, res) -> res.sendWebsocket((in, out) ->
+				                      in.aggregateFrames().receiveFrames().take(1).then()))
+				              .bindNow();
+
+		httpClient.websocket()
+		          .uri("/ws")
+		          .handle((in, out) -> out.sendObject(Flux.just(new TextWebSocketFrame(false, 0, "hello"),
+		                                                        new ContinuationWebSocketFrame(true, 0, " world")))
+		                                  .then())
+		          .as(StepVerifier::create)
+		          .expectComplete()
+		          .verify(Duration.ofSeconds(30));
+
+		await().atMost(5, TimeUnit.SECONDS)
+		       .pollInterval(50, TimeUnit.MILLISECONDS)
+		       .untilAsserted(() -> {
+		           // "hello" + " world" is one message: recorded once, on the final fragment
+		           assertDistributionSummary(registry, WS_SERVER_DATA_RECEIVED, URI, "/ws")
+		                   .hasCountEqualTo(1)
+		                   .hasTotalAmountEqualTo(11);
+
+		           assertTimer(registry, WS_SERVER_DATA_RECEIVED_TIME, URI, "/ws")
+		                   .hasCountEqualTo(1)
+		                   .hasTotalTimeGreaterThan(0);
+		       });
+	}
+
+	@Test
+	void testServerWebSocketErrorsOnApplicationErrorMicrometer() throws Exception {
+		// The handler's outbound Publisher errors. This flows through
+		// WebsocketSubscriber.onError -> ChannelOperations.onError -> WebsocketServerOperations
+		// .onOutboundError, a path that never reaches exceptionCaught, so it would otherwise never
+		// be counted by the errors meter.
+		disposableServer =
+				createServer().host("127.0.0.1")
+				              .metrics(true, Function.identity())
+				              .doOnConnection(cnx -> serverCloseHandler.register(cnx.channel()))
+				              .handle((req, res) -> res.sendWebsocket((in, out) ->
+				                      out.sendString(Flux.error(new RuntimeException("boom")))))
+				              .bindNow();
+
+		httpClient.websocket()
+		          .uri("/ws")
+		          .handle((in, out) -> in.receiveFrames().then())
+		          .then()
+		          .onErrorResume(e -> Mono.empty())
+		          .as(StepVerifier::create)
+		          .expectComplete()
+		          .verify(Duration.ofSeconds(30));
+
+		assertThat(serverCloseHandler.awaitClientClosedOnServer()).as("awaitClientClosedOnServer timeout").isTrue();
+
+		await().atMost(5, TimeUnit.SECONDS)
+		       .pollInterval(50, TimeUnit.MILLISECONDS)
+		       .untilAsserted(() ->
+		               assertCounter(registry, WS_SERVER_ERRORS, URI, "/ws")
+		                       .hasCountEqualTo(1));
+	}
+
+	/**
+	 * Counts down when the server side of the connection goes inactive, so that a test can wait for
+	 * the close before reading meters that are recorded on close.
+	 */
+	static final class ServerCloseHandler extends ChannelInboundHandlerAdapter {
+
+		static final String HANDLER_NAME = "WebSocketServerMetricsHandlerTests.ServerCloseHandler";
+
+		private @Nullable CountDownLatch latch;
+
+		void register(Channel channel) {
+			this.latch = new CountDownLatch(1);
+			if (channel instanceof Http2StreamChannel) {
+				if (channel.parent().pipeline().get(HANDLER_NAME) == null) {
+					channel.parent().pipeline().addLast(HANDLER_NAME, this);
+				}
+			}
+			else {
+				channel.pipeline().addBefore(NettyPipeline.ReactiveBridge, HANDLER_NAME, this);
+			}
+		}
+
+		@Override
+		public void channelInactive(ChannelHandlerContext ctx) {
+			if (latch != null) {
+				latch.countDown();
+			}
+			ctx.fireChannelInactive();
+		}
+
+		@Override
+		public boolean isSharable() {
+			return true;
+		}
+
+		boolean awaitClientClosedOnServer() throws InterruptedException {
+			return latch == null || latch.await(30, TimeUnit.SECONDS);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add WebSocket server metrics, mirroring the client WebSocket metrics (#4118). This is the first step of #4305. The meters are registered under the `reactor.netty.websocket.server` prefix, tagged with `uri` (mapped through the configured `uriTagValue` when one is set, as for the HTTP server meters):

- `handshake.time` (tags `uri`, `status`): `101` on a successful HTTP/1.1 upgrade, `200` on a successful HTTP/2 Extended CONNECT, `ERROR` when the handshake fails after the metrics handler is installed. Pre-upgrade rejections (unsupported version on HTTP/1.1, invalid Extended CONNECT on HTTP/2) are answered before installation and record no WebSocket meter
- `connection.duration`: from handler installation on upgrade to pipeline removal on close, so it includes the handshake and is also recorded when the handshake fails (same as the client)
- `data.received`, `data.sent`, `data.received.time`, `data.sent.time`: recorded once per message on the final fragment; control frames (Close, Ping, Pong) are excluded
- `errors`: pipeline exceptions and application errors raised while sending the WebSocket outbound

On the Micrometer path — as on the client — the handshake meter is produced by a `reactor.netty.websocket.server.handshake.time` observation instead of a direct recorder call.

## Changes

On upgrade, `WebsocketServerOperations` (HTTP/1.1) and `Http2WebsocketServerOperations` (HTTP/2) install a WebSocket metrics handler at the `WsMetricsHandler` slot, selected from the configured HTTP metrics handler the same way the client's `swapMetricsHandler` does. The Micrometer path always uses the built-in WebSocket recorder; on the other two, a recorder that does not implement the matching WebSocket type (`ContextAwareWebSocketServerMetricsRecorder` on the context-aware path, `WebSocketServerMetricsRecorder` on the plain one) is wrapped in an adapter that delegates the inherited HTTP methods and no-ops the two WebSocket ones. The `WebsocketHttpServerMetricsHandler` pass-through is kept unchanged, since it carries the connection/stream count accounting (#4290); the new handler is additive.

New public API: `WebSocketServerMetricsRecorder` (extends `HttpServerMetricsRecorder`, two methods) and `ContextAwareWebSocketServerMetricsRecorder` (adds the two `ContextView` overloads), plus `Metrics.WEBSOCKET_SERVER_PREFIX`. All other new types are package-private, and no meter of the built-in Micrometer recorder carries a `remote.address` or `proxy.address` tag. Native-image reflection configuration for the four new handlers and a reference documentation section are included.

## Test plan

- [x] Handshake time on HTTP/1.1 (`101`) and HTTP/2 Extended CONNECT (`200`)
- [x] Connection duration recorded on close
- [x] Data metrics in both directions, byte counts and timings
- [x] Errors counted on the application-error path
- [x] `ERROR` handshake status when the handshake fails after the handler is installed
- [x] `uriTagValue` mapping applied to the `uri` tag
- [x] Control frames excluded from the data metrics, inbound and outbound
- [x] A fragmented inbound message recorded once, on its final fragment
- [x] A burst of messages recorded per message in both directions, with exact byte attribution

These cover the Micrometer recorder path. The custom-recorder path is exercised end to end by the existing `testServerConnectionsWebsocketRecorder`, but no test asserts the WebSocket recordings made on it, and the context-aware recorder path is not covered by a test yet.

Related to #4305
