### PR TITLE
Add CheckReturnValue and CanIgnoreReturnValue annotations

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/lang/CanIgnoreReturnValue.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/lang/CanIgnoreReturnValue.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.lang;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies that the return value of the annotated method can be ignored.
+ *
+ * <p>This annotation overrides an enclosing {@link CheckReturnValue} annotation:
+ * when a type is annotated with {@link CheckReturnValue}, a method within that type
+ * can be annotated with this annotation to indicate that its return value is only
+ * <i>additional</i> information and callers are free to discard it. Static analysis
+ * tools such as Error Prone and IntelliJ IDEA apply the nearest annotation:
+ * a method-level annotation wins over a type-level one.
+ *
+ * <p>Inspired by {@code com.google.errorprone.annotations.CanIgnoreReturnValue} and
+ * {@code org.assertj.core.annotations.CanIgnoreReturnValue}, this variant has been
+ * introduced in the {@code reactor.netty.lang} package to avoid requiring an extra
+ * dependency, while still following similar semantics.
+ *
+ * @author Filip Hrisafov
+ * @since 1.4.0
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR})
+public @interface CanIgnoreReturnValue {
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/lang/CheckReturnValue.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/lang/CheckReturnValue.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.lang;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies that the method return value must be used.
+ *
+ * <p>Inspired by {@code org.jetbrains.annotations.CheckReturnValue} and
+ * {@code org.springframework.lang.CheckReturnValue}, this variant
+ * has been introduced in the {@code reactor.netty.lang} package to avoid
+ * requiring an extra dependency, while still following similar semantics.
+ *
+ * <p>This annotation should not be used if the return value of the method
+ * provides only <i>additional</i> information. For example, the main purpose
+ * of {@link java.util.Collection#add(Object)} is to modify the collection
+ * and the return value is only interesting when adding an element to a set,
+ * to see if the set already contained that element before.
+ *
+ * <p>When used on a type, the annotation applies to all constructors and all
+ * methods that do not return {@code void}.
+ *
+ * @author Filip Hrisafov
+ * @since 1.4.0
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR})
+public @interface CheckReturnValue {
+}

--- a/reactor-netty-core/src/main/java/reactor/netty/lang/package-info.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/lang/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Common annotations with language-level semantics: nullability as well as JDK API indications.
+ * These annotations sit at the lowest level of Reactor Netty's package dependency arrangement, even
+ * lower than {@code reactor.netty.internal.util}, with no Reactor Netty-specific concepts implied.
+ *
+ * <p>Used descriptively within the codebase. Can be validated by build-time tools
+ * (for example, FindBugs or Animal Sniffer), alternative JVM languages (for example, Kotlin), as well as IDEs
+ * (for example, IntelliJ IDEA or Eclipse with corresponding project setup).
+ */
+@NullMarked
+package reactor.netty.lang;
+
+import org.jspecify.annotations.NullMarked;

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/ClientTransport.java
@@ -32,6 +32,7 @@ import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
+import reactor.netty.lang.CheckReturnValue;
 import reactor.netty.resources.LoopResources;
 
 /**
@@ -43,6 +44,7 @@ import reactor.netty.resources.LoopResources;
  * @author Violeta Georgieva
  * @since 1.0.0
  */
+@CheckReturnValue
 public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 		CONF extends ClientTransportConfig<CONF>>
 		extends Transport<T, CONF> {
@@ -146,6 +148,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @param doOnConnect a consumer observing connect events
 	 * @return a new {@link ClientTransport} reference
 	 */
+	@CheckReturnValue
 	public T doOnConnect(Consumer<? super CONF> doOnConnect) {
 		Objects.requireNonNull(doOnConnect, "doOnConnect");
 		T dup = duplicate();
@@ -161,6 +164,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @param doOnConnected a consumer observing connected events
 	 * @return a new {@link ClientTransport} reference
 	 */
+	@CheckReturnValue
 	public T doOnConnected(Consumer<? super Connection> doOnConnected) {
 		Objects.requireNonNull(doOnConnected, "doOnConnected");
 		T dup = duplicate();
@@ -176,6 +180,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @param doOnDisconnected a consumer observing disconnected events
 	 * @return a new {@link ClientTransport} reference
 	 */
+	@CheckReturnValue
 	public T doOnDisconnected(Consumer<? super Connection> doOnDisconnected) {
 		Objects.requireNonNull(doOnDisconnected, "doOnDisconnected");
 		T dup = duplicate();
@@ -192,6 +197,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @return a new {@link ClientTransport} reference
 	 * @since 1.0.1
 	 */
+	@CheckReturnValue
 	public final T doOnResolve(Consumer<? super Connection> doOnResolve) {
 		Objects.requireNonNull(doOnResolve, "doOnResolve");
 		T dup = duplicate();
@@ -208,6 +214,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @return a new {@link ClientTransport} reference
 	 * @since 1.0.1
 	 */
+	@CheckReturnValue
 	public final T doAfterResolve(BiConsumer<? super Connection, ? super SocketAddress> doAfterResolve) {
 		Objects.requireNonNull(doAfterResolve, "doAfterResolve");
 		T dup = duplicate();
@@ -225,6 +232,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @return a new {@link ClientTransport} reference
 	 * @since 1.0.1
 	 */
+	@CheckReturnValue
 	public final T doOnResolveError(BiConsumer<? super Connection, ? super Throwable> doOnResolveError) {
 		Objects.requireNonNull(doOnResolveError, "doOnResolveError");
 		T dup = duplicate();
@@ -241,6 +249,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @param host the host to connect to
 	 * @return a new {@link ClientTransport} reference
 	 */
+	@CheckReturnValue
 	public T host(String host) {
 		Objects.requireNonNull(host, "host");
 		return remoteAddress(() -> AddressUtils.updateHost(configuration().remoteAddress(), host));
@@ -254,6 +263,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 *
 	 * @return a new {@link ClientTransport} reference
 	 */
+	@CheckReturnValue
 	public T noProxy() {
 		if (configuration().hasProxy()) {
 			T dup = duplicate();
@@ -275,6 +285,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @param port the port to connect to
 	 * @return a new {@link ClientTransport} reference
 	 */
+	@CheckReturnValue
 	public T port(int port) {
 		return remoteAddress(() -> AddressUtils.updatePort(configuration().remoteAddress(), port));
 	}
@@ -294,6 +305,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @see #resolver(AddressResolverGroup)
 	 * @see #resolver(Consumer)
 	 */
+	@CheckReturnValue
 	public T proxy(Consumer<? super ProxyProvider.TypeSpec> proxyOptions) {
 		Objects.requireNonNull(proxyOptions, "proxyOptions");
 		ProxyProvider.Build builder = (ProxyProvider.Build) ProxyProvider.builder();
@@ -340,6 +352,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @see #resolver(AddressResolverGroup)
 	 * @see #resolver(Consumer)
 	 */
+	@CheckReturnValue
 	public final T proxyWithSystemProperties() {
 		return proxyWithSystemProperties(System.getProperties());
 	}
@@ -360,6 +373,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @param remoteAddressSupplier A supplier of the address to connect to.
 	 * @return a new {@link ClientTransport}
 	 */
+	@CheckReturnValue
 	public T remoteAddress(Supplier<? extends SocketAddress> remoteAddressSupplier) {
 		Objects.requireNonNull(remoteAddressSupplier, "remoteAddressSupplier");
 		T dup = duplicate();
@@ -375,6 +389,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @return a new {@link ClientTransport}
 	 * @since 1.2.5
 	 */
+	@CheckReturnValue
 	public T resolvedAddressesSelector(ResolvedAddressSelector<? super CONF> resolvedAddressesSelector) {
 		Objects.requireNonNull(resolvedAddressesSelector, "resolvedAddressesSelector");
 		T dup = duplicate();
@@ -394,6 +409,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @param resolver the new {@link AddressResolverGroup}
 	 * @return a new {@link ClientTransport} reference
 	 */
+	@CheckReturnValue
 	public T resolver(AddressResolverGroup<?> resolver) {
 		Objects.requireNonNull(resolver, "resolver");
 		T dup = duplicate();
@@ -414,6 +430,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @param nameResolverSpec the name resolver callback
 	 * @return a new {@link ClientTransport} reference
 	 */
+	@CheckReturnValue
 	public T resolver(Consumer<NameResolverProvider.NameResolverSpec> nameResolverSpec) {
 		Objects.requireNonNull(nameResolverSpec, "nameResolverSpec");
 		NameResolverProvider.Build builder = new NameResolverProvider.Build();
@@ -432,6 +449,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	}
 
 	@Override
+	@CheckReturnValue
 	public T runOn(LoopResources loopResources, boolean preferNative) {
 		T dup = super.runOn(loopResources, preferNative);
 		CONF conf = dup.configuration();
@@ -460,6 +478,7 @@ public abstract class ClientTransport<T extends ClientTransport<T, CONF>,
 	 * @return a {@link Mono} representing the completion of the warmup
 	 * @since 1.0.3
 	 */
+	@CheckReturnValue
 	public Mono<Void> warmup() {
 		return Mono.fromRunnable(() -> {
 			configuration().eventLoopGroup();

--- a/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/transport/Transport.java
@@ -34,6 +34,7 @@ import reactor.netty.ConnectionObserver;
 import reactor.netty.DisposableChannel;
 import reactor.netty.channel.ChannelMetricsRecorder;
 import reactor.netty.internal.util.Metrics;
+import reactor.netty.lang.CheckReturnValue;
 import reactor.netty.transport.logging.AdvancedByteBufFormat;
 import reactor.netty.resources.LoopResources;
 import reactor.util.Logger;
@@ -48,6 +49,7 @@ import reactor.util.Loggers;
  * @author Violeta Georgieva
  * @since 1.0.0
  */
+@CheckReturnValue
 public abstract class Transport<T extends Transport<T, C>, C extends TransportConfig> {
 
 	/**
@@ -58,6 +60,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param <A> the attribute type
 	 * @return a new {@link Transport} reference
 	 */
+	@CheckReturnValue
 	public <A> T attr(AttributeKey<A> key, @Nullable A value) {
 		Objects.requireNonNull(key, "key");
 		T dup = duplicate();
@@ -71,6 +74,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param bindAddressSupplier A supplier of the address to bind to.
 	 * @return a new {@link Transport}
 	 */
+	@CheckReturnValue
 	public T bindAddress(Supplier<? extends SocketAddress> bindAddressSupplier) {
 		Objects.requireNonNull(bindAddressSupplier, "bindAddressSupplier");
 		T dup = duplicate();
@@ -90,6 +94,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param channelGroup a {@link ChannelGroup}
 	 * @return a new {@link Transport} reference
 	 */
+	@CheckReturnValue
 	public T channelGroup(ChannelGroup channelGroup) {
 		Objects.requireNonNull(channelGroup, "channelGroup");
 		T dup = duplicate();
@@ -102,6 +107,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 *
 	 * @return a {@link TransportConfig}
 	 */
+	@CheckReturnValue
 	public abstract C configuration();
 
 	/**
@@ -110,6 +116,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param doOnChannelInit configure the channel pipeline while initializing the channel
 	 * @return a new {@link Transport} reference
 	 */
+	@CheckReturnValue
 	public T doOnChannelInit(ChannelPipelineConfigurer doOnChannelInit) {
 		Objects.requireNonNull(doOnChannelInit, "doOnChannelInit");
 		T dup = duplicate();
@@ -161,6 +168,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param recorder a supplier for the {@link ChannelMetricsRecorder}
 	 * @return a new {@link Transport} reference
 	 */
+	@CheckReturnValue
 	public T metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder) {
 		if (enable) {
 			T dup = duplicate();
@@ -185,6 +193,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param observer the {@link ConnectionObserver} to be set or add
 	 * @return a new {@link Transport} reference
 	 */
+	@CheckReturnValue
 	public T observe(ConnectionObserver observer) {
 		Objects.requireNonNull(observer, "observer");
 		T dup = duplicate();
@@ -203,6 +212,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @return a new {@link Transport} reference
 	 */
 	@SuppressWarnings("ReferenceEquality")
+	@CheckReturnValue
 	public <O> T option(ChannelOption<O> key, @Nullable O value) {
 		Objects.requireNonNull(key, "key");
 		// Reference comparison is deliberate
@@ -225,6 +235,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param eventLoopGroup an eventLoopGroup to share
 	 * @return a new {@link Transport} reference
 	 */
+	@CheckReturnValue
 	public T runOn(EventLoopGroup eventLoopGroup) {
 		return runOn(new EventLoopGroupLoopResources(eventLoopGroup));
 	}
@@ -238,6 +249,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * returning an eventLoopGroup
 	 * @return a new {@link Transport} reference
 	 */
+	@CheckReturnValue
 	public T runOn(LoopResources channelResources) {
 		Objects.requireNonNull(channelResources, "channelResources");
 		return runOn(channelResources, LoopResources.DEFAULT_NATIVE);
@@ -250,6 +262,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param preferNative should prefer running on epoll, io_uring, kqueue or similar instead of java NIO
 	 * @return a new {@link Transport} reference
 	 */
+	@CheckReturnValue
 	public T runOn(LoopResources loopResources, boolean preferNative) {
 		Objects.requireNonNull(loopResources, "loopResources");
 		T dup = duplicate();
@@ -267,6 +280,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param enable specifies whether the wire logger configuration will be added to the pipeline
 	 * @return a new {@link Transport} reference
 	 */
+	@CheckReturnValue
 	public T wiretap(boolean enable) {
 		if (enable) {
 			T dup = duplicate();
@@ -293,6 +307,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param category the logger category
 	 * @return a new {@link Transport} reference
 	 */
+	@CheckReturnValue
 	public T wiretap(String category) {
 		Objects.requireNonNull(category, "category");
 		return wiretap(category, LogLevel.DEBUG);
@@ -307,6 +322,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param level the logger level
 	 * @return a new {@link Transport} reference
 	 */
+	@CheckReturnValue
 	public T wiretap(String category, LogLevel level) {
 		Objects.requireNonNull(category, "category");
 		Objects.requireNonNull(level, "level");
@@ -331,6 +347,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param format the {@link ByteBuf} format
 	 * @return a new {@link Transport} reference
 	 */
+	@CheckReturnValue
 	public final T wiretap(String category, LogLevel level, AdvancedByteBufFormat format) {
 		Objects.requireNonNull(category, "category");
 		Objects.requireNonNull(level, "level");
@@ -358,6 +375,7 @@ public abstract class Transport<T extends Transport<T, C>, C extends TransportCo
 	 * @param charset  the charset
 	 * @return a new {@link Transport} reference
 	 */
+	@CheckReturnValue
 	public final T wiretap(String category, LogLevel level, AdvancedByteBufFormat format, Charset charset) {
 		Objects.requireNonNull(category, "category");
 		Objects.requireNonNull(level, "level");

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportTest.java
@@ -222,13 +222,13 @@ class ClientTransportTest {
 	@Test
 	void proxyOverriddenWithNullIfSystemPropertiesHaveNoProxySet() {
 		TestClientTransport transport = createTestTransportForProxy();
-		transport.proxy(spec -> spec.type(ProxyProvider.Proxy.HTTP).host("proxy").port(8080));
+		transport = transport.proxy(spec -> spec.type(ProxyProvider.Proxy.HTTP).host("proxy").port(8080));
 		TestClientTransportConfig configuration1 = transport.configuration();
 		assertThat(configuration1.proxyProvider).isNull();
 		assertThat(configuration1.proxyProviderSupplier).isNotNull();
 		assertThat(configuration1.resolver()).isSameAs(NoopAddressResolverGroup.INSTANCE);
 
-		transport.proxyWithSystemProperties(new Properties());
+		transport = transport.proxyWithSystemProperties(new Properties());
 		TestClientTransportConfig configuration2 = transport.configuration();
 		assertThat(configuration2.proxyProvider).isNull();
 		assertThat(configuration2.proxyProviderSupplier).isNull();
@@ -243,7 +243,7 @@ class ClientTransportTest {
 		assertThat(configuration1.proxyProviderSupplier).isNull();
 		assertThat(configuration1.resolver()).isNull();
 
-		transport.proxyWithSystemProperties(new Properties());
+		transport = transport.proxyWithSystemProperties(new Properties());
 		TestClientTransportConfig configuration2 = transport.configuration();
 		assertThat(configuration2.proxyProvider).isNull();
 		assertThat(configuration2.proxyProviderSupplier).isNull();
@@ -364,7 +364,7 @@ class ClientTransportTest {
 
 		@Override
 		protected TestClientTransport duplicate() {
-			return new TestClientTransport(this.connect, this.config);
+			return new TestClientTransport(this.connect, this.config != null ? new TestClientTransportConfig(this.config) : this.config);
 		}
 	}
 
@@ -375,6 +375,10 @@ class ClientTransportTest {
 		TestClientTransportConfig(ConnectionProvider connectionProvider, Map<ChannelOption<?>, ?> options,
 				Supplier<? extends SocketAddress> remoteAddress) {
 			super(connectionProvider, options, remoteAddress);
+		}
+
+		TestClientTransportConfig(TestClientTransportConfig parent) {
+			super(parent);
 		}
 
 		@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClient.java
@@ -65,6 +65,7 @@ import reactor.netty.http.logging.ReactorNettyHttpMessageLogFactory;
 import reactor.netty.http.websocket.WebsocketInbound;
 import reactor.netty.http.websocket.WebsocketOutbound;
 import reactor.netty.internal.util.Metrics;
+import reactor.netty.lang.CheckReturnValue;
 import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.tcp.SslProvider;
 import reactor.netty.tcp.TcpClient;
@@ -114,6 +115,7 @@ import static reactor.netty.http.internal.Http3.isHttp3Available;
  * @author Violeta Georgieva
  * @author raccoonback
  */
+@CheckReturnValue
 public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientConfig> {
 
 	public static final String USER_AGENT = String.format("ReactorNetty/%s", reactorNettyVersion());
@@ -121,6 +123,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	/**
 	 * A URI configuration.
 	 */
+	@CheckReturnValue
 	public interface UriConfiguration<S extends UriConfiguration<?>> {
 
 		/**
@@ -131,6 +134,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return the appropriate sending or receiving contract
 		 */
+		@CheckReturnValue
 		S uri(String uri);
 
 		/**
@@ -141,6 +145,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return the appropriate sending or receiving contract
 		 */
+		@CheckReturnValue
 		S uri(Mono<String> uri);
 
 		/**
@@ -150,6 +155,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 * @param uri target URI which is an absolute, fully constructed {@link URI}
 		 * @return the appropriate sending or receiving contract
 		 */
+		@CheckReturnValue
 		S uri(URI uri);
 	}
 
@@ -157,6 +163,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * Allow a request body configuration before calling one of the terminal, {@link
 	 * Publisher} based, {@link ResponseReceiver} API.
 	 */
+	@CheckReturnValue
 	public interface RequestSender extends ResponseReceiver<RequestSender> {
 
 		/**
@@ -176,6 +183,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return a new {@link ResponseReceiver}
 		 */
+		@CheckReturnValue
 		ResponseReceiver<?> send(Publisher<? extends ByteBuf> body);
 
 		/**
@@ -197,6 +205,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return a new {@link ResponseReceiver}
 		 */
+		@CheckReturnValue
 		ResponseReceiver<?> send(BiFunction<? super HttpClientRequest, ? super NettyOutbound, ? extends Publisher<Void>> sender);
 
 		/**
@@ -217,6 +226,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return a new {@link ResponseReceiver}
 		 */
+		@CheckReturnValue
 		default ResponseReceiver<?> sendForm(BiConsumer<? super HttpClientRequest, HttpClientForm> formCallback) {
 			return sendForm(formCallback, null);
 		}
@@ -240,6 +250,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return a new {@link ResponseReceiver}
 		 */
+		@CheckReturnValue
 		ResponseReceiver<?> sendForm(BiConsumer<? super HttpClientRequest, HttpClientForm> formCallback,
 				@Nullable Consumer<Flux<Long>> progress);
 	}
@@ -248,6 +259,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * Allow a request body configuration before calling one of the terminal, {@link
 	 * Publisher} based, {@link WebsocketReceiver} API.
 	 */
+	@CheckReturnValue
 	public interface WebsocketSender extends WebsocketReceiver<WebsocketSender> {
 
 		/**
@@ -259,6 +271,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return a new {@link ResponseReceiver}
 		 */
+		@CheckReturnValue
 		WebsocketReceiver<?> send(Function<? super HttpClientRequest, ? extends Publisher<Void>> sender);
 	}
 
@@ -267,6 +280,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * {@link ResponseReceiver} API returns {@link Flux} or {@link Mono},
 	 * requesting is always deferred to {@link Publisher#subscribe(Subscriber)}.
 	 */
+	@CheckReturnValue
 	public interface ResponseReceiver<S extends ResponseReceiver<?>>
 			extends UriConfiguration<S> {
 
@@ -278,6 +292,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return the response status and headers as {@link HttpClientResponse}
 		 */
+		@CheckReturnValue
 		Mono<HttpClientResponse> response();
 
 		/**
@@ -291,6 +306,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return a {@link Flux} forwarding the returned {@link Publisher} sequence
 		 */
+		@CheckReturnValue
 		<V> Flux<V> response(BiFunction<? super HttpClientResponse, ? super ByteBufFlux, ? extends Publisher<V>> receiver);
 
 		/**
@@ -305,6 +321,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return a {@link Flux} forwarding the returned {@link Publisher} sequence
 		 */
+		@CheckReturnValue
 		<V> Flux<V> responseConnection(BiFunction<? super HttpClientResponse, ? super Connection, ? extends Publisher<V>> receiver);
 
 		/**
@@ -315,6 +332,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return the response body chunks as {@link ByteBufFlux}.
 		 */
+		@CheckReturnValue
 		ByteBufFlux responseContent();
 
 		/**
@@ -329,6 +347,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return a {@link Mono} forwarding the returned {@link Mono} result
 		 */
+		@CheckReturnValue
 		<V> Mono<V> responseSingle(BiFunction<? super HttpClientResponse, ? super ByteBufMono, ? extends Mono<V>> receiver);
 	}
 
@@ -337,6 +356,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * {@link Flux} or {@link Mono}, requesting is always deferred to
 	 * {@link Publisher#subscribe(Subscriber)}.
 	 */
+	@CheckReturnValue
 	public interface WebsocketReceiver<S extends WebsocketReceiver<?>> extends UriConfiguration<S> {
 		/**
 		 * Negotiate a websocket upgrade and return a {@link Mono} of {@link Connection}. If
@@ -348,6 +368,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return a {@link Mono} of {@link Connection}
 		 */
+		@CheckReturnValue
 		Mono<? extends Connection> connect();
 
 		/**
@@ -366,6 +387,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return a {@link Flux} of the extracted data via the returned {@link Publisher}
 		 */
+		@CheckReturnValue
 		<V> Flux<V> handle(BiFunction<? super WebsocketInbound, ? super WebsocketOutbound, ? extends Publisher<V>> receiver);
 
 		/**
@@ -379,6 +401,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 		 *
 		 * @return a {@link ByteBufFlux} of the inbound websocket content
 		 */
+		@CheckReturnValue
 		ByteBufFlux receive();
 	}
 
@@ -404,6 +427,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public static HttpClient create() {
 		return new HttpClientConnect(new HttpConnectionProvider());
 	}
@@ -416,6 +440,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @param connectionProvider the {@link ConnectionProvider} to be used
 	 * @return a {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public static HttpClient create(ConnectionProvider connectionProvider) {
 		Objects.requireNonNull(connectionProvider, "connectionProvider");
 		return new HttpClientConnect(new HttpConnectionProvider(connectionProvider));
@@ -485,6 +510,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * This method will be removed in version 1.1.0.
 	 */
 	@Deprecated
+	@CheckReturnValue
 	public static HttpClient from(TcpClient tcpClient) {
 		Objects.requireNonNull(tcpClient, "tcpClient");
 		return HttpClientConnect.applyTcpClientConfig(tcpClient.configuration());
@@ -497,6 +523,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public static HttpClient newConnection() {
 		return new HttpClientConnect(new HttpConnectionProvider(ConnectionProvider.newConnection()));
 	}
@@ -511,6 +538,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return the appropriate sending or receiving contract
 	 */
+	@CheckReturnValue
 	public final HttpClient baseUrl(String baseUrl) {
 		Objects.requireNonNull(baseUrl, "baseUrl");
 		HttpClient dup = duplicate();
@@ -528,6 +556,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @param compressionEnabled if true, compression (gzip, Brotli, and zstd) is enabled, otherwise disabled (default: false)
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient compress(boolean compressionEnabled) {
 		if (compressionEnabled) {
 			// Enabling the compression means at least "acceptGzip" is enabled.
@@ -571,6 +600,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient cookie(Cookie cookie) {
 		Objects.requireNonNull(cookie, "cookie");
 		if (!cookie.value().isEmpty()) {
@@ -592,6 +622,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @deprecated as of 1.1.0. Use {@link #cookie(Cookie)} for configuring cookies. This will be removed in 2.0.0.
 	 */
 	@Deprecated
+	@CheckReturnValue
 	public final HttpClient cookie(String name, Consumer<? super Cookie> cookieBuilder) {
 		Objects.requireNonNull(name, "name");
 		Objects.requireNonNull(cookieBuilder, "cookieBuilder");
@@ -611,6 +642,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as Netty 5 supports only strict validation.
 	 */
 	@Deprecated
+	@CheckReturnValue
 	public final HttpClient cookieCodec(ClientCookieEncoder encoder) {
 		Objects.requireNonNull(encoder, "encoder");
 		ClientCookieDecoder decoder = encoder == ClientCookieEncoder.LAX ?
@@ -629,6 +661,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @deprecated as of 1.1.0. This will be removed in 2.0.0 as Netty 5 supports only strict validation.
 	 */
 	@Deprecated
+	@CheckReturnValue
 	public final HttpClient cookieCodec(ClientCookieEncoder encoder, ClientCookieDecoder decoder) {
 		Objects.requireNonNull(encoder, "encoder");
 		Objects.requireNonNull(decoder, "decoder");
@@ -645,6 +678,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient cookiesWhen(String name, Function<? super Cookie, Mono<? extends Cookie>> cookieBuilder) {
 		Objects.requireNonNull(name, "name");
 		Objects.requireNonNull(cookieBuilder, "cookieBuilder");
@@ -670,6 +704,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a {@link RequestSender} ready to prepare the content for response
 	 */
+	@CheckReturnValue
 	public final RequestSender delete() {
 		return request(HttpMethod.DELETE);
 	}
@@ -684,6 +719,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @return a new {@link HttpClient}
 	 * @since 0.9.6
 	 */
+	@CheckReturnValue
 	public final HttpClient disableRetry(boolean disableRetry) {
 		if (disableRetry == configuration().retryDisabled) {
 			return this;
@@ -701,6 +737,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient doAfterRequest(BiConsumer<? super HttpClientRequest, ? super Connection> doAfterRequest) {
 		Objects.requireNonNull(doAfterRequest, "doAfterRequest");
 		HttpClient dup = duplicate();
@@ -721,6 +758,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @return a new {@link HttpClient}
 	 * @since 0.9.5
 	 */
+	@CheckReturnValue
 	public final HttpClient doAfterResponseSuccess(BiConsumer<? super HttpClientResponse, ? super Connection> doAfterResponseSuccess) {
 		Objects.requireNonNull(doAfterResponseSuccess, "doAfterResponseSuccess");
 		HttpClient dup = duplicate();
@@ -744,6 +782,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient doOnError(BiConsumer<? super HttpClientRequest, ? super Throwable> doOnRequestError,
 			BiConsumer<? super HttpClientResponse, ? super Throwable> doOnResponseError) {
 		Objects.requireNonNull(doOnRequestError, "doOnRequestError");
@@ -775,6 +814,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @return a new {@link HttpClient}
 	 * @since 0.9.6
 	 */
+	@CheckReturnValue
 	public final HttpClient doOnRedirect(BiConsumer<? super HttpClientResponse, ? super Connection> doOnRedirect) {
 		Objects.requireNonNull(doOnRedirect, "doOnRedirect");
 		HttpClient dup = duplicate();
@@ -793,6 +833,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient doOnRequest(BiConsumer<? super HttpClientRequest, ? super Connection> doOnRequest) {
 		Objects.requireNonNull(doOnRequest, "doOnRequest");
 		HttpClient dup = duplicate();
@@ -813,6 +854,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient doOnRequestError(BiConsumer<? super HttpClientRequest, ? super Throwable> doOnRequestError) {
 		Objects.requireNonNull(doOnRequestError, "doOnRequestError");
 		HttpClient dup = duplicate();
@@ -831,6 +873,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient doOnResponse(BiConsumer<? super HttpClientResponse, ? super Connection> doOnResponse) {
 		Objects.requireNonNull(doOnResponse, "doOnResponse");
 		HttpClient dup = duplicate();
@@ -849,6 +892,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient doOnResponseError(BiConsumer<? super HttpClientResponse, ? super Throwable> doOnResponseError) {
 		Objects.requireNonNull(doOnResponseError, "doOnResponseError");
 		HttpClient dup = duplicate();
@@ -879,6 +923,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @return a new {@link HttpClient}
 	 * @see #followRedirect(boolean) for automatic redirect on standard 30x status codes
 	 */
+	@CheckReturnValue
 	public final HttpClient followRedirect(BiPredicate<HttpClientRequest, HttpClientResponse> predicate) {
 		return followRedirect(predicate, (Consumer<HttpClientRequest>) null);
 	}
@@ -913,6 +958,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @since 0.9.12
 	 * @see #followRedirect(boolean, BiConsumer) for automatic redirect on standard 30x status codes
 	 */
+	@CheckReturnValue
 	public final HttpClient followRedirect(BiPredicate<HttpClientRequest, HttpClientResponse> predicate,
 			@Nullable BiConsumer<HttpHeaders, HttpClientRequest> redirectRequestBiConsumer) {
 		Objects.requireNonNull(predicate, "predicate");
@@ -952,6 +998,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @since 0.9.5
 	 * @see #followRedirect(boolean, Consumer) for automatic redirect on standard 30x status codes
 	 */
+	@CheckReturnValue
 	public final HttpClient followRedirect(BiPredicate<HttpClientRequest, HttpClientResponse> predicate,
 			@Nullable Consumer<HttpClientRequest> redirectRequestConsumer) {
 		Objects.requireNonNull(predicate, "predicate");
@@ -978,6 +1025,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @return a new {@link HttpClient}
 	 * @see #followRedirect(BiPredicate) for custom redirect logic based on a user-provided predicate
 	 */
+	@CheckReturnValue
 	public final HttpClient followRedirect(boolean followRedirect) {
 		if (!followRedirect && configuration().followRedirectPredicate == null &&
 					configuration().redirectRequestConsumer == null &&
@@ -1017,6 +1065,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @since 0.9.12
 	 * @see #followRedirect(BiPredicate, BiConsumer) for custom redirect logic based on a user-provided predicate
 	 */
+	@CheckReturnValue
 	public final HttpClient followRedirect(boolean followRedirect,
 			@Nullable BiConsumer<HttpHeaders, HttpClientRequest> redirectRequestBiConsumer) {
 		if (followRedirect) {
@@ -1060,6 +1109,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @since 0.9.5
 	 * @see #followRedirect(BiPredicate, Consumer) for custom redirect logic based on a user-provided predicate
 	 */
+	@CheckReturnValue
 	public final HttpClient followRedirect(boolean followRedirect, @Nullable Consumer<HttpClientRequest> redirectRequestConsumer) {
 		if (followRedirect) {
 			return followRedirect(HttpClientConfig.FOLLOW_REDIRECT_PREDICATE, redirectRequestConsumer);
@@ -1078,6 +1128,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a {@link RequestSender} ready to consume for response
 	 */
+	@CheckReturnValue
 	public final ResponseReceiver<?> get() {
 		return request(HttpMethod.GET);
 	}
@@ -1087,6 +1138,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a {@link RequestSender} ready to consume for response
 	 */
+	@CheckReturnValue
 	public final ResponseReceiver<?> head() {
 		return request(HttpMethod.HEAD);
 	}
@@ -1098,6 +1150,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient headers(Consumer<? super HttpHeaders> headerBuilder) {
 		Objects.requireNonNull(headerBuilder, "headerBuilder");
 		HttpClient dup = duplicate();
@@ -1114,6 +1167,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient headersWhen(Function<? super HttpHeaders, Mono<? extends HttpHeaders>> headerBuilder) {
 		Objects.requireNonNull(headerBuilder, "headerBuilder");
 		HttpClient dup = duplicate();
@@ -1135,6 +1189,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @param http2Settings configures {@link Http2SettingsSpec} before requesting
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient http2Settings(Consumer<Http2SettingsSpec.Builder> http2Settings) {
 		Objects.requireNonNull(http2Settings, "http2Settings");
 		Http2SettingsSpec.Builder builder = Http2SettingsSpec.builder();
@@ -1155,6 +1210,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @return a new {@link HttpClient}
 	 * @since 1.2.0
 	 */
+	@CheckReturnValue
 	public final HttpClient http3Settings(Consumer<Http3SettingsSpec.Builder> http3Settings) {
 		Objects.requireNonNull(http3Settings, "http3Settings");
 		if (!isHttp3Available()) {
@@ -1188,6 +1244,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @return a new {@link HttpClient}
 	 * @since 1.0.24
 	 */
+	@CheckReturnValue
 	public final HttpClient httpMessageLogFactory(HttpMessageLogFactory httpMessageLogFactory) {
 		Objects.requireNonNull(httpMessageLogFactory, "httpMessageLogFactory");
 		HttpClient dup = duplicate();
@@ -1201,6 +1258,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @param responseDecoderOptions a function to mutate the provided Http response decoder options
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient httpResponseDecoder(Function<HttpResponseDecoderSpec, HttpResponseDecoderSpec> responseDecoderOptions) {
 		Objects.requireNonNull(responseDecoderOptions, "responseDecoderOptions");
 		HttpResponseDecoderSpec decoder = responseDecoderOptions.apply(new HttpResponseDecoderSpec()).build();
@@ -1219,6 +1277,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient keepAlive(boolean keepAlive) {
 		HttpClient dup = duplicate();
 		HttpHeaders headers = configuration().headers.copy();
@@ -1236,6 +1295,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient mapConnect(
 			Function<? super Mono<? extends Connection>, ? extends Mono<? extends Connection>> connector) {
 		Objects.requireNonNull(connector, "mapConnect");
@@ -1273,6 +1333,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @return a new {@link HttpClient}
 	 * @since 0.9.7
 	 */
+	@CheckReturnValue
 	public final HttpClient metrics(boolean enable, Function<String, String> uriTagValue) {
 		if (enable) {
 			if (!Metrics.isMicrometerAvailable() && !Metrics.isTracingAvailable()) {
@@ -1303,6 +1364,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	}
 
 	@Override
+	@CheckReturnValue
 	public final HttpClient metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder) {
 		return super.metrics(enable, recorder);
 	}
@@ -1323,6 +1385,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * that will be used when the metrics are propagated to the recorder.
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient metrics(boolean enable, Supplier<? extends ChannelMetricsRecorder> recorder, Function<String, String> uriValue) {
 		if (enable) {
 			HttpClient dup = duplicate();
@@ -1346,6 +1409,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient noSSL() {
 		if (configuration().isSecure()) {
 			HttpClient dup = duplicate();
@@ -1356,6 +1420,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	}
 
 	@Override
+	@CheckReturnValue
 	public final HttpClient observe(ConnectionObserver observer) {
 		return super.observe(observer);
 	}
@@ -1365,6 +1430,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a {@link RequestSender} ready to consume for response
 	 */
+	@CheckReturnValue
 	public final ResponseReceiver<?> options() {
 		return request(HttpMethod.OPTIONS);
 	}
@@ -1374,6 +1440,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a {@link RequestSender} ready to finalize request and consume for response
 	 */
+	@CheckReturnValue
 	public final RequestSender patch() {
 		return request(HttpMethod.PATCH);
 	}
@@ -1387,6 +1454,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @return a new {@link HttpClient}
 	 */
 	@Override
+	@CheckReturnValue
 	public final HttpClient port(int port) {
 		return super.port(port);
 	}
@@ -1396,6 +1464,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a {@link RequestSender} ready to finalize request and consume for response
 	 */
+	@CheckReturnValue
 	public final RequestSender post() {
 		return request(HttpMethod.POST);
 	}
@@ -1407,6 +1476,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient protocol(HttpProtocol... supportedProtocols) {
 		Objects.requireNonNull(supportedProtocols, "supportedProtocols");
 		HttpClient dup = duplicate();
@@ -1438,11 +1508,13 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a {@link RequestSender} ready to finalize request and consume for response
 	 */
+	@CheckReturnValue
 	public final RequestSender put() {
 		return request(HttpMethod.PUT);
 	}
 
 	@Override
+	@CheckReturnValue
 	public final HttpClient remoteAddress(Supplier<? extends SocketAddress> remoteAddressSupplier) {
 		return super.remoteAddress(remoteAddressSupplier);
 	}
@@ -1454,6 +1526,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a {@link RequestSender} ready to finalize request and consume for response
 	 */
+	@CheckReturnValue
 	public RequestSender request(HttpMethod method) {
 		Objects.requireNonNull(method, "method");
 		HttpClientFinalizer dup = new HttpClientFinalizer(new HttpClientConfig(configuration()));
@@ -1478,6 +1551,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @since 0.9.11
 	 * @see io.netty.handler.timeout.ReadTimeoutHandler
 	 */
+	@CheckReturnValue
 	public final HttpClient responseTimeout(@Nullable Duration maxReadOperationInterval) {
 		if (Objects.equals(maxReadOperationInterval, configuration().responseTimeout)) {
 			return this;
@@ -1501,6 +1575,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient secure() {
 		SslProvider sslProvider = HttpClientSecure.defaultSslProvider(configuration());
 		if (sslProvider.equals(configuration().sslProvider)) {
@@ -1526,6 +1601,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @param sslProviderBuilder builder callback for further customization of SslContext.
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public final HttpClient secure(Consumer<? super SslProvider.SslContextSpec> sslProviderBuilder) {
 		Objects.requireNonNull(sslProviderBuilder, "sslProviderBuilder");
 		SslProvider.SslContextSpec builder = SslProvider.builder();
@@ -1560,6 +1636,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @param sslProvider The provider to set when configuring SSL
 	 * @return a new {@link HttpClient}
 	 */
+	@CheckReturnValue
 	public HttpClient secure(SslProvider sslProvider) {
 		Objects.requireNonNull(sslProvider, "sslProvider");
 		HttpClient dup = duplicate();
@@ -1643,6 +1720,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 */
 	@Deprecated
 	@SuppressWarnings("ReturnValueIgnored")
+	@CheckReturnValue
 	public final HttpClient tcpConfiguration(Function<? super TcpClient, ? extends TcpClient> tcpMapper) {
 		Objects.requireNonNull(tcpMapper, "tcpMapper");
 		HttpClientTcpConfig tcpClient = new HttpClientTcpConfig(this);
@@ -1665,6 +1743,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @since 1.0.3
 	 */
 	@Override
+	@CheckReturnValue
 	public Mono<Void> warmup() {
 		return Mono.when(
 				super.warmup(),
@@ -1692,6 +1771,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @see #resolver(AddressResolverGroup)
 	 * @see #resolver(Consumer)
 	 */
+	@CheckReturnValue
 	public final HttpClient proxyWhen(
 			BiFunction<HttpClientConfig, ? super ProxyProvider.TypeSpec, Mono<? extends ProxyProvider.Builder>> proxyBuilder) {
 		Objects.requireNonNull(proxyBuilder, "proxyBuilder");
@@ -1718,6 +1798,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 *
 	 * @return a {@link WebsocketSender} ready to consume for response
 	 */
+	@CheckReturnValue
 	public final WebsocketSender websocket() {
 		return websocket(WebsocketClientSpec.builder().build());
 	}
@@ -1729,6 +1810,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @return a {@link WebsocketSender} ready to consume for response
 	 * @since 0.9.7
 	 */
+	@CheckReturnValue
 	public final WebsocketSender websocket(WebsocketClientSpec websocketClientSpec) {
 		Objects.requireNonNull(websocketClientSpec, "websocketClientSpec");
 		WebsocketFinalizer dup = new WebsocketFinalizer(new HttpClientConfig(configuration()));
@@ -1738,6 +1820,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	}
 
 	@Override
+	@CheckReturnValue
 	public final HttpClient wiretap(boolean enable) {
 		return super.wiretap(enable);
 	}
@@ -1786,6 +1869,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @see #httpAuthentication(BiPredicate, BiConsumer, int)
 	 * @see #httpAuthenticationWhen(BiPredicate, BiFunction)
 	 */
+	@CheckReturnValue
 	public final HttpClient httpAuthentication(
 			BiPredicate<? super HttpClientRequest, ? super HttpClientResponse> predicate,
 			BiConsumer<? super HttpClientRequest, ? super SocketAddress> authenticator) {
@@ -1836,6 +1920,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @since 1.3.1
 	 * @see #httpAuthenticationWhen(BiPredicate, BiFunction, int)
 	 */
+	@CheckReturnValue
 	public final HttpClient httpAuthentication(
 			BiPredicate<? super HttpClientRequest, ? super HttpClientResponse> predicate,
 			BiConsumer<? super HttpClientRequest, ? super SocketAddress> authenticator,
@@ -1896,6 +1981,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @see #httpAuthenticationWhen(BiPredicate, BiFunction, int)
 	 * @see #httpAuthentication(BiPredicate, BiConsumer)
 	 */
+	@CheckReturnValue
 	public final HttpClient httpAuthenticationWhen(
 			BiPredicate<? super HttpClientRequest, ? super HttpClientResponse> predicate,
 			BiFunction<? super HttpClientRequest, ? super SocketAddress, ? extends Mono<Void>> authenticator) {
@@ -1947,6 +2033,7 @@ public abstract class HttpClient extends ClientTransport<HttpClient, HttpClientC
 	 * @since 1.3.1
 	 * @see #httpAuthentication(BiPredicate, BiConsumer, int)
 	 */
+	@CheckReturnValue
 	public final HttpClient httpAuthenticationWhen(
 			BiPredicate<? super HttpClientRequest, ? super HttpClientResponse> predicate,
 			BiFunction<? super HttpClientRequest, ? super SocketAddress, ? extends Mono<Void>> authenticator,

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -2853,7 +2853,8 @@ class HttpClientTest extends BaseHttpTest {
 	}
 
 	@Test
-	@SuppressWarnings("deprecation")
+	// intentional: configuration() is called only to trigger UnsupportedOperationException, its return value is unused by design
+	@SuppressWarnings({"deprecation", "CheckReturnValue"})
 	void testTcpConfigurationUnsupported_4() {
 		assertThatExceptionOfType(UnsupportedOperationException.class)
 				.isThrownBy(() -> HttpClient.create()

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -2219,7 +2219,8 @@ class HttpServerTests extends BaseHttpTest {
 	}
 
 	@Test
-	@SuppressWarnings("deprecation")
+	// intentional: configuration() is called only to trigger UnsupportedOperationException, its return value is unused by design
+	@SuppressWarnings({"deprecation", "CheckReturnValue"})
 	void testTcpConfigurationUnsupported_3() {
 		assertThatExceptionOfType(UnsupportedOperationException.class)
 				.isThrownBy(() -> HttpServer.create()


### PR DESCRIPTION
Introduce reactor.netty.lang.CheckReturnValue and CanIgnoreReturnValue and apply CheckReturnValue at class level to Transport, ClientTransport, and HttpClient including its nested interfaces (UriConfiguration, RequestSender, ResponseReceiver, WebsocketSender, WebsocketReceiver). Error Prone and IntelliJ IDEA match these annotations by simple name, so discarding the result of the immutable fluent API is reported without requiring an extra dependency. Also fix test call sites that discarded fluent results.

The reason why `@CheckReturnValue` is applied both on method and class is due to that fact that IntelliJ does not go up the chat to look for `@CheckReturnValue`. It only does that for

* `javax.annotation.CheckReturnValue`
* `org.assertj.core.util.CheckReturnValue`
* `com.google.errorprone.annotations.CheckReturnValue`
* `org.jetbrains.annotations.CheckReturnValue`
* `org.springframework.lang.CheckReturnValue`

See https://github.com/JetBrains/intellij-community/blob/d9318167d85d96c9d2febad78c9198af853b5cb7/java/java-impl-inspections/src/com/siyeh/ig/bugs/IgnoreResultOfCallInspection.java#L141-L146

---

The reason I was inspired to do this was due to the fact that we had something like:

```java
httpClient.compress(true);

return httpClient.onConnected(...);
```

This lead to the `httpClient.compress(true)` not doing anything.

I am more than happy to apply this to other places in the codebase as well