### PR TITLE
Add a WebSocket echo client example

### DIFF
--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/websocket/echo/WebsocketClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/websocket/echo/WebsocketClient.java
@@ -46,7 +46,8 @@ public final class WebsocketClient {
 				Http2SslContextSpec http2SslContextSpec =
 						Http2SslContextSpec.forClient()
 						                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
-				client = client.secure(spec -> spec.sslContext(http2SslContextSpec));
+				client = client.secure(spec -> spec.sslContext(http2SslContextSpec))
+				               .protocol(HttpProtocol.H2);
 			}
 			else {
 				Http11SslContextSpec http11SslContextSpec =
@@ -54,10 +55,6 @@ public final class WebsocketClient {
 						                    .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
 				client = client.secure(spec -> spec.sslContext(http11SslContextSpec));
 			}
-		}
-
-		if (HTTP2) {
-			client = client.protocol(HttpProtocol.H2);
 		}
 
 		client.websocket()

--- a/reactor-netty-examples/src/main/java/reactor/netty/examples/websocket/echo/WebsocketClient.java
+++ b/reactor-netty-examples/src/main/java/reactor/netty/examples/websocket/echo/WebsocketClient.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 VMware, Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.netty.examples.websocket.echo;
+
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.Http11SslContextSpec;
+import reactor.netty.http.Http2SslContextSpec;
+import reactor.netty.http.HttpProtocol;
+import reactor.netty.http.client.HttpClient;
+
+/**
+ * A WebSocket client that sends a message to the WebSocket server and
+ * receives as a response the message that was sent.
+ *
+ * @author Jeongkyun An
+ */
+public final class WebsocketClient {
+
+	static final boolean SECURE = System.getProperty("secure") != null;
+	static final int PORT = Integer.parseInt(System.getProperty("port", SECURE ? "8443" : "8080"));
+	static final boolean WIRETAP = System.getProperty("wiretap") != null;
+	static final boolean HTTP2 = System.getProperty("http2") != null;
+
+	public static void main(String[] args) {
+		HttpClient client =
+				HttpClient.create()
+				          .port(PORT)
+				          .wiretap(WIRETAP);
+
+		if (SECURE) {
+			if (HTTP2) {
+				Http2SslContextSpec http2SslContextSpec =
+						Http2SslContextSpec.forClient()
+						                   .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+				client = client.secure(spec -> spec.sslContext(http2SslContextSpec));
+			}
+			else {
+				Http11SslContextSpec http11SslContextSpec =
+						Http11SslContextSpec.forClient()
+						                    .configure(builder -> builder.trustManager(InsecureTrustManagerFactory.INSTANCE));
+				client = client.secure(spec -> spec.sslContext(http11SslContextSpec));
+			}
+		}
+
+		if (HTTP2) {
+			client = client.protocol(HttpProtocol.H2);
+		}
+
+		client.websocket()
+		      .uri("/ws")
+		      .handle((in, out) -> out.sendString(Mono.just("Hello World!"))
+		                              .then(in.receive()
+		                                      .asString()
+		                                      .next()
+		                                      .doOnNext(System.out::println)
+		                                      .then()))
+		      .blockLast();
+	}
+}


### PR DESCRIPTION
The `websocket/echo` sample only has a server. The other samples come as a client and server pair mirroring the Netty examples, so this adds the client half, corresponding to Netty's `http/websocketx/client` example.

Follows the same shape as `http/echo/EchoClient`, with the `secure`, `port`, `wiretap` and `http2` system properties.

Verified against the existing `WebsocketServer`:

```
$ ... WebsocketServer &
$ ... WebsocketClient
Hello World!
```

The send and receive are structured the way `WebsocketTest` does it, bounding the inbound with `next()` and returning `Mono<Void>`. Sending first and then subscribing to the inbound as a separate `Flux` made the server complete its side and close before the echo was read.

Related to #761
