### PR TITLE
Guard FluxReceive.cleanQueue against already released buffers

### DIFF
--- a/reactor-netty-core/src/main/java/reactor/netty/channel/FluxReceive.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/FluxReceive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
+import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.ReferenceCountUtil;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Subscription;
@@ -221,7 +222,14 @@ final class FluxReceive extends Flux<Object> implements Subscription, Disposable
 				if (log.isDebugEnabled()) {
 					log.debug(format(parent.channel(), "{}: dropping frame {}"), this, parent.asDebugLogMessage(o));
 				}
-				ReferenceCountUtil.release(o);
+				try {
+					ReferenceCountUtil.release(o);
+				}
+				catch (IllegalReferenceCountException e) {
+					if (log.isDebugEnabled()) {
+						log.debug("", e);
+					}
+				}
 			}
 		}
 	}

--- a/reactor-netty-core/src/test/java/reactor/netty/channel/FluxReceiveTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/channel/FluxReceiveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2023-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,18 @@ package reactor.netty.channel;
 
 import java.time.Duration;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.IllegalReferenceCountException;
 import org.junit.jupiter.api.Test;
 import reactor.netty.NettyInbound;
 import reactor.netty.NettyOutbound;
 import reactor.test.subscriber.TestSubscriber;
 import reactor.test.util.RaceTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class FluxReceiveTest {
 
@@ -38,5 +44,53 @@ public class FluxReceiveTest {
 
 			subscriber.block(Duration.ofSeconds(5));
 		}
+	}
+
+	@Test
+	void cleanQueueReleasesEveryBufferWhenOneWasAlreadyReleased() {
+		EmbeddedChannel channel = new EmbeddedChannel();
+		ChannelOperations<NettyInbound, NettyOutbound> operations =
+				new ChannelOperations<>(() -> channel, (connection, newState) -> {
+				});
+		FluxReceive receive = new FluxReceive(operations);
+
+		receive.subscribe(TestSubscriber.builder().initialRequest(0).build());
+
+		ByteBuf releasedElsewhere = Unpooled.buffer().writeByte(1);
+		ByteBuf queuedBehindIt = Unpooled.buffer().writeByte(2);
+		receive.onInboundNext(releasedElsewhere);
+		receive.onInboundNext(queuedBehindIt);
+		assertThat(receive.getPending()).isEqualTo(2);
+
+		releasedElsewhere.release();
+
+		assertThatCode(receive::cancel).doesNotThrowAnyException();
+
+		assertThat(queuedBehindIt.refCnt()).as("buffer queued behind an already released one").isZero();
+	}
+
+	@Test
+	void cleanQueueStillTerminatesTheReceiverWhenABufferWasAlreadyReleased() {
+		EmbeddedChannel channel = new EmbeddedChannel();
+		ChannelOperations<NettyInbound, NettyOutbound> operations =
+				new ChannelOperations<>(() -> channel, (connection, newState) -> {
+				});
+		FluxReceive receive = new FluxReceive(operations);
+
+		TestSubscriber<Object> subscriber = TestSubscriber.builder().initialRequest(0).build();
+		receive.subscribe(subscriber);
+
+		ByteBuf delivered = Unpooled.buffer().writeByte(1);
+		ByteBuf queuedBehindIt = Unpooled.buffer().writeByte(2);
+		receive.onInboundNext(delivered);
+		receive.onInboundNext(queuedBehindIt);
+
+		delivered.release();
+		queuedBehindIt.release();
+
+		assertThatCode(() -> receive.request(1)).doesNotThrowAnyException();
+
+		assertThat(subscriber.isTerminated()).as("receiver terminated").isTrue();
+		assertThat(subscriber.expectTerminalError()).isInstanceOf(IllegalReferenceCountException.class);
 	}
 }

--- a/reactor-netty-core/src/test/java/reactor/netty/channel/FluxReceiveTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/channel/FluxReceiveTest.java
@@ -20,8 +20,8 @@ import java.time.Duration;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.IllegalReferenceCountException;
 import org.junit.jupiter.api.Test;
+import reactor.netty.ConnectionObserver;
 import reactor.netty.NettyInbound;
 import reactor.netty.NettyOutbound;
 import reactor.test.subscriber.TestSubscriber;
@@ -47,50 +47,108 @@ public class FluxReceiveTest {
 	}
 
 	@Test
-	void cleanQueueReleasesEveryBufferWhenOneWasAlreadyReleased() {
+	void consumeImmediatelyReactorNettyReleases() {
 		EmbeddedChannel channel = new EmbeddedChannel();
-		ChannelOperations<NettyInbound, NettyOutbound> operations =
-				new ChannelOperations<>(() -> channel, (connection, newState) -> {
-				});
-		FluxReceive receive = new FluxReceive(operations);
+		try {
+			ChannelOperations<?, ?> ops = bindReceiveOperations(channel);
+			TestSubscriber<ByteBuf> subscriber = TestSubscriber.builder().initialRequest(0).build();
+			ops.receive().subscribe(subscriber);
 
-		receive.subscribe(TestSubscriber.builder().initialRequest(0).build());
+			ByteBuf first = Unpooled.buffer().writeByte(1);
+			ByteBuf second = Unpooled.buffer().writeByte(2);
+			channel.writeInbound(first, second);
+			channel.runPendingTasks();
 
-		ByteBuf releasedElsewhere = Unpooled.buffer().writeByte(1);
-		ByteBuf queuedBehindIt = Unpooled.buffer().writeByte(2);
-		receive.onInboundNext(releasedElsewhere);
-		receive.onInboundNext(queuedBehindIt);
-		assertThat(receive.getPending()).isEqualTo(2);
+			assertThat(first.refCnt()).as("queued until demand, Reactor Netty owns").isOne();
+			assertThat(second.refCnt()).isOne();
 
-		releasedElsewhere.release();
+			subscriber.request(Long.MAX_VALUE);
+			channel.runPendingTasks();
 
-		assertThatCode(receive::cancel).doesNotThrowAnyException();
-
-		assertThat(queuedBehindIt.refCnt()).as("buffer queued behind an already released one").isZero();
+			assertThat(first.refCnt()).as("consume immediately: Reactor Netty released").isZero();
+			assertThat(second.refCnt()).as("consume immediately: Reactor Netty released").isZero();
+		}
+		finally {
+			channel.finishAndReleaseAll();
+		}
 	}
 
 	@Test
-	void cleanQueueStillTerminatesTheReceiverWhenABufferWasAlreadyReleased() {
+	void retainThenApplicationReleases() {
 		EmbeddedChannel channel = new EmbeddedChannel();
-		ChannelOperations<NettyInbound, NettyOutbound> operations =
-				new ChannelOperations<>(() -> channel, (connection, newState) -> {
-				});
-		FluxReceive receive = new FluxReceive(operations);
+		try {
+			ChannelOperations<?, ?> ops = bindReceiveOperations(channel);
+			TestSubscriber<ByteBuf> subscriber = TestSubscriber.builder().initialRequest(0).build();
+			ops.receive()
+			   .retain()
+			   .subscribe(subscriber);
 
-		TestSubscriber<Object> subscriber = TestSubscriber.builder().initialRequest(0).build();
-		receive.subscribe(subscriber);
+			ByteBuf first = Unpooled.buffer().writeByte(1);
+			ByteBuf second = Unpooled.buffer().writeByte(2);
+			channel.writeInbound(first, second);
+			channel.runPendingTasks();
 
-		ByteBuf delivered = Unpooled.buffer().writeByte(1);
-		ByteBuf queuedBehindIt = Unpooled.buffer().writeByte(2);
-		receive.onInboundNext(delivered);
-		receive.onInboundNext(queuedBehindIt);
+			subscriber.request(1);
+			channel.runPendingTasks();
 
-		delivered.release();
-		queuedBehindIt.release();
+			assertThat(first.refCnt()).as("retain: Reactor Netty released, application still holds").isOne();
+			assertThat(second.refCnt()).as("not yet delivered").isOne();
 
-		assertThatCode(() -> receive.request(1)).doesNotThrowAnyException();
+			first.release();
+			assertThat(first.refCnt()).as("application released").isZero();
 
-		assertThat(subscriber.isTerminated()).as("receiver terminated").isTrue();
-		assertThat(subscriber.expectTerminalError()).isInstanceOf(IllegalReferenceCountException.class);
+			subscriber.request(1);
+			channel.runPendingTasks();
+			assertThat(second.refCnt()).isOne();
+			second.release();
+			assertThat(second.refCnt()).isZero();
+		}
+		finally {
+			channel.finishAndReleaseAll();
+		}
+	}
+
+	@Test
+	void cancelAfterConsumeImmediatelyReleasesRemainingQueue() {
+		EmbeddedChannel channel = new EmbeddedChannel();
+		try {
+			ChannelOperations<?, ?> ops = bindReceiveOperations(channel);
+			TestSubscriber<ByteBuf> subscriber = TestSubscriber.builder().initialRequest(0).build();
+			ops.receive().subscribe(subscriber);
+
+			ByteBuf consumedImmediately = Unpooled.buffer().writeByte(1);
+			ByteBuf queuedBehindIt = Unpooled.buffer().writeByte(2);
+			ByteBuf alsoQueued = Unpooled.buffer().writeByte(3);
+			channel.writeInbound(consumedImmediately, queuedBehindIt, alsoQueued);
+			channel.runPendingTasks();
+
+			subscriber.request(1);
+			channel.runPendingTasks();
+
+			assertThat(consumedImmediately.refCnt())
+					.as("already released by Reactor Netty after consume immediately")
+					.isZero();
+			assertThat(queuedBehindIt.refCnt()).isOne();
+			assertThat(alsoQueued.refCnt()).isOne();
+
+			assertThatCode(subscriber::cancel).doesNotThrowAnyException();
+			channel.runPendingTasks();
+
+			assertThat(queuedBehindIt.refCnt()).as("cleanQueue released remaining").isZero();
+			assertThat(alsoQueued.refCnt()).as("cleanQueue released remaining").isZero();
+		}
+		finally {
+			channel.finishAndReleaseAll();
+		}
+	}
+
+	static ChannelOperations<?, ?> bindReceiveOperations(EmbeddedChannel channel) {
+		ChannelOperations.addReactiveBridge(channel,
+				(conn, observer, msg) -> new ChannelOperations<>(conn, observer),
+				ConnectionObserver.emptyListener());
+		channel.pipeline().fireChannelActive();
+		ChannelOperations<?, ?> ops = ChannelOperations.get(channel);
+		assertThat(ops).as("ChannelOperations bound after Netty channelActive").isNotNull();
+		return ops;
 	}
 }


### PR DESCRIPTION
`FluxReceive.cleanQueue` released queued frames without guarding against an already released buffer. One `IllegalReferenceCountException` aborted the drain, so remaining buffers leaked, `terminateReceiver` was skipped at the call sites that depend on `cleanQueue` completing, and the exception surfaced as an unhandled event-loop task failure.

`drainReceiver` already catches that exception when releasing the delivered frame (#3406 / #3448), but its `catch` still called the unguarded `cleanQueue`.

Catch `IllegalReferenceCountException` per queued item (same approach as `drainReceiver` / `ChannelOperationsHandler.safeRelease`) so the rest of the queue is released and the subscriber is still terminated.

Fixes #4343.
