### PR TITLE
Resume the read when the pipelined queue drains without a request

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -578,9 +578,13 @@ final class HttpTrafficHandler extends ChannelDuplexHandler implements Runnable 
 			ctx.executor().execute(this);
 		}
 		else {
-			IdleTimeoutHandler.addIdleTimeoutHandler(ctx.pipeline(), idleTimeout, HttpConnectionLiveness.CLOSE);
-			ctx.read();
+			requestRead();
 		}
+	}
+
+	void requestRead() {
+		IdleTimeoutHandler.addIdleTimeoutHandler(ctx.pipeline(), idleTimeout, HttpConnectionLiveness.CLOSE);
+		ctx.read();
 	}
 
 	@Override
@@ -662,6 +666,12 @@ final class HttpTrafficHandler extends ChannelDuplexHandler implements Runnable 
 			}
 		}
 		overflow = false;
+
+		// The queue drained without dispatching a request, so no HttpServerOperations will terminate
+		// and resume the read; without this the next request stays unread until the peer gives up.
+		if (nextRequest == null && persistentConnection) {
+			requestRead();
+		}
 	}
 
 	@Override

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -17,10 +17,13 @@ package reactor.netty.http.server;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -105,6 +108,7 @@ import io.netty.handler.ssl.SslHandshakeTimeoutException;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.AttributeKey;
+import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.DefaultEventExecutor;
@@ -408,6 +412,50 @@ class HttpServerTests extends BaseHttpTest {
 				          .responseSingle((res, buf) -> Mono.just(res.status().code()))
 				          .block(Duration.ofSeconds(5));
 		assertThat(code).isEqualTo(500);
+	}
+
+	@Test
+	void pipelinedRequestResumesReadWhenOnlyTrailingContentIsQueued() throws Exception {
+		disposableServer =
+				createServer()
+				        .route(r -> r.get("/slow", (req, res) ->
+				                             res.sendString(Mono.delay(Duration.ofMillis(500)).thenReturn("slow")))
+				                     .get("/fast", (req, res) -> res.sendString(Mono.just("fast")))
+				                     .get("/next", (req, res) -> res.sendString(Mono.just("next"))))
+				        .bindNow();
+
+		try (Socket socket = new Socket("localhost", disposableServer.port())) {
+			socket.setSoTimeout(10_000);
+			OutputStream out = socket.getOutputStream();
+			InputStream in = socket.getInputStream();
+
+			// One write, so /fast is buffered while /slow is still in flight and is then answered off
+			// the pipelined queue, leaving only its own trailing content behind.
+			out.write((getRequest("/slow") + getRequest("/fast")).getBytes(CharsetUtil.US_ASCII));
+			out.flush();
+			assertThat(readUntil(in, "fast")).contains("slow", "fast");
+
+			out.write(getRequest("/next").getBytes(CharsetUtil.US_ASCII));
+			out.flush();
+			assertThat(readUntil(in, "next")).contains("next");
+		}
+	}
+
+	private static String getRequest(String uri) {
+		return "GET " + uri + " HTTP/1.1\r\nHost: localhost\r\n\r\n";
+	}
+
+	private static String readUntil(InputStream in, String token) throws IOException {
+		StringBuilder received = new StringBuilder();
+		byte[] buffer = new byte[256];
+		while (received.indexOf(token) < 0) {
+			int read = in.read(buffer);
+			if (read < 0) {
+				throw new IOException("Connection closed before receiving '" + token + "': " + received);
+			}
+			received.append(new String(buffer, 0, read, CharsetUtil.US_ASCII));
+		}
+		return received.toString();
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
`HttpTrafficHandler` reads on demand, so every read has to be re-armed by an explicit `ctx.read()`. `resumeRead()` delegates to `run()` whenever the pipelined queue is non-empty, and `run()` is the only path that never re-arms it — it drains the queue, sets `overflow = false`, and returns.

That is fine as long as `run()` dispatches a request, because the resulting `HttpServerOperations` will terminate and call `resumeRead()` again. It is not fine when the queue drains without one:

1. A keep-alive request arrives before the previous request's `HttpServerOperations` has terminated, so it is buffered (`Buffering keep-alive request, previous ops not yet terminated`), along with its trailing `LastHttpContent`.
2. The previous operations terminate, `resumeRead()` sees a non-empty queue and schedules `run()`.
3. `run()` dispatches the buffered request, which is answered and terminates re-entrantly. `resumeRead()` runs again, still sees a non-empty queue — the trailing content — and schedules another `run()`.
4. The outer `run()` drains that trailing content and returns. The scheduled `run()` then finds an empty queue and returns too.

Nobody called `ctx.read()`. The idle timeout handler is not armed either, since it is installed only in the other `resumeRead()` branch, so nothing reaps the connection. The next request sits unread in the socket until the peer gives up; the server logs it only once the peer closes and the resulting read delivers it.

Captured from a server run with `reactor.netty.http.server` at `DEBUG`, on the connection that stalls:

```
41.855 [186] Buffering keep-alive request, previous ops not yet terminated
41.856 Draining next pipelined HTTP request, pending responses count: 1, queued: 2
41.857 AccessLog: "DELETE /… HTTP/1.1" 403 13 2
41.857 [187] Last HTTP packet was sent, terminating the channel
41.857 Draining next pipelined HTTP request, pending responses count: 0, queued: 1
41.858 [client] request_sent  GET /consent          <- never read
46.860 [client] Http client inbound receiver cancelled, closing channel.
46.862 [server] Increasing pending responses count: 1   <- the request, 5s late
```

## Why this is worth fixing

The window is narrow, but it does not require HTTP pipelining on the client's part — only connection reuse. A client that sends its next request as soon as it has read the previous response can land in it, and a busy event loop widens the gap between "last response frame written" and "operations terminated". We hit it as an intermittent hang in a `WebTestClient` test suite against a booted Spring Boot WebFlux application, roughly 3% of full-suite runs on a 2-vCPU CI machine, always as a request that never reaches a handler and unsticks the moment the client cancels. The same shape is reachable behind a load balancer that keeps connections alive to its targets, where it surfaces as a gateway timeout.

## The fix

Extract the read-arming into `requestRead()` and call it at the end of `run()` when the queue drained without a request being dispatched, since in that case no operations remain whose termination would do it. `IdleTimeoutHandler.addIdleTimeoutHandler` already no-ops when the handler is present, so sharing it between the two call sites is safe, and an extra `ctx.read()` is harmless.

## The test

`pipelinedRequestResumesReadWhenOnlyTrailingContentIsQueued` writes two requests in a single write so the second is buffered while the first is still in flight and is then answered off the queue, leaving only its trailing content. A third request is then sent, and the assertion is that it gets a response. It is deterministic — no retries or timing tolerance beyond the socket read timeout — and fails on an unpatched build with `java.net.SocketTimeoutException: Read timed out` on that third request.

## Verification

- `./gradlew :reactor-netty-http:test` — 2730 tests, 0 failures.
- `./gradlew check` — passes.

## Branch

Targeted at `1.2.x` as the oldest active maintenance branch, since #4189 touched this same handler and landed in 1.2.18. `resumeRead()` and `run()` are identical on `1.3.x` and `main`, so it applies cleanly to either — happy to retarget if triage prefers a different branch.
