### PR TITLE
Reuse per-connection address and byte meters in the Micrometer client metrics path

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package reactor.netty.channel;
 
 import io.micrometer.common.KeyValues;
+import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.observation.Observation;
 import io.netty.channel.ChannelHandler;
@@ -63,6 +64,9 @@ import static reactor.netty.channel.ConnectObservations.ConnectTimeLowCardinalit
 public final class MicrometerChannelMetricsHandler extends AbstractChannelMetricsHandler {
 
 	final MicrometerChannelMetricsRecorder recorder;
+	// The meter is constant for the life of a connection; cache it here rather than re-resolving per event.
+	@Nullable DistributionSummary dataReceivedMeter;
+	@Nullable DistributionSummary dataSentMeter;
 
 	MicrometerChannelMetricsHandler(MicrometerChannelMetricsRecorder recorder, @Nullable SocketAddress remoteAddress, boolean onServer) {
 		super(remoteAddress, onServer);
@@ -81,6 +85,35 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 	@Override
 	public MicrometerChannelMetricsRecorder recorder() {
 		return recorder;
+	}
+
+	@Override
+	protected void recordRead(ChannelHandlerContext ctx, SocketAddress address, long bytes) {
+		// A null remoteAddress means the address varies per datagram (unconnected UDP), so it can't be cached.
+		if (remoteAddress == null) {
+			super.recordRead(ctx, address, bytes);
+			return;
+		}
+		if (dataReceivedMeter == null) {
+			dataReceivedMeter = recorder.dataReceivedMeter(address, proxyAddress == null ? NA : formatSocketAddress(proxyAddress));
+		}
+		if (dataReceivedMeter != null) {
+			dataReceivedMeter.record(bytes);
+		}
+	}
+
+	@Override
+	protected void recordWrite(ChannelHandlerContext ctx, SocketAddress address, long bytes) {
+		if (remoteAddress == null) {
+			super.recordWrite(ctx, address, bytes);
+			return;
+		}
+		if (dataSentMeter == null) {
+			dataSentMeter = recorder.dataSentMeter(address, proxyAddress == null ? NA : formatSocketAddress(proxyAddress));
+		}
+		if (dataSentMeter != null) {
+			dataSentMeter.record(bytes);
+		}
 	}
 
 	// ConnectMetricsHandler is Observation.Context and ChannelOutboundHandler in order to reduce allocations,

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
@@ -95,9 +95,18 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 	}
 
 	void recordDataReceived(SocketAddress remoteAddress, String proxyAddress, long bytes) {
+		DistributionSummary ds = dataReceivedMeter(remoteAddress, proxyAddress);
+		if (ds != null) {
+			ds.record(bytes);
+		}
+	}
+
+	// Resolves the meter without recording, so a caller can cache the result and skip re-resolving it
+	// on every event.
+	@Nullable DistributionSummary dataReceivedMeter(SocketAddress remoteAddress, String proxyAddress) {
 		String address = formatSocketAddress(remoteAddress);
 		MeterKey meterKey = new MeterKey(null, address, proxyAddress, null, null);
-		DistributionSummary ds = MapUtils.computeIfAbsent(dataReceivedCache, meterKey, key -> {
+		return MapUtils.computeIfAbsent(dataReceivedCache, meterKey, key -> {
 			DistributionSummary.Builder builder =
 					DistributionSummary.builder(name + DATA_RECEIVED)
 					                   .baseUnit(ChannelMeters.DATA_RECEIVED.getBaseUnit())
@@ -108,9 +117,6 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 			}
 			return filter(builder.register(REGISTRY));
 		});
-		if (ds != null) {
-			ds.record(bytes);
-		}
 	}
 
 	@Override
@@ -124,9 +130,16 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 	}
 
 	void recordDataSent(SocketAddress remoteAddress, String proxyAddress, long bytes) {
+		DistributionSummary ds = dataSentMeter(remoteAddress, proxyAddress);
+		if (ds != null) {
+			ds.record(bytes);
+		}
+	}
+
+	@Nullable DistributionSummary dataSentMeter(SocketAddress remoteAddress, String proxyAddress) {
 		String address = formatSocketAddress(remoteAddress);
 		MeterKey meterKey = new MeterKey(null, address, proxyAddress, null, null);
-		DistributionSummary ds = MapUtils.computeIfAbsent(dataSentCache, meterKey, key -> {
+		return MapUtils.computeIfAbsent(dataSentCache, meterKey, key -> {
 			DistributionSummary.Builder builder =
 					DistributionSummary.builder(name + DATA_SENT)
 					                   .baseUnit(ChannelMeters.DATA_SENT.getBaseUnit())
@@ -137,9 +150,6 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 			}
 			return filter(builder.register(REGISTRY));
 		});
-		if (ds != null) {
-			ds.record(bytes);
-		}
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
@@ -61,6 +61,9 @@ import static reactor.netty.http.client.HttpClientObservations.ResponseTimeLowCa
  */
 final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetricsHandler {
 	final MicrometerHttpClientMetricsRecorder recorder;
+	// Fixed for the life of the connection; format once and reuse across every recorder dispatch.
+	final String remoteAddressStr;
+	final String proxyAddressStr;
 
 	@SuppressWarnings("NullAway")
 	// Deliberately suppress "NullAway"
@@ -78,11 +81,15 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 			@Nullable Function<String, String> uriTagValue) {
 		super(remoteAddress, proxyAddress, uriTagValue);
 		this.recorder = recorder;
+		this.remoteAddressStr = formatSocketAddress(remoteAddress);
+		this.proxyAddressStr = proxyAddress != null ? formatSocketAddress(proxyAddress) : NA;
 	}
 
 	MicrometerHttpClientMetricsHandler(MicrometerHttpClientMetricsHandler copy) {
 		super(copy);
 		this.recorder = copy.recorder;
+		this.remoteAddressStr = copy.remoteAddressStr;
+		this.proxyAddressStr = copy.proxyAddressStr;
 
 		this.responseTimeHandlerContext = copy.responseTimeHandlerContext;
 		this.responseTimeObservation = copy.responseTimeObservation;
@@ -96,18 +103,10 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 
 	@Override
 	protected void recordRead(Channel channel) {
-		if (proxyAddress == null) {
-			recorder().recordDataReceivedTime(remoteAddress, requireNonNull(path), requireNonNull(method), requireNonNull(status),
-					Duration.ofNanos(System.nanoTime() - dataReceivedTime));
+		recorder.recordDataReceivedTime(remoteAddressStr, proxyAddressStr, requireNonNull(path), requireNonNull(method), requireNonNull(status),
+				Duration.ofNanos(System.nanoTime() - dataReceivedTime));
 
-			recorder().recordDataReceived(remoteAddress, path, dataReceived);
-		}
-		else {
-			recorder().recordDataReceivedTime(remoteAddress, proxyAddress, requireNonNull(path), requireNonNull(method), requireNonNull(status),
-					Duration.ofNanos(System.nanoTime() - dataReceivedTime));
-
-			recorder().recordDataReceived(remoteAddress, proxyAddress, path, dataReceived);
-		}
+		recorder.recordDataReceived(remoteAddressStr, proxyAddressStr, path, dataReceived);
 
 		// Cannot invoke the recorder anymore:
 		// 1. The recorder is one instance only, it is invoked for all requests that can happen
@@ -117,6 +116,14 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 		responseTimeObservation.stop();
 
 		setChannelContext(channel, parentContextView);
+	}
+
+	@Override
+	protected void recordWrite() {
+		recorder.recordDataSentTime(remoteAddressStr, proxyAddressStr, requireNonNull(path), requireNonNull(method),
+				Duration.ofNanos(System.nanoTime() - dataSentTime));
+
+		recorder.recordDataSent(remoteAddressStr, proxyAddressStr, path, dataSent);
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,11 +77,15 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 	}
 
 	void recordDataReceivedTime(SocketAddress remoteAddress, String proxyAddress, String uri, String method, String status, Duration time) {
-		String address = formatSocketAddress(remoteAddress);
-		MeterKey meterKey = new MeterKey(uri, address, proxyAddress, method, status);
+		recordDataReceivedTime(formatSocketAddress(remoteAddress), proxyAddress, uri, method, status, time);
+	}
+
+	// Fast path: the caller already has the formatted address, so it isn't rebuilt per request.
+	void recordDataReceivedTime(String remoteAddress, String proxyAddress, String uri, String method, String status, Duration time) {
+		MeterKey meterKey = new MeterKey(uri, remoteAddress, proxyAddress, method, status);
 		Timer dataReceivedTime = MapUtils.computeIfAbsent(dataReceivedTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_RECEIVED_TIME)
-				                   .tags(HttpClientMeters.DataReceivedTimeTags.REMOTE_ADDRESS.asString(), address,
+				                   .tags(HttpClientMeters.DataReceivedTimeTags.REMOTE_ADDRESS.asString(), remoteAddress,
 				                         HttpClientMeters.DataReceivedTimeTags.PROXY_ADDRESS.asString(), proxyAddress,
 				                         HttpClientMeters.DataReceivedTimeTags.URI.asString(), uri,
 				                         HttpClientMeters.DataReceivedTimeTags.METHOD.asString(), method,
@@ -103,11 +107,14 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 	}
 
 	void recordDataSentTime(SocketAddress remoteAddress, String proxyAddress, String uri, String method, Duration time) {
-		String address = formatSocketAddress(remoteAddress);
-		MeterKey meterKey = new MeterKey(uri, address, proxyAddress, method, null);
+		recordDataSentTime(formatSocketAddress(remoteAddress), proxyAddress, uri, method, time);
+	}
+
+	void recordDataSentTime(String remoteAddress, String proxyAddress, String uri, String method, Duration time) {
+		MeterKey meterKey = new MeterKey(uri, remoteAddress, proxyAddress, method, null);
 		Timer dataSentTime = MapUtils.computeIfAbsent(dataSentTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_SENT_TIME)
-				                   .tags(HttpClientMeters.DataSentTimeTags.REMOTE_ADDRESS.asString(), address,
+				                   .tags(HttpClientMeters.DataSentTimeTags.REMOTE_ADDRESS.asString(), remoteAddress,
 				                         HttpClientMeters.DataSentTimeTags.PROXY_ADDRESS.asString(), proxyAddress,
 				                         HttpClientMeters.DataSentTimeTags.URI.asString(), uri,
 				                         HttpClientMeters.DataSentTimeTags.METHOD.asString(), method)
@@ -152,12 +159,15 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 	}
 
 	void recordDataReceived(SocketAddress remoteAddress, String proxyAddress, String uri, long bytes) {
-		String address = Metrics.formatSocketAddress(remoteAddress);
-		MeterKey meterKey = new MeterKey(uri, address, proxyAddress, null, null);
+		recordDataReceived(Metrics.formatSocketAddress(remoteAddress), proxyAddress, uri, bytes);
+	}
+
+	void recordDataReceived(String remoteAddress, String proxyAddress, String uri, long bytes) {
+		MeterKey meterKey = new MeterKey(uri, remoteAddress, proxyAddress, null, null);
 		DistributionSummary dataReceived = MapUtils.computeIfAbsent(dataReceivedCache, meterKey,
 				key -> filter(DistributionSummary.builder(name() + DATA_RECEIVED)
 				                                 .baseUnit(ChannelMeters.DATA_RECEIVED.getBaseUnit())
-				                                 .tags(ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address,
+				                                 .tags(ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), remoteAddress,
 				                                       ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddress,
 				                                       ChannelMeters.ChannelMetersTags.URI.asString(), uri)
 				                                 .register(REGISTRY)));
@@ -177,12 +187,15 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 	}
 
 	void recordDataSent(SocketAddress remoteAddress, String proxyAddress, String uri, long bytes) {
-		String address = Metrics.formatSocketAddress(remoteAddress);
-		MeterKey meterKey = new MeterKey(uri, address, proxyAddress, null, null);
+		recordDataSent(Metrics.formatSocketAddress(remoteAddress), proxyAddress, uri, bytes);
+	}
+
+	void recordDataSent(String remoteAddress, String proxyAddress, String uri, long bytes) {
+		MeterKey meterKey = new MeterKey(uri, remoteAddress, proxyAddress, null, null);
 		DistributionSummary dataSent = MapUtils.computeIfAbsent(dataSentCache, meterKey,
 				key -> filter(DistributionSummary.builder(name() + DATA_SENT)
 				                                 .baseUnit(ChannelMeters.DATA_SENT.getBaseUnit())
-				                                 .tags(ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address,
+				                                 .tags(ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), remoteAddress,
 				                                       ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddress,
 				                                       ChannelMeters.ChannelMetersTags.URI.asString(), uri)
 				                                 .register(REGISTRY)));


### PR DESCRIPTION
### Summary

With metrics enabled, the client rebuilt per-connection-constant state on every recorded request/event: the remote address was re-formatted on each of the ~5 recorder dispatches, and the TCP-level byte meters were re-resolved (address format + key build + map lookup) on every I/O event.

- Format the remote/proxy address once per MicrometerHttpClientMetricsHandler and pass the strings to fast-path recorder methods; the public SocketAddress recorder API is kept as a thin delegating layer.
- Cache the resolved dataReceived/dataSent DistributionSummary per connection in MicrometerChannelMetricsHandler, guarded to the fixed-address case (unconnected UDP, where the address varies per datagram, keeps the per-event path).

Same meters, same tags, same recorded values; removes redundant per-request and per-event allocation and map lookups. Public API unchanged (japicmp clean).

### Benchmarks

Each rig arm runs the same load generator — client threads issuing HTTP/2 requests against a loopback server
for 180 s after a 30 s warmup — and reports steady-state throughput alongside async-profiler CPU and
allocation samples attributed to the client event-loop threads; arms differ only in the code under test, with
harness, JVM and parameters held fixed.

Rig: H2C loopback, 32 threads, JDK 17, `SimpleMeterRegistry` backing the global composite (metrics on for
both arms). JMH: 2 forks, 5×1s warmup, 5×1s measurement, JDK 17, `-prof gc` for allocation.

| Benchmark | Metric | Before | After | Δ |
|---|---|--:|--:|--:|
| Rig A/B, full client loop under real network I/O | Metrics-wrapper CPU | 4.48% of loop | 2.40% of loop | **−46.4%** |
| Rig A/B, full client loop under real network I/O | Metrics-wrapper allocation | 12,929 alloc samples | 5,645 alloc samples | **−56.3%** |
| Rig A/B, full client loop under real network I/O | Throughput | 94,367 req/s | 96,123 req/s | **+1.9%** |