### PR TITLE
Skip the client response-time Observation when no tracing is configured

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
@@ -17,8 +17,11 @@ package reactor.netty;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.observation.GlobalObservationConvention;
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationFilter;
 import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationPredicate;
 import io.micrometer.observation.ObservationRegistry;
 import io.netty.channel.Channel;
 import io.netty.util.AttributeKey;
@@ -39,12 +42,16 @@ import java.net.SocketAddress;
 public class Metrics {
 	public static final MeterRegistry REGISTRY = io.micrometer.core.instrument.Metrics.globalRegistry;
 	public static final String OBSERVATION_KEY = "micrometer.observation";
-	public static ObservationRegistry OBSERVATION_REGISTRY = ObservationRegistry.create();
+	static final DefaultObservationRegistry DEFAULT_OBSERVATION_REGISTRY = new DefaultObservationRegistry();
+	public static ObservationRegistry OBSERVATION_REGISTRY = DEFAULT_OBSERVATION_REGISTRY;
 	static {
 		OBSERVATION_REGISTRY.observationConfig().observationHandler(
 				new ObservationHandler.FirstMatchingCompositeObservationHandler(
 						new ReactorNettyTimerObservationHandler(REGISTRY),
 						new DefaultMeterObservationHandler(REGISTRY)));
+		// Arm tracking only after the built-in handler is installed, so the baseline registration above
+		// does not count as user customization.
+		DEFAULT_OBSERVATION_REGISTRY.arm();
 	}
 
 
@@ -346,6 +353,23 @@ public class Metrics {
 		return previous;
 	}
 
+	/**
+	 * Whether the built-in metrics recorders must drive their response-time timer through a full
+	 * {@link Observation}. Consumed by Reactor Netty's own recorders; not intended as user API.
+	 * Returns {@code false} only when the {@link ObservationRegistry} is the untouched built-in default
+	 * (no tracing/observation handler, predicate, filter or convention has been registered and the registry
+	 * has not been swapped), in which case the recorder may record the timer directly and skip the per-request
+	 * Observation lifecycle. Any user customization re-engages the lifecycle.
+	 *
+	 * @return {@code true} if the full {@link Observation} lifecycle must run, {@code false} if the timer may
+	 * be recorded directly
+	 * @since 1.4.0
+	 */
+	public static boolean observationLifecycleRequired() {
+		return OBSERVATION_REGISTRY != DEFAULT_OBSERVATION_REGISTRY
+				|| DEFAULT_OBSERVATION_REGISTRY.customized();
+	}
+
 	public static Context updateContext(Context context, Object observation) {
 		return context.hasKey(OBSERVATION_KEY) ? context : context.put(OBSERVATION_KEY, observation);
 	}
@@ -375,5 +399,87 @@ public class Metrics {
 			channel.attr(CONTEXT_VIEW).set(Context.of(OBSERVATION_KEY, observation));
 		}
 		return parentContextView;
+	}
+
+	/**
+	 * The built-in default {@link ObservationRegistry}. Reactor Netty owns the instance so it can tell whether
+	 * anything beyond the built-in meter handler has been registered — {@code SimpleObservationRegistry} only
+	 * exposes that through package-private accessors. The current-observation scope is delegated to a real
+	 * {@code SimpleObservationRegistry} (whose scope {@link ThreadLocal} is static, hence shared across every
+	 * registry instance), so cross-registry current-observation visibility is unchanged.
+	 * <p>Unlike {@code SimpleObservationRegistry} this does not report {@code isNoop()} when its handler list is
+	 * empty; it relies on the static initializer always installing the built-in handler, so it is never no-op.
+	 */
+	static final class DefaultObservationRegistry implements ObservationRegistry {
+		final ObservationRegistry scopeDelegate = ObservationRegistry.create();
+		final TrackedObservationConfig observationConfig = new TrackedObservationConfig();
+
+		void arm() {
+			observationConfig.armed = true;
+		}
+
+		boolean customized() {
+			return observationConfig.customized;
+		}
+
+		@Override
+		public ObservationConfig observationConfig() {
+			return observationConfig;
+		}
+
+		@Override
+		public @Nullable Observation getCurrentObservation() {
+			return scopeDelegate.getCurrentObservation();
+		}
+
+		@Override
+		public Observation.@Nullable Scope getCurrentObservationScope() {
+			return scopeDelegate.getCurrentObservationScope();
+		}
+
+		@Override
+		public void setCurrentObservationScope(Observation.@Nullable Scope current) {
+			scopeDelegate.setCurrentObservationScope(current);
+		}
+	}
+
+	/**
+	 * {@link ObservationRegistry.ObservationConfig} that flags {@code customized} the first time any public
+	 * mutator runs after the registry has been {@code armed} (i.e. after Reactor Netty installed its own
+	 * built-in handler).
+	 */
+	static final class TrackedObservationConfig extends ObservationRegistry.ObservationConfig {
+		volatile boolean armed;
+		volatile boolean customized;
+
+		@Override
+		public ObservationRegistry.ObservationConfig observationHandler(ObservationHandler<?> handler) {
+			markCustomized();
+			return super.observationHandler(handler);
+		}
+
+		@Override
+		public ObservationRegistry.ObservationConfig observationPredicate(ObservationPredicate observationPredicate) {
+			markCustomized();
+			return super.observationPredicate(observationPredicate);
+		}
+
+		@Override
+		public ObservationRegistry.ObservationConfig observationFilter(ObservationFilter observationFilter) {
+			markCustomized();
+			return super.observationFilter(observationFilter);
+		}
+
+		@Override
+		public ObservationRegistry.ObservationConfig observationConvention(GlobalObservationConvention<?> observationConvention) {
+			markCustomized();
+			return super.observationConvention(observationConvention);
+		}
+
+		private void markCustomized() {
+			if (armed) {
+				customized = true;
+			}
+		}
 	}
 }

--- a/reactor-netty-core/src/test/java/reactor/netty/MetricsObservationLifecycleTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/MetricsObservationLifecycleTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link Metrics#observationLifecycleRequired()}, which gates the built-in recorders' fast path that
+ * records the response-time timer directly instead of through a full {@link io.micrometer.observation.Observation}.
+ * <p>Methods are ordered because customizing the default registry is a one-way, JVM-global change: the
+ * "pristine default" assertion must run before it.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class MetricsObservationLifecycleTest {
+
+	@Test
+	@Order(0)
+	void trackedConfigOverridesEveryPublicObservationConfigMutator() {
+		// TrackedObservationConfig detects customization only through the fluent mutators it overrides. If a
+		// Micrometer upgrade adds a new one, this must fail until the matching override is added — not stay
+		// green while the new mutator silently bypasses detection.
+		Set<String> fluentMutators = Arrays.stream(ObservationRegistry.ObservationConfig.class.getMethods())
+				.filter(m -> m.getReturnType() == ObservationRegistry.ObservationConfig.class)
+				.map(Method::getName)
+				.collect(Collectors.toSet());
+		Set<String> trackedOverrides = Arrays.stream(Metrics.TrackedObservationConfig.class.getDeclaredMethods())
+				.map(Method::getName)
+				.collect(Collectors.toSet());
+		assertThat(trackedOverrides).containsAll(fluentMutators);
+	}
+
+	@Test
+	@Order(1)
+	void everyMutatorMarksCustomizedOnceArmed() {
+		List<Consumer<Metrics.TrackedObservationConfig>> mutators = Arrays.asList(
+				config -> config.observationHandler(context -> true),
+				config -> config.observationPredicate((name, context) -> true),
+				config -> config.observationFilter(context -> context),
+				config -> config.observationConvention(context -> true));
+
+		for (Consumer<Metrics.TrackedObservationConfig> mutate : mutators) {
+			Metrics.TrackedObservationConfig config = new Metrics.TrackedObservationConfig();
+			mutate.accept(config);
+			assertThat(config.customized).as("unarmed mutator call is not customization").isFalse();
+
+			config.armed = true;
+			mutate.accept(config);
+			assertThat(config.customized).as("armed mutator call marks the config customized").isTrue();
+		}
+	}
+
+	@Test
+	@Order(2)
+	void pristineDefaultRegistryDoesNotRequireObservationLifecycle() {
+		assertThat(Metrics.OBSERVATION_REGISTRY).isSameAs(Metrics.DEFAULT_OBSERVATION_REGISTRY);
+		assertThat(Metrics.observationLifecycleRequired()).isFalse();
+	}
+
+	@Test
+	@Order(3)
+	void swappedRegistryRequiresObservationLifecycle() {
+		ObservationRegistry previous = Metrics.OBSERVATION_REGISTRY;
+		try {
+			Metrics.observationRegistry(ObservationRegistry.create());
+			assertThat(Metrics.observationLifecycleRequired()).isTrue();
+		}
+		finally {
+			Metrics.observationRegistry(previous);
+		}
+	}
+
+	@Test
+	@Order(4)
+	void noopRegistryRequiresObservationLifecycle() {
+		ObservationRegistry previous = Metrics.OBSERVATION_REGISTRY;
+		try {
+			Metrics.observationRegistry(ObservationRegistry.NOOP);
+			assertThat(Metrics.observationLifecycleRequired()).isTrue();
+		}
+		finally {
+			Metrics.observationRegistry(previous);
+		}
+	}
+
+	@Test
+	@Order(5)
+	void customizedDefaultRegistryRequiresObservationLifecycle() {
+		// Registering any handler on the default registry marks it customized for the rest of the JVM,
+		// so the bypass disengages. This is intentionally the last test — it cannot be undone.
+		Metrics.OBSERVATION_REGISTRY.observationConfig().observationHandler(context -> true);
+		assertThat(Metrics.observationLifecycleRequired()).isTrue();
+	}
+}

--- a/reactor-netty-core/src/test/java/reactor/netty/MetricsObservationLifecycleTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/MetricsObservationLifecycleTest.java
@@ -44,14 +44,17 @@ class MetricsObservationLifecycleTest {
 	void trackedConfigOverridesEveryPublicObservationConfigMutator() {
 		// TrackedObservationConfig detects customization only through the fluent mutators it overrides. If a
 		// Micrometer upgrade adds a new one, this must fail until the matching override is added — not stay
-		// green while the new mutator silently bypasses detection.
+		// green while the new mutator silently bypasses detection. Match on full signature, not name: an
+		// overload of an existing mutator is just as much a hole as a brand-new one.
 		Set<String> fluentMutators = Arrays.stream(ObservationRegistry.ObservationConfig.class.getMethods())
 				.filter(m -> m.getReturnType() == ObservationRegistry.ObservationConfig.class)
-				.map(Method::getName)
+				.map(MetricsObservationLifecycleTest::signature)
 				.collect(Collectors.toSet());
 		Set<String> trackedOverrides = Arrays.stream(Metrics.TrackedObservationConfig.class.getDeclaredMethods())
-				.map(Method::getName)
+				.map(MetricsObservationLifecycleTest::signature)
 				.collect(Collectors.toSet());
+		// A covariant return type upstream would empty the filter and make containsAll vacuously true.
+		assertThat(fluentMutators).as("fluent mutators discovered on ObservationConfig").isNotEmpty();
 		assertThat(trackedOverrides).containsAll(fluentMutators);
 	}
 
@@ -115,5 +118,9 @@ class MetricsObservationLifecycleTest {
 		// so the bypass disengages. This is intentionally the last test — it cannot be undone.
 		Metrics.OBSERVATION_REGISTRY.observationConfig().observationHandler(context -> true);
 		assertThat(Metrics.observationLifecycleRequired()).isTrue();
+	}
+
+	static String signature(Method method) {
+		return method.getName() + Arrays.toString(method.getParameterTypes());
 	}
 }

--- a/reactor-netty-http/build.gradle
+++ b/reactor-netty-http/build.gradle
@@ -181,6 +181,7 @@ dependencies {
 	contextPropagationTestImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
 	contextPropagationTestImplementation "ch.qos.logback:logback-classic:$logbackVersion"
 	contextPropagationTestImplementation "io.micrometer:context-propagation:$contextPropagationVersion"
+	contextPropagationTestImplementation "io.micrometer:micrometer-core:$micrometerVersion"
 	contextPropagationTestImplementation "io.netty:netty-pkitesting:$nettyVersion"
 	contextPropagationTestRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformLauncherVersion"
 	contextPropagationTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/reactor-netty-http/src/contextPropagationTest/java/reactor/netty/MetricsObservationBypassTest.java
+++ b/reactor-netty-http/src/contextPropagationTest/java/reactor/netty/MetricsObservationBypassTest.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty;
+
+import io.micrometer.context.ContextRegistry;
+import io.micrometer.context.ContextSnapshot;
+import io.micrometer.context.ThreadLocalAccessor;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.LastHttpContent;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.server.HttpServer;
+import reactor.util.context.ContextView;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.netty.ReactorNetty.getChannelContext;
+
+/**
+ * Deterministic coverage for the client response-time Observation bypass. Runs in the
+ * {@code contextPropagationTest} JVM, which never customizes the default {@link ObservationRegistry}, so the
+ * bypass is reliably active — unlike the shared {@code test} JVM, where {@code ObservabilitySmokeTest}
+ * permanently customizes it and the path taken would be class-order dependent.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class MetricsObservationBypassTest {
+
+	static final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+	DisposableServer server;
+
+	@BeforeAll
+	static void addRegistry() {
+		// reactor-netty's REGISTRY is the global composite; without a child, record() fans to nothing.
+		io.micrometer.core.instrument.Metrics.addRegistry(meterRegistry);
+	}
+
+	@AfterAll
+	static void removeRegistry() {
+		io.micrometer.core.instrument.Metrics.removeRegistry(meterRegistry);
+		meterRegistry.close();
+	}
+
+	@BeforeEach
+	void bindServer() {
+		server = HttpServer.create()
+		                   .port(0)
+		                   .handle((in, out) -> out.send(in.receive().retain()))
+		                   .bindNow();
+	}
+
+	@AfterEach
+	void stopServer() {
+		if (server != null) {
+			server.disposeNow();
+		}
+	}
+
+	@Test
+	@Order(1)
+	void metricsOnlyRecordsResponseTimeAndLeavesNoObservationInChannelContext() {
+		assertThat(Metrics.observationLifecycleRequired())
+				.as("pristine default registry engages the bypass")
+				.isFalse();
+
+		AtomicReference<ContextView> channelContext = new AtomicReference<>();
+
+		String response =
+				HttpClient.create()
+				          .port(server.port())
+				          .metrics(true, Function.identity())
+				          .post()
+				          .uri("/bypass")
+				          .send((req, out) -> out.withConnection(conn -> conn.addHandlerLast(
+				                          new ChannelContextAfterReadCapturingHandler(channelContext)))
+				                                 .sendString(Mono.just("hello")))
+				          .responseContent()
+				          .aggregate()
+				          .asString()
+				          .block(Duration.ofSeconds(10));
+
+		assertThat(response).isEqualTo("hello");
+
+		Timer responseTime =
+				meterRegistry.find("reactor.netty.http.client.response.time")
+				             .tag("uri", "/bypass")
+				             .tag("method", "POST")
+				             .tag("status", "200")
+				             .timer();
+		assertThat(responseTime).as("response.time recorded on the bypass path").isNotNull();
+		assertThat(responseTime.count()).isEqualTo(1);
+
+		// The bypass must not write the response-time observation into the channel context.
+		ContextView captured = channelContext.get();
+		assertThat(captured == null || !captured.hasKey(Metrics.OBSERVATION_KEY))
+				.as("bypass leaves no observation in the channel context")
+				.isTrue();
+	}
+
+	@Test
+	@Order(2)
+	void tracingReEngagesWhenAnObservationHandlerIsConfigured() {
+		RecordingObservationHandler handler = new RecordingObservationHandler();
+		ObservationRegistry traced = ObservationRegistry.create();
+		traced.observationConfig().observationHandler(handler);
+		// Swap (not in-place customization) so the default registry stays pristine for other tests in this JVM.
+		ObservationRegistry previous = Metrics.observationRegistry(traced);
+		try {
+			assertThat(Metrics.observationLifecycleRequired())
+					.as("a swapped-in registry disengages the bypass")
+					.isTrue();
+
+			String response =
+					HttpClient.create()
+					          .port(server.port())
+					          .metrics(true, Function.identity())
+					          .post()
+					          .uri("/traced")
+					          .send(ByteBufMono.fromString(Mono.just("hello")))
+					          .responseContent()
+					          .aggregate()
+					          .asString()
+					          .block(Duration.ofSeconds(10));
+
+			assertThat(response).isEqualTo("hello");
+			assertThat(handler.started).as("Observation lifecycle re-engaged (onStart)").hasPositiveValue();
+			assertThat(handler.stopped).as("Observation lifecycle re-engaged (onStop)").hasPositiveValue();
+		}
+		finally {
+			Metrics.observationRegistry(previous);
+		}
+	}
+
+	@Test
+	@Order(3)
+	void tracedObservationIsPoppedFromChannelContextByRecordRead() {
+		RecordingObservationHandler handler = new RecordingObservationHandler();
+		ObservationRegistry traced = ObservationRegistry.create();
+		traced.observationConfig().observationHandler(handler);
+		ObservationRegistry previous = Metrics.observationRegistry(traced);
+		AtomicReference<ContextView> channelContextAfterRecordRead = new AtomicReference<>();
+		try {
+			assertThat(Metrics.observationLifecycleRequired())
+					.as("a swapped-in registry disengages the bypass")
+					.isTrue();
+
+			// A bodiless GET: reactor-netty's send-path (MonoSendMany) is what seeds the Reactor subscriber
+			// Context with a non-empty entry (its onDiscard hook), which is what makes
+			// DefaultPooledConnectionProvider.onNext write a parent context onto the channel at acquire time.
+			// Without a body, that Context is genuinely empty, onNext skips the write, and parentContextView
+			// (captured in startWrite) is null — the case recordRead must still correctly reset.
+			String response =
+					HttpClient.create()
+					          .port(server.port())
+					          .metrics(true, Function.identity())
+					          .get()
+					          .uri("/traced-pop")
+					          .responseConnection((res, conn) -> {
+					              conn.addHandlerLast(new ChannelContextAfterReadCapturingHandler(channelContextAfterRecordRead));
+					              return conn.inbound().receive().aggregate().asString();
+					          })
+					          .blockLast(Duration.ofSeconds(10));
+
+			assertThat(response).as("bodiless GET completes normally").isNullOrEmpty();
+			assertThat(handler.stopped).as("Observation lifecycle ran").hasPositiveValue();
+
+			// recordRead must pop its own (now-stopped) Observation from the channel context immediately —
+			// not rely on DefaultPooledConnectionProvider's later release() cleanup to eventually get to it.
+			ContextView captured = channelContextAfterRecordRead.get();
+			assertThat(captured == null || !captured.hasKey(Metrics.OBSERVATION_KEY))
+					.as("recordRead restores the channel context before the connection is released")
+					.isTrue();
+		}
+		finally {
+			Metrics.observationRegistry(previous);
+		}
+	}
+
+	@Test
+	@Order(4)
+	void bypassDoesNotEraseAlreadyPresentChannelContext() {
+		ContextRegistry registry = ContextRegistry.getInstance();
+		registry.registerThreadLocalAccessor(new TestThreadLocalAccessor());
+		AtomicReference<String> restoredValue = new AtomicReference<>();
+		try {
+			assertThat(Metrics.observationLifecycleRequired())
+					.as("pristine default registry engages the bypass")
+					.isFalse();
+
+			TestThreadLocalHolder.value("propagated");
+
+			String response =
+					HttpClient.create()
+					          .port(server.port())
+					          .metrics(true, Function.identity())
+					          // Seeds a non-empty Reactor Context so DefaultPooledConnectionProvider.onNext
+					          // writes the propagated snapshot onto the channel at connection-acquire time.
+					          .mapConnect(mono -> mono.contextWrite(ctx ->
+					                  ContextSnapshot.captureAll(registry).updateContext(ctx)))
+					          .post()
+					          .uri("/bypass-propagation")
+					          .send((req, out) -> out.withConnection(conn -> conn.addHandlerLast(
+					                          new PropagationCapturingHandler(restoredValue)))
+					                                 .sendString(Mono.just("hello")))
+					          .responseContent()
+					          .aggregate()
+					          .asString()
+					          .block(Duration.ofSeconds(10));
+
+			assertThat(response).isEqualTo("hello");
+			assertThat(restoredValue.get())
+					.as("the bypass path must not erase the channel context DefaultPooledConnectionProvider " +
+							"populated from context propagation, even though it never writes to that attribute itself")
+					.isEqualTo("propagated");
+		}
+		finally {
+			TestThreadLocalHolder.reset();
+			registry.removeThreadLocalAccessor(TestThreadLocalAccessor.KEY);
+		}
+	}
+
+	static final class ChannelContextAfterReadCapturingHandler extends ChannelInboundHandlerAdapter {
+		final AtomicReference<ContextView> captured;
+
+		ChannelContextAfterReadCapturingHandler(AtomicReference<ContextView> captured) {
+			this.captured = captured;
+		}
+
+		@Override
+		public boolean isSharable() {
+			return false;
+		}
+
+		@Override
+		public void channelRead(ChannelHandlerContext ctx, Object msg) {
+			// AbstractHttpClientMetricsHandler calls recordRead(), then reset(), then fireChannelRead() — all
+			// before this handler (added last) sees the message, so this observes exactly what recordRead left
+			// in the channel context, before the connection pool's own release() cleanup runs.
+			if (msg instanceof LastHttpContent) {
+				captured.set(getChannelContext(ctx.channel()));
+			}
+			ctx.fireChannelRead(msg);
+		}
+	}
+
+	static final class RecordingObservationHandler implements ObservationHandler<Observation.Context> {
+		final AtomicInteger started = new AtomicInteger();
+		final AtomicInteger stopped = new AtomicInteger();
+
+		@Override
+		public void onStart(Observation.Context context) {
+			started.incrementAndGet();
+		}
+
+		@Override
+		public void onStop(Observation.Context context) {
+			stopped.incrementAndGet();
+		}
+
+		@Override
+		public boolean supportsContext(Observation.Context context) {
+			return true;
+		}
+	}
+
+	static final class PropagationCapturingHandler extends ChannelInboundHandlerAdapter {
+		final AtomicReference<String> restored;
+
+		PropagationCapturingHandler(AtomicReference<String> restored) {
+			this.restored = restored;
+		}
+
+		@Override
+		public boolean isSharable() {
+			return false;
+		}
+
+		@Override
+		public void channelRead(ChannelHandlerContext ctx, Object msg) {
+			// AbstractHttpClientMetricsHandler calls recordRead(), then reset(), then fireChannelRead() — all
+			// before this handler (added last) sees the message, so this observes exactly what recordRead left
+			// in the channel context.
+			if (msg instanceof LastHttpContent) {
+				try (ContextSnapshot.Scope scope = ContextSnapshot.setAllThreadLocalsFrom(ctx.channel())) {
+					restored.set(TestThreadLocalHolder.value());
+				}
+			}
+			ctx.fireChannelRead(msg);
+		}
+	}
+
+	static final class TestThreadLocalAccessor implements ThreadLocalAccessor<String> {
+		static final String KEY = "metricsObservationBypassTest";
+
+		@Override
+		public Object key() {
+			return KEY;
+		}
+
+		@Override
+		public String getValue() {
+			return TestThreadLocalHolder.value();
+		}
+
+		@Override
+		public void setValue(String value) {
+			TestThreadLocalHolder.value(value);
+		}
+
+		@Override
+		public void reset() {
+			TestThreadLocalHolder.reset();
+		}
+	}
+
+	static final class TestThreadLocalHolder {
+		static final ThreadLocal<String> holder = new ThreadLocal<>();
+
+		static void reset() {
+			holder.remove();
+		}
+
+		static String value() {
+			return holder.get();
+		}
+
+		static void value(String value) {
+			holder.set(value);
+		}
+	}
+}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
@@ -36,9 +36,9 @@ import java.util.function.Supplier;
 import static java.util.Objects.requireNonNull;
 import static reactor.netty.Metrics.NA;
 import static reactor.netty.Metrics.OBSERVATION_REGISTRY;
-import static reactor.netty.Metrics.RESPONSE_TIME;
 import static reactor.netty.Metrics.UNKNOWN;
 import static reactor.netty.Metrics.formatSocketAddress;
+import static reactor.netty.Metrics.observationLifecycleRequired;
 import static reactor.netty.Metrics.updateChannelContext;
 import static reactor.netty.ReactorNetty.setChannelContext;
 import static reactor.netty.http.client.HttpClientObservations.ResponseTimeHighCardinalityTags.HTTP_STATUS_CODE;
@@ -108,14 +108,24 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 
 		recorder.recordDataReceived(remoteAddressStr, proxyAddressStr, path, dataReceived);
 
-		// Cannot invoke the recorder anymore:
-		// 1. The recorder is one instance only, it is invoked for all requests that can happen
-		// 2. The recorder does not have knowledge about request lifecycle
-		//
-		// Move the implementation from the recorder here
-		responseTimeObservation.stop();
+		if (responseTimeObservation != null) {
+			// Cannot invoke the recorder anymore:
+			// 1. The recorder is one instance only, it is invoked for all requests that can happen
+			// 2. The recorder does not have knowledge about request lifecycle
+			//
+			// Move the implementation from the recorder here
+			responseTimeObservation.stop();
 
-		setChannelContext(channel, parentContextView);
+			setChannelContext(channel, parentContextView);
+		}
+		else {
+			// startWrite skipped the Observation (no tracing consumer configured); record the timer directly.
+			Timer responseTime = recorder.getResponseTimeTimer(recorder.responseTimeName,
+					remoteAddressStr, proxyAddressStr, path, method, status);
+			if (responseTime != null) {
+				responseTime.record(Duration.ofNanos(System.nanoTime() - dataSentTime));
+			}
+		}
 	}
 
 	@Override
@@ -127,11 +137,15 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 	}
 
 	@Override
+	protected void reset() {
+		super.reset();
+		clearResponseTimeState();
+	}
+
 	@SuppressWarnings("NullAway")
 	// Deliberately suppress "NullAway"
 	// This is a lazy initialization
-	protected void reset() {
-		super.reset();
+	private void clearResponseTimeState() {
 		responseTimeHandlerContext = null;
 		responseTimeObservation = null;
 		parentContextView = null;
@@ -142,8 +156,10 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 	protected void startRead(HttpResponse msg) {
 		super.startRead(msg);
 
-		responseTimeHandlerContext.setResponse(msg);
-		responseTimeHandlerContext.status = requireNonNull(status);
+		if (responseTimeHandlerContext != null) {
+			responseTimeHandlerContext.setResponse(msg);
+			responseTimeHandlerContext.status = requireNonNull(status);
+		}
 	}
 
 	// writing the request
@@ -151,10 +167,21 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 	protected void startWrite(HttpRequest msg, Channel channel) {
 		super.startWrite(msg, channel);
 
-		responseTimeHandlerContext = new ResponseTimeHandlerContext(recorder, msg, requireNonNull(path), remoteAddress, proxyAddress);
-		responseTimeObservation = Observation.createNotStarted(recorder.name() + RESPONSE_TIME, responseTimeHandlerContext, OBSERVATION_REGISTRY);
-		parentContextView = updateChannelContext(channel, responseTimeObservation);
-		responseTimeObservation.start();
+		// Run the full Observation lifecycle only when a tracing consumer is configured; otherwise recordRead
+		// records the response-time timer directly. Both paths tag the remote with remoteAddressStr, so the
+		// recorded meter is identical either way.
+		if (observationLifecycleRequired()) {
+			responseTimeHandlerContext = new ResponseTimeHandlerContext(recorder, msg, requireNonNull(path), remoteAddressStr, remoteAddress, proxyAddress);
+			responseTimeObservation = Observation.createNotStarted(recorder.responseTimeName, responseTimeHandlerContext, OBSERVATION_REGISTRY);
+			parentContextView = updateChannelContext(channel, responseTimeObservation);
+			responseTimeObservation.start();
+		}
+		else {
+			// Clear any observation a prior request left set: recordRead uses a null observation as the
+			// "bypass" latch, and reset() is skipped when a recorder call throws, so stale state here would
+			// make this request stop the previous observation and drop its own timer.
+			clearResponseTimeState();
+		}
 	}
 
 	/*
@@ -170,6 +197,8 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 		static final String TYPE = "client";
 
 		final String method;
+		// Remote-address tag for the response-time meter; shares formatting with every other client meter.
+		final String remoteAddressStr;
 		final String netPeerName;
 		final String netPeerPort;
 		final String path;
@@ -180,10 +209,11 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 		String status = UNKNOWN;
 
 		ResponseTimeHandlerContext(MicrometerHttpClientMetricsRecorder recorder, HttpRequest request, String path,
-				SocketAddress remoteAddress, @Nullable SocketAddress proxyAddress) {
+				String remoteAddressStr, SocketAddress remoteAddress, @Nullable SocketAddress proxyAddress) {
 			super((carrier, key, value) -> Objects.requireNonNull(carrier).headers().set(key, value));
 			this.recorder = recorder;
 			this.method = request.method().name();
+			this.remoteAddressStr = remoteAddressStr;
 			if (remoteAddress instanceof InetSocketAddress) {
 				InetSocketAddress address = (InetSocketAddress) remoteAddress;
 				this.netPeerName = address.getHostString();
@@ -206,7 +236,7 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 
 		@Override
 		public @Nullable Timer getTimer() {
-			return recorder.getResponseTimeTimer(recorder.name() + RESPONSE_TIME, netPeerName + ":" + netPeerPort, proxyAddress == null ? NA : proxyAddress, path, method, status);
+			return recorder.getResponseTimeTimer(recorder.responseTimeName, remoteAddressStr, proxyAddress == null ? NA : proxyAddress, path, method, status);
 		}
 
 		@Override
@@ -218,7 +248,7 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues() {
-			return KeyValues.of(METHOD.asString(), method, REMOTE_ADDRESS.asString(), netPeerName + ":" + netPeerPort,
+			return KeyValues.of(METHOD.asString(), method, REMOTE_ADDRESS.asString(), remoteAddressStr,
 					PROXY_ADDRESS.asString(), proxyAddress == null ? NA : proxyAddress,
 					STATUS.asString(), status, URI.asString(), path);
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
@@ -62,8 +62,12 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 
 	private final ConcurrentMap<MeterKey, Counter> errorsCache = new ConcurrentHashMap<>();
 
+	// Constant per recorder; precomputed to avoid rebuilding the response-time meter name every request.
+	final String responseTimeName;
+
 	private MicrometerHttpClientMetricsRecorder() {
 		super(HTTP_CLIENT_PREFIX, "http", false);
+		this.responseTimeName = name() + RESPONSE_TIME;
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
@@ -125,7 +125,7 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 
 	@Override
 	public void recordResponseTime(SocketAddress remoteAddress, String uri, String method, String status, Duration time) {
-		Timer responseTime = getResponseTimeTimer(name() + RESPONSE_TIME, formatSocketAddress(remoteAddress), NA, uri, method, status);
+		Timer responseTime = getResponseTimeTimer(responseTimeName, formatSocketAddress(remoteAddress), NA, uri, method, status);
 		if (responseTime != null) {
 			responseTime.record(time);
 		}
@@ -133,7 +133,7 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 
 	@Override
 	public void recordResponseTime(SocketAddress remoteAddress, SocketAddress proxyAddress, String uri, String method, String status, Duration time) {
-		Timer responseTime = getResponseTimeTimer(name() + RESPONSE_TIME, formatSocketAddress(remoteAddress), formatSocketAddress(proxyAddress), uri, method, status);
+		Timer responseTime = getResponseTimeTimer(responseTimeName, formatSocketAddress(remoteAddress), formatSocketAddress(proxyAddress), uri, method, status);
 		if (responseTime != null) {
 			responseTime.record(time);
 		}


### PR DESCRIPTION
## Change

With `.metrics(true)` and no tracing configured, the client runs a full Micrometer `Observation` per request to
record one timer. Nothing consumes it. It is 43.4% of the allocation that enabling metrics adds to the client
event loop.

When the `ObservationRegistry` is the untouched built-in default, `startWrite` now skips the `Observation` and
`recordRead` records the `response.time` `Timer` directly. Same meter, name, tags and value.

Deciding "untouched" needs Reactor Netty to own the registry: `ObservationConfig`'s accessors are
package-private, and the documented tracing setup mutates the default registry in place rather than replacing
it, so registry identity alone can't answer it. `DEFAULT_OBSERVATION_REGISTRY` tracks whether any handler,
predicate, filter or convention was registered after Reactor Netty installed its own. Registering any of them,
or assigning `OBSERVATION_REGISTRY`, re-engages the full lifecycle.

The response-time meter name is also precomputed on the recorder rather than rebuilt twice per request.

## Behaviour

Two visible deltas, both intended:

- With the untouched default registry there is no longer an `Observation` on the channel context, so code
  reading `OBSERVATION_KEY` off a client channel finds nothing. Registering any handler, predicate, filter
  or convention — or assigning `OBSERVATION_REGISTRY` — restores it.
- The `REMOTE_ADDRESS` tag on `response.time` now uses `formatSocketAddress`, like every other client meter,
  instead of `netPeerName + ":" + netPeerPort`. For an `InetSocketAddress` the two are identical. For other
  remotes — a domain socket, say — the tag loses the trailing `:` the old form left when the port was empty.
  That is a meter-identity change for those users. The `NET_PEER_NAME` and `NET_PEER_PORT` high-cardinality
  tags are unchanged.

## Benchmarks

Rig: H2C loopback, 32 threads, JDK 17, 180 s after a 30 s warmup, `SimpleMeterRegistry` on the global
composite, metrics on in both arms, back-to-back in one session. Allocation sampled at a fixed `--alloc 512k`
interval. 

| Benchmark | Metric | Before | After | Δ |
|---|---|--:|--:|--:|
| Rig A/B, full client loop | Client-loop allocation | 102,193 samples | 92,270 samples | **−9.7%** |
| Rig A/B, full client loop | Throughput | 94,923 req/s | 97,671 / 98,719 req/s | **+3–4%** |
