### PR TITLE
Parse one-digit ports in HttpClient String URIs

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/UriEndpointFactory.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/UriEndpointFactory.java
@@ -31,7 +31,7 @@ final class UriEndpointFactory {
 	final BiFunction<String, Integer, InetSocketAddress> inetSocketAddressFunction;
 
 	static final Pattern URL_PATTERN = Pattern.compile(
-			"(?:(\\w+)://)?((?:\\[.+?])|(?<!\\[)(?:[^/?]+?))(?::(\\d{2,5}))?([/?].*)?");
+			"(?:(\\w+)://)?((?:\\[.+?])|(?<!\\[)(?:[^/?]+?))(?::(\\d{1,5}))?([/?].*)?");
 	static final Pattern SCHEME_PATTERN = Pattern.compile("https?|wss?");
 
 	UriEndpointFactory(Supplier<? extends SocketAddress> connectAddress, boolean defaultSecure,

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/UriEndpointFactoryTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/UriEndpointFactoryTest.java
@@ -69,7 +69,13 @@ class UriEndpointFactoryTest {
 				new @Nullable String[]{"localhost?key=val", null, "localhost", null, "?key=val"},
 				new @Nullable String[]{"localhost:80", null, "localhost", "80", null},
 				new @Nullable String[]{"localhost:80?key=val", null, "localhost", "80", "?key=val"},
-				new @Nullable String[]{"localhost/:1234", null, "localhost", null, "/:1234"}
+				new @Nullable String[]{"localhost/:1234", null, "localhost", null, "/:1234"},
+				new String[]{"http://localhost:1/path", "http", "localhost", "1", "/path"},
+				new String[]{"http://localhost:1", "http", "localhost", "1", null},
+				new String[]{"http://127.0.0.1:1", "http", "127.0.0.1", "1", null},
+				new String[]{"http://127.0.0.1:1/path", "http", "127.0.0.1", "1", "/path"},
+				new String[]{"http://[::1]:1", "http", "[::1]", "1", null},
+				new @Nullable String[]{"localhost:1", null, "localhost", "1", null}
 				);
 
 		for (String[] input : inputs) {
@@ -114,12 +120,25 @@ class UriEndpointFactoryTest {
 				new String[]{"http://[::1]:80?key=val", "http://[::1]/?key=val"},
 				new String[]{"http://[::1]:80/?key=val#fragment", "http://[::1]/?key=val"},
 				new String[]{"http://[::1]:80/?key=%223", "http://[::1]/?key=%223"},
-				new String[]{"http://[::1]:1234", "http://[::1]:1234/"}
-		);
+				new String[]{"http://[::1]:1234", "http://[::1]:1234/"},
+				new String[]{"http://localhost:1", "http://localhost:1/"},
+				new String[]{"http://127.0.0.1:1/path", "http://127.0.0.1:1/path"},
+				new String[]{"http://[::1]:1", "http://[::1]:1/"}
+				);
 
 		for (String[] input : inputs) {
 			assertThat(externalForm(this.builder.build(), input[0], false, true)).isEqualTo(input[1]);
 		}
+	}
+
+	@Test
+	void createUriEndpointOneDigitPort() {
+		UriEndpoint endpoint = this.builder.build()
+				.createUriEndpoint("http://127.0.0.1:1", false);
+
+		assertThat(endpoint.host).isEqualTo("127.0.0.1");
+		assertThat(endpoint.port).isEqualTo(1);
+		assertThat(endpoint.toExternalForm()).isEqualTo("http://127.0.0.1:1/");
 	}
 
 	@Test


### PR DESCRIPTION
`UriEndpointFactory.URL_PATTERN` only accepted explicit ports of 2-5 digits. A String URI such as `http://127.0.0.1:1` therefore kept `:1` in the host group and defaulted the port to 80, which can turn an intended loopback refusal into a DNS lookup. The `URI` overload already parses one-digit ports correctly.

This change accepts 1-5 digit ports in the String parser and adds coverage for IPv4, IPv6, and host-only forms.

Fixes #4357

## Tests

- `./gradlew :reactor-netty-http:test --tests reactor.netty.http.client.UriEndpointFactoryTest` (GREEN)
- `./gradlew :reactor-netty-http:checkstyleMain :reactor-netty-http:checkstyleTest spotlessCheck` (GREEN)